### PR TITLE
release: v1.8.1 — privacy &amp; auth polish (VIN masking, ConfigEntryAuthFailed, diagnostics scrub)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -122,8 +122,21 @@ body:
         HA → Einstellungen → System → Logs → nach "vag_connect" filtern.
         Debug-Logging über Integration → Debug-Logging aktivieren.
 
-        **Please remove or mask VIN, email, tokens, GPS coordinates and S-PIN!**
-        Bitte VIN, Email, Tokens, GPS-Koordinaten und S-PIN entfernen / schwärzen!
+        **Privacy — required masking before posting:**
+        - **VIN** → keep only last 6 chars (e.g. `***003577`). A full VIN ties to registration, insurance and ownership records.
+        - **Email** → mask local part, e.g. `u***@***.com`
+        - **Tokens** (`access_token`, `refresh_token`, `id_token`) → remove completely
+        - **GPS** (`latitude`, `longitude`) → round to 1 decimal or remove
+        - **S-PIN** → never share, even masked
+        - **Account ID / user_id** → remove
+
+        **Datenschutz — vor dem Posten Pflicht:**
+        - **VIN** nur letzte 6 Zeichen (z.B. `***003577`). Eine vollständige VIN ist mit Zulassung, Versicherung und Eigentümerdaten verknüpft.
+        - **Email** lokalen Teil schwärzen, z.B. `u***@***.com`
+        - **Tokens** (`access_token`, `refresh_token`, `id_token`) komplett entfernen
+        - **GPS** (`latitude`, `longitude`) auf 1 Nachkommastelle runden oder löschen
+        - **S-PIN** nie teilen, auch nicht geschwärzt
+        - **Account ID / user_id** entfernen
       render: text
 
   - type: textarea
@@ -132,10 +145,13 @@ body:
       label: Diagnostics / Diagnose-Daten (optional)
       description: |
         Settings → Devices & Services → VAG Connect → ⋮ → Download diagnostics.
-        Sensitive data (password, S-PIN, GPS, email) is auto-redacted.
+        Sensitive data (VIN, password, S-PIN, GPS, email, address, user_id) is auto-redacted by v1.8.x+.
 
         HA → Einstellungen → Integrationen → VAG Connect → 3-Punkte-Menü → Diagnose herunterladen.
-        Sensible Daten (Passwort, S-PIN, GPS, Email) sind automatisch geschwärzt.
+        Sensible Daten (VIN, Passwort, S-PIN, GPS, Email, Adresse, user_id) werden ab v1.8.x automatisch geschwärzt.
+
+        If you are on an older version: please open the JSON, mask VINs and email manually before pasting.
+        Bei älterer Version: bitte JSON öffnen und VIN + Email vor dem Einfügen manuell schwärzen.
       render: json
 
   - type: checkboxes
@@ -144,5 +160,5 @@ body:
       label: Privacy confirmation / Datenschutz-Bestätigung
       description: Required / Pflicht
       options:
-        - label: I have removed tokens, full VIN, email, GPS and S-PIN from logs/diagnostics. / Ich habe Tokens, vollständige VIN, Email, GPS-Koordinaten und S-PIN aus Logs/Diagnose entfernt.
+        - label: I have masked VIN to last 6 chars and removed tokens, email, GPS and S-PIN from logs/diagnostics. / Ich habe die VIN auf die letzten 6 Zeichen gekürzt und Tokens, Email, GPS und S-PIN aus Logs/Diagnose entfernt.
           required: true

--- a/.github/ISSUE_TEMPLATE/new_brand.yml
+++ b/.github/ISSUE_TEMPLATE/new_brand.yml
@@ -86,7 +86,16 @@ body:
 
         Welche Entities erscheinen? Welche Aktionen funktionieren / scheitern?
 
