### PR TITLE
v1.8.3 — Session 2B (capability gating) — replacement for #71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,60 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-04-27
+
+### Session 2B — Button capability gating (SEAT/CUPRA only)
+
+- **`vehicle_supports_capability(vin, capability_id)`** on the coordinator
+  returns ``True`` / ``False`` / ``None`` (three-valued logic). Conservative
+  on purpose — ``None`` (unknown) keeps entities visible, only an explicit
+  ``False`` from the cached OLA capabilities document hides them.
+
+- **`button.py` reads from the helper** for two SEAT/CUPRA buttons:
+  - `VagFlashButton` — only created if `honkAndFlash` capability is
+    supported (or unknown for non-OLA brands)
+  - `VagWakeButton` — same gating against `vehicleWakeUpTrigger`
+  - `VagRefreshButton` — always created (coordinator-level, not a
+    vehicle command)
+
+- **No effect on Audi / VW EU / Škoda / Porsche / VW NA** — those brands
+  have no capabilities endpoint implemented yet, so the helper returns
+  ``None`` and all three buttons appear as before. Capability methods for
+  those brands land in 2C / Session 3.
+
+- **Verification case:** Gerhard's CUPRA Born (#53) returned
+  `400 missing-capability` for both flash and wake in v1.8.0. With v1.8.3,
+  if his vehicle's OLA capabilities document doesn't list those features,
+  the buttons disappear at next reload — no more failed presses, no more
+  log spam.
+
+### Session 2B — Button-Capability-Gating (nur SEAT/CUPRA)
+
+Vorbereitung für sauberere Entity-Listen pro Fahrzeug. Die Lichthupe und
+"Auto aufwecken" Buttons werden jetzt für SEAT/CUPRA nur noch erstellt
+wenn die OLA-Capabilities-API sagt dass das Fahrzeug die Funktionen
+unterstützt. Verifikations-Case ist Gerhards CUPRA Born (#53) — bei dem
+die beiden Buttons in v1.8.3 nach dem nächsten Reload verschwinden
+sollten statt 400-Fehler zu produzieren. Andere Marken bleiben
+unverändert (kein Capabilities-Endpoint implementiert → drei Buttons wie
+bisher).
+
+### Release notes / Release-Notes (CI)
+
+- **Release pages now embed the full CHANGELOG section** instead of only
+  matching `### Added` / `### Changed` / `### Fixed` / `### Removed`.
+  Older notes since v1.7 were effectively empty for human readers because
+  our entries use topical headings (e.g. `### Privacy`, `### Authentication`)
+  that the old generator dropped.
+- Bilingual EN/DE for every release-page heading, plus a "Recent
+  releases" pointer to the previous 3 tags with dates and a readable
+  compare URL.
+
+  Release-Seiten zeigen jetzt den vollständigen CHANGELOG-Abschnitt
+  wortwörtlich — alle Sub-Headings, Code-Blöcke und EN+DE-Absätze.
+  Plus einen "Letzte Releases"-Pointer auf die letzten 3 Tags mit
+  Datum und eine lesbare Compare-URL.
+
 ## [1.8.2] - 2026-04-27
 
 ### Session 2A — Capabilities foundation (no entity changes)

--- a/custom_components/vag_connect/button.py
+++ b/custom_components/vag_connect/button.py
@@ -1,5 +1,5 @@
 # Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
-"""Button entities for VAG Connect (flash lights, force refresh)."""
+"""Button entities for VAG Connect (flash lights, force refresh, wake)."""
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
@@ -8,6 +8,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity
+
+# OLA capability IDs (per pycupra) used to gate flash + wake buttons on
+# SEAT/CUPRA. Other brands have no capabilities cache yet, so the helper
+# returns None for them and the buttons are created unconditionally —
+# matching pre-Session-2B behaviour.
+_CAP_HONK_AND_FLASH = "honkAndFlash"
+_CAP_VEHICLE_WAKEUP = "vehicleWakeUpTrigger"
 
 
 async def async_setup_entry(
@@ -18,9 +25,17 @@ async def async_setup_entry(
     coordinator: VagConnectCoordinator = entry.runtime_data
     entities: list[VagConnectEntity] = []
     for vin in coordinator.vehicles:
-        entities.append(VagFlashButton(coordinator, vin))
+        # Refresh button never gates — it's a coordinator-level operation,
+        # not a vehicle command.
         entities.append(VagRefreshButton(coordinator, vin))
-        entities.append(VagWakeButton(coordinator, vin))
+
+        # Capability gating: only skip if we have an explicit ``False`` from
+        # the cache. ``None`` (unknown / no capabilities endpoint) keeps the
+        # button so other brands behave as before.
+        if coordinator.vehicle_supports_capability(vin, _CAP_HONK_AND_FLASH) is not False:
+            entities.append(VagFlashButton(coordinator, vin))
+        if coordinator.vehicle_supports_capability(vin, _CAP_VEHICLE_WAKEUP) is not False:
+            entities.append(VagWakeButton(coordinator, vin))
     async_add_entities(entities)
 
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -359,6 +359,41 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             return False
         return bool(datetime.now(tz=timezone.utc) - fetched_at < _CAPABILITIES_TTL)
 
+    def vehicle_supports_capability(
+        self, vin: str, capability_id: str
+    ) -> bool | None:
+        """Return ``True`` / ``False`` / ``None`` for a capability lookup.
+
+        - ``True``  — capability is present in the cached document and has
+          no documented limitations (empty ``status`` array on OLA).
+        - ``False`` — capability is present but the backend lists explicit
+          limitations, OR the cache is populated and the capability is not
+          listed at all (callers can treat both as "do not show entity").
+        - ``None``  — no cached document for this VIN yet (e.g. brand has
+          no capabilities endpoint, or the prefetch failed). Callers must
+          NOT hide entities in this case — the data simply isn't there.
+
+        Conservative on purpose: returns ``None`` for unknown rather than
+        guessing. Only an explicit cache hit warrants gating decisions.
+        """
+        caps = getattr(self, "vehicle_capabilities", {}).get(vin)
+        if not isinstance(caps, dict):
+            return None
+        items = caps.get("capabilities")
+        if not isinstance(items, list):
+            return None
+        for entry in items:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("id") != capability_id:
+                continue
+            status = entry.get("status")
+            # Empty list / missing → fully usable. Anything in status[] is
+            # a limitation (e.g. deactivated, license required, ...).
+            return not bool(status)
+        # Cache is populated but capability isn't listed — explicit absence.
+        return False
+
     async def refresh_capabilities(self, vin: str, force: bool = False) -> None:
         """Best-effort fetch of the per-VIN capabilities document.
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.8.2"
+  "version": "1.8.3"
 }

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -3160,3 +3160,121 @@ class TestCapabilitiesCacheTTL:
             coord.refresh_capabilities("VIN1", force=True)
         )
         coord._cariad_client.get_capabilities.assert_called_once_with("VIN1")
+
+
+# ── Session 2B: capability lookup + button gating ─────────────────────────────
+
+
+class TestVehicleSupportsCapability:
+    """Three-valued capability lookup: True / False / None."""
+
+    def _coord(self, caps_for_vin=None):
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        coord.vehicle_capabilities = {"VIN1": caps_for_vin} if caps_for_vin else {}
+        return coord
+
+    def test_no_cache_returns_none(self):
+        """No cached document → callers must not gate."""
+        coord = self._coord()
+        assert coord.vehicle_supports_capability("VIN1", "honkAndFlash") is None
+
+    def test_capability_present_no_status_returns_true(self):
+        coord = self._coord({"capabilities": [
+            {"id": "honkAndFlash", "status": []},
+        ]})
+        assert coord.vehicle_supports_capability("VIN1", "honkAndFlash") is True
+
+    def test_capability_with_status_entries_returns_false(self):
+        """status[] non-empty → backend says limited / unavailable."""
+        coord = self._coord({"capabilities": [
+            {"id": "honkAndFlash", "status": [{"reason": "deactivated"}]},
+        ]})
+        assert coord.vehicle_supports_capability("VIN1", "honkAndFlash") is False
+
+    def test_capability_not_listed_returns_false(self):
+        """Cache populated but capability missing → explicit absence."""
+        coord = self._coord({"capabilities": [
+            {"id": "differentFeature", "status": []},
+        ]})
+        assert coord.vehicle_supports_capability("VIN1", "honkAndFlash") is False
+
+    def test_malformed_capability_doc_returns_none(self):
+        coord = self._coord({"capabilities": "not a list"})
+        assert coord.vehicle_supports_capability("VIN1", "honkAndFlash") is None
+
+    def test_other_vin_returns_none(self):
+        coord = self._coord({"capabilities": [{"id": "honkAndFlash", "status": []}]})
+        assert coord.vehicle_supports_capability("VIN_OTHER", "honkAndFlash") is None
+
+
+class TestButtonCapabilityGating:
+    """Session 2B: flash/wake skipped when capabilities say no, refresh always created."""
+
+    def _coord(self, caps=None):
+        from unittest.mock import MagicMock
+        coord = MagicMock()
+        coord.vehicles = {"VIN1": {"vin": "VIN1", "model": "Born"}}
+        coord.vehicle_capabilities = {"VIN1": caps} if caps else {}
+
+        # Real method needs to be called, not a MagicMock auto-method
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        coord.vehicle_supports_capability = (
+            lambda vin, cap_id, _coord=coord: VagConnectCoordinator.vehicle_supports_capability(
+                _coord, vin, cap_id,
+            )
+        )
+        return coord
+
+    def _entry(self, coord):
+        from unittest.mock import MagicMock
+        entry = MagicMock()
+        entry.runtime_data = coord
+        return entry
+
+    def _setup(self, coord):
+        import asyncio
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.button import async_setup_entry
+        added: list = []
+        asyncio.get_event_loop().run_until_complete(
+            async_setup_entry(MagicMock(), self._entry(coord), added.extend)
+        )
+        return added
+
+    def test_no_capabilities_creates_all_three(self):
+        """Brand without capabilities (e.g. Audi) → all 3 buttons created."""
+        added = self._setup(self._coord(caps=None))
+        names = [type(e).__name__ for e in added]
+        assert "VagFlashButton" in names
+        assert "VagWakeButton" in names
+        assert "VagRefreshButton" in names
+
+    def test_explicit_unsupported_skips_flash_and_wake(self):
+        """OLA reports neither feature → only refresh button stays."""
+        added = self._setup(self._coord(caps={"capabilities": [
+            {"id": "differentFeature", "status": []},
+        ]}))
+        names = [type(e).__name__ for e in added]
+        assert "VagFlashButton" not in names
+        assert "VagWakeButton" not in names
+        assert "VagRefreshButton" in names
+
+    def test_partial_support(self):
+        """Flash supported, wake unavailable → only flash + refresh."""
+        added = self._setup(self._coord(caps={"capabilities": [
+            {"id": "honkAndFlash", "status": []},
+            {"id": "vehicleWakeUpTrigger", "status": [{"reason": "deactivated"}]},
+        ]}))
+        names = [type(e).__name__ for e in added]
+        assert "VagFlashButton" in names
+        assert "VagWakeButton" not in names
+        assert "VagRefreshButton" in names
+
+    def test_refresh_button_always_created(self):
+        """Refresh is coordinator-level — never gated."""
+        # Even with worst-case capabilities cache
+        added = self._setup(self._coord(caps={"capabilities": []}))
+        names = [type(e).__name__ for e in added]
+        assert "VagRefreshButton" in names


### PR DESCRIPTION
## Replacement PR — Session 2B got dropped from PR #71

PR #71 was merged with **only the first commit** (release notes) due to a race condition: the second commit `7b5a79b` (Session 2B) was pushed after the merge dialog was already loaded but before the merge button was clicked, so GitHub merged the older head SHA. The PR API confirms `commits: 1, head.sha: 8f4d002`.

This PR ships only that dropped commit — the v1.8.3 release manifest bump + button capability gating that was supposed to land in PR #71.

## What's in this PR

Single commit `7b5a79b` (no rebase, no changes). Identical to what was on PR #71 at merge time but never made it in.

### Session 2B — Capability gating for SEAT/CUPRA flash + wake buttons

Builds on the Session 2A foundation (#68 / v1.8.2): now the button platform actually reads from `coordinator.vehicle_capabilities` and decides whether to create the flash + wake buttons.

`coordinator.py` — new helper:
```python
def vehicle_supports_capability(self, vin: str, capability_id: str) -> bool | None:
    """True / False / None — three-valued, conservative."""
```
- ``True``  — capability listed in cache with empty ``status`` array
- ``False`` — listed with limitations OR explicitly absent from a populated cache
- ``None``  — no cached document at all (unknown brand or fetch failed)

`button.py` reads from the helper for two SEAT/CUPRA capabilities:
- `honkAndFlash` → `VagFlashButton`
- `vehicleWakeUpTrigger` → `VagWakeButton`
- `VagRefreshButton` is always created (coordinator-level, not a vehicle command)

| Brand | Effect |
|---|---|
| **SEAT, CUPRA** | Buttons disappear if OLA capabilities say no. Verification case: Gerhard's CUPRA Born (#53). |
| Audi, VW EU, Škoda, Porsche, VW NA | **No change.** Their capabilities endpoints aren't implemented yet (helper returns `None`). |

### Tests (+118 lines, 10 new tests)

- `TestVehicleSupportsCapability` — 6 cases: True / False / None / malformed / other-VIN
- `TestButtonCapabilityGating` — 4 cases: no capabilities, explicit unsupported, partial support, refresh-always

### CHANGELOG entry already present

The v1.8.3 CHANGELOG block is part of this commit.

## Verification case (#53)

Gerhard tested v1.8.0 and got `400 missing-capability` on both flash and wake on his CUPRA Born. After v1.8.3 ships, on next reload, both buttons should disappear from his entity list.

## Compatibility

- Existing entity unique IDs unchanged
- Audi / VW / Škoda / Porsche / VW NA users see no change at all
- SEAT/CUPRA users may see flash + wake buttons disappear if their vehicle doesn't have those capabilities. Refresh button stays. Status sensors stay.

## Test plan

- [ ] CI green
- [ ] **Merge with the latest commit visible** (refresh the page before clicking — the previous PR was a casualty of stale merge dialog)
- [ ] After merge: tag v1.8.3 with current main HEAD, release.yml builds artifact with the new bilingual notes (already in main from PR #71)

## References

- #71 — previous PR that was supposed to ship this but didn't
- #68 — Session 2A foundation issue
- #53 — Gerhard's CUPRA Born verification case

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVkoYSDnzmMpstTZUpHTNF)_