### PR TITLE
v1.8.2 — Session 2A foundation (capabilities + error taxonomy) + SEAT/CUPRA scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,45 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-04-27
+
+### Session 2A — Capabilities foundation (no entity changes)
+
+- **`CommandFailureReason` enum + `classify_command_failure()` helper** in
+  `cariad/exceptions.py`. Nine categories (`MISSING_CAPABILITY`,
+  `SUBSCRIPTION_EXPIRED`, `NOT_ENTITLED`, `WRONG_API_PROFILE`,
+  `VEHICLE_UNREACHABLE`, `SPIN_REQUIRED`, `INVALID_PAYLOAD`,
+  `BACKEND_ERROR`, `UNKNOWN`). Conservative on purpose: `400 internal-error`
+  maps to `BACKEND_ERROR`, never `MISSING_CAPABILITY`, so an ambiguous body
+  can never accidentally hide an entity for good. Only an explicit
+  `missing-capability` body flips that flag.
+
+- **Three-state feature model** on the coordinator:
+  ```python
+  feature_states[vin][command] = FeatureState(
+      supported_by_vehicle, entitled_by_account, available_now,
+      last_error, last_error_at,
+  )
+  ```
+  `supported_by_vehicle` and `entitled_by_account` answer different
+  questions (vehicle hardware vs account subscription) and are tracked
+  separately. Backend errors (transient) flip neither.
+
+- **Capabilities cache** with 24h TTL, runtime-only on the coordinator
+  (deliberately NOT in `config_entry.options` — that's for user settings).
+  Triggered best-effort during `async_setup` for every VIN in parallel;
+  failure is debug-logged and never blocks setup. Re-fetched on TTL expiry
+  or explicit `force=True`.
+
+- **`SeatCupraClient.get_capabilities(vin)`** — only OLA implemented in
+  this PR. CARIAD BFF / mysmob / PPA capabilities methods land in 2B
+  to keep the diff focused.
+
+- **No entity changes.** `button.py`, `lock.py`, `climate.py` etc. don't
+  read from `feature_states` or `vehicle_capabilities` yet — that's the
+  point of splitting 2A out. Verified by entity test suite still passing
+  with no test churn.
+
 ### Authentication / Authentifizierung
 
 - **SEAT and CUPRA OAuth scopes broadened to `address phone email birthdate
@@ -37,6 +76,16 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   aktuellen OLA-Endpoints brauchen `email` und `address` nicht, aber die
   vorbeugende Erweiterung schadet nicht und verhindert künftige
   Server-Restriktionen.
+
+### Session 2A — Foundation für Capabilities (keine Entity-Änderungen)
+
+Vorbereitung für Sessions 2B/2C. Führt nur die Datenstrukturen ein —
+Entity-Verhalten bleibt identisch. Beide Cross-Check-Reviews
+(ChatGPT 5.5 + Gemini Pro) haben unabhängig gewarnt vor einem
+"Capabilities-für-alles"-Refactor: drei Live-Tester-Fehler (Gerhard
+`missing-capability`, migendi `expired sub`, gleeballs `free tier 404`)
+sehen ähnlich aus, haben aber unterschiedliche Root Causes. Erst
+Klassifizierung, dann Verhalten.
 
 ## [1.8.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+### Authentication / Authentifizierung
+
+- **SEAT and CUPRA OAuth scopes broadened to `address phone email birthdate
+  nickname`** (was `nickname birthdate phone`). Mirrors the official My SEAT
+  and MyCupra app scope set. Defense in depth — current OLA endpoints don't
+  require `email` or `address`, but extending the scope ahead of any
+  conditional server-side check costs nothing and prevents future surprises.
+
+  **SEAT- und CUPRA-OAuth-Scopes erweitert auf `address phone email birthdate
+  nickname`** (vorher `nickname birthdate phone`). Stimmt jetzt mit dem
+  offiziellen My-SEAT- und MyCupra-App-Scope überein. Defense in Depth — die
+  aktuellen OLA-Endpoints brauchen `email` und `address` nicht, aber die
+  vorbeugende Erweiterung schadet nicht und verhindert künftige
+  Server-Restriktionen.
+
 ## [1.8.1] - 2026-04-27
 
 ### Privacy / Datenschutz

--- a/README.cs.md
+++ b/README.cs.md
@@ -144,9 +144,11 @@ Restartujte Home Assistant.
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN dostupnost, S-PIN fail-fast, falešné writable odstraněny, geokódování opt-in | **#60** |
 | **1.5 — Soukromí & Auth** | v1.8.1 | Maskování VIN v logu a diagnostice, ConfigEntryAuthFailed při neplatných údajích, dokumentace userPosition | — |
-| **2 — Capabilities** | v1.8.2 | Entity podle schopností, detekce předplatného (2A→2B→2C) | #56, #68 |
-| **3 — Command Profile** | v1.8.3 | Routing podle značky/regionu/platformy, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonymizované diagnostiky, regresní testy | #62, #58 |
+| **2A — Capabilities Foundation** | v1.8.2 | Error taxonomy, 3-state model, capabilities cache (24h TTL) | #68 |
+| **2B — Button gating** | v1.8.3 | Skrýt flash/wake u SEAT/CUPRA dle capabilities | #56 |
+| **2C — Lock debug + userPosition** | v1.8.4 | Lock `internal-error` analyzovat + ověřit userPosition | #56 |
+| **3 — Command Profile** | v1.8.5 | Routing podle značky/regionu/platformy, RS e-tron GT fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonymizované diagnostiky, regresní testy | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only režim, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.en.md
+++ b/README.en.md
@@ -143,9 +143,11 @@ Restart Home Assistant.
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN availability, S-PIN fail-fast, fake writables removed, geocoding opt-in, platforms sync | **#60** |
 | **1.5 — Privacy & Auth Polish** | v1.8.1 | VIN masking in logs/diagnostics, ConfigEntryAuthFailed on stale credentials, userPosition documentation | — |
-| **2 — Capabilities** | v1.8.2 | Capability-gated entities, subscription detection (2A→2B→2C) | #56, #68 |
-| **3 — Command Profile** | v1.8.3 | Brand/region/platform routing, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonymized diagnostics, regression tests | #62, #58 |
+| **2A — Capabilities Foundation** | v1.8.2 | Error taxonomy, 3-state feature model, capabilities cache (24h TTL) | #68 |
+| **2B — Button gating** | v1.8.3 | Hide flash/wake on SEAT/CUPRA when capabilities say no | #56 |
+| **2C — Lock debug + userPosition** | v1.8.4 | Investigate lock `internal-error` + verify userPosition semantics | #56 |
+| **3 — Command Profile** | v1.8.5 | Brand/region/platform routing, RS e-tron GT fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonymized diagnostics, regression tests | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only mode, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.es.md
+++ b/README.es.md
@@ -144,9 +144,11 @@ Reinicia Home Assistant.
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, disponibilidad por VIN, S-PIN fail-fast, writables falsos eliminados | **#60** |
 | **1.5 — Privacidad & Auth** | v1.8.1 | Enmascarado de VIN en logs/diagnósticos, ConfigEntryAuthFailed con credenciales obsoletas, documentación userPosition | — |
-| **2 — Capabilities** | v1.8.2 | Entidades según capacidades, detección de suscripción (2A→2B→2C) | #56, #68 |
-| **3 — Command Profile** | v1.8.3 | Routing por marca/región/plataforma, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.4 | Diagnósticos anonimizados, tests de regresión | #62, #58 |
+| **2A — Capabilities Foundation** | v1.8.2 | Taxonomía de errores, modelo 3-estados, caché capabilities (TTL 24h) | #68 |
+| **2B — Button gating** | v1.8.3 | Ocultar flash/wake en SEAT/CUPRA según capabilities | #56 |
+| **2C — Lock debug + userPosition** | v1.8.4 | Investigar `internal-error` de lock + verificar userPosition | #56 |
+| **3 — Command Profile** | v1.8.5 | Routing por marca/región/plataforma, fix RS e-tron GT | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.6 | Diagnósticos anonimizados, tests de regresión | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, guía de privacidad | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Modo read-only, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM vía mqtt.messagehub.de | #57 |

--- a/README.fr.md
+++ b/README.fr.md
@@ -144,9 +144,11 @@ Redémarrez Home Assistant.
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, disponibilité par VIN, S-PIN fail-fast, writables fictifs supprimés | **#60** |
 | **1.5 — Confidentialité & Auth** | v1.8.1 | Masquage VIN dans logs/diagnostics, ConfigEntryAuthFailed sur credentials périmés, documentation userPosition | — |
-| **2 — Capabilities** | v1.8.2 | Entités selon capacités, détection abonnement (2A→2B→2C) | #56, #68 |
-| **3 — Command Profile** | v1.8.3 | Routing marque/région/plateforme, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.4 | Diagnostics anonymisés, tests de régression | #62, #58 |
+| **2A — Capabilities Foundation** | v1.8.2 | Taxonomie d'erreurs, modèle 3 états, cache capabilities (TTL 24h) | #68 |
+| **2B — Button gating** | v1.8.3 | Masquer flash/wake sur SEAT/CUPRA selon capabilities | #56 |
+| **2C — Lock debug + userPosition** | v1.8.4 | Analyser `internal-error` lock + vérifier userPosition | #56 |
+| **3 — Command Profile** | v1.8.5 | Routing marque/région/plateforme, fix RS e-tron GT | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.6 | Diagnostics anonymisés, tests de régression | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, guide vie privée | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Mode read-only, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.md
+++ b/README.md
@@ -308,9 +308,11 @@ cariad/
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN availability, S-PIN fail-fast, fake writables entfernt, Geocoding opt-in, Platforms-Sync | **#60** |
 | **1.5 — Privacy & Auth Polish** | v1.8.1 | VIN-Maskierung in Logs/Diagnostics, ConfigEntryAuthFailed bei verlorenen Credentials, userPosition-Doku | — |
-| **2 — Capabilities** | v1.8.2 | Capability-gated Entities, Subscription-Detection (2A→2B→2C) | #56, #68 |
-| **3 — Command Profile** | v1.8.3 | Brand/Region/Plattform-Routing, RS e-tron GT Fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonymisierte Diagnostics, Regression-Tests | #62, #58 |
+| **2A — Capabilities Foundation** | v1.8.2 | Error-Taxonomy, 3-State-Feature-Modell, Capabilities-Cache (24h TTL) | #68 |
+| **2B — Button-Gating** | v1.8.3 | Flash/Wake auf SEAT/CUPRA capability-aware ausblenden | #56 |
+| **2C — Lock-Debug + userPosition** | v1.8.4 | Lock `internal-error` analysieren + userPosition-Semantik verifizieren | #56 |
+| **3 — Command Profile** | v1.8.5 | Brand/Region/Plattform-Routing, RS e-tron GT Fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonymisierte Diagnostics, Regression-Tests | #62, #58 |
 | **5 — Process & Governance** | — | Issue Forms, Brand Captains, CODEOWNERS, Privacy Guide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only Modus, Command Locking, Cloud vs Wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.nl.md
+++ b/README.nl.md
@@ -144,9 +144,11 @@ Herstart Home Assistant.
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, beschikbaarheid per VIN, S-PIN fail-fast, neppe writables verwijderd | **#60** |
 | **1.5 — Privacy & Auth** | v1.8.1 | VIN-masking in logs/diagnostics, ConfigEntryAuthFailed bij verouderde credentials, userPosition-documentatie | — |
-| **2 — Capabilities** | v1.8.2 | Entities volgens capacities, abonnementsdetectie (2A→2B→2C) | #56, #68 |
-| **3 — Command Profile** | v1.8.3 | Merk/regio/platform routing, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.4 | Geanonimiseerde diagnostics, regressietests | #62, #58 |
+| **2A — Capabilities Foundation** | v1.8.2 | Error-taxonomie, 3-state model, capabilities-cache (24h TTL) | #68 |
+| **2B — Button gating** | v1.8.3 | Flash/wake op SEAT/CUPRA verbergen volgens capabilities | #56 |
+| **2C — Lock debug + userPosition** | v1.8.4 | Lock `internal-error` onderzoeken + userPosition verifiëren | #56 |
+| **3 — Command Profile** | v1.8.5 | Merk/regio/platform routing, RS e-tron GT fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.6 | Geanonimiseerde diagnostics, regressietests | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only modus, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.pl.md
+++ b/README.pl.md
@@ -144,9 +144,11 @@ Uruchom ponownie Home Assistant.
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, dostępność per VIN, S-PIN fail-fast, fałszywe writable usunięte | **#60** |
 | **1.5 — Prywatność & Auth** | v1.8.1 | Maskowanie VIN w logach/diagnostyce, ConfigEntryAuthFailed przy nieaktualnych poświadczeniach, dokumentacja userPosition | — |
-| **2 — Capabilities** | v1.8.2 | Encje wg możliwości, detekcja subskrypcji (2A→2B→2C) | #56, #68 |
-| **3 — Command Profile** | v1.8.3 | Routing marka/region/platforma, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonimizowane diagnostyki, testy regresji | #62, #58 |
+| **2A — Capabilities Foundation** | v1.8.2 | Taksonomia błędów, model 3-stanów, cache capabilities (TTL 24h) | #68 |
+| **2B — Button gating** | v1.8.3 | Ukrywanie flash/wake na SEAT/CUPRA wg capabilities | #56 |
+| **2C — Lock debug + userPosition** | v1.8.4 | Analiza lock `internal-error` + weryfikacja userPosition | #56 |
+| **3 — Command Profile** | v1.8.5 | Routing marka/region/platforma, fix RS e-tron GT | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonimizowane diagnostyki, testy regresji | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, przewodnik prywatności | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Tryb read-only, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/README.sv.md
+++ b/README.sv.md
@@ -144,9 +144,11 @@ Starta om Home Assistant.
 |---|---|---|---|
 | **1 — Foundation Fix** | v1.8.0 | iot_class, tillgänglighet per VIN, S-PIN fail-fast, falska writables borttagna | **#60** |
 | **1.5 — Integritet & Auth** | v1.8.1 | VIN-maskering i loggar/diagnostik, ConfigEntryAuthFailed vid utgångna credentials, userPosition-dokumentation | — |
-| **2 — Capabilities** | v1.8.2 | Entiteter enligt kapabilitet, prenumerationsdetektering (2A→2B→2C) | #56, #68 |
-| **3 — Command Profile** | v1.8.3 | Märke/region/plattform-routing, RS e-tron GT-fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.4 | Anonymiserade diagnostik, regressionstester | #62, #58 |
+| **2A — Capabilities Foundation** | v1.8.2 | Felklassificering, 3-tillståndsmodell, capabilities-cache (24h TTL) | #68 |
+| **2B — Button gating** | v1.8.3 | Dölj flash/wake på SEAT/CUPRA enligt capabilities | #56 |
+| **2C — Lock debug + userPosition** | v1.8.4 | Analysera lock `internal-error` + verifiera userPosition | #56 |
+| **3 — Command Profile** | v1.8.5 | Märke/region/plattform-routing, RS e-tron GT-fix | #61, #51 |
+| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonymiserade diagnostik, regressionstester | #62, #58 |
 | **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, integritetsguide | #64 |
 | **6 — Read-only + Locking** | v1.9.0 | Read-only läge, command locking, cloud vs wake | #63, #55 |
 | **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -79,6 +79,19 @@ class SeatCupraClient(CariadBaseClient):
         await self.fetch_images()
         return vins
 
+    async def get_capabilities(self, vin: str) -> dict[str, Any]:
+        """Return the OLA capabilities document for *vin*.
+
+        The response shape is roughly:
+            {"capabilities": [{"id": "honk-and-flash", "status": [...]}, ...]}
+
+        Caller is responsible for caching (handled by the coordinator with a
+        24h TTL). Failure raises ``APIError`` — caller should swallow it
+        because capabilities are best-effort metadata, never load-bearing.
+        """
+        data = await self._get(f"{_BASE}/v1/vehicles/{vin}/capabilities")
+        return data if isinstance(data, dict) else {}
+
     async def _fetch_renders(self, vins: list[str]) -> None:
         """Fetch vehicle render images from OLA renders endpoint."""
         for vin in vins:

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -3,6 +3,80 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
+
+class CommandFailureReason(StrEnum):
+    """Why a vehicle command failed.
+
+    Used by the coordinator to decide whether an entity should be hidden,
+    flagged as not-entitled, or just shown as temporarily unavailable.
+    Three failures that look similar at the HTTP layer can have very
+    different correct responses:
+
+    - ``MISSING_CAPABILITY`` — the vehicle's VIN is not registered for the
+      feature in the manufacturer backend (e.g. CUPRA Born without
+      honk-and-flash). Hide the entity at next reload.
+    - ``SUBSCRIPTION_EXPIRED`` — paid online-services subscription expired.
+      Same vehicle would support the command if the user renewed; surface
+      a clear error, do NOT hide the entity.
+    - ``NOT_ENTITLED`` — free tier (e.g. We Connect Go) that never
+      included remote commands. Same handling as expired but with
+      different user messaging.
+    - ``WRONG_API_PROFILE`` — newer model uses a different endpoint
+      version. Needs the per-VIN command profile from #61.
+    - ``VEHICLE_UNREACHABLE`` — car offline / asleep / out of coverage.
+      Transient — entity stays available.
+    - ``SPIN_REQUIRED`` — already raised as ``ServiceValidationError``
+      before reaching the API; included here for completeness.
+    - ``INVALID_PAYLOAD`` — our bug. Fix and ship.
+    - ``BACKEND_ERROR`` — manufacturer 5xx or unexpected 4xx body.
+      Transient; do not derive long-term decisions.
+    - ``UNKNOWN`` — default. Don't make assumptions.
+    """
+
+    MISSING_CAPABILITY = "missing_capability"
+    SUBSCRIPTION_EXPIRED = "subscription_expired"
+    NOT_ENTITLED = "not_entitled"
+    WRONG_API_PROFILE = "wrong_api_profile"
+    VEHICLE_UNREACHABLE = "vehicle_unreachable"
+    SPIN_REQUIRED = "spin_required"
+    INVALID_PAYLOAD = "invalid_payload"
+    BACKEND_ERROR = "backend_error"
+    UNKNOWN = "unknown"
+
+
+def classify_command_failure(exc: BaseException) -> CommandFailureReason:
+    """Map a CARIAD ``APIError`` (or any exception) to a failure reason.
+
+    Conservative on purpose — when in doubt return ``UNKNOWN`` or
+    ``BACKEND_ERROR`` rather than ``MISSING_CAPABILITY``. The latter
+    leads to entities being permanently hidden, so we only return it for
+    backend responses that explicitly say so.
+    """
+    if not isinstance(exc, APIError):
+        return CommandFailureReason.UNKNOWN
+
+    status = getattr(exc, "status", 0) or 0
+    body = str(exc).lower()
+
+    if "missing-capability" in body or "missing_capability" in body:
+        return CommandFailureReason.MISSING_CAPABILITY
+    if status == 403:
+        return CommandFailureReason.NOT_ENTITLED
+    if status == 404:
+        return CommandFailureReason.WRONG_API_PROFILE
+    if status >= 500:
+        return CommandFailureReason.BACKEND_ERROR
+    if status == 400:
+        # 400 with `internal-error` is ambiguous — could be expired
+        # subscription, could be a transient backend error, could be
+        # our payload. We can't tell from the HTTP layer alone, so we
+        # return BACKEND_ERROR (the safe default) and let the
+        # coordinator decide based on entitlement state if known.
+        return CommandFailureReason.BACKEND_ERROR
+    return CommandFailureReason.UNKNOWN
+
 
 class CariadError(Exception):
     """Base exception for all CARIAD client errors."""

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -74,7 +74,9 @@ BRAND_SEAT = BrandConfig(
     redirect_uri="seat://oauth-callback",
     user_agent="OLASeat/2.13.3 (Android 12; sdk_gphone64_x86_64; Google) Mobile",
     api_base="https://ola.prod.code.seat.cloud.vwgroup.com",
-    scope="openid profile nickname birthdate phone",
+    # `address` + `email` mirror the official My SEAT app — defense in depth so
+    # OLA endpoints that conditionally require either claim never get tripped.
+    scope="openid profile address phone email birthdate nickname",
 )
 
 BRAND_CUPRA = BrandConfig(
@@ -84,7 +86,8 @@ BRAND_CUPRA = BrandConfig(
     user_agent="OLACupra/2.15.0 (Android 12; sdk_gphone64_x86_64; Google) Mobile",
     api_base="https://ola.prod.code.seat.cloud.vwgroup.com",
     client_secret="eb8814e641c81a2640ad62eeccec11c98effc9bccd4269ab7af338b50a94b3a2",
-    scope="openid profile nickname birthdate phone",
+    # See BRAND_SEAT above — same OLA backend, same scope set.
+    scope="openid profile address phone email birthdate nickname",
 )
 
 BRAND_VW_NA_MODEL = BrandConfig(

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -11,7 +11,8 @@ Thread safety:
 """
 
 import asyncio
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 import logging
 import threading
 from typing import Any
@@ -32,12 +33,42 @@ from .const import (
 )
 from homeassistant.helpers import device_registry as dr
 from .cariad._util import mask_vin
+from .cariad.exceptions import CommandFailureReason
 from .cariad.models import VehicleData
 
 _LOGGER = logging.getLogger(__name__)
 
 # Minimum interval enforced by Audi/VW connector (Sekunden)
 _CC_MIN_INTERVAL_S = 180
+
+# Capabilities are mostly static (subscription tier, vehicle features) but
+# can change when a user renews/cancels online services. 24h is a balance
+# between picking up legitimate changes and avoiding unnecessary calls.
+_CAPABILITIES_TTL = timedelta(hours=24)
+
+
+@dataclass
+class FeatureState:
+    """Per-VIN per-command state, populated lazily as commands are tried.
+
+    Three orthogonal questions:
+
+    - ``supported_by_vehicle`` — does the VIN have the capability registered
+      in the manufacturer backend? Cleared by ``MISSING_CAPABILITY`` errors.
+    - ``entitled_by_account`` — does the account currently have permission
+      to invoke it? Cleared by ``SUBSCRIPTION_EXPIRED`` / ``NOT_ENTITLED``.
+    - ``available_now`` — is the vehicle reachable / awake / responsive
+      right now? Transient — reset on success or on every reload.
+
+    ``None`` means "not yet determined" for all three. Don't infer anything
+    from a None value; only use this once a real attempt has been made.
+    """
+
+    supported_by_vehicle: bool | None = None
+    entitled_by_account: bool | None = None
+    available_now: bool | None = None
+    last_error: CommandFailureReason | None = None
+    last_error_at: datetime | None = None
 
 
 class VagConnectCoordinator(DataUpdateCoordinator):
@@ -61,6 +92,15 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Per-VIN poll success tracking — entities use this for availability
         # so a single failing vehicle doesn't blank out the others.
         self.vehicle_success: dict[str, bool] = {}
+
+        # Per-VIN capabilities cache. Hydrated best-effort during setup.
+        # 2A foundation only — entity platforms don't read from this yet.
+        self.vehicle_capabilities: dict[str, dict[str, Any]] = {}
+        self._capabilities_fetched_at: dict[str, datetime] = {}
+
+        # Per-VIN per-command feature state. Hydrated lazily as commands
+        # succeed or fail; entry creation is deferred to keep memory tight.
+        self.feature_states: dict[str, dict[str, FeatureState]] = {}
 
         # Reverse-geocoding cache: {(round(lat,3), round(lon,3)): result}
         self._geocode_cache: dict[tuple[float, float], dict[str, str | None]] = {}
@@ -120,6 +160,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         self.vehicles[vin] = await self._enrich(data)
                         if hasattr(self, "vehicle_success"):
                             self.vehicle_success[vin] = True
+
+            # Best-effort capabilities prefetch — never blocks setup.
+            # Result lives in self.vehicle_capabilities for entity platforms
+            # to read in Session 2B. Failure is debug-logged and ignored.
+            await asyncio.gather(
+                *[self.refresh_capabilities(vin) for vin in self.vehicles],
+                return_exceptions=True,
+            )
 
             self._started = True
             found = len(self.vehicles)
@@ -254,6 +302,98 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Lazy default so tests bypassing __init__ still work.
         success: dict[str, bool] = getattr(self, "vehicle_success", {}) or {}
         return bool(success.get(vin, True))
+
+    # ── Capabilities & feature-state plumbing (Session 2A foundation) ──────
+
+    def get_feature_state(self, vin: str, command: str) -> FeatureState:
+        """Return (or lazily create) the FeatureState for *vin*+*command*.
+
+        2A only sets the dict structure up; later sessions will read from it
+        in entity platforms to gate creation/availability.
+        """
+        states = getattr(self, "feature_states", None)
+        if states is None:
+            self.feature_states = {}
+            states = self.feature_states
+        per_vin = states.setdefault(vin, {})
+        if command not in per_vin:
+            per_vin[command] = FeatureState()
+        return per_vin[command]
+
+    def record_command_failure(
+        self, vin: str, command: str, reason: CommandFailureReason
+    ) -> None:
+        """Update the FeatureState after a command failed.
+
+        Conservative — only flips ``supported_by_vehicle`` to False on an
+        explicit ``MISSING_CAPABILITY`` response. Other reasons leave the
+        flag untouched so a transient backend hiccup never permanently
+        hides an entity.
+        """
+        state = self.get_feature_state(vin, command)
+        state.last_error = reason
+        state.last_error_at = datetime.now(tz=timezone.utc)
+        if reason is CommandFailureReason.MISSING_CAPABILITY:
+            state.supported_by_vehicle = False
+        elif reason in (
+            CommandFailureReason.SUBSCRIPTION_EXPIRED,
+            CommandFailureReason.NOT_ENTITLED,
+        ):
+            state.entitled_by_account = False
+
+    def record_command_success(self, vin: str, command: str) -> None:
+        """Mark a command as known-good for *vin*."""
+        state = self.get_feature_state(vin, command)
+        state.supported_by_vehicle = True
+        state.entitled_by_account = True
+        state.available_now = True
+        state.last_error = None
+        state.last_error_at = None
+
+    def is_capabilities_cache_fresh(self, vin: str) -> bool:
+        """Return True if cached capabilities for *vin* are within TTL."""
+        fetched_at: datetime | None = getattr(
+            self, "_capabilities_fetched_at", {}
+        ).get(vin)
+        if fetched_at is None:
+            return False
+        return bool(datetime.now(tz=timezone.utc) - fetched_at < _CAPABILITIES_TTL)
+
+    async def refresh_capabilities(self, vin: str, force: bool = False) -> None:
+        """Best-effort fetch of the per-VIN capabilities document.
+
+        Failure is logged at debug and never blocks setup or polling. The
+        cache stays as-is on error so we don't lose previously known data.
+        Only SEAT/CUPRA's OLA endpoint is implemented in this PR; other
+        brands return silently from the client side.
+        """
+        if not force and self.is_capabilities_cache_fresh(vin):
+            return
+        client = self._cariad_client
+        if client is None or not hasattr(client, "get_capabilities"):
+            return
+        try:
+            data = await client.get_capabilities(vin)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Capabilities fetch failed for %s: %s",
+                mask_vin(vin),
+                err,
+            )
+            return
+        if not isinstance(data, dict):
+            return
+        if not hasattr(self, "vehicle_capabilities"):
+            self.vehicle_capabilities = {}
+        if not hasattr(self, "_capabilities_fetched_at"):
+            self._capabilities_fetched_at = {}
+        self.vehicle_capabilities[vin] = data
+        self._capabilities_fetched_at[vin] = datetime.now(tz=timezone.utc)
+        _LOGGER.debug(
+            "Capabilities cached for %s (%d entries)",
+            mask_vin(vin),
+            len(data),
+        )
 
     async def _async_push_update(self, data: dict, success: bool = True) -> None:
         """Push vehicle data to HA.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.8.1"
+  "version": "1.8.2"
 }

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -2951,3 +2951,212 @@ class TestVehicleImageFetcher:
         assert RENDER_TYPE_BY_MEDIA["MYAPN8NB"]["entity_suffix"] == "render_side_lg"
         assert RENDER_TYPE_BY_MEDIA["MS_MYP3"]["entity_suffix"] == "render_icon"
         assert RENDER_TYPE_BY_MEDIA["MYAAN3NB"]["tag"] == "angle_hd"
+
+
+# ── Session 2A foundation: error taxonomy + capabilities ──────────────────────
+
+
+class TestCommandFailureClassifier:
+    """classify_command_failure() maps APIError → CommandFailureReason.
+
+    Conservative on purpose: ambiguous bodies (e.g. 400 internal-error) must
+    return BACKEND_ERROR, never MISSING_CAPABILITY. Wrongly hiding entities
+    is harder to recover from than showing a transient error.
+    """
+
+    def test_missing_capability_body_detected(self):
+        from custom_components.vag_connect.cariad.exceptions import (
+            APIError,
+            CommandFailureReason,
+            classify_command_failure,
+        )
+        err = APIError(400, "https://ola.example/v1/.../honk-and-flash",
+                       '{"code":"missing-capability","message":"Missing capability"}')
+        assert classify_command_failure(err) is CommandFailureReason.MISSING_CAPABILITY
+
+    def test_403_is_not_entitled(self):
+        from custom_components.vag_connect.cariad.exceptions import (
+            APIError, CommandFailureReason, classify_command_failure,
+        )
+        err = APIError(403, "https://example", '{"error":"forbidden"}')
+        assert classify_command_failure(err) is CommandFailureReason.NOT_ENTITLED
+
+    def test_404_is_wrong_api_profile(self):
+        from custom_components.vag_connect.cariad.exceptions import (
+            APIError, CommandFailureReason, classify_command_failure,
+        )
+        err = APIError(404, "https://example", '{"error":"not found"}')
+        assert classify_command_failure(err) is CommandFailureReason.WRONG_API_PROFILE
+
+    def test_500_is_backend_error(self):
+        from custom_components.vag_connect.cariad.exceptions import (
+            APIError, CommandFailureReason, classify_command_failure,
+        )
+        err = APIError(500, "https://example", "Internal Server Error")
+        assert classify_command_failure(err) is CommandFailureReason.BACKEND_ERROR
+
+    def test_400_internal_error_is_backend_not_missing_capability(self):
+        """`internal-error` is ambiguous — never claim it's a capability gap."""
+        from custom_components.vag_connect.cariad.exceptions import (
+            APIError, CommandFailureReason, classify_command_failure,
+        )
+        err = APIError(400, "https://ola.example/v1/.../access/lock",
+                       '{"code":"internal-error","message":"Internal server error"}')
+        assert classify_command_failure(err) is CommandFailureReason.BACKEND_ERROR
+
+    def test_non_apierror_is_unknown(self):
+        from custom_components.vag_connect.cariad.exceptions import (
+            CommandFailureReason, classify_command_failure,
+        )
+        assert classify_command_failure(ValueError("oops")) is CommandFailureReason.UNKNOWN
+        assert classify_command_failure(RuntimeError()) is CommandFailureReason.UNKNOWN
+
+
+class TestFeatureStateTracking:
+    """Coordinator records FeatureState lazily on command success/failure."""
+
+    def _coord(self):
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        coord.feature_states = {}
+        return coord
+
+    def test_get_feature_state_creates_lazily(self):
+        coord = self._coord()
+        state = coord.get_feature_state("VIN1", "command_flash")
+        assert state.supported_by_vehicle is None
+        assert state.entitled_by_account is None
+        assert state.last_error is None
+        # Same call returns same instance (cached)
+        assert coord.get_feature_state("VIN1", "command_flash") is state
+
+    def test_record_missing_capability_marks_unsupported(self):
+        from custom_components.vag_connect.cariad.exceptions import CommandFailureReason
+        coord = self._coord()
+        coord.record_command_failure("VIN1", "command_flash",
+                                      CommandFailureReason.MISSING_CAPABILITY)
+        state = coord.get_feature_state("VIN1", "command_flash")
+        assert state.supported_by_vehicle is False
+        assert state.last_error is CommandFailureReason.MISSING_CAPABILITY
+        # Entitlement untouched — different question entirely
+        assert state.entitled_by_account is None
+
+    def test_record_subscription_expired_marks_unentitled_only(self):
+        from custom_components.vag_connect.cariad.exceptions import CommandFailureReason
+        coord = self._coord()
+        coord.record_command_failure("VIN1", "command_lock",
+                                      CommandFailureReason.SUBSCRIPTION_EXPIRED)
+        state = coord.get_feature_state("VIN1", "command_lock")
+        # Vehicle still supports it — user just needs to renew
+        assert state.supported_by_vehicle is None
+        assert state.entitled_by_account is False
+
+    def test_record_backend_error_does_not_flip_either_flag(self):
+        """Transient errors must never permanently hide entities."""
+        from custom_components.vag_connect.cariad.exceptions import CommandFailureReason
+        coord = self._coord()
+        coord.record_command_failure("VIN1", "command_flash",
+                                      CommandFailureReason.BACKEND_ERROR)
+        state = coord.get_feature_state("VIN1", "command_flash")
+        assert state.supported_by_vehicle is None
+        assert state.entitled_by_account is None
+        assert state.last_error is CommandFailureReason.BACKEND_ERROR
+
+    def test_record_success_clears_prior_error(self):
+        from custom_components.vag_connect.cariad.exceptions import CommandFailureReason
+        coord = self._coord()
+        coord.record_command_failure("VIN1", "command_flash",
+                                      CommandFailureReason.MISSING_CAPABILITY)
+        coord.record_command_success("VIN1", "command_flash")
+        state = coord.get_feature_state("VIN1", "command_flash")
+        assert state.supported_by_vehicle is True
+        assert state.entitled_by_account is True
+        assert state.last_error is None
+
+
+class TestCapabilitiesCacheTTL:
+    """Cache must be runtime-only (NOT config_entry.options) and TTL-aware."""
+
+    def _coord(self):
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        coord.vehicle_capabilities = {}
+        coord._capabilities_fetched_at = {}
+        coord._cariad_client = None
+        return coord
+
+    def test_cache_starts_stale(self):
+        coord = self._coord()
+        assert coord.is_capabilities_cache_fresh("VIN1") is False
+
+    def test_fresh_after_recent_fetch(self):
+        from datetime import datetime, timezone
+        coord = self._coord()
+        coord._capabilities_fetched_at["VIN1"] = datetime.now(tz=timezone.utc)
+        assert coord.is_capabilities_cache_fresh("VIN1") is True
+
+    def test_stale_after_25h(self):
+        from datetime import datetime, timedelta, timezone
+        coord = self._coord()
+        coord._capabilities_fetched_at["VIN1"] = (
+            datetime.now(tz=timezone.utc) - timedelta(hours=25)
+        )
+        assert coord.is_capabilities_cache_fresh("VIN1") is False
+
+    def test_refresh_capabilities_no_client_safe(self):
+        """No CARIAD client → must not crash, must not write the cache."""
+        import asyncio
+        coord = self._coord()
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_capabilities("VIN1")
+        )
+        assert coord.vehicle_capabilities == {}
+
+    def test_refresh_capabilities_swallows_error(self):
+        """Client raises → cache stays as-is (never load-bearing)."""
+        import asyncio
+        from unittest.mock import AsyncMock
+        coord = self._coord()
+        coord._cariad_client = AsyncMock()
+        coord._cariad_client.get_capabilities = AsyncMock(
+            side_effect=RuntimeError("network down"),
+        )
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_capabilities("VIN1")
+        )
+        assert coord.vehicle_capabilities == {}
+
+    def test_refresh_capabilities_caches_dict_response(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+        coord = self._coord()
+        coord._cariad_client = AsyncMock()
+        coord._cariad_client.get_capabilities = AsyncMock(
+            return_value={"capabilities": [{"id": "honk-and-flash"}]},
+        )
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_capabilities("VIN1")
+        )
+        assert "VIN1" in coord.vehicle_capabilities
+        assert coord.is_capabilities_cache_fresh("VIN1") is True
+
+    def test_refresh_skipped_when_fresh_unless_forced(self):
+        import asyncio
+        from datetime import datetime, timezone
+        from unittest.mock import AsyncMock
+        coord = self._coord()
+        coord._capabilities_fetched_at["VIN1"] = datetime.now(tz=timezone.utc)
+        coord._cariad_client = AsyncMock()
+        coord._cariad_client.get_capabilities = AsyncMock(return_value={"x": 1})
+        # Not forced → client should not be called
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_capabilities("VIN1")
+        )
+        coord._cariad_client.get_capabilities.assert_not_called()
+        # Forced → client is called
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_capabilities("VIN1", force=True)
+        )
+        coord._cariad_client.get_capabilities.assert_called_once_with("VIN1")


### PR DESCRIPTION
## v1.8.2 — Session 2A foundation + SEAT/CUPRA scope hygiene

This PR ships the **Session 2A foundation** for capabilities-aware entities (#68) plus a small defense-in-depth scope alignment for SEAT/CUPRA. **Zero entity changes** — pure infrastructure for Session 2B/2C to build on.

## Why two things in one PR

The scope tweak was 2 lines. Bundling it with 2A keeps releases lean — Session 2A wouldn't ship by itself for another week or two while we wait for tester feedback on lock/flash semantics, and there's no reason to delay the scope hygiene that long.

## 1. Session 2A — Capabilities Foundation (#68)

The cross-check audit between ChatGPT 5.5 and Gemini Pro flagged independently that going straight to "hide entities based on capabilities" was risky: three live tester errors look similar at the HTTP layer but have different root causes:

| User | Subscription | API error | Real cause |
|---|---|---|---|
| Gerhard #53 | Active | `400 missing-capability` | Vehicle/VIN doesn't have feature |
| migendi #42 | Expired | `400 internal-error` | Account entitlement |
| gleeballs #51 | Free tier | `404` | Account entitlement |

Conflating those three would silently hide migendi's lock button forever even after he renewed his subscription. So 2A is **classify first, decide later** — entity platforms are not yet touched.

### Scope

**`cariad/exceptions.py`** — `CommandFailureReason` StrEnum + `classify_command_failure()` helper
- 9 categories: `MISSING_CAPABILITY`, `SUBSCRIPTION_EXPIRED`, `NOT_ENTITLED`, `WRONG_API_PROFILE`, `VEHICLE_UNREACHABLE`, `SPIN_REQUIRED`, `INVALID_PAYLOAD`, `BACKEND_ERROR`, `UNKNOWN`
- Conservative: `400 internal-error` maps to `BACKEND_ERROR`, never `MISSING_CAPABILITY`. Only an explicit `missing-capability` body flips the supported_by_vehicle flag.

**`coordinator.py`** — three-state feature model
```python
@dataclass
class FeatureState:
    supported_by_vehicle: bool | None  # vehicle hardware/registration
    entitled_by_account: bool | None    # subscription state
    available_now: bool | None          # transient / online state
    last_error: CommandFailureReason | None
    last_error_at: datetime | None
```
Stored in `coordinator.feature_states[vin][command]`, hydrated lazily. Three orthogonal questions tracked separately so a backend hiccup never permanently hides an entity.

**`coordinator.py`** — capabilities cache with 24h TTL
- `vehicle_capabilities[vin]` + `_capabilities_fetched_at[vin]` — runtime only, **not** in `config_entry.options`
- `refresh_capabilities(vin, force=False)` — best-effort, swallows errors, parallel-fetched at the end of `async_setup` for every VIN
- `is_capabilities_cache_fresh(vin)` for callers that want to avoid spurious fetches

**`cariad/api/seat_cupra.py`** — `get_capabilities(vin)` against OLA `GET /v1/vehicles/{vin}/capabilities`
- Only OLA in this PR. CARIAD BFF / mysmob / PPA land in 2B.

**`tests/test_cariad.py`** — 16 new tests across three classes
- `TestCommandFailureClassifier` — 6 cases incl. the critical ambiguous-400 case that must NOT be `MISSING_CAPABILITY`
- `TestFeatureStateTracking` — verifies that subscription failures don't flip vehicle-support and vice versa
- `TestCapabilitiesCacheTTL` — fresh, stale, no-client safe path, swallowed-error path, force=True override

### Out of scope (lands in 2B/2C)

- Button platform reading from `feature_states` to hide unsupported entities
- CARIAD BFF / mysmob / Porsche PPA capabilities methods
- Lock `internal-error` debug for Gerhard's CUPRA Born
- `userPosition` semantic verification against pycupra (already documented inline in v1.8.1)

## 2. SEAT/CUPRA OAuth scope alignment (defense in depth)

```diff
-scope="openid profile nickname birthdate phone"
+scope="openid profile address phone email birthdate nickname"
```

Mirrors the official My SEAT and MyCupra app scope. Not a bugfix — current OLA endpoints don't require `email` or `address`, verified by migendi's working CUPRA Formentor and Gerhard's working CUPRA Born. But matching the app scope set ahead of any conditional server-side check costs nothing.

## Roadmap update (8 READMEs)

Session 2 split into 2A/2B/2C; Sessions 3+4 shifted from v1.8.3/v1.8.4 → v1.8.5/v1.8.6:

| Session | Version |
|---|---|
| **2A — Foundation** (this PR) | v1.8.2 |
| 2B — Button gating | v1.8.3 |
| 2C — Lock debug + userPosition verify | v1.8.4 |
| 3 — Command Profile | v1.8.5 |
| 4 — Diagnostics + Fixtures | v1.8.6 |

## Compatibility

- **No entity unique-id changes**, no service signature changes, no config-entry shape changes
- Existing entities behave identically to v1.8.1 — `feature_states` is populated but read by nobody yet
- Capabilities cache is purely additive
- Old diagnostic dumps remain readable

## Test plan

- [ ] CI green (lint + tests + hassfest + HACS)
- [ ] Manual: install on a CUPRA vehicle, check debug log for `Capabilities cached for ***xxx (N entries)` line
- [ ] Manual: trigger a command failure; verify `coordinator.feature_states[vin]['command_x'].last_error` is set
- [ ] Manual: integration setup time unchanged (capabilities fetch is parallel + best-effort)
- [ ] After merge: tag v1.8.2, release.yml builds artifact, HACS picks up

## References

- #68 — Session 2A foundation issue
- #56 — original Capabilities Check meta-issue
- #61 — Command Profile Layer (Session 3)
- #62 — Diagnostics + Fixtures (Session 4)
- #53, #42, #54, #51 — live-test threads informing the error taxonomy