-        Please remove VIN, email, tokens, GPS and S-PIN from logs.
-        Bitte VIN, Email, Tokens, GPS-Koordinaten und S-PIN aus Logs entfernen.
+        **Privacy — required masking before posting:**
+        - **VIN** → only last 6 chars, e.g. `***003577` (a full VIN ties to registration / insurance)
+        - **Email** → mask local part, e.g. `u***@***.com`
+        - **Tokens / S-PIN** → never share
+        - **GPS** → round to 1 decimal or remove
+
+        **Datenschutz — vor dem Posten Pflicht:**
+        - **VIN** nur letzte 6 Zeichen, z.B. `***003577` (vollständige VIN ist mit Zulassung / Versicherung verknüpft)
+        - **Email** lokalen Teil schwärzen, z.B. `u***@***.com`
+        - **Tokens / S-PIN** nie teilen
+        - **GPS** auf 1 Nachkommastelle runden oder löschen
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,17 +23,85 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
-### Removed
+## [1.8.1] - 2026-04-27
+
+### Privacy / Datenschutz
+
+- **VIN masking in logs and diagnostics.** A new `mask_vin()` helper
+  returns `***` + last 6 chars of the VIN. Applied to all coordinator
+  log messages (warning + error level) and to the diagnostics output —
+  the per-vehicle dictionary is now keyed by the masked VIN instead of
+  the full VIN. A full VIN ties to vehicle registration, insurance and
+  ownership records, so it must not appear in support material that
+  users post to GitHub issues.
+
+  **VIN-Maskierung in Logs und Diagnostics.** Neuer `mask_vin()` Helper
+  liefert `***` + letzte 6 Zeichen. Wird jetzt in allen Coordinator-Logs
+  (Warning + Error Level) und im Diagnostics-Export verwendet — die
+  Fahrzeug-Dictionaries werden mit der gemaskten VIN als Schlüssel
+  abgelegt statt der vollständigen VIN. Eine vollständige VIN ist mit
+  Zulassung, Versicherung und Eigentümerdaten verknüpft und gehört
+  daher nicht in Support-Material das User auf GitHub posten.
+
+- **Diagnostics now redact more PII fields by default:** `vin`, `address`,
+  `parking_address`, `user_id`, `account_id` and `email` join the
+  existing `password`, `spin`, `latitude`, `longitude` redaction list.
+  Recursive scrubbing handles nested structures.
+
+  **Diagnostics schwärzen jetzt mehr PII-Felder standardmässig:** `vin`,
+  `address`, `parking_address`, `user_id`, `account_id` und `email`
+  ergänzen die bestehenden `password`, `spin`, `latitude`, `longitude`.
+  Rekursives Scrubbing erfasst auch verschachtelte Strukturen.
+
+- **Issue templates** (`bug_report.yml`, `new_brand.yml`) spell out the
+  required masking before posting (VIN to last 6 chars, email/local
+  part, no tokens or S-PIN, GPS to 1 decimal) in both English and German.
+
+  **Issue-Templates** beschreiben jetzt explizit zweisprachig was vor
+  dem Posten geschwärzt werden muss (VIN auf letzte 6 Zeichen, Email
+  lokalen Teil, keine Tokens oder S-PIN, GPS auf 1 Nachkommastelle).
+
+### Authentication / Authentifizierung
+
+- **`ConfigEntryAuthFailed` is now raised when credentials are stale.**
+  Previously, persistent token refresh failures and rejected re-logins
+  caused the integration to retry forever and flood the log. Now setup
+  raises `ConfigEntryAuthFailed` (which triggers Home Assistant's
+  reauth UI) and the runtime poll loop calls `entry.async_start_reauth()`
+  if auth fails after the client's refresh-then-relogin fallback gave up.
+
+  **`ConfigEntryAuthFailed` wird jetzt geworfen wenn Credentials veraltet
+  sind.** Bisher haben fehlgeschlagene Token-Refreshes und abgelehnte
+  Re-Logins zu endlosen Retries und Log-Spam geführt. Jetzt wirft Setup
+  `ConfigEntryAuthFailed` (das löst Home Assistants Reauth-UI aus) und
+  der Poll-Loop ruft `entry.async_start_reauth()` auf wenn auch der
+  Re-Login-Fallback im Client gescheitert ist.
+
+### Documentation / Dokumentation
+
+- The `userPosition` field in the SEAT/CUPRA honk-and-flash payload is
+  now documented as a misnomer in the OLA API contract: the field
+  expects the **vehicle's** last-known GPS, not the user's phone GPS.
+  Verified against pycupra `vehicle.set_honkandflash` (uses
+  `findCarResponse` lat/lon) and myskoda equivalent (`PositionType.VEHICLE`).
+
+  Das `userPosition` Feld bei SEAT/CUPRA honk-and-flash ist jetzt im
+  Code dokumentiert als irreführender Name im OLA-API-Vertrag: das Feld
+  erwartet die **Fahrzeug**position, nicht die Phone-Position. Verifiziert
+  gegen pycupra (`vehicle.set_honkandflash` nutzt `findCarResponse`)
+  und myskoda (`PositionType.VEHICLE`).
+
+### Removed (carried over from previous Unreleased)
+
 - Stale icon and translation entries for entities that were removed in
   v1.8.0 (`seat_heating_switch`, `auto_unlock_switch`, `max_charge_current`).
-  The keys had no corresponding entity since the v1.8.0 cleanup and were
-  unused by HA. Cleaned across `icons.json`, `strings.json` and all
-  8 language files.
+  Cleaned across `icons.json`, `strings.json` and all 8 language files.
 
-### Changed
+### Changed (carried over from previous Unreleased)
+
 - `docs/research/ARCHITECTURE_DECISION.md` and
   `docs/research/DEPENDENCY_AUDIT.md` marked as historical
