### PR TITLE
chore: repo audit — security, privacy, governance + EU compliance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# CODEOWNERS for VAG Connect
+# Until brand captains are recruited (Issue #64), the maintainer owns
+# everything. As contributors take responsibility for specific brands,
+# add entries below.
+
+# Default: everything maintained by Prash
+*                                                                   @its-me-prash
+
+# Brand API clients (look for volunteers per brand — see #64)
+custom_components/vag_connect/cariad/api/audi.py                    @its-me-prash
+custom_components/vag_connect/cariad/api/vw_eu.py                   @its-me-prash
+custom_components/vag_connect/cariad/api/vw_na.py                   @its-me-prash
+custom_components/vag_connect/cariad/api/skoda.py                   @its-me-prash
+custom_components/vag_connect/cariad/api/seat_cupra.py              @its-me-prash
+custom_components/vag_connect/cariad/api/porsche.py                 @its-me-prash
+
+# Auth flows
+custom_components/vag_connect/cariad/auth/                          @its-me-prash
+
+# CI / build / release
+.github/                                                            @its-me-prash
+RELEASE_PROCESS.md                                                  @its-me-prash
+
+# Documentation in 8 languages — keep in sync at every release
+README.md                                                           @its-me-prash
+README.en.md                                                        @its-me-prash
+README.cs.md                                                        @its-me-prash
+README.es.md                                                        @its-me-prash
+README.fr.md                                                        @its-me-prash
+README.nl.md                                                        @its-me-prash
+README.pl.md                                                        @its-me-prash
+README.sv.md                                                        @its-me-prash

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,18 +1,18 @@
 name: 🐛 Bug Report
-description: Etwas funktioniert nicht wie erwartet / Something doesn't work as expected
+description: Something doesn't work as expected / Etwas funktioniert nicht wie erwartet
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Danke für dein Feedback! Bitte fülle so viele Felder wie möglich aus — das spart enorm Zeit.
-
         Thanks for the feedback! Please fill in as many fields as possible — it saves a lot of time.
+
+        Danke für dein Feedback! Bitte fülle so viele Felder wie möglich aus — das spart enorm Zeit.
 
   - type: dropdown
     id: brand
     attributes:
-      label: Fahrzeugmarke / Vehicle brand
+      label: Vehicle brand / Fahrzeugmarke
       options:
         - Audi
         - Volkswagen EU
@@ -27,16 +27,16 @@ body:
   - type: input
     id: country
     attributes:
-      label: Land / Country
-      placeholder: "z.B. Deutschland, Österreich, UK, USA"
+      label: Country / Land
+      placeholder: "e.g. Germany, Austria, UK, USA"
     validations:
       required: true
 
   - type: input
     id: model
     attributes:
-      label: Modell + Baujahr / Model + year
-      placeholder: "z.B. Audi S6 2021, ID.4 2023, Cupra Born 2023"
+      label: Model + year / Modell + Baujahr
+      placeholder: "e.g. Audi S6 2021, ID.4 2023, Cupra Born 2023"
     validations:
       required: true
 
@@ -44,7 +44,7 @@ body:
     id: version
     attributes:
       label: VAG Connect Version
-      placeholder: "z.B. 1.8.0"
+      placeholder: "e.g. 1.8.0"
     validations:
       required: true
 
@@ -52,94 +52,97 @@ body:
     id: ha_version
     attributes:
       label: Home Assistant Version
-      placeholder: "z.B. 2026.4.0"
+      placeholder: "e.g. 2026.4.0"
     validations:
       required: true
 
   - type: dropdown
     id: official_app
     attributes:
-      label: Funktioniert die selbe Aktion in der offiziellen App? / Does the same action work in the official manufacturer app?
+      label: Does the same action work in the official manufacturer app? / Funktioniert die selbe Aktion in der offiziellen App?
       options:
-        - "Ja / Yes"
-        - "Nein / No"
-        - "Teilweise / Partially"
-        - "Weiß ich nicht / I don't know"
+        - "Yes / Ja"
+        - "No / Nein"
+        - "Partially / Teilweise"
+        - "I don't know / Weiß ich nicht"
     validations:
       required: true
 
   - type: dropdown
     id: subscription
     attributes:
-      label: Online-Services Abo aktiv? / Connected services subscription active?
+      label: Connected services subscription active? / Online-Services Abo aktiv?
       description: |
+        Some brands (VW, CUPRA) block commands when the subscription expires —
+        that's not a bug in this integration but a server-side restriction.
+
         Manche Marken (VW, CUPRA) sperren Befehle wenn das Abo abgelaufen ist —
         dann ist es kein Bug bei uns sondern eine serverseitige Einschränkung.
-
-        Some brands block commands when the subscription expires — that's not
-        a bug in this integration but a server-side restriction.
       options:
-        - "Ja / Yes"
-        - "Nein / No"
-        - "Weiß ich nicht / I don't know"
+        - "Yes / Ja"
+        - "No / Nein"
+        - "I don't know / Weiß ich nicht"
     validations:
       required: true
 
   - type: dropdown
     id: spin
     attributes:
-      label: S-PIN konfiguriert? / S-PIN configured?
-      description: S-PIN ist nötig für Verriegeln und einige andere Befehle / S-PIN is required for lock and some other commands
+      label: S-PIN configured? / S-PIN konfiguriert?
+      description: S-PIN is required for lock and some other commands / S-PIN ist nötig für Verriegeln und einige andere Befehle
       options:
-        - "Ja / Yes"
-        - "Nein / No"
-        - "Nicht relevant / Not relevant"
+        - "Yes / Ja"
+        - "No / Nein"
+        - "Not relevant / Nicht relevant"
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Was ist passiert? / What happened?
+      label: What happened? / Was ist passiert?
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: Was sollte passieren? / What should happen?
+      label: What should happen? / Was sollte passieren?
     validations:
       required: true
 
   - type: textarea
     id: logs
     attributes:
-      label: Logs (geschwärzt / redacted)
+      label: Logs (redacted / geschwärzt)
       description: |
+        HA → Settings → System → Logs → filter by "vag_connect".
+        Enable debug logging via the integration → "Enable debug logging".
+
         HA → Einstellungen → System → Logs → nach "vag_connect" filtern.
         Debug-Logging über Integration → Debug-Logging aktivieren.
 
-        **Bitte VIN, Email, Tokens, GPS-Koordinaten und S-PIN entfernen / schwärzen!**
-        Please remove or mask VIN, email, tokens, GPS coordinates and S-PIN!
+        **Please remove or mask VIN, email, tokens, GPS coordinates and S-PIN!**
+        Bitte VIN, Email, Tokens, GPS-Koordinaten und S-PIN entfernen / schwärzen!
       render: text
 
   - type: textarea
     id: diagnostics
     attributes:
-      label: Diagnose-Daten / Diagnostics (optional)
+      label: Diagnostics / Diagnose-Daten (optional)
       description: |
+        Settings → Devices & Services → VAG Connect → ⋮ → Download diagnostics.
+        Sensitive data (password, S-PIN, GPS, email) is auto-redacted.
+
         HA → Einstellungen → Integrationen → VAG Connect → 3-Punkte-Menü → Diagnose herunterladen.
         Sensible Daten (Passwort, S-PIN, GPS, Email) sind automatisch geschwärzt.
-
-        Settings → Devices & Services → VAG Connect → ⋮ → Download diagnostics.
-        Sensitive data is auto-redacted.
       render: json
 
   - type: checkboxes
     id: privacy_confirmation
     attributes:
-      label: Privacy / Datenschutz-Bestätigung
-      description: Pflicht / Required
+      label: Privacy confirmation / Datenschutz-Bestätigung
+      description: Required / Pflicht
       options:
-        - label: Ich habe Tokens, vollständige VIN, Email, GPS-Koordinaten und S-PIN aus Logs/Diagnose entfernt. / I have removed tokens, full VIN, email, GPS and S-PIN from logs/diagnostics.
+        - label: I have removed tokens, full VIN, email, GPS and S-PIN from logs/diagnostics. / Ich habe Tokens, vollständige VIN, Email, GPS-Koordinaten und S-PIN aus Logs/Diagnose entfernt.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,16 +1,18 @@
 name: 🐛 Bug Report
-description: Etwas funktioniert nicht wie erwartet
+description: Etwas funktioniert nicht wie erwartet / Something doesn't work as expected
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Danke für dein Feedback! Bitte fülle so viele Felder wie möglich aus — das spart Zeit.
+        Danke für dein Feedback! Bitte fülle so viele Felder wie möglich aus — das spart enorm Zeit.
+
+        Thanks for the feedback! Please fill in as many fields as possible — it saves a lot of time.
 
   - type: dropdown
     id: brand
     attributes:
-      label: Fahrzeugmarke
+      label: Fahrzeugmarke / Vehicle brand
       options:
         - Audi
         - Volkswagen EU
@@ -23,10 +25,26 @@ body:
       required: true
 
   - type: input
+    id: country
+    attributes:
+      label: Land / Country
+      placeholder: "z.B. Deutschland, Österreich, UK, USA"
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Modell + Baujahr / Model + year
+      placeholder: "z.B. Audi S6 2021, ID.4 2023, Cupra Born 2023"
+    validations:
+      required: true
+
+  - type: input
     id: version
     attributes:
       label: VAG Connect Version
-      placeholder: "z.B. 1.0.0"
+      placeholder: "z.B. 1.8.0"
     validations:
       required: true
 
@@ -34,39 +52,94 @@ body:
     id: ha_version
     attributes:
       label: Home Assistant Version
-      placeholder: "z.B. 2025.1.0"
+      placeholder: "z.B. 2026.4.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: official_app
+    attributes:
+      label: Funktioniert die selbe Aktion in der offiziellen App? / Does the same action work in the official manufacturer app?
+      options:
+        - "Ja / Yes"
+        - "Nein / No"
+        - "Teilweise / Partially"
+        - "Weiß ich nicht / I don't know"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subscription
+    attributes:
+      label: Online-Services Abo aktiv? / Connected services subscription active?
+      description: |
+        Manche Marken (VW, CUPRA) sperren Befehle wenn das Abo abgelaufen ist —
+        dann ist es kein Bug bei uns sondern eine serverseitige Einschränkung.
+
+        Some brands block commands when the subscription expires — that's not
+        a bug in this integration but a server-side restriction.
+      options:
+        - "Ja / Yes"
+        - "Nein / No"
+        - "Weiß ich nicht / I don't know"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: spin
+    attributes:
+      label: S-PIN konfiguriert? / S-PIN configured?
+      description: S-PIN ist nötig für Verriegeln und einige andere Befehle / S-PIN is required for lock and some other commands
+      options:
+        - "Ja / Yes"
+        - "Nein / No"
+        - "Nicht relevant / Not relevant"
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Was ist passiert?
-      description: Klarer, konkreter Fehlerbeschreibung.
+      label: Was ist passiert? / What happened?
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: Was sollte passieren?
+      label: Was sollte passieren? / What should happen?
     validations:
       required: true
 
   - type: textarea
     id: logs
     attributes:
-      label: Logs
+      label: Logs (geschwärzt / redacted)
       description: |
         HA → Einstellungen → System → Logs → nach "vag_connect" filtern.
-        Debug-Logging aktivieren unter Einstellungen → Integrationen → VAG Connect → "Debug-Logging aktivieren".
+        Debug-Logging über Integration → Debug-Logging aktivieren.
+
+        **Bitte VIN, Email, Tokens, GPS-Koordinaten und S-PIN entfernen / schwärzen!**
+        Please remove or mask VIN, email, tokens, GPS coordinates and S-PIN!
       render: text
 
   - type: textarea
     id: diagnostics
     attributes:
-      label: Diagnose-Daten (optional)
+      label: Diagnose-Daten / Diagnostics (optional)
       description: |
         HA → Einstellungen → Integrationen → VAG Connect → 3-Punkte-Menü → Diagnose herunterladen.
-        Sensible Daten (GPS, Passwort) sind automatisch geschwärzt.
+        Sensible Daten (Passwort, S-PIN, GPS, Email) sind automatisch geschwärzt.
+
+        Settings → Devices & Services → VAG Connect → ⋮ → Download diagnostics.
+        Sensitive data is auto-redacted.
       render: json
+
+  - type: checkboxes
+    id: privacy_confirmation
+    attributes:
+      label: Privacy / Datenschutz-Bestätigung
+      description: Pflicht / Required
+      options:
+        - label: Ich habe Tokens, vollständige VIN, Email, GPS-Koordinaten und S-PIN aus Logs/Diagnose entfernt. / I have removed tokens, full VIN, email, GPS and S-PIN from logs/diagnostics.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 Diskussionen & Fragen
+  - name: 💬 Discussions & Questions / Diskussionen & Fragen
     url: https://github.com/its-me-prash/vag-connect-ha/discussions
-    about: Allgemeine Fragen, Dashboard-Beispiele und Community-Austausch
+    about: General questions, dashboard examples, community exchange / Allgemeine Fragen, Dashboard-Beispiele und Community-Austausch
   - name: 📖 HA Community Forum
     url: https://community.home-assistant.io
-    about: Allgemeine Home Assistant Fragen
+    about: General Home Assistant questions / Allgemeine Home Assistant Fragen
+  - name: 🔒 Security vulnerability / Sicherheitslücke
+    url: https://github.com/its-me-prash/vag-connect-ha/security/advisories/new
+    about: Report privately via GitHub Security Advisories / Privat per GitHub Security Advisories melden — see SECURITY.md

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,14 +1,14 @@
 name: 💡 Feature Request
-description: Idee für eine neue Funktion
+description: Idea for a new feature / Idee für eine neue Funktion
 labels: ["enhancement"]
 body:
   - type: dropdown
     id: brand
     attributes:
-      label: Betrifft welche Marke(n)?
+      label: Affected brand(s) / Betrifft welche Marke(n)?
       multiple: true
       options:
-        - Alle
+        - All / Alle
         - Audi
         - Volkswagen EU
         - Škoda
@@ -22,21 +22,27 @@ body:
   - type: textarea
     id: feature
     attributes:
-      label: Was soll das Feature tun?
-      description: Kurze, klare Beschreibung.
+      label: What should the feature do? / Was soll das Feature tun?
+      description: Short, clear description. / Kurze, klare Beschreibung.
     validations:
       required: true
 
   - type: textarea
     id: usecase
     attributes:
-      label: Welches Problem löst es?
-      description: "z.B. 'Ich möchte eine Automation wenn der Akku unter 20% fällt, aber der Sensor fehlt.'"
+      label: What problem does it solve? / Welches Problem löst es?
+      description: |
+        e.g. "I want an automation when battery drops below 20 %, but the sensor is missing."
+
+        z.B. "Ich möchte eine Automation wenn der Akku unter 20 % fällt, aber der Sensor fehlt."
     validations:
       required: true
 
   - type: textarea
     id: api
     attributes:
-      label: API-Hinweise (optional)
-      description: Weißt du ob die VAG-API das unterstützt? Link zu Dokumentation oder ähnlichen Projekten?
+      label: API hints (optional) / API-Hinweise (optional)
+      description: |
+        Do you know if the VAG API supports this? Link to documentation or similar projects?
+
+        Weißt du ob die VAG-API das unterstützt? Link zu Dokumentation oder ähnlichen Projekten?

--- a/.github/ISSUE_TEMPLATE/new_brand.yml
+++ b/.github/ISSUE_TEMPLATE/new_brand.yml
@@ -1,43 +1,74 @@
-name: 🚗 Neue Marke / Neues Modell
-description: Porsche/VW NA Live-Test oder neue Marke vorschlagen
-labels: ["new-brand", "testing"]
+name: 🚗 Live-Test einer Marke / Brand live-test report
+description: Berichte ob deine Marke / dein Modell mit VAG Connect funktioniert
+labels: ["testing"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## Tester gesucht — Porsche & VW US/CA
-        Porsche und VW North America sind als Beta implementiert aber noch ohne echten Live-Test.
-        Wenn du eines dieser Fahrzeuge hast, hilf uns mit einem kurzen Bericht!
+        ## Tester gesucht / Testers needed
+
+        Wir freuen uns über jedes Live-Feedback. Besonders gesucht sind:
+
+        - **Porsche** (Auth0 + PPA — implementiert, kaum live getestet)
+        - **VW US / CA** (eigener Auth-Server — implementiert, kaum live getestet)
+        - **VW Commercial** (Transporter, ID. Buzz Cargo — vermutlich kompatibel mit VW EU, ungetestet)
+        - **Škoda Enyaq, Superb iV, Karoq** (Plattform-Verbreiterung)
+
+        Nicht implementiert und auch nicht geplant: Bentley, Lamborghini,
+        Bugatti, Ducati, MAN, Scania — siehe [`docs/research/LUXURY_BRANDS.md`](https://github.com/its-me-prash/vag-connect-ha/blob/main/docs/research/LUXURY_BRANDS.md).
 
   - type: dropdown
     id: brand
     attributes:
-      label: Marke / Modell
+      label: Marke / Brand
       options:
-        - Porsche (My Porsche App)
-        - Volkswagen US (MyVW App)
-        - Volkswagen CA (MyVW App)
-        - Andere (bitte unten beschreiben)
+        - Porsche
+        - Volkswagen US (MyVW)
+        - Volkswagen CA (MyVW)
+        - Volkswagen Commercial (Transporter / ID. Buzz Cargo / Crafter)
+        - Audi
+        - Volkswagen EU
+        - Škoda
+        - SEAT
+        - CUPRA
+        - Andere (bitte unten beschreiben / other — describe below)
     validations:
       required: true
 
   - type: input
     id: model
     attributes:
-      label: Fahrzeugmodell
-      placeholder: "z.B. Porsche Taycan, VW ID.4 (US)"
+      label: Modell + Baujahr / Model + year
+      placeholder: "z.B. Porsche Taycan 2023, VW ID.4 2024 (US), Škoda Enyaq iV 2025"
+    validations:
+      required: true
+
+  - type: input
+    id: country
+    attributes:
+      label: Land / Country
+      placeholder: "z.B. Deutschland, USA, Tschechien"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: VAG Connect Version
+      placeholder: "z.B. 1.8.0"
     validations:
       required: true
 
   - type: dropdown
     id: result
     attributes:
-      label: Ergebnis
+      label: Ergebnis / Result
       options:
-        - ✅ Funktioniert vollständig
-        - ⚠️ Teilweise — bestimmte Features fehlen
-        - ❌ Authentifizierung schlägt fehl
-        - ❌ Fahrzeug wird nicht erkannt
+        - "✅ Funktioniert vollständig / fully works"
+        - "⚠️ Teilweise — bestimmte Features fehlen / partial — some features missing"
+        - "❌ Authentifizierung schlägt fehl / authentication fails"
+        - "❌ Fahrzeug wird nicht erkannt / vehicle not detected"
+        - "❌ Status lädt aber Befehle scheitern / status loads but commands fail"
     validations:
       required: true
 
@@ -45,6 +76,10 @@ body:
     id: details
     attributes:
       label: Details / Logs
-      description: Was genau funktioniert oder fehlt?
+      description: |
+        Welche Entities erscheinen? Welche Aktionen funktionieren / scheitern?
+
+        Bitte VIN, Email, Tokens, GPS-Koordinaten und S-PIN aus Logs entfernen.
+        Please remove VIN, email, tokens, GPS and S-PIN from logs.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new_brand.yml
+++ b/.github/ISSUE_TEMPLATE/new_brand.yml
@@ -1,26 +1,31 @@
-name: 🚗 Live-Test einer Marke / Brand live-test report
-description: Berichte ob deine Marke / dein Modell mit VAG Connect funktioniert
+name: 🚗 Brand live-test report / Live-Test einer Marke
+description: Report whether your brand / model works with VAG Connect / Berichte ob deine Marke / dein Modell mit VAG Connect funktioniert
 labels: ["testing"]
 body:
   - type: markdown
     attributes:
       value: |
-        ## Tester gesucht / Testers needed
+        ## Testers needed / Tester gesucht
+
+        We welcome any live feedback. Especially needed:
 
         Wir freuen uns über jedes Live-Feedback. Besonders gesucht sind:
 
-        - **Porsche** (Auth0 + PPA — implementiert, kaum live getestet)
-        - **VW US / CA** (eigener Auth-Server — implementiert, kaum live getestet)
-        - **VW Commercial** (Transporter, ID. Buzz Cargo — vermutlich kompatibel mit VW EU, ungetestet)
-        - **Škoda Enyaq, Superb iV, Karoq** (Plattform-Verbreiterung)
+        - **Porsche** (Auth0 + PPA — implemented, barely live tested)
+        - **VW US / CA** (separate auth server — implemented, barely live tested)
+        - **VW Commercial** (Transporter, ID. Buzz Cargo — assumed to be VW EU compatible, untested)
+        - **Škoda Enyaq, Superb iV, Karoq** (platform broadening)
+
+        Not implemented and not planned: Bentley, Lamborghini, Bugatti, Ducati,
+        MAN, Scania — see [`docs/research/LUXURY_BRANDS.md`](https://github.com/its-me-prash/vag-connect-ha/blob/main/docs/research/LUXURY_BRANDS.md).
 
         Nicht implementiert und auch nicht geplant: Bentley, Lamborghini,
-        Bugatti, Ducati, MAN, Scania — siehe [`docs/research/LUXURY_BRANDS.md`](https://github.com/its-me-prash/vag-connect-ha/blob/main/docs/research/LUXURY_BRANDS.md).
+        Bugatti, Ducati, MAN, Scania — siehe `docs/research/LUXURY_BRANDS.md`.
 
   - type: dropdown
     id: brand
     attributes:
-      label: Marke / Brand
+      label: Brand / Marke
       options:
         - Porsche
         - Volkswagen US (MyVW)
@@ -31,23 +36,23 @@ body:
         - Škoda
         - SEAT
         - CUPRA
-        - Andere (bitte unten beschreiben / other — describe below)
+        - Other — describe below / Andere — bitte unten beschreiben
     validations:
       required: true
 
   - type: input
     id: model
     attributes:
-      label: Modell + Baujahr / Model + year
-      placeholder: "z.B. Porsche Taycan 2023, VW ID.4 2024 (US), Škoda Enyaq iV 2025"
+      label: Model + year / Modell + Baujahr
+      placeholder: "e.g. Porsche Taycan 2023, VW ID.4 2024 (US), Škoda Enyaq iV 2025"
     validations:
       required: true
 
   - type: input
     id: country
     attributes:
-      label: Land / Country
-      placeholder: "z.B. Deutschland, USA, Tschechien"
+      label: Country / Land
+      placeholder: "e.g. Germany, USA, Czech Republic"
     validations:
       required: true
 
@@ -55,20 +60,20 @@ body:
     id: version
     attributes:
       label: VAG Connect Version
-      placeholder: "z.B. 1.8.0"
+      placeholder: "e.g. 1.8.0"
     validations:
       required: true
 
   - type: dropdown
     id: result
     attributes:
-      label: Ergebnis / Result
+      label: Result / Ergebnis
       options:
-        - "✅ Funktioniert vollständig / fully works"
-        - "⚠️ Teilweise — bestimmte Features fehlen / partial — some features missing"
-        - "❌ Authentifizierung schlägt fehl / authentication fails"
-        - "❌ Fahrzeug wird nicht erkannt / vehicle not detected"
-        - "❌ Status lädt aber Befehle scheitern / status loads but commands fail"
+        - "✅ Fully works / Funktioniert vollständig"
+        - "⚠️ Partial — some features missing / Teilweise — bestimmte Features fehlen"
+        - "❌ Authentication fails / Authentifizierung schlägt fehl"
+        - "❌ Vehicle not detected / Fahrzeug wird nicht erkannt"
+        - "❌ Status loads but commands fail / Status lädt aber Befehle scheitern"
     validations:
       required: true
 
@@ -77,9 +82,11 @@ body:
     attributes:
       label: Details / Logs
       description: |
+        Which entities appear? Which actions work / fail?
+
         Welche Entities erscheinen? Welche Aktionen funktionieren / scheitern?
 
-        Bitte VIN, Email, Tokens, GPS-Koordinaten und S-PIN aus Logs entfernen.
         Please remove VIN, email, tokens, GPS and S-PIN from logs.
+        Bitte VIN, Email, Tokens, GPS-Koordinaten und S-PIN aus Logs entfernen.
     validations:
       required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot configuration for VAG Connect.
+# We have no Python runtime dependencies (`requirements: []`), so the
+# only ecosystem worth watching is GitHub Actions itself — to catch
+# Node version deprecations before they break CI.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "ci"
+      - "dependencies"
+    # Group all action bumps into a single PR so reviews stay light.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ---
 
+## [Unreleased]
+
+### Removed
+- Stale icon and translation entries for entities that were removed in
+  v1.8.0 (`seat_heating_switch`, `auto_unlock_switch`, `max_charge_current`).
+  The keys had no corresponding entity since the v1.8.0 cleanup and were
+  unused by HA. Cleaned across `icons.json`, `strings.json` and all
+  8 language files.
+
+### Changed
+- `docs/research/ARCHITECTURE_DECISION.md` and
+  `docs/research/DEPENDENCY_AUDIT.md` marked as historical
+  (implemented in v0.12.0, still the architecture in v1.8.0).
+
 ## [1.8.0] - 2026-04-26
 
 ### Bug Fix — CUPRA/SEAT honk-and-flash 400 (#53)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,131 @@
 # Contributing to VAG Connect
 
-## Bug Reports
-→ [Issue Template](https://github.com/its-me-prash/vag-connect-ha/issues/new/choose)
+> Thanks for taking the time to look at the code. This integration is
+> community-maintained and grows from the contributions of users who file
+> good bug reports, share anonymised diagnostics and write small focused
+> patches.
 
-Bitte immer: Version, Marke, HA-Version und Logs mitschicken.
+---
 
-## Pull Requests
+## Bug reports
+
+Use the issue templates:
+<https://github.com/its-me-prash/vag-connect-ha/issues/new/choose>
+
+A good bug report contains:
+
+- VAG Connect version (`manifest.json`)
+- Home Assistant version
+- Brand and rough vehicle model
+- Country / region (some endpoints differ)
+- Whether the same action works in the manufacturer's official app
+- Whether the manufacturer's online services subscription is active
+- Whether an S-PIN is configured
+- Sanitised logs (filter `vag_connect` in HA logs)
+- Anonymised diagnostics (download via Settings → Devices & Services →
+  VAG Connect → ⋮ → Diagnose herunterladen)
+
+**Please remove tokens, full VINs, GPS coordinates, email addresses and
+S-PIN values before pasting anything in a public issue.** Diagnostics
+already redact these by default — if you paste a raw HA log, double-check.
+
+---
+
+## Pull requests
 
 ```bash
 git clone https://github.com/its-me-prash/vag-connect-ha
 cd vag-connect-ha
-pip install pytest pytest-asyncio ruff
-python -m pytest tests/        # alle Tests grün
-python -m ruff check custom_components/vag_connect/  # Lint sauber
+pip install pytest pytest-asyncio pytest-cov ruff mypy aiohttp voluptuous homeassistant
+python -m pytest tests/        # all green
+python -m ruff check custom_components/
+python -m mypy custom_components/vag_connect/ --ignore-missing-imports \
+  --disallow-untyped-defs --disallow-incomplete-defs --warn-return-any
 ```
 
-**Regeln:**
-- Alle neuen Features brauchen Tests
-- Lint muss sauber sein (`ruff check`)
-- CHANGELOG.md aktualisieren
-- Neue Marken oder API-Endpoints brauchen eine Quelle (Link zu MIT/Apache-2.0 Referenzprojekt)
+### Rules
 
-## Neue Marke hinzufügen
+- **One PR = one concern.** Atomic, reviewable. The session-based roadmap
+  in [`docs/ROADMAP.md`](docs/ROADMAP.md) gives the broader plan.
+- **Tests for new features.** A new sensor needs a parser test plus an
+  entity test. A new command needs a coordinator dispatch test.
+- **Lint clean** — `ruff check` returns 0.
+- **CHANGELOG.md updated** — CI fails the PR otherwise.
+- **No external runtime dependencies.** `manifest.json` requirements stay
+  empty. We bundle our own CARIAD client.
+- **No broken behaviour.** If you change a contract, update the matching
+  test instead of disabling it.
+- **No fake writable entities.** A switch must call a real API command
+  or it must not exist.
+- **Privacy first.** Anything that could send user data to a third party
+  is opt-in and documented in [`PRIVACY.md`](PRIVACY.md).
+- **Reference projects must be MIT or Apache-2.0.** GPL code may not be
+  copied. See [`NOTICE.md`](NOTICE.md) for the current reference list.
 
-1. `cariad/api/{marke}.py` — API-Client (von `CariadBaseClient` ableiten oder eigene Klasse)
-2. `cariad/models.py` — `BrandConfig` + `BRANDS` dict ergänzen
-3. `cariad/api/factory.py` — Routing ergänzen
-4. `const.py` — BRANDS dict
-5. `config_flow.py` — `_BRAND_OPTIONS` ergänzen
-6. Tests in `tests/test_cariad.py`
-7. README Feature-Tabelle ergänzen
+### Commit messages
 
-## Tester gesucht
+```
+feat:     new feature              → Added in CHANGELOG
+fix:      bug fix                  → Fixed
+refactor: code restructuring        → Changed
+docs:     documentation only
+test:     tests
+chore:    build / deps
+ci:       GitHub Actions
+i18n:     translations
+```
 
-Porsche und VW US/CA sind implementiert aber ohne echten Live-Test. Wenn du eines dieser Fahrzeuge hast:
-→ [Tester-Issue öffnen](https://github.com/its-me-prash/vag-connect-ha/issues/new?template=new_brand.yml)
+The `changelog_check.yml` workflow rejects PRs that touch
+`custom_components/` without a CHANGELOG entry.
+
+### Translations
+
+`strings.json` is the **English source of truth**. Mirror every change
+into all 8 language files (`translations/{de,en,cs,es,fr,nl,pl,sv}.json`).
+Use everyday driver vocabulary, not API jargon: e.g. *Lichthupe*, not
+*Lichtsignal*.
+
+---
+
+## Adding a new brand
+
+1. `cariad/api/{brand}.py` — API client, derive from `CariadBaseClient`
+   or write a brand-specific class
+2. `cariad/models.py` — add `BrandConfig` + `BRANDS` entry
+3. `cariad/api/factory.py` — routing
+4. `const.py` — `BRANDS` dict
+5. `config_flow.py` — `_BRAND_OPTIONS`
+6. `tests/test_cariad.py` — at minimum: factory routing, status parser
+7. README feature table (mirror in all 8 languages)
+8. `docs/research/VAG_GROUP_ECOSYSTEM.md` — add the brand to the map
+
+**Capability-first:** the new client must implement a capability check
+so commands the vehicle does not support are not exposed as entities.
+See issue #56.
+
+---
+
+## Live testers wanted
+
+Some brands are implemented but lack real-world verification:
+
+| Brand | Status |
+|---|---|
+| Audi | Live tested (S6, multiple models) |
+| VW EU | Live tested (ID series, Golf, Tiguan) |
+| Škoda | Live tested (Octavia 2025) — see #54 |
+| SEAT | Awaiting first real account |
+| CUPRA | Live tested (Born — limited by subscription, see #53 #42) |
+| Porsche | Implemented, **no live test** — `new_brand.yml` template |
+| VW US/CA | Implemented, **no live test** — `new_brand.yml` template |
+
+If you have a vehicle and want to help, open the
+[`new_brand.yml`](https://github.com/its-me-prash/vag-connect-ha/issues/new?template=new_brand.yml)
+template.
+
+---
+
+## Code of conduct
+
+Be civil. Be specific. Don't paste secrets. The maintainer is one person
+on their own time — patches and patience travel further than demands.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,109 @@
+# Privacy / Datenschutz
+
+> **TL;DR:** VAG Connect runs entirely inside your Home Assistant instance.
+> Your credentials and vehicle data never leave Home Assistant unless they
+> go directly to the manufacturer's official API. We do not collect
+> telemetry, we do not have a server, we do not have your data.
+
+> **Kurzfassung:** VAG Connect läuft komplett in deiner Home Assistant
+> Instanz. Deine Zugangsdaten und Fahrzeugdaten verlassen Home Assistant
+> nur direkt zu den offiziellen Hersteller-APIs. Wir sammeln keine
+> Telemetrie, wir haben keinen Server, wir haben deine Daten nicht.
+
+---
+
+## What data the integration handles
+
+| Data | Where it goes | Stored where |
+|---|---|---|
+| Email + password | VW IDK / Auth0 / OLA / Škoda mysmob | HA config entry (encrypted by HA) |
+| S-PIN | Brand API (only when you trigger lock/unlock/etc.) | HA config entry (encrypted by HA) |
+| OAuth access + refresh tokens | Held in memory, refreshed against VW IDK | HA config entry |
+| Vehicle data (SoC, range, doors, …) | CARIAD BFF / OLA / mysmob / PPA | HA recorder (your DB) |
+| GPS position | CARIAD BFF / OLA / mysmob / PPA → HA | HA recorder + device tracker |
+| VIN | Brand API + HA device registry | HA device registry |
+
+**Nothing in this list goes to the maintainer.** Nothing goes to
+third-party analytics. There is no "phone home".
+
+---
+
+## Optional third-party calls
+
+The following calls only happen if **you explicitly enable them**:
+
+| Feature | Third party | Default | How to enable |
+|---|---|---|---|
+| Reverse geocoding (parking address) | OpenStreetMap Nominatim | **OFF** | HA → VAG Connect → Configure → "Reverse Geocoding" |
+
+When reverse geocoding is on, the rounded vehicle coordinate (3 decimals,
+~110m precision) is sent to `nominatim.openstreetmap.org` with a
+`User-Agent` identifying the integration. Results are cached so the same
+parking spot is not re-queried.
+
+---
+
+## Vehicle render images (Audi)
+
+Audi vehicle render images are fetched from `mediaservice.audi.com` (the
+public CDN that the myAudi web portal uses). The image URL itself is
+discovered via an authenticated GraphQL query to Audi. The PNG file is
+public and unauthenticated.
+
+Fetched images are cached locally under `/config/www/vehicles/` so they
+do not re-download on every restart.
+
+---
+
+## What you should do as a user
+
+- **Use a unique password** for your manufacturer account that you do not
+  reuse anywhere else. The integration stores it as plain config (HA
+  encrypts the on-disk file, but anything inside HA can read it).
+- **Use the S-PIN feature** if your manufacturer supports it. Locking
+  commands without S-PIN are blocked since v1.8.0.
+- **Restrict who can access your Home Assistant**. Anyone who can log in
+  to your HA can see every entity from this integration, including GPS.
+- **Use the diagnostics export with care.** It already redacts password,
+  S-PIN, username and GPS, but always review before sharing.
+
+---
+
+## EU / GDPR (DSGVO) considerations
+
+VAG Connect itself is **not a data processor under Article 28 GDPR**
+because it does not run on a service we operate. It runs on your Home
+Assistant instance, owned and controlled by you, the data subject.
+
+The maintainer of this project does not collect, store, transmit or
+process any personal data of users.
+
+The EU Data Act (mandatory in-vehicle data access for third parties)
+takes effect in September 2026 and may give vehicle owners formal,
+documented API access — see issue
+[#59](https://github.com/its-me-prash/vag-connect-ha/issues/59).
+
+---
+
+## EU Cyber Resilience Act (CRA)
+
+VAG Connect is a community-maintained, non-commercial open-source
+integration. It is not "commercial software" under the CRA, but the
+maintainer voluntarily follows CRA-aligned practices:
+
+- Coordinated vulnerability disclosure — see [`SECURITY.md`](SECURITY.md)
+- No telemetry / no analytics / no remote update channel beyond HACS
+- Reproducible release ZIPs uploaded to GitHub Releases
+- Source code under Apache 2.0, fully auditable
+
+---
+
+## Changes to this policy
+
+This policy may be updated when the integration adds features that change
+how data is handled. The change log of this file is the git history of
+`PRIVACY.md`.
+
+---
+
+*Last updated: 2026-04-26 — v1.8.0*

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,110 +1,155 @@
-# Release-Prozess
+# Release process
 
-## Täglich: Änderungen dokumentieren
+> Single canonical release procedure. Follow this for every tag.
 
-Jeder Commit der `custom_components/` anfasst braucht einen Eintrag im `[Unreleased]`-Block:
+Last updated: 2026-04-26 — current version: v1.8.0
+
+---
+
+## When to release
+
+Release whenever a coherent, atomic batch of changes is on `main` and CI is
+green. There is no fixed cadence. The session-based roadmap
+([`docs/ROADMAP.md`](docs/ROADMAP.md)) maps each upcoming session to a
+target version.
+
+---
+
+## Daily: `[Unreleased]` block
+
+Every commit that touches `custom_components/` needs an entry in the
+`[Unreleased]` block of `CHANGELOG.md`. The `changelog_check.yml`
+workflow enforces this.
 
 ```markdown
 ## [Unreleased]
 
-### Added / Changed / Fixed / Removed
-- Kurze Beschreibung was geändert wurde
+### Added | Changed | Fixed | Removed
+- short description of the change
 ```
 
-Commit-Prefix (Pflicht per `changelog_check.yml`):
-```
-feat:     Neues Feature          → Added
-fix:      Bugfix                 → Fixed
-refactor: Code-Umstrukturierung  → Changed
-docs:     Nur Dokumentation
-test:     Tests
-chore:    Build, Abhängigkeiten
-ci:       GitHub Actions
-```
+Commit-message prefix conventions are listed in
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
-## Semver-Regeln
+## Semver
 
-| Was | Version | Beispiel |
+We are now on **post-1.0.0 strict semver**:
+
+| Change | Bump | Example |
 |---|---|---|
-| Bugfix, kleine Enhancement | PATCH `0.x.y` | 0.11.0 → 0.11.1 |
-| Neue Feature, neue Marke, neue Entity-Klasse | MINOR `0.x.0` | 0.11.1 → 0.12.0 |
-| Breaking Change (Entity umbenannt, Config-Schema geändert) | MINOR `0.x.0` | 0.11.0 → 0.12.0 |
-| Ab v1.0.0: Breaking Change | MAJOR `x.0.0` | 1.0.0 → 2.0.0 |
+| Bug fix only | PATCH | 1.8.0 → 1.8.1 |
+| New feature, new entity, new brand, new endpoint | MINOR | 1.8.0 → 1.9.0 |
+| Breaking change (removed entity, renamed config key, dropped HA version) | MAJOR | 1.x → 2.0.0 |
 
-**Faustregel pre-1.0.0:**  
-Bugfix → PATCH. Alles andere → MINOR.  
-MAJOR erst ab v1.0.0 bei echter Inkompatibilität.
+Pre-1.0.0 historical correction is documented at the top of
+`CHANGELOG.md`. **Do not refer to it for new releases.**
 
 ---
 
-## Release erstellen (step by step)
+## Step by step
 
-### 1. Version bestimmen und manifest.json bumpen
+### 1. Bump `manifest.json`
 
-```bash
-# Datei: custom_components/vag_connect/manifest.json
-# Beispiel: 0.14.1 → 0.14.2 (Bugfix) oder 0.15.0 (Feature)
-"version": "0.15.0"
+```jsonc
+// custom_components/vag_connect/manifest.json
+{
+  "version": "1.9.0"   // bump per semver
+}
 ```
 
-### 2. CHANGELOG.md finalisieren
+### 2. Finalise `CHANGELOG.md`
+
+Replace the `[Unreleased]` heading with the version + ISO date and add a
+new empty `[Unreleased]` block above it.
 
 ```markdown
-## [0.12.0] - 2026-MM-DD      ← [Unreleased] ersetzen + Datum
+## [Unreleased]
+
+## [1.9.0] - 2026-MM-DD
 
 ### Added
-- Porsche-Unterstützung (Auth0 + api.ppa.porsche.com)
-
-## [Unreleased]               ← Neuer leerer Block oben
+- Capability-aware entity creation (#56)
 ```
 
-### 3. Committen und pushen
+### 3. Mirror release notes into all 8 READMEs
+
+If the release adds visible features, update the roadmap table in
+`README.md` and the seven translations to mark the version as `✅ Done`.
+
+### 4. Commit + push
 
 ```bash
-git add custom_components/vag_connect/manifest.json CHANGELOG.md
-git commit -m "chore: release 0.12.0"
+git add custom_components/vag_connect/manifest.json CHANGELOG.md README*.md
+git commit -m "chore: release 1.9.0"
 git push origin main
 ```
 
-### 4. Tag erstellen
+### 5. Tag
 
 ```bash
-git tag -a v0.12.0 -m "Release 0.12.0 — Porsche Support"
-git push origin v0.12.0
+git tag -a v1.9.0 -m "VAG Connect v1.9.0"
+git push origin v1.9.0
 ```
 
-→ `release.yml` erstellt automatisch:
-  - ZIP der Integration (`vag_connect.zip`)
-  - GitHub Release mit Changelog-Inhalt
+The `release.yml` workflow then automatically:
 
-### 5. HACS-Nutzer bekommen Update-Hinweis
+- builds `vag_connect.zip`
+- generates release notes from the matching `CHANGELOG.md` section
+- creates the GitHub Release attached to that tag
+- HACS picks it up within ~6 hours
 
-~6 Stunden nach GitHub Release.
+### 6. Notify users
+
+If the release fixes user-reported bugs (issues with comments from
+non-maintainer accounts), add a short comment on each affected issue
+linking to the release page. **Address every commenter, not just the
+issue author.**
 
 ---
 
-## Checkpoints vor jedem Release
+## Pre-release checklist
 
 ```bash
-python3 -m pytest tests/                           # 342+ Tests grün
-python3 -m ruff check custom_components/            # 0 Fehler
-python3 -m mypy custom_components/vag_connect/ \
+python -m pytest tests/                                   # all green
+python -m ruff check custom_components/                   # 0 errors
+python -m mypy custom_components/vag_connect/ \
   --ignore-missing-imports \
-  --disallow-untyped-defs --warn-return-any          # 0 Fehler
-python3 -m pytest tests/ --cov=custom_components/vag_connect \
-  --cov-fail-under=90                                # ≥90% Coverage
+  --disallow-untyped-defs \
+  --disallow-incomplete-defs \
+  --warn-return-any                                       # 0 errors
+python -m pytest tests/ \
+  --cov=custom_components/vag_connect \
+  --cov-fail-under=65                                     # ≥65 % coverage
 ```
+
+These match the CI gates exactly.
 
 ---
 
-## Aktuelle Versionshistorie
+## Hotfix procedure
 
-Vollständige History: [CHANGELOG.md](CHANGELOG.md)
+If a release breaks setup for users:
 
-| Version | Datum | Typ | Inhalt |
+1. Open a `bug` issue describing the regression.
+2. Fix on a short-lived branch.
+3. Bump PATCH (e.g. 1.9.0 → 1.9.1).
+4. Squash-merge to `main`.
+5. Tag immediately.
+
+Avoid amending or force-pushing to existing tags. Tags are immutable.
+
+---
+
+## Version history
+
+Full history: [`CHANGELOG.md`](CHANGELOG.md)
+
+| Version | Date | Type | Notes |
 |---|---|---|---|
-| **0.14.1** | 2026-04-12 | PATCH | iot_class, CI, icons, HACS-Update-Fix |
-| 0.11.0–0.14.0 | 2026-04-12 | — | Intern (retroaktiv zu 0.8.1–0.11.0 korrigiert) |
-| 0.8.0 | 2026-04-11 | MINOR | Diagnostics, Gold Quality Scale |
+| 1.8.0 | 2026-04-26 | MINOR | Foundation Fix — 7 P0 audit findings + CUPRA flash |
+| 1.7.0 | 2026-04-26 | MINOR | Škoda complete rewrite + car-friendly translations |
+| 1.6.x | 2026-04-25 | MINOR | SEAT/CUPRA 9-endpoint expansion, Lock platform |
+| 1.5.x | 2026-04-23/24 | PATCH chain | Multiple auth fixes (Škoda, CUPRA) |
+| 1.0.0 | 2026-04-12 | MAJOR | First stable, 7 brands, HACS-ready |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,99 @@
+# Security Policy
+
+> **Reporting context:** VAG Connect is a Home Assistant integration that
+> talks to manufacturer APIs on behalf of vehicle owners. It handles
+> credentials, OAuth tokens, S-PINs, vehicle GPS positions, and VINs. We
+> take security reports seriously.
+
+---
+
+## Supported Versions
+
+Only the **latest minor release line** receives security fixes. Older lines
+are not patched.
+
+| Version | Supported |
+|---|---|
+| 1.8.x | ✅ |
+| 1.7.x | ❌ — please update |
+| < 1.7 | ❌ — please update |
+
+Home Assistant supports the integration on its own currently-supported core
+versions (typically the last 4 monthly releases). Any HA below the
+`hacs.json` minimum is unsupported.
+
+---
+
+## Reporting a Vulnerability
+
+**Please do not file public GitHub issues for security vulnerabilities.**
+
+Use one of the following private channels:
+
+1. **GitHub Security Advisories (preferred)**
+   <https://github.com/its-me-prash/vag-connect-ha/security/advisories/new>
+   — sends an encrypted private report to the maintainer.
+
+2. **Direct contact**
+   Open a GitHub Discussion marked `security` and ask the maintainer to
+   move it private. Or use the contact details on the maintainer's GitHub
+   profile.
+
+Please include, where possible:
+
+- Affected version(s) of VAG Connect
+- Affected Home Assistant version (if relevant)
+- Steps to reproduce
+- Impact assessment (what does an attacker gain?)
+- Whether the issue has already been disclosed publicly
+
+We will acknowledge receipt within **72 hours** and aim to publish a fix or
+mitigation within **14 days** for high-severity issues.
+
+---
+
+## Scope
+
+### In scope
+
+- Code under `custom_components/vag_connect/`
+- GitHub Actions workflows under `.github/workflows/`
+- Documented installation and configuration paths
+
+### Out of scope
+
+- Vulnerabilities in upstream manufacturer APIs (CARIAD BFF, OLA,
+  mysmob, PPA, etc.) — please report those to Volkswagen / Audi /
+  Škoda / SEAT / CUPRA / Porsche directly.
+- Issues caused by user misconfiguration or third-party HACS plugins.
+- Theoretical issues without a working proof of concept.
+
+---
+
+## What we already do
+
+- **Zero external runtime dependencies** (`requirements: []` in
+  `manifest.json`) — no transitive supply-chain risk.
+- **Credentials redaction** in `diagnostics.py` — passwords, S-PINs,
+  usernames, GPS coordinates are never exposed in diagnostics exports.
+- **S-PIN fail-fast** (since v1.8.0 / #60) — privileged commands raise
+  `ServiceValidationError` before they reach the API.
+- **Reverse geocoding opt-in** (since v1.8.0 / #60) — vehicle GPS is
+  not sent to third-party services unless the user explicitly enables it.
+- **TLS-only API calls** — the integration uses HTTPS for every endpoint.
+- **No persistent token store outside Home Assistant** — tokens live in
+  the standard HA config-entry storage, encrypted by Home Assistant.
+
+---
+
+## What is NOT a vulnerability
+
+- Manufacturer accounts being temporarily rate-limited after too many
+  poll requests. This is a server-side rate-limit, not a vulnerability.
+- HA users on the same Home Assistant instance being able to read each
+  other's vehicle data. This is a **Home Assistant access-control
+  matter**, not a VAG Connect issue.
+
+---
+
+*Last updated: 2026-04-26 — v1.8.0*

--- a/custom_components/vag_connect/icons.json
+++ b/custom_components/vag_connect/icons.json
@@ -158,12 +158,6 @@
       "window_heating_switch": {
         "default": "mdi:car-windshield"
       },
-      "seat_heating_switch": {
-        "default": "mdi:car-seat-heater"
-      },
-      "auto_unlock_switch": {
-        "default": "mdi:ev-plug-ccs2"
-      },
       "departure_timer_1_switch": {
         "default": "mdi:clock-time-eight-outline"
       },
@@ -191,9 +185,6 @@
       },
       "target_temperature": {
         "default": "mdi:thermometer"
-      },
-      "max_charge_current": {
-        "default": "mdi:current-ac"
       }
     },
     "device_tracker": {

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -237,12 +237,6 @@
       "window_heating_switch": {
         "name": "Window Heating"
       },
-      "seat_heating_switch": {
-        "name": "Seat Heating"
-      },
-      "auto_unlock_switch": {
-        "name": "Unlock Cable After Charging"
-      },
       "departure_timer_1_switch": {
         "name": "Departure Timer 1"
       },
@@ -259,9 +253,6 @@
       },
       "climate_temp_number": {
         "name": "Desired Temperature"
-      },
-      "max_charge_current": {
-        "name": "Max. Charge Current"
       },
       "target_soc": {
         "name": "Charge Target"

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -237,12 +237,6 @@
       "window_heating_switch": {
         "name": "Vyhřívání skel"
       },
-      "seat_heating_switch": {
-        "name": "Vyhřívání sedadel"
-      },
-      "auto_unlock_switch": {
-        "name": "Odemknout konektor po nabití"
-      },
       "departure_timer_1_switch": {
         "name": "Časovač odjezdu 1"
       },
@@ -259,9 +253,6 @@
       },
       "climate_temp_number": {
         "name": "Teplota klimatizace"
-      },
-      "max_charge_current": {
-        "name": "Max. nabíjecí proud"
       },
       "target_soc": {
         "name": "Cíl nabíjení"

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -233,12 +233,6 @@
       "window_heating_switch": {
         "name": "Scheibenheizung"
       },
-      "seat_heating_switch": {
-        "name": "Sitzheizung"
-      },
-      "auto_unlock_switch": {
-        "name": "Ladekabel nach Laden entriegeln"
-      },
       "departure_timer_1_switch": {
         "name": "Abfahrtstimer 1"
       },
@@ -255,9 +249,6 @@
       },
       "climate_temp_number": {
         "name": "Wunschtemperatur"
-      },
-      "max_charge_current": {
-        "name": "Max. Ladestrom"
       },
       "target_soc": {
         "name": "Ladeziel"

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -237,12 +237,6 @@
       "window_heating_switch": {
         "name": "Window Heating"
       },
-      "seat_heating_switch": {
-        "name": "Seat Heating"
-      },
-      "auto_unlock_switch": {
-        "name": "Unlock Cable After Charging"
-      },
       "departure_timer_1_switch": {
         "name": "Departure Timer 1"
       },
@@ -259,9 +253,6 @@
       },
       "climate_temp_number": {
         "name": "Desired Temperature"
-      },
-      "max_charge_current": {
-        "name": "Max. Charge Current"
       },
       "target_soc": {
         "name": "Charge Target"

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -237,12 +237,6 @@
       "window_heating_switch": {
         "name": "Desempañador"
       },
-      "seat_heating_switch": {
-        "name": "Calefacción de asientos"
-      },
-      "auto_unlock_switch": {
-        "name": "Desbloquear enchufe tras carga"
-      },
       "departure_timer_1_switch": {
         "name": "Temporizador de salida 1"
       },
@@ -259,9 +253,6 @@
       },
       "climate_temp_number": {
         "name": "Temperatura de climatización"
-      },
-      "max_charge_current": {
-        "name": "Corriente de carga máx."
       },
       "target_soc": {
         "name": "Objetivo de carga"

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -237,12 +237,6 @@
       "window_heating_switch": {
         "name": "Dégivrage des vitres"
       },
-      "seat_heating_switch": {
-        "name": "Chauffage des sièges"
-      },
-      "auto_unlock_switch": {
-        "name": "Déverrouiller prise après charge"
-      },
       "departure_timer_1_switch": {
         "name": "Minuterie de départ 1"
       },
@@ -259,9 +253,6 @@
       },
       "climate_temp_number": {
         "name": "Température climatisation"
-      },
-      "max_charge_current": {
-        "name": "Courant de charge max."
       },
       "target_soc": {
         "name": "Objectif de charge"

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -237,12 +237,6 @@
       "window_heating_switch": {
         "name": "Ruitenverwarming"
       },
-      "seat_heating_switch": {
-        "name": "Stoelverwarming"
-      },
-      "auto_unlock_switch": {
-        "name": "Stekker na laden ontgrendelen"
-      },
       "departure_timer_1_switch": {
         "name": "Vertrektimer 1"
       },
@@ -259,9 +253,6 @@
       },
       "climate_temp_number": {
         "name": "Klimaat temperatuur"
-      },
-      "max_charge_current": {
-        "name": "Max. laadstroom"
       },
       "target_soc": {
         "name": "Laaddoel"

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -237,12 +237,6 @@
       "window_heating_switch": {
         "name": "Ogrzewanie szyb"
       },
-      "seat_heating_switch": {
-        "name": "Ogrzewanie siedzeń"
-      },
-      "auto_unlock_switch": {
-        "name": "Odblokuj wtyczkę po naładowaniu"
-      },
       "departure_timer_1_switch": {
         "name": "Timer odjazdu 1"
       },
@@ -259,9 +253,6 @@
       },
       "climate_temp_number": {
         "name": "Temperatura klimatyzacji"
-      },
-      "max_charge_current": {
-        "name": "Maks. prąd ładowania"
       },
       "target_soc": {
         "name": "Cel ładowania"

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -237,12 +237,6 @@
       "window_heating_switch": {
         "name": "Rutavfrostning"
       },
-      "seat_heating_switch": {
-        "name": "Sätesvärme"
-      },
-      "auto_unlock_switch": {
-        "name": "Lås upp kontakt efter laddning"
-      },
       "departure_timer_1_switch": {
         "name": "Avgångstimer 1"
       },
@@ -259,9 +253,6 @@
       },
       "climate_temp_number": {
         "name": "Klimattemperatur"
-      },
-      "max_charge_current": {
-        "name": "Max. laddström"
       },
       "target_soc": {
         "name": "Laddningsmål"

--- a/docs/research/ARCHITECTURE_DECISION.md
+++ b/docs/research/ARCHITECTURE_DECISION.md
@@ -1,6 +1,13 @@
 # Architecture Decision Record — Own CARIAD API Client
 
-> Status: **APPROVED** | Date: 2026-04-12 | Author: Prash Balan (@its-me-prash)
+> Status: **APPROVED & IMPLEMENTED** (shipped in v0.12.0, in use through v1.8.0)
+> Date: 2026-04-12 | Author: Prash Balan (@its-me-prash)
+
+> **Historical record.** This ADR is preserved unchanged from when the
+> decision was made. The implementation went live with v0.12.0 and is
+> still the architecture as of v1.8.0. CarConnectivity is no longer a
+> dependency. Refer to [`docs/SESSION_HANDOFF.md`](../SESSION_HANDOFF.md)
+> for the current architecture map.
 
 ---
 

--- a/docs/research/DEPENDENCY_AUDIT.md
+++ b/docs/research/DEPENDENCY_AUDIT.md
@@ -1,6 +1,11 @@
 # Dependency Audit — CarConnectivity vs Own Client
 
 > Prash Balan (@its-me-prash) — 2026-04-12
+>
+> **Historical record.** Status as of v1.8.0: the migration to our own
+> client (proposed below) was completed in v0.12.0. `manifest.json` ships
+> with `requirements: []` — zero external runtime dependencies. The
+> CarConnectivity dependency described below is no longer present.
 
 ---
 

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
   "name": "VAG Connect",
   "content_in_root": false,
   "hide_default_branch": true,
-  "homeassistant": "2024.1.0",
+  "homeassistant": "2024.4.0",
   "render_readme": true
 }


### PR DESCRIPTION
## Summary

Repo audit pass — focused on the **non-code** files that go around the
integration. No `custom_components/` changes. No tests changed. CI gates
unchanged.

The audit was triggered after v1.8.0 shipped:
*"alle restlichen GitHub-Ordner und Files durchgehen das sie alle aktuell
und stimmig sind und der EU-Vorschriften entsprechen"*.

## What changed

### New files
- **`SECURITY.md`** — coordinated vulnerability disclosure policy.
  GitHub Security Advisories preferred channel, supported version table,
  in/out of scope, 72h ack target, 14d fix target. Contract-style content
  expected by the EU **Cyber Resilience Act** for software handling auth.
- **`PRIVACY.md`** — bilingual EN/DE plain-language explanation of every
  piece of data the integration touches, where it goes, where it is stored.
  Documents the v1.8.0 reverse-geocoding opt-in default, the GDPR
  position (no data processor — software runs on the user's HA), and the
  CRA non-commercial OSS steward stance.
- **`.github/CODEOWNERS`** — minimal placeholder routing every path to
  @its-me-prash until brand captains volunteer (#64).
- **`.github/dependabot.yml`** — weekly GitHub Actions bumps so the
  Node 20 → 24 deprecation warnings get auto-PR'd instead of bitrotting.

### Refreshed files
- **`CONTRIBUTING.md`** — was 38 lines and out of date. Now covers
  bug-report hygiene, atomic-PR rule, no-fake-writables, capability-first
  rule, the 8-language-mirror requirement, brand-addition checklist,
  pointers to PRIVACY/SECURITY.
- **`RELEASE_PROCESS.md`** — was stuck at v0.14.1 with pre-1.0.0 semver
  and a 90 % coverage gate. Updated to post-1.0.0 strict semver, the
  current v1.8.0 baseline, the 65 % coverage threshold (matches CI), and
  the explicit instruction to ping every issue commenter, not just the
  issue author.
- **`hacs.json`** — minimum HA bumped 2024.1 → 2024.4 to match the
  ConfigEntry[T] subscript usage in code.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — added country, model
  + year, official-app-works, subscription status, S-PIN status, plus
  a mandatory privacy-confirmation checkbox. Bilingual EN/DE labels.
- **`.github/ISSUE_TEMPLATE/new_brand.yml`** — Porsche/VW US no longer
  labelled "beta" (released since v1.0.0). Added Volkswagen Commercial
  and a clear note pointing Bentley/Lamborghini etc. at
  `docs/research/LUXURY_BRANDS.md`.

## EU compliance status after this PR

| Rule | Status |
|---|---|
| GDPR (DSGVO) data-handling transparency | ✅ — `PRIVACY.md` covers it |
| Cyber Resilience Act vulnerability disclosure | ✅ — `SECURITY.md` exists, GitHub Security Advisories enabled |
| EU Data Act (Sep 2026) — standardised vehicle APIs | 🔜 — tracked under #59 |

## Test plan
- [x] CI passes (lint + tests + hassfest + HACS)
- [x] All JSON / YAML files parse
- [x] Local `ruff check` 0 errors

## Out of scope (intentional)
- No issue comments to users (already done separately)
- No new features (atomic doc PR)