### PR TITLE
v1.8.4 — Session 2C: SEAT/CUPRA SecToken lock fix + capabilities rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,47 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.8.4] - 2026-04-27
+
+### Session 2C — SEAT/CUPRA lock fix + capabilities for more brands
+
+- **SEAT/CUPRA `command_lock` and `command_unlock` now use the SecToken
+  flow** documented in pycupra. Verified by the live tester report (#53)
+  where Gerhard's CUPRA Born returned `400 internal-error` on lock — root
+  cause was a missing `SecToken` header. The new flow:
+  1. `POST /v2/users/{userId}/spin/verify` with `{"spin": "<pin>"}` →
+     response `{"securityToken": "..."}`
+  2. `POST /v1/vehicles/{vin}/access/lock` (or `/unlock`) with header
+     `SecToken: <token>` and **no JSON body** (matching pycupra exactly)
+- **`coordinator.async_lock` now requires S-PIN for SEAT/CUPRA brands**
+  and raises `ServiceValidationError(spin_required)` before any API call,
+  so users get a translated error rather than a backend 400.
+- **`SpinError`** is raised when the verify call returns an error or
+  no token, surfacing wrong-PIN cases cleanly.
+- **`get_capabilities()` added to CARIAD BFF (VW EU + Audi via inheritance)**
+  using the documented `/vehicle/v1/vehicles/{vin}/capabilities` endpoint.
+- **`get_capabilities()` stubs added to Porsche and VW NA clients**
+  (return `{}`) so the coordinator can call them uniformly. Neither brand
+  has a discrete capabilities endpoint yet.
+- **Button capability gating scoped to SEAT/CUPRA only.** Audi / VW EU /
+  Škoda / Porsche / VW NA buttons are now never gated even though their
+  capabilities cache may be populated, because their capability ID
+  vocabulary has not been verified end-to-end. Will be unlocked
+  per-brand once we have live test confirmation of the IDs.
+
+### Session 2C — Lock-Fix für SEAT/CUPRA + Capabilities für weitere Marken
+
+Der `internal-error` beim Verriegeln (Gerhard #53) war ein fehlender
+`SecToken`-Header. SEAT/CUPRA verlangen einen zweistufigen Ablauf:
+erst S-PIN gegen `/v2/users/{userId}/spin/verify` validieren und dann
+mit dem zurückgegebenen `securityToken` als Header das eigentliche
+Lock/Unlock-POST abschicken — ohne Body, exakt wie pycupra. Mit v1.8.4
+wirft die Integration zudem schon im Coordinator `spin_required` wenn
+der S-PIN für SEAT/CUPRA fehlt, statt einen Backend-Fehler zu kassieren.
+Capabilities-Endpoint dazu für CARIAD BFF (Audi + VW EU); Stubs für
+Porsche und VW NA. Button-Gating bleibt bewusst auf SEAT/CUPRA
+beschränkt bis die Capability-IDs anderer Marken live verifiziert sind.
+
 ## [1.8.3] - 2026-04-27
 
 ### Session 2B — Button capability gating (SEAT/CUPRA only)

--- a/custom_components/vag_connect/button.py
+++ b/custom_components/vag_connect/button.py
@@ -6,15 +6,23 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .const import CONF_BRAND
 from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity
 
-# OLA capability IDs (per pycupra) used to gate flash + wake buttons on
-# SEAT/CUPRA. Other brands have no capabilities cache yet, so the helper
-# returns None for them and the buttons are created unconditionally —
-# matching pre-Session-2B behaviour.
+# Capability IDs vary by backend. The OLA documentation (pycupra) uses
+# camelCase strings like below for SEAT/CUPRA. CARIAD BFF (Audi/VW EU)
+# uses a different vocabulary that we have not yet verified against
+# real vehicles, so gating is currently scoped to brands whose IDs we
+# trust — see ``_BRANDS_WITH_CAPABILITY_GATING`` below.
 _CAP_HONK_AND_FLASH = "honkAndFlash"
 _CAP_VEHICLE_WAKEUP = "vehicleWakeUpTrigger"
+
+# Brands whose capability vocabulary we've verified end-to-end. Other
+# brands fetch capabilities (cache populated) but the IDs may not match
+# what we look up below, so we skip gating for them to avoid hiding
+# entities by mistake.
+_BRANDS_WITH_CAPABILITY_GATING = frozenset({"seat", "cupra"})
 
 
 async def async_setup_entry(
@@ -23,6 +31,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: VagConnectCoordinator = entry.runtime_data
+    brand = str(entry.data.get(CONF_BRAND, "")).lower()
+    gating_active = brand in _BRANDS_WITH_CAPABILITY_GATING
+
     entities: list[VagConnectEntity] = []
     for vin in coordinator.vehicles:
         # Refresh button never gates — it's a coordinator-level operation,
@@ -30,11 +41,21 @@ async def async_setup_entry(
         entities.append(VagRefreshButton(coordinator, vin))
 
         # Capability gating: only skip if we have an explicit ``False`` from
-        # the cache. ``None`` (unknown / no capabilities endpoint) keeps the
-        # button so other brands behave as before.
-        if coordinator.vehicle_supports_capability(vin, _CAP_HONK_AND_FLASH) is not False:
+        # the cache AND the brand uses the OLA capability vocabulary.
+        # ``None`` (unknown) keeps the button so other brands behave as before.
+        flash_supported = (
+            coordinator.vehicle_supports_capability(vin, _CAP_HONK_AND_FLASH)
+            if gating_active
+            else None
+        )
+        wake_supported = (
+            coordinator.vehicle_supports_capability(vin, _CAP_VEHICLE_WAKEUP)
+            if gating_active
+            else None
+        )
+        if flash_supported is not False:
             entities.append(VagFlashButton(coordinator, vin))
-        if coordinator.vehicle_supports_capability(vin, _CAP_VEHICLE_WAKEUP) is not False:
+        if wake_supported is not False:
             entities.append(VagWakeButton(coordinator, vin))
     async_add_entities(entities)
 

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -91,6 +91,18 @@ class CariadBaseClient:
         """Remote unlock — may require S-PIN."""
         raise NotImplementedError
 
+    async def get_capabilities(self, vin: str) -> dict[str, Any]:
+        """Return the per-VIN capabilities document.
+
+        Default implementation returns ``{}`` (i.e. "no data") so callers
+        can rely on the helper existing without checking ``hasattr``.
+        Brand-specific clients that have a real capabilities endpoint
+        override this — currently SEAT/CUPRA (OLA) and the CARIAD BFF
+        family (VW EU + Audi). Škoda mysmob and Porsche PPA do not expose
+        a discrete capabilities endpoint and keep the default.
+        """
+        return {}
+
     async def command_start_climate(self, vin: str) -> None:
         """Start pre-conditioning."""
         raise NotImplementedError

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -144,6 +144,16 @@ class PorscheClient:
 
         return d
 
+    async def get_capabilities(self, vin: str) -> dict[str, Any]:  # noqa: ARG002
+        """Porsche PPA does not expose a discrete capabilities endpoint.
+
+        Returning ``{}`` keeps the interface consistent with the
+        CARIAD/OLA clients so the coordinator can call this without
+        feature detection. Buttons will not be capability-gated for
+        Porsche until/unless an endpoint is found.
+        """
+        return {}
+
     async def command_lock(self, vin: str) -> None:
         await self._command(vin, "LOCK")
 

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from aiohttp import ClientSession
 
-from ..exceptions import APIError
+from ..exceptions import APIError, SpinError
 from ..models import BRAND_CUPRA, BRAND_SEAT, BrandConfig, VehicleData
 from .base import CariadBaseClient
 
@@ -246,14 +246,56 @@ class SeatCupraClient(CariadBaseClient):
 
     # ── Commands ─────────────────────────────────────────────────────────────
 
+    async def _get_sec_token(self, spin: str) -> str:
+        """Verify the S-PIN against OLA and return a SecToken.
+
+        SEAT/CUPRA lock/unlock both require a per-call SecToken obtained
+        from a separate `spin/verify` POST. Pycupra does this verbatim:
+        POST `/v2/users/{userId}/spin/verify` with ``{"spin": "<pin>"}``,
+        read ``securityToken`` from the response, then send that as the
+        ``SecToken`` header on the actual lock/unlock POST.
+
+        The S-PIN is passed plain — there's no client-side hashing,
+        challenge/response or RSA. The OLA backend handles verification.
+        """
+        if not spin:
+            raise SpinError("S-PIN required for SEAT/CUPRA lock/unlock.")
+        if not self._user_id:
+            await self._fetch_user_id()
+        url = f"{_BASE}/v2/users/{self._user_id}/spin/verify"
+        try:
+            resp = await self._post(url, json={"spin": spin})
+        except APIError as err:
+            # 400/401 from /spin/verify means the PIN is wrong or the
+            # account is locked. Surface a SpinError so HA can show the
+            # right reauth/correct-pin prompt instead of a raw API error.
+            raise SpinError(
+                f"S-PIN verification failed (HTTP {getattr(err, 'status', '?')}). "
+                "Update the S-PIN in the integration options."
+            ) from err
+        token = (resp or {}).get("securityToken") if isinstance(resp, dict) else None
+        if not token:
+            raise SpinError("S-PIN verify returned no securityToken.")
+        return str(token)
+
     async def command_lock(self, vin: str) -> None:
-        await self._post(f"{_BASE}/v1/vehicles/{vin}/access/lock", json={})
+        """Lock the vehicle. Requires a verified S-PIN SecToken."""
+        token = await self._get_sec_token(self._spin)
+        # Empty body is intentional — pycupra/OLA expect no payload here,
+        # only the SecToken header. _request adds the Authorization +
+        # Content-Type headers automatically.
+        await self._post(
+            f"{_BASE}/v1/vehicles/{vin}/access/lock",
+            headers={"SecToken": token},
+        )
 
     async def command_unlock(self, vin: str, spin: str = "") -> None:
-        payload: dict[str, Any] = {}
-        if spin or self._spin:
-            payload["spin"] = spin or self._spin
-        await self._post(f"{_BASE}/v1/vehicles/{vin}/access/unlock", json=payload)
+        """Unlock the vehicle. Requires a verified S-PIN SecToken."""
+        token = await self._get_sec_token(spin or self._spin)
+        await self._post(
+            f"{_BASE}/v1/vehicles/{vin}/access/unlock",
+            headers={"SecToken": token},
+        )
 
     async def command_start_climate(self, vin: str) -> None:
         await self._post(f"{_BASE}/v2/vehicles/{vin}/climatisation", json={"action": "start"})

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -105,6 +105,19 @@ class VWEUClient(CariadBaseClient):
 
         return vins
 
+    async def get_capabilities(self, vin: str) -> dict[str, Any]:
+        """Return CARIAD BFF capabilities document for *vin*.
+
+        Endpoint identical for VW EU + Audi (same backend, different brand
+        token). The JSON shape is roughly:
+            {"capabilities": [{"id": "honkAndFlash", "status": [...]}, ...]}
+
+        Failure raises ``APIError`` — caller should swallow it because
+        capabilities are best-effort metadata, never load-bearing.
+        """
+        data = await self._get(f"{_BASE}/vehicle/v1/vehicles/{vin}/capabilities")
+        return data if isinstance(data, dict) else {}
+
     async def get_status(self, vin: str) -> VehicleData:
         """Fetch full vehicle status via selectivestatus."""
         url = f"{_BASE}/vehicle/v1/vehicles/{vin}/selectivestatus"

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -177,6 +177,16 @@ class VWNAClient:
         d.is_hybrid      = d.has_battery and d.has_combustion
         return d
 
+    async def get_capabilities(self, vin: str) -> dict[str, Any]:  # noqa: ARG002
+        """VW NA does not expose a discrete capabilities endpoint.
+
+        Returning ``{}`` keeps the interface consistent with the other
+        clients so the coordinator can call this without feature
+        detection. Buttons will not be capability-gated for VW NA until
+        an endpoint is documented.
+        """
+        return {}
+
     async def command_lock(self, vin: str) -> None:
         uuid = self._vin_to_uuid.get(vin, vin)
         await self._post(f"{self._base}/ev/v1/vehicle/{uuid}/lock", json={"action": "lock"})

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -644,6 +644,23 @@ class VagConnectCoordinator(DataUpdateCoordinator):
 
 
     async def async_lock(self, vin: str) -> None:
+        # SEAT/CUPRA lock requires a SecToken obtained from S-PIN verify.
+        # Surface the missing-PIN case before the API call so HA shows a
+        # clean translation key rather than a low-level SpinError trace.
+        brand = self.entry.data.get(CONF_BRAND, "").lower()
+        if brand in ("seat", "cupra"):
+            options = getattr(self.entry, "options", None) or {}
+            data = getattr(self.entry, "data", None) or {}
+            spin = ""
+            if isinstance(options, dict):
+                spin = str(options.get(CONF_SPIN) or "")
+            if not spin and isinstance(data, dict):
+                spin = str(data.get(CONF_SPIN) or "")
+            if not spin:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="spin_required",
+                )
         await self._cariad_cmd(vin, "command_lock")
 
     async def async_unlock(self, vin: str) -> None:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.8.3"
+  "version": "1.8.4"
 }

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -1094,14 +1094,25 @@ class TestSeatCupraGetStatus:
 
     def test_seat_commands(self):
         client = self._client("seat")
-        # command_flash is excluded here — SEAT/CUPRA require userPosition
-        # and are exercised separately in test_seat_command_flash_requires_position.
-        for cmd in ["lock", "unlock", "start_climate", "stop_climate",
+        # Excluded from this loop:
+        #  - command_flash         — needs userPosition (separate test)
+        #  - command_lock/unlock   — need S-PIN SecToken (separate test below)
+        for cmd in ["start_climate", "stop_climate",
                     "start_charging", "stop_charging", "wake"]:
             fn = getattr(client, f"command_{cmd}")
             asyncio.get_event_loop().run_until_complete(fn("VIN_SEAT"))
         asyncio.get_event_loop().run_until_complete(client.command_set_target_soc("VIN_SEAT", 80))
         asyncio.get_event_loop().run_until_complete(client.command_set_climate_temperature("VIN_SEAT", 20.0))
+
+    def test_seat_lock_unlock_require_spin(self):
+        """v1.8.4 (#53): lock/unlock without S-PIN must raise SpinError before any HTTP call."""
+        from custom_components.vag_connect.cariad.exceptions import SpinError
+        client = self._client("seat")  # _client() does not configure an S-PIN
+
+        with pytest.raises(SpinError):
+            asyncio.get_event_loop().run_until_complete(client.command_lock("VIN_SEAT"))
+        with pytest.raises(SpinError):
+            asyncio.get_event_loop().run_until_complete(client.command_unlock("VIN_SEAT"))
 
     def test_seat_command_flash_requires_position(self):
         """v1.8.0 / #53: SEAT/CUPRA honk-and-flash needs userPosition.

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -3227,25 +3227,35 @@ class TestButtonCapabilityGating:
         )
         return coord
 
-    def _entry(self, coord):
+    def _entry(self, coord, brand="cupra"):
         from unittest.mock import MagicMock
         entry = MagicMock()
         entry.runtime_data = coord
+        entry.data = {"brand": brand}
         return entry
 
-    def _setup(self, coord):
+    def _setup(self, coord, brand="cupra"):
         import asyncio
         from unittest.mock import MagicMock
         from custom_components.vag_connect.button import async_setup_entry
         added: list = []
         asyncio.get_event_loop().run_until_complete(
-            async_setup_entry(MagicMock(), self._entry(coord), added.extend)
+            async_setup_entry(MagicMock(), self._entry(coord, brand), added.extend)
         )
         return added
 
     def test_no_capabilities_creates_all_three(self):
-        """Brand without capabilities (e.g. Audi) → all 3 buttons created."""
+        """SEAT/CUPRA brand but no capabilities cache → all 3 buttons created."""
         added = self._setup(self._coord(caps=None))
+        names = [type(e).__name__ for e in added]
+        assert "VagFlashButton" in names
+        assert "VagWakeButton" in names
+        assert "VagRefreshButton" in names
+
+    def test_audi_brand_never_gates_buttons(self):
+        """Audi capability vocabulary is unverified — gating must be skipped."""
+        # Worst-case capabilities cache that would block CUPRA buttons
+        added = self._setup(self._coord(caps={"capabilities": []}), brand="audi")
         names = [type(e).__name__ for e in added]
         assert "VagFlashButton" in names
         assert "VagWakeButton" in names
@@ -3278,3 +3288,151 @@ class TestButtonCapabilityGating:
         added = self._setup(self._coord(caps={"capabilities": []}))
         names = [type(e).__name__ for e in added]
         assert "VagRefreshButton" in names
+
+
+# ── Session 2C: SEAT/CUPRA SecToken flow + capabilities for other brands ──────
+
+
+class TestSeatCupraSecTokenFlow:
+    """SEAT/CUPRA lock/unlock require an S-PIN-derived SecToken header.
+
+    Verified against pycupra: POST /v2/users/{uid}/spin/verify with
+    {"spin": pin} → response {"securityToken": ...} → use that as
+    SecToken header on the /access/lock or /access/unlock POST (empty body).
+    """
+
+    def _client(self, spin="1234", user_id="u-123"):
+        from unittest.mock import AsyncMock, MagicMock
+        from custom_components.vag_connect.cariad.api.seat_cupra import SeatCupraClient
+        client = SeatCupraClient.__new__(SeatCupraClient)
+        client._spin = spin
+        client._user_id = user_id
+        client._post = AsyncMock(return_value={"securityToken": "TOK_ABC"})
+        client._fetch_user_id = AsyncMock()
+        return client
+
+    def test_get_sec_token_calls_verify_endpoint(self):
+        import asyncio
+        client = self._client()
+        token = asyncio.get_event_loop().run_until_complete(
+            client._get_sec_token("1234")
+        )
+        assert token == "TOK_ABC"
+        url = client._post.call_args[0][0]
+        assert url.endswith("/v2/users/u-123/spin/verify")
+        assert client._post.call_args.kwargs["json"] == {"spin": "1234"}
+
+    def test_get_sec_token_raises_spin_error_on_empty_pin(self):
+        import asyncio, pytest
+        from custom_components.vag_connect.cariad.exceptions import SpinError
+        client = self._client(spin="")
+        with pytest.raises(SpinError):
+            asyncio.get_event_loop().run_until_complete(
+                client._get_sec_token("")
+            )
+
+    def test_get_sec_token_wraps_apierror_as_spin_error(self):
+        """Wrong PIN → 400 from /spin/verify → user-facing SpinError."""
+        import asyncio, pytest
+        from unittest.mock import AsyncMock
+        from custom_components.vag_connect.cariad.exceptions import APIError, SpinError
+        client = self._client()
+        client._post = AsyncMock(side_effect=APIError(400, "x", "wrong pin"))
+        with pytest.raises(SpinError):
+            asyncio.get_event_loop().run_until_complete(
+                client._get_sec_token("1234")
+            )
+
+    def test_get_sec_token_raises_when_no_token_in_response(self):
+        import asyncio, pytest
+        from unittest.mock import AsyncMock
+        from custom_components.vag_connect.cariad.exceptions import SpinError
+        client = self._client()
+        client._post = AsyncMock(return_value={"unexpected": "field"})
+        with pytest.raises(SpinError):
+            asyncio.get_event_loop().run_until_complete(
+                client._get_sec_token("1234")
+            )
+
+    def test_command_lock_sends_sectoken_header_no_body(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+        client = self._client()
+        # Two calls: spin/verify + access/lock. Mock _post to handle both.
+        verify_resp = {"securityToken": "TOK_LOCK"}
+        client._post = AsyncMock(side_effect=[verify_resp, None])
+        asyncio.get_event_loop().run_until_complete(
+            client.command_lock("VINX")
+        )
+        # First call = spin/verify
+        assert client._post.call_args_list[0][0][0].endswith("/v2/users/u-123/spin/verify")
+        # Second call = lock with SecToken header, no JSON body
+        lock_call = client._post.call_args_list[1]
+        assert lock_call[0][0].endswith("/v1/vehicles/VINX/access/lock")
+        assert lock_call.kwargs["headers"] == {"SecToken": "TOK_LOCK"}
+        assert "json" not in lock_call.kwargs
+
+    def test_command_unlock_sends_sectoken_header_no_body(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+        client = self._client()
+        verify_resp = {"securityToken": "TOK_UNL"}
+        client._post = AsyncMock(side_effect=[verify_resp, None])
+        asyncio.get_event_loop().run_until_complete(
+            client.command_unlock("VINX", spin="9999")
+        )
+        # spin/verify uses the kwarg-supplied PIN, not self._spin
+        assert client._post.call_args_list[0].kwargs["json"] == {"spin": "9999"}
+        unlock_call = client._post.call_args_list[1]
+        assert unlock_call[0][0].endswith("/v1/vehicles/VINX/access/unlock")
+        assert unlock_call.kwargs["headers"] == {"SecToken": "TOK_UNL"}
+        assert "json" not in unlock_call.kwargs
+
+
+class TestCariadBffGetCapabilities:
+    """VW EU + Audi share the CARIAD BFF capabilities endpoint."""
+
+    def test_vw_eu_get_capabilities_endpoint(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        client = VWEUClient.__new__(VWEUClient)
+        client._get = AsyncMock(return_value={"capabilities": [{"id": "x"}]})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_capabilities("VINY")
+        )
+        assert result == {"capabilities": [{"id": "x"}]}
+        url = client._get.call_args[0][0]
+        assert "emea.bff.cariad.digital" in url
+        assert url.endswith("/vehicle/v1/vehicles/VINY/capabilities")
+
+    def test_get_capabilities_returns_empty_dict_on_non_dict_response(self):
+        import asyncio
+        from unittest.mock import AsyncMock
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        client = VWEUClient.__new__(VWEUClient)
+        client._get = AsyncMock(return_value=["unexpected list"])
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_capabilities("VIN")
+        )
+        assert result == {}
+
+    def test_porsche_returns_empty_dict_no_endpoint(self):
+        """Porsche PPA has no capabilities endpoint — must not raise."""
+        import asyncio
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.cariad.api.porsche import PorscheClient
+        client = PorscheClient.__new__(PorscheClient)
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_capabilities("VIN")
+        )
+        assert result == {}
+
+    def test_vw_na_returns_empty_dict_no_endpoint(self):
+        import asyncio
+        from custom_components.vag_connect.cariad.api.vw_na import VWNAClient
+        client = VWNAClient.__new__(VWNAClient)
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_capabilities("VIN")
+        )
+        assert result == {}


### PR DESCRIPTION
## v1.8.4 — Session 2C: SEAT/CUPRA lock fix + capabilities for more brands

Two related changes that together close the loop on Gerhard's CUPRA Born live test (#53) and extend the capabilities foundation across the brand fleet.

## 1. SEAT/CUPRA lock fix — root cause: missing SecToken header

Gerhard's `400 internal-error` on `/access/lock` was not a capability gap or a subscription issue. After researching pycupra's `setLock` implementation, the actual flow that the OLA backend expects is:

1. `POST /v2/users/{userId}/spin/verify` with `{"spin": "<pin>"}` → response `{"securityToken": "..."}`
2. `POST /v1/vehicles/{vin}/access/lock` (or `/unlock`) with header `SecToken: <token>` and **no JSON body**

Our v1.8.0–v1.8.3 sent `POST {}` with no SecToken — backend rejected it.

### Implementation

- New `SeatCupraClient._get_sec_token(spin)` method that handles step 1, wraps a verify-time APIError as `SpinError` so HA shows "S-PIN verification failed" rather than a raw API trace.
- `command_lock` and `command_unlock` use the helper. Empty body sent (`headers={"SecToken": token}` only).
- `coordinator.async_lock` now raises `ServiceValidationError(spin_required)` for SEAT/CUPRA brands before any API call, so missing-PIN cases get a clean translation key instead of a backend 400.

### Verification path for Gerhard

After v1.8.4 is released and Gerhard updates, his lock button should:
- Show "S-PIN required" if S-PIN isn't configured (translated)
- Send the SecToken-authorised lock command if it is
- Return a clean SpinError if the configured PIN is wrong

The previous `400 internal-error` should disappear entirely.

## 2. `get_capabilities()` on every client

Session 2A only had it on `SeatCupraClient`. Now:

- **`CariadBaseClient`** — base method returns `{}` so callers can rely on the method existing without `hasattr` checks
- **`VWEUClient`** (and `AudiClient` via inheritance) — hits the documented CARIAD BFF endpoint `/vehicle/v1/vehicles/{vin}/capabilities`
- **`PorscheClient`** and **`VWNAClient`** — explicit `{}` stubs (no endpoint known yet, comment explains)

The coordinator's `refresh_capabilities` parallel prefetch now hits all brands uniformly. CARIAD BFF will populate cache for Audi and VW EU users on next setup.

## 3. Button gating brand-scoped

Added a `_BRANDS_WITH_CAPABILITY_GATING = {"seat", "cupra"}` set in `button.py`. CARIAD BFF capabilities use a different vocabulary (the IDs `honkAndFlash` and `vehicleWakeUpTrigger` aren't necessarily what Audi uses), so gating Audi buttons against those names would falsely hide them. We'll unlock other brands one at a time once we have live test confirmation of their capability IDs.

## Tests (+155 lines)

- **`TestSeatCupraSecTokenFlow`** — 6 cases: verify endpoint URL + payload, empty-PIN raises `SpinError`, APIError gets wrapped as `SpinError`, missing-token-in-response raises, `command_lock` end-to-end with assertion that no JSON body is sent, `command_unlock` end-to-end with kwarg PIN
- **`TestCariadBffGetCapabilities`** — VW EU URL, non-dict response coerced to `{}`, Porsche/VW NA stubs return `{}`
- **`TestButtonCapabilityGating`** extended: new `test_audi_brand_never_gates_buttons` locks in the brand-scoping invariant against future regressions

## Compatibility

- **SEAT/CUPRA users without S-PIN configured** — locking now throws `spin_required` immediately. Previously it silently failed. They need to set the S-PIN in integration options.
- **SEAT/CUPRA users with S-PIN** — lock should now actually work (before: `400 internal-error`).
- **Audi / VW EU / Škoda / Porsche / VW NA** — no behavioural change to entities. Capabilities cache is populated on Audi/VW EU, but nothing reads from it yet.

## Test plan

- [ ] CI green
- [ ] Live test: Gerhard updates to v1.8.4 and tries lock — should work
- [ ] Live test: any SEAT/CUPRA user without S-PIN — should see translated "S-PIN required" error
- [ ] Live test: Audi/VW user — no entity changes, no missed buttons

## References

- #53 — Gerhard's CUPRA Born live test (lock root cause documented in this PR)
- #68 — Session 2A foundation issue (this builds on it)
- #56 — Capabilities Check meta-issue
- pycupra `setLock` / `get_sec_token` (Apache-2.0) — reference implementation

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVkoYSDnzmMpstTZUpHTNF)_