-  (implemented in v0.12.0, still the architecture in v1.8.0).
+  (implemented in v0.12.0, still the architecture in v1.8.x).
 
 ## [1.8.0] - 2026-04-26
 

--- a/README.cs.md
+++ b/README.cs.md
@@ -143,9 +143,10 @@ Restartujte Home Assistant.
 | Session | Verze | Rozsah | Issues |
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN dostupnost, S-PIN fail-fast, falešné writable odstraněny, geokódování opt-in | **#60** |
-| **2 — Capabilities** | v1.8.1 | Entity podle schopností, detekce předplatného | #56 |
-| **3 — Command Profile** | v1.8.2 | Routing podle značky/regionu/platformy, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.3 | Anonymizované diagnostiky, regresní testy | #62, #58 |
+| **1.5 — Soukromí & Auth** | v1.8.1 | Maskování VIN v logu a diagnostice, ConfigEntryAuthFailed při neplatných údajích, dokumentace userPosition | — |
+| **2 — Capabilities** | v1.8.2 | Entity podle schopností, detekce předplatného (2A→2B→2C) | #56, #68 |
+| **3 — Command Profile** | v1.8.3 | Routing podle značky/regionu/platformy, RS e-tron GT fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonymizované diagnostiky, regresní testy | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only režim, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.en.md
+++ b/README.en.md
@@ -142,9 +142,10 @@ Restart Home Assistant.
 | Session | Version | Scope | Issues |
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN availability, S-PIN fail-fast, fake writables removed, geocoding opt-in, platforms sync | **#60** |
-| **2 — Capabilities** | v1.8.1 | Capability-gated entities, subscription detection | #56 |
-| **3 — Command Profile** | v1.8.2 | Brand/region/platform routing, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.3 | Anonymized diagnostics, regression tests | #62, #58 |
+| **1.5 — Privacy & Auth Polish** | v1.8.1 | VIN masking in logs/diagnostics, ConfigEntryAuthFailed on stale credentials, userPosition documentation | — |
+| **2 — Capabilities** | v1.8.2 | Capability-gated entities, subscription detection (2A→2B→2C) | #56, #68 |
+| **3 — Command Profile** | v1.8.3 | Brand/region/platform routing, RS e-tron GT fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonymized diagnostics, regression tests | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only mode, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.es.md
+++ b/README.es.md
@@ -143,9 +143,10 @@ Reinicia Home Assistant.
 | Sesión | Versión | Alcance | Issues |
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, disponibilidad por VIN, S-PIN fail-fast, writables falsos eliminados | **#60** |
-| **2 — Capabilities** | v1.8.1 | Entidades según capacidades, detección de suscripción | #56 |
-| **3 — Command Profile** | v1.8.2 | Routing por marca/región/plataforma, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.3 | Diagnósticos anonimizados, tests de regresión | #62, #58 |
+| **1.5 — Privacidad & Auth** | v1.8.1 | Enmascarado de VIN en logs/diagnósticos, ConfigEntryAuthFailed con credenciales obsoletas, documentación userPosition | — |
+| **2 — Capabilities** | v1.8.2 | Entidades según capacidades, detección de suscripción (2A→2B→2C) | #56, #68 |
+| **3 — Command Profile** | v1.8.3 | Routing por marca/región/plataforma, fix RS e-tron GT | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.4 | Diagnósticos anonimizados, tests de regresión | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, guía de privacidad | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Modo read-only, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM vía mqtt.messagehub.de | #57 |

--- a/README.fr.md
+++ b/README.fr.md
@@ -143,9 +143,10 @@ Redémarrez Home Assistant.
 | Session | Version | Portée | Issues |
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, disponibilité par VIN, S-PIN fail-fast, writables fictifs supprimés | **#60** |
-| **2 — Capabilities** | v1.8.1 | Entités selon capacités, détection abonnement | #56 |
-| **3 — Command Profile** | v1.8.2 | Routing marque/région/plateforme, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.3 | Diagnostics anonymisés, tests de régression | #62, #58 |
+| **1.5 — Confidentialité & Auth** | v1.8.1 | Masquage VIN dans logs/diagnostics, ConfigEntryAuthFailed sur credentials périmés, documentation userPosition | — |
+| **2 — Capabilities** | v1.8.2 | Entités selon capacités, détection abonnement (2A→2B→2C) | #56, #68 |
+| **3 — Command Profile** | v1.8.3 | Routing marque/région/plateforme, fix RS e-tron GT | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.4 | Diagnostics anonymisés, tests de régression | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, guide vie privée | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Mode read-only, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.md
+++ b/README.md
@@ -307,9 +307,10 @@ cariad/
 | Session | Version | Scope | Issues |
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN availability, S-PIN fail-fast, fake writables entfernt, Geocoding opt-in, Platforms-Sync | **#60** |
-| **2 — Capabilities** | v1.8.1 | Capability-gated Entities, Subscription-Detection | #56 |
-| **3 — Command Profile** | v1.8.2 | Brand/Region/Plattform-Routing, RS e-tron GT Fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.3 | Anonymisierte Diagnostics, Regression-Tests | #62, #58 |
+| **1.5 — Privacy & Auth Polish** | v1.8.1 | VIN-Maskierung in Logs/Diagnostics, ConfigEntryAuthFailed bei verlorenen Credentials, userPosition-Doku | — |
+| **2 — Capabilities** | v1.8.2 | Capability-gated Entities, Subscription-Detection (2A→2B→2C) | #56, #68 |
+| **3 — Command Profile** | v1.8.3 | Brand/Region/Plattform-Routing, RS e-tron GT Fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonymisierte Diagnostics, Regression-Tests | #62, #58 |
 | **5 — Process & Governance** | — | Issue Forms, Brand Captains, CODEOWNERS, Privacy Guide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only Modus, Command Locking, Cloud vs Wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.nl.md
+++ b/README.nl.md
@@ -143,9 +143,10 @@ Herstart Home Assistant.
 | Sessie | Versie | Scope | Issues |
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, beschikbaarheid per VIN, S-PIN fail-fast, neppe writables verwijderd | **#60** |
-| **2 — Capabilities** | v1.8.1 | Entities volgens capacities, abonnementsdetectie | #56 |
-| **3 — Command Profile** | v1.8.2 | Merk/regio/platform routing, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.3 | Geanonimiseerde diagnostics, regressietests | #62, #58 |
+| **1.5 — Privacy & Auth** | v1.8.1 | VIN-masking in logs/diagnostics, ConfigEntryAuthFailed bij verouderde credentials, userPosition-documentatie | — |
+| **2 — Capabilities** | v1.8.2 | Entities volgens capacities, abonnementsdetectie (2A→2B→2C) | #56, #68 |
+| **3 — Command Profile** | v1.8.3 | Merk/regio/platform routing, RS e-tron GT fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.4 | Geanonimiseerde diagnostics, regressietests | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only modus, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.pl.md
+++ b/README.pl.md
@@ -143,9 +143,10 @@ Uruchom ponownie Home Assistant.
 | Sesja | Wersja | Zakres | Issues |
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, dostępność per VIN, S-PIN fail-fast, fałszywe writable usunięte | **#60** |
-| **2 — Capabilities** | v1.8.1 | Encje wg możliwości, detekcja subskrypcji | #56 |
-| **3 — Command Profile** | v1.8.2 | Routing marka/region/platforma, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.3 | Anonimizowane diagnostyki, testy regresji | #62, #58 |
+| **1.5 — Prywatność & Auth** | v1.8.1 | Maskowanie VIN w logach/diagnostyce, ConfigEntryAuthFailed przy nieaktualnych poświadczeniach, dokumentacja userPosition | — |
+| **2 — Capabilities** | v1.8.2 | Encje wg możliwości, detekcja subskrypcji (2A→2B→2C) | #56, #68 |
+| **3 — Command Profile** | v1.8.3 | Routing marka/region/platforma, fix RS e-tron GT | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonimizowane diagnostyki, testy regresji | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, przewodnik prywatności | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Tryb read-only, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.sv.md
+++ b/README.sv.md
@@ -143,9 +143,10 @@ Starta om Home Assistant.
 | Session | Version | Omfattning | Issues |
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, tillgänglighet per VIN, S-PIN fail-fast, falska writables borttagna | **#60** |
-| **2 — Capabilities** | v1.8.1 | Entiteter enligt kapabilitet, prenumerationsdetektering | #56 |
-| **3 — Command Profile** | v1.8.2 | Märke/region/plattform-routing, RS e-tron GT-fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.3 | Anonymiserade diagnostik, regressionstester | #62, #58 |
+| **1.5 — Integritet & Auth** | v1.8.1 | VIN-maskering i loggar/diagnostik, ConfigEntryAuthFailed vid utgångna credentials, userPosition-dokumentation | — |
+| **2 — Capabilities** | v1.8.2 | Entiteter enligt kapabilitet, prenumerationsdetektering (2A→2B→2C) | #56, #68 |
+| **3 — Command Profile** | v1.8.3 | Märke/region/plattform-routing, RS e-tron GT-fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonymiserade diagnostik, regressionstester | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, integritetsguide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only läge, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -18,7 +18,11 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    ServiceValidationError,
+)
 from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN, CONF_BRAND, CONF_USERNAME, CONF_PASSWORD
@@ -83,7 +87,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: VagConnectConfigEntry) -
         reason = str(err)
         from .repairs import raise_issue_auth_required  # noqa: PLC0415
         raise_issue_auth_required(hass, entry.entry_id, reason)
-        raise ConfigEntryNotReady(_SETUP_ERRORS.get(reason, str(err))) from err
+        message = _SETUP_ERRORS.get(reason, str(err))
+        # invalid_credentials is a hard auth failure — let HA show the reauth
+        # prompt instead of looping ConfigEntryNotReady retries forever.
+        if reason == "invalid_credentials":
+            raise ConfigEntryAuthFailed(message) from err
+        raise ConfigEntryNotReady(message) from err
     except Exception as err:  # noqa: BLE001
         if "RequirementsNotFound" in type(err).__name__ or "requirements" in str(err).lower():
             from .repairs import raise_issue_requirements_conflict  # noqa: PLC0415

--- a/custom_components/vag_connect/cariad/_util.py
+++ b/custom_components/vag_connect/cariad/_util.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""Pure helpers usable from both the API client layer and the HA layer."""
+
+from __future__ import annotations
+
+
+def mask_vin(vin: str | None) -> str:
+    """Return a privacy-safe VIN representation for logs and diagnostics.
+
+    Keeps the last 6 characters (enough for support to disambiguate vehicles
+    on a single account) and drops the rest. A VIN ties to registration,
+    insurance and ownership records, so full VINs must never end up in
+    GitHub issues, public diagnostics or third-party log forwarders.
+    """
+    if not vin:
+        return "***"
+    if len(vin) <= 6:
+        return f"***{vin}"
+    return f"***{vin[-6:]}"

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from aiohttp import ClientSession, ClientTimeout
 
+from .._util import mask_vin as _mask_vin
 from ..auth.porsche import PorscheAuth
 from ..exceptions import APIError, AuthenticationError, TokenExpiredError
 from ..models import VehicleData, TokenSet
@@ -59,7 +60,7 @@ class PorscheClient:
             vin = v.get("vin") or v.get("VIN")
             if vin:
                 vins.append(vin)
-                _LOGGER.debug("Porsche: found VIN %s model=%s", vin, v.get("modelName"))
+                _LOGGER.debug("Porsche: found VIN %s model=%s", _mask_vin(vin), v.get("modelName"))
         return vins
 
     async def get_status(self, vin: str) -> VehicleData:

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -262,9 +262,16 @@ class SeatCupraClient(CariadBaseClient):
     ) -> None:
         """SEAT/CUPRA honk-and-flash.
 
-        Requires `userPosition` (per pycupra) — without it the API returns
-        HTTP 400 "internal-error". Mode is lowercase "flash" (not "FLASH_ONLY").
-        Coordinates are rounded to 4 decimals (~11m precision) like the app.
+        The OLA endpoint requires a `userPosition` field; without it the API
+        returns HTTP 400 "internal-error". Mode must be lowercase "flash"
+        (not "FLASH_ONLY"). Coordinates are truncated to 4 decimals (~11 m).
+
+        Despite the field name, OLA expects the **vehicle's** last-known
+        position, not the user's phone GPS. Verified against pycupra
+        `vehicle.set_honkandflash` (uses `findCarResponse` lat/lon) and the
+        myskoda equivalent (sends `PositionType.VEHICLE`). The name is a
+        misnomer in the OLA contract — the field acts as a server-side
+        sanity token bound to the car's known location.
         """
         if latitude is None or longitude is None:
             raise APIError(

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from aiohttp import ClientSession
 
+from .._util import mask_vin as _mask_vin
 from ..models import VehicleData
 from ..exceptions import AuthenticationError, APIError, TokenExpiredError
 from ..auth.idk import IDKAuth
@@ -89,7 +90,7 @@ class VWNAClient:
                 if uuid:
                     self._vin_to_uuid[vin] = uuid
                 vins.append(vin)
-                _LOGGER.debug("VW NA: found VIN %s uuid=%s", vin, uuid)
+                _LOGGER.debug("VW NA: found VIN %s uuid=%s", _mask_vin(vin), uuid)
         return vins
 
     async def get_status(self, vin: str) -> VehicleData:

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -17,7 +17,7 @@ import threading
 from typing import Any
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import ConfigEntryAuthFailed, ServiceValidationError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
@@ -31,6 +31,7 @@ from .const import (
     DOMAIN,
 )
 from homeassistant.helpers import device_registry as dr
+from .cariad._util import mask_vin
 from .cariad.models import VehicleData
 
 _LOGGER = logging.getLogger(__name__)
@@ -109,7 +110,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             with self._vehicles_lock:
                 for vin, result in zip(vins, results):
                     if isinstance(result, Exception):
-                        _LOGGER.warning("Could not fetch status for %s: %s", vin, result)
+                        _LOGGER.warning("Could not fetch status for %s: %s", mask_vin(vin), result)
                         if hasattr(self, "vehicle_success"):
                             self.vehicle_success[vin] = False
                         continue
@@ -141,6 +142,23 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         except Exception as err:  # noqa: BLE001
             _LOGGER.error("VAG Connect setup failed: %s", err)
             return False
+
+    def _trigger_reauth(self, reason: str) -> None:
+        """Stop the poll loop and ask HA to start the reauth flow.
+
+        Used when refresh + re-login both fail at runtime so the user gets a
+        proper UI prompt instead of a silently failing integration that floods
+        the log with retries.
+        """
+        self._started = False
+        for vin in list(self.vehicles.keys()):
+            self.vehicle_success[vin] = False
+        try:
+            self.entry.async_start_reauth(self.hass)
+        except Exception:  # noqa: BLE001
+            # entry may not support reauth in tests; the loop stop is enough.
+            pass
+        _LOGGER.error("VAG Connect: stopping poll loop, reauth required (%s)", reason)
 
     async def _poll_loop(self) -> None:
         """Background polling loop — runs independently of HA scheduler.
@@ -181,7 +199,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 any_success = False
                 for vin, result in zip(vins, results):
                     if isinstance(result, Exception):
-                        _LOGGER.debug("Poll failed for %s: %s", vin, result)
+                        _LOGGER.debug("Poll failed for %s: %s", mask_vin(vin), result)
                         old = self.vehicles.get(vin, {})
                         old["_poll_failed"] = True
                         fresh[vin] = old
@@ -200,6 +218,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     self.vehicles.update(fresh)
                 await self._async_push_update(fresh, success=any_success)
             except Exception as err:  # noqa: BLE001
+                # Auth failure that survived the client's refresh-then-relogin
+                # fallback means the credentials are stale. Trigger HA reauth.
+                from .cariad.exceptions import AuthenticationError  # noqa: PLC0415
+                if isinstance(err, AuthenticationError):
+                    self._trigger_reauth(str(err) or type(err).__name__)
+                    await self._async_push_update({}, success=False)
+                    return
                 _LOGGER.error("VAG Connect poll error: %s", err)
                 if not hasattr(self, "vehicle_success"):
                     self.vehicle_success = {}
@@ -429,7 +454,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             with self._vehicles_lock:
                 for vin, result in zip(vins, results):
                     if isinstance(result, Exception):
-                        _LOGGER.debug("Refresh failed for %s: %s", vin, result)
+                        _LOGGER.debug("Refresh failed for %s: %s", mask_vin(vin), result)
                         continue
                     if isinstance(result, VehicleData):
                         data = result.to_dict()
@@ -518,9 +543,9 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             fn = getattr(self._cariad_client, method)
             await fn(vin, **kwargs)
             await self.async_request_refresh()
-            _LOGGER.debug("VAG Connect: %s(%s) OK", method, vin)
+            _LOGGER.debug("VAG Connect: %s(%s) OK", method, mask_vin(vin))
         except Exception as err:  # noqa: BLE001
-            _LOGGER.error("VAG Connect: %s(%s) failed: %s", method, vin, err)
+            _LOGGER.error("VAG Connect: %s(%s) failed: %s", method, mask_vin(vin), err)
             raise
 
     async def async_set_charge_mode(self, vin: str, mode: str) -> None:

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -17,7 +17,7 @@ import threading
 from typing import Any
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ServiceValidationError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -8,36 +8,59 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .cariad._util import mask_vin
 from .const import CONF_PASSWORD, CONF_SPIN, CONF_USERNAME
 from .coordinator import VagConnectCoordinator
 
-_REDACT = frozenset({CONF_PASSWORD, CONF_SPIN, CONF_USERNAME, "latitude", "longitude"})
+_REDACT_KEYS = frozenset({
+    CONF_PASSWORD,
+    CONF_SPIN,
+    CONF_USERNAME,
+    "latitude",
+    "longitude",
+    "vin",
+    "address",
+    "parking_address",
+    "user_id",
+    "account_id",
+    "email",
+})
+
+
+def _scrub(value: Any) -> Any:
+    """Recursively redact sensitive fields from diagnostics output."""
+    if isinstance(value, dict):
+        scrubbed: dict[str, Any] = {}
+        for k, v in value.items():
+            if k in ("_client", "_vehicle"):
+                continue
+            if k in _REDACT_KEYS:
+                scrubbed[k] = "**REDACTED**"
+            else:
+                scrubbed[k] = _scrub(v)
+        return scrubbed
+    if isinstance(value, list):
+        return [_scrub(v) for v in value]
+    return value
 
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant,
     entry: ConfigEntry,
 ) -> dict[str, Any]:
-    """Return diagnostics data — credentials and GPS coordinates are redacted."""
+    """Return diagnostics with VIN, GPS, credentials and other PII redacted."""
     coordinator: VagConnectCoordinator = entry.runtime_data
 
-    # Redact sensitive config fields
-    config_diag = {
-        k: ("**REDACTED**" if k in _REDACT else v)
-        for k, v in entry.data.items()
-    }
+    config_diag = _scrub(dict(entry.data))
+    options_diag = _scrub(dict(entry.options))
 
-    # Per-vehicle data with GPS and credentials redacted
     vehicles_diag: dict[str, Any] = {}
     for vin, vdata in coordinator.vehicles.items():
-        vehicles_diag[vin] = {
-            k: ("**REDACTED**" if k in _REDACT else v)
-            for k, v in vdata.items()
-            if k not in ("_client", "_vehicle")  # never include raw objects
-        }
+        vehicles_diag[mask_vin(vin)] = _scrub(vdata)
 
     return {
         "config": config_diag,
+        "options": options_diag,
         "vehicles": vehicles_diag,
         "vehicle_count": len(coordinator.vehicles),
         "last_update_success": coordinator.last_update_success,

--- a/custom_components/vag_connect/image.py
+++ b/custom_components/vag_connect/image.py
@@ -27,6 +27,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .cariad._util import mask_vin
 from .cariad.api.graphql import RENDER_IMAGE_TYPES
 from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity
@@ -82,10 +83,10 @@ async def async_setup_entry(
             if new:
                 entities.extend(new)
                 added_vins.add(vin)
-                _LOGGER.debug("Image entities created for %s (%d entities)", vin, len(new))
+                _LOGGER.debug("Image entities created for %s (%d entities)", mask_vin(vin), len(new))
         else:
             _LOGGER.debug(
-                "No image_urls for %s at setup — will retry on next coordinator update", vin
+                "No image_urls for %s at setup — will retry on next coordinator update", mask_vin(vin)
             )
 
     if entities:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.8.0"
+  "version": "1.8.1"
 }

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -2074,9 +2074,13 @@ class TestAsyncSetupEntry:
         hass.config_entries.async_forward_entry_setups = AsyncMock()
         return hass
 
-    def test_setup_entry_raises_config_not_ready_on_value_error(self):
-        """ValueError from coordinator maps to ConfigEntryNotReady."""
-        from homeassistant.exceptions import ConfigEntryNotReady
+    def test_setup_entry_raises_auth_failed_on_invalid_credentials(self):
+        """ValueError('invalid_credentials') maps to ConfigEntryAuthFailed.
+
+        Triggers HA's reauth UI prompt instead of looping
+        ConfigEntryNotReady retries forever.
+        """
+        from homeassistant.exceptions import ConfigEntryAuthFailed
         from custom_components.vag_connect import async_setup_entry
 
         hass = self._hass()
@@ -2084,6 +2088,24 @@ class TestAsyncSetupEntry:
 
         mock_coord = MagicMock()
         mock_coord.async_setup = AsyncMock(side_effect=ValueError("invalid_credentials"))
+        mock_coord.vehicles = {}
+
+        with patch("custom_components.vag_connect.VagConnectCoordinator", return_value=mock_coord):
+            with pytest.raises(ConfigEntryAuthFailed):
+                asyncio.get_event_loop().run_until_complete(
+                    async_setup_entry(hass, entry)
+                )
+
+    def test_setup_entry_other_value_errors_still_config_not_ready(self):
+        """Non-credential ValueErrors keep raising ConfigEntryNotReady."""
+        from homeassistant.exceptions import ConfigEntryNotReady
+        from custom_components.vag_connect import async_setup_entry
+
+        hass = self._hass()
+        entry = self._entry()
+
+        mock_coord = MagicMock()
+        mock_coord.async_setup = AsyncMock(side_effect=ValueError("too_many_requests"))
         mock_coord.vehicles = {}
 
         with patch("custom_components.vag_connect.VagConnectCoordinator", return_value=mock_coord):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -593,6 +593,7 @@ class TestDiagnostics:
             "password": "secret",
             "spin": "1234",
         }
+        entry.options = {}
         result = asyncio.get_event_loop().run_until_complete(
             async_get_config_entry_diagnostics(MagicMock(), entry)
         )
@@ -609,13 +610,29 @@ class TestDiagnostics:
         entry = MagicMock()
         entry.runtime_data = coord
         entry.data = {"brand": "audi", "username": "u@a.de", "password": "pw", "spin": ""}
+        entry.options = {}
         result = asyncio.get_event_loop().run_until_complete(
             async_get_config_entry_diagnostics(MagicMock(), entry)
         )
-        vin = list(coord.vehicles.keys())[0]
-        assert result["vehicles"][vin].get("latitude") == "**REDACTED**"
-        assert result["vehicles"][vin].get("longitude") == "**REDACTED**"
-        assert "_vehicle" not in result["vehicles"][vin]
+        # VINs are masked to last 6 chars in diagnostics output
+        masked_keys = list(result["vehicles"].keys())
+        assert len(masked_keys) == 1
+        masked_vin = masked_keys[0]
+        assert masked_vin.startswith("***")
+        assert len(masked_vin) <= 9  # "***" + up to 6 chars
+        veh = result["vehicles"][masked_vin]
+        assert veh.get("latitude") == "**REDACTED**"
+        assert veh.get("longitude") == "**REDACTED**"
+        assert veh.get("vin") == "**REDACTED**"
+        assert veh.get("parking_address") == "**REDACTED**"
+        assert "_vehicle" not in veh
+
+    def test_mask_vin_helper(self):
+        from custom_components.vag_connect.cariad._util import mask_vin
+        assert mask_vin("WVGZZZ1KZAW123456") == "***123456"
+        assert mask_vin(None) == "***"
+        assert mask_vin("") == "***"
+        assert mask_vin("ABC") == "***ABC"
 
 
 # ── __init__ service helpers ───────────────────────────────────────────────────


### PR DESCRIPTION
## v1.8.1 — Privacy & Auth Polish

Patch release bundling defensive hardening done as pre-work for Session 2A (#68). **No entity changes, no API surface changes for users** — pure defensive improvements that came out of the cross-check audit between ChatGPT 5.5 and Gemini Pro on the Session 2 plan.

## What's in this PR

### 1. VIN masking everywhere

A new helper `cariad/_util.mask_vin()` returns `***` + last 6 chars. Applied to:

- All coordinator log messages (warning + error level): status fetch failures, poll failures, refresh failures, command success/failure
- `image.py` setup logs
- `porsche.py` and `vw_na.py` vehicle-discovery debug logs
- **Diagnostics output** — the per-vehicle dictionary is now keyed by the masked VIN instead of the full VIN

A full VIN ties to vehicle registration, insurance and ownership records, so it must not appear in support material that users post to GitHub issues.

### 2. Diagnostics redaction expanded

Six new PII fields join the redaction list: `vin`, `address`, `parking_address`, `user_id`, `account_id`, `email` — plus recursive scrubbing for nested structures. Existing redactions for `password`, `spin`, `latitude`, `longitude` are kept.

### 3. ConfigEntryAuthFailed on stale credentials

Two issues fixed:

- **Setup time:** `AuthenticationError` previously caused an infinite `ConfigEntryNotReady` retry loop. Now it raises `ConfigEntryAuthFailed` so HA shows the reauth UI immediately.
- **Runtime polling:** `_poll_loop` previously caught `Exception` generically and silently retried forever. Now it detects `AuthenticationError` (after the client's own refresh-then-relogin fallback gave up), stops the loop, and calls `entry.async_start_reauth()`.

### 4. userPosition documentation

The `userPosition` field on the SEAT/CUPRA `honk-and-flash` endpoint expects the **vehicle's** GPS, not the user's phone GPS. Verified against pycupra (`vehicle.set_honkandflash` uses `findCarResponse` lat/lon) and myskoda (`PositionType.VEHICLE`). The misnomer is now documented inline.

### 5. Issue templates hardened

`bug_report.yml` and `new_brand.yml` now spell out the required masking before posting (VIN to last 6 chars, email/local part, no tokens or S-PIN, GPS to 1 decimal) bilingually in EN+DE.

### 6. Roadmap renumbered

Session 2 Capabilities was previously slotted as v1.8.1. Now:

| Session | Version |
|---|---|
| 1 — Foundation Fix | v1.8.0 ✅ |
| 1.5 — Privacy & Auth Polish | **v1.8.1 (this PR)** |
| 2 — Capabilities | v1.8.2 (#68 = 2A) |
| 3 — Command Profile | v1.8.3 |
| 4 — Diagnostics + Fixtures | v1.8.4 |

All 8 language READMEs updated.

## Why a separate release before Session 2

The cross-check on the Session 2 plan flagged that we were bundling capability-detection refactors with VIN-leakage cleanup and broken auth handling. Splitting them lets us ship the privacy/auth fixes immediately to all users while Session 2 (which has explicit live test dependencies on Gerhard, GitHobi and migendi) takes its own time.

## Compatibility

- No breaking changes to entity unique IDs, services, or config entry data
- Old diagnostic dumps remain readable (the JSON shape for keys changed but field values are still strings)
- Reauth flow already exists in `config_flow.py` (added in earlier release) — this PR just wires it to the right code paths

## Test plan

- [ ] CI pipeline green (lint + pytest + hassfest + coverage)
- [ ] Manual: trigger an auth failure (rotate password externally), verify HA shows reauth prompt instead of looping retries
- [ ] Manual: download diagnostics, confirm no full VIN, address, email or user_id leaks anywhere in the JSON
- [ ] Manual: integration setup still works for all brands
- [ ] After merge: tag v1.8.1, release.yml builds the artifact, HACS picks it up

## References

- #68 — Session 2A foundation issue (next release after this one)
- #56 — Capabilities Check meta-issue
- #53, #42, #54, #51 — active live-test threads informed the privacy hardening