### PR TITLE
docs: v1.8.6 truthfulness hotfix (README + 8 translations + audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,90 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.8.6] - 2026-04-29
+
+### Docs Truthfulness Hotfix — README + 8 translations + CI badge
+
+Pure documentation release. Kein Code-Change, keine Verhaltensänderung —
+nur die README-Familie auf den realen v1.8.5-Stand bringen und die strategische
+Multi-Brand-Successor-Positionierung aufnehmen.
+
+**Was korrigiert wurde:**
+
+- **README.en.md sagte "cloud-push architecture"** — falsch seit v1.8.0
+  (`iot_class` ist `cloud_polling`). Jetzt korrekt.
+- **README.en.md sagte "14 services"**, README.md sagte "16 services" —
+  beide jetzt vereinheitlicht auf die echte Zahl (14, verifiziert in
+  `services.yaml`).
+- **Hardcoded Test-Badge** ("Tests-337/337" in 7 Übersetzungen,
+  "Tests-363/363" im DE-Master) ersetzt durch dynamischen
+  GitHub-Actions-CI-Badge — driftet nicht mehr auseinander.
+
+**Was neu hinzugekommen ist (in allen 8 Sprachen identisch):**
+
+1. **Successor-Box** direkt nach dem Pitch: Aktiv gepflegter Multi-Brand-Nachfolger
+   für `mitch-dc/volkswagen_we_connect_id` (archiviert 2025-10-29) und
+   `skodaconnect/homeassistant-skodaconnect` (deprecated 2025-03-14). Eine
+   Integration für Audi, VW, Škoda, SEAT, CUPRA, Porsche und VW US/CA.
+2. **"Aktueller Stand & ehrliche Limits (v1.8.5)" Section** mit fünf
+   transparenten Disclaimern:
+   - Capability-Gating aktuell nur SEAT/CUPRA Flash/Wake
+   - CARIAD v1/v2 Auto-Fallback aktuell nur 4 Set-Value Commands
+   - Image-Plattform: kein offizielles Render-API existiert
+   - PPC/PPE-Plattform (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):
+     Graceful Degradation statt 404, Endpoints noch nicht reverse-engineered
+   - Privacy-Voraussetzung "Standort teilen" in der App muss aktiv sein
+
+**Warum jetzt:**
+
+Die unabhängige Multi-Source-Audit vom 29.04.2026 (siehe
+`docs/AUDIT_2026-04-29.md`) hat festgestellt: Code und Releases sind weiter
+als die README. Vor neuen Features (Session 3B/3C/3S) sollten Tester und
+HACS-Browser realistische Erwartungen bekommen — sonst sieht die Integration
+für sich beim ersten Klick "kaputt" aus, obwohl sie bewusst capability-gated
+oder graceful-degraded.
+
+### Docs Truthfulness Hotfix — README + 8 Translations + CI Badge (English)
+
+Pure documentation release. No code change, no behaviour change — just
+aligning the README family to the actual v1.8.5 state and adding the
+strategic multi-brand-successor positioning.
+
+**What was corrected:**
+
+- README.en.md said "cloud-push architecture" — wrong since v1.8.0
+  (`iot_class` is `cloud_polling`). Now correct.
+- README.en.md said "14 services", README.md said "16 services" — both
+  now unified to the real count (14, verified in `services.yaml`).
+- Hardcoded test badge ("Tests-337/337" in 7 translations,
+  "Tests-363/363" in the DE master) replaced by a dynamic
+  GitHub Actions CI badge — no more drift.
+
+**What was added (identically in all 8 languages):**
+
+1. **Successor box** right after the pitch: active multi-brand successor
+   to `mitch-dc/volkswagen_we_connect_id` (archived 2025-10-29) and
+   `skodaconnect/homeassistant-skodaconnect` (deprecated 2025-03-14).
+   One integration for Audi, VW, Škoda, SEAT, CUPRA, Porsche and VW US/CA.
+2. **"Current state & honest limits (v1.8.5)" section** with five
+   transparent disclaimers:
+   - Capability-gating currently only SEAT/CUPRA flash/wake
+   - CARIAD v1/v2 auto-fallback currently only 4 set-value commands
+   - Image platform: no official render API exists
+   - PPC/PPE platform (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):
+     graceful degradation instead of 404, endpoints not yet
+     reverse-engineered publicly
+   - Privacy prerequisite "Share my position" must be enabled in the app
+
+**Why now:**
+
+The independent multi-source audit on 2026-04-29 (see
+`docs/AUDIT_2026-04-29.md`) found: code and releases are ahead of the
+README. Before shipping new features (Session 3B/3C/3S), testers and
+HACS browsers should get realistic expectations — otherwise the
+integration looks "broken" on first click, when it is in fact
+deliberately capability-gated or graceful-degraded.
+
 ## [1.8.5] - 2026-04-27
 
 ### Session 3A — Command Profile Layer foundation + v1/v2 fallback (#61, #51, #74)

--- a/README.cs.md
+++ b/README.cs.md
@@ -12,7 +12,7 @@
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="../tests/"><img src="https://img.shields.io/badge/Tests-337%2F337-brightgreen?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
@@ -34,7 +34,21 @@ Chtěl jsem plně ovládat své Audi v Home Assistant. Tak jsem to postavil.
 
 **VAG Connect** je samostatná integrace Home Assistant pro všechny značky VAG. Bez externích závislostí, bez Dockeru, bez externích služeb.
 
-Od v0.14.1 integrace **přímo** komunikuje s CARIAD API — vlastní async klient, plně autonomní.
+Od v0.14.1 integrace **přímo** komunikuje s CARIAD API — vlastní async klient, plně autonomní. Architektura cloud-polling, 80+ entit napříč 10 platformami, 14 služeb.
+
+> ✅ **Aktivně udržovaný multi-značkový nástupce** projektů [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivováno 2025-10-29) a [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). Jedna integrace pro Audi, VW, Škoda, SEAT, CUPRA, Porsche a VW US/CA — bez samostatného pluginu pro každou značku.
+
+## Aktuální stav a upřímné limity (v1.8.5)
+
+VAG Connect se aktivně vyvíjí. Abys věděl, co funguje a co ne:
+
+- **Capability-gating:** Aktuálně aktivní pouze pro tlačítka flash a wake u SEAT/CUPRA. U ostatních značek se entity stále vytvářejí bez kontroly capability — mohou tedy zobrazit "nedostupné", pokud tvůj model funkci nemá. Postupné nasazování značka po značce (Session 3B / 3C / 3S).
+- **CARIAD v1/v2 automatický fallback:** Aktuálně aktivní pouze pro 4 set-value příkazy (cíl nabíjení, teplota klimatizace, režim nabíjení, minimální SoC). To odblokuje Audi RS e-tron GT a VW Passat 2025 od v1.8.5. Lock/unlock, climate start/stop a charging start/stop přijdou v Session 3B.
+- **Image platforma:** V CARIAD pipeline neexistuje oficiální API pro render obrázků vozidla. Image entita je proto placeholder a bude v v1.10.0 buď odstraněna nebo přepnuta na URL poskytnuté uživatelem.
+- **PPC/PPE platforma (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):** Tyto modely 2025+ používají novou architekturu E³ 1.2. Žádné reverse-engineered endpointy zatím nejsou veřejně známy. VAG Connect tyto vozy detekuje a nevytváří pro ně command-entity, místo aby generoval 404 chyby.
+- **Předpoklad ochrany soukromí:** GPS pozice, stav vozidla a nezávislé topení vyžadují aktivní volbu **"Sdílet mou polohu"** v aplikaci My-VW / My-Audi / MySkoda / MyCupra — jinak backend odpoví chybou 403.
+
+Aktuální roadmap a detailní stav: [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md)
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -12,7 +12,7 @@
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="../tests/"><img src="https://img.shields.io/badge/Tests-337%2F337-brightgreen?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
@@ -32,9 +32,23 @@
 
 **VAG Connect** connects Home Assistant directly to your Audi, VW, Škoda, SEAT, CUPRA, Porsche or VW US/CA — no middleware, no Docker, no extra service. Enter your app credentials, done.
 
-80+ entities across 10 platforms, 14 services, cloud-push architecture. All 7 VAG Group brands in one integration — no separate plugin per brand needed.
+80+ entities across 10 platforms, 14 services, cloud-polling architecture. All 7 VAG Group brands in one integration — no separate plugin per brand needed.
 
 Since v0.14.1, VAG Connect speaks **directly** to the CARIAD API via its own async client. No external dependencies, no upstream blockers.
+
+> ✅ **Active multi-brand successor** to [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archived 2025-10-29) and [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). One integration for Audi, VW, Škoda, SEAT, CUPRA, Porsche and VW US/CA — no separate plugin per brand.
+
+## Current state & honest limits (v1.8.5)
+
+VAG Connect is under active development. So you know what works and what doesn't:
+
+- **Capability-gating:** Currently active only for SEAT/CUPRA flash and wake buttons. Other brands still create entities without capability checks — they may show "unavailable" if your model lacks the feature. Rolling out brand-by-brand (Sessions 3B / 3C / 3S).
+- **CARIAD v1/v2 auto-fallback:** Currently active only for 4 set-value commands (charge target, climate temperature, charge mode, min SoC). This unblocks Audi RS e-tron GT and VW Passat 2025 from v1.8.5. Lock/unlock, climate start/stop and charging start/stop follow in Session 3B.
+- **Image platform:** There is no official render-image API in the CARIAD pipeline. The image entity is therefore a placeholder and will be either removed or switched to user-supplied URLs in v1.10.0.
+- **PPC/PPE platform (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):** These 2025+ models use the new E³ 1.2 architecture. No reverse-engineered endpoints are publicly known yet. VAG Connect detects these vehicles and skips command entities instead of producing 404 errors.
+- **Privacy prerequisite:** GPS position, vehicle status and pre-heating require **"Share my position"** enabled in your My-VW / My-Audi / MySkoda / MyCupra app — otherwise the backend responds with 403.
+
+Current roadmap and detailed state: [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md)
 
 ## Supported Brands
 

--- a/README.es.md
+++ b/README.es.md
@@ -12,7 +12,7 @@
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="../tests/"><img src="https://img.shields.io/badge/Tests-337%2F337-brightgreen?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
@@ -34,7 +34,21 @@ Quería controlar mi Audi en Home Assistant — completamente. Así que constru�
 
 **VAG Connect** es una integración autónoma de Home Assistant para todas las marcas VAG. Sin dependencias externas, sin Docker, sin servicios externos.
 
-Desde v0.14.1, la integración habla **directamente** con la API CARIAD — cliente async propio, completamente autónomo.
+Desde v0.14.1, la integración habla **directamente** con la API CARIAD — cliente async propio, completamente autónomo. Arquitectura cloud-polling, 80+ entidades en 10 plataformas, 14 servicios.
+
+> ✅ **Sucesor multi-marca mantenido activamente** de [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivado el 2025-10-29) y [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (obsoleto el 2025-03-14). Una integración para Audi, VW, Škoda, SEAT, CUPRA, Porsche y VW US/CA — sin plugin separado por marca.
+
+## Estado actual y límites honestos (v1.8.5)
+
+VAG Connect está en desarrollo activo. Para que sepas qué funciona y qué no:
+
+- **Capability-gating:** Activo actualmente solo para los botones flash y wake de SEAT/CUPRA. Para otras marcas, las entidades se crean sin verificación de capability — pueden mostrar "no disponible" si tu modelo carece de la función. Despliegue marca por marca (Sesiones 3B / 3C / 3S).
+- **Auto-fallback CARIAD v1/v2:** Activo actualmente solo para 4 comandos set-value (objetivo de carga, temperatura climatización, modo de carga, SoC mínimo). Esto desbloquea Audi RS e-tron GT y VW Passat 2025 desde v1.8.5. Lock/unlock, climate start/stop y charging start/stop siguen en Sesión 3B.
+- **Plataforma image:** No existe una API oficial de render de imagen en el pipeline CARIAD. La entidad image es por tanto un placeholder y será o eliminada o cambiada a URLs proporcionadas por el usuario en v1.10.0.
+- **Plataforma PPC/PPE (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):** Estos modelos 2025+ usan la nueva arquitectura E³ 1.2. Ningún endpoint reverse-engineered se conoce públicamente todavía. VAG Connect detecta estos vehículos y no crea entidades de comando, en lugar de producir errores 404.
+- **Requisito de privacidad:** La posición GPS, el estado del vehículo y la calefacción estacionaria requieren **"Compartir mi posición"** activado en tu app My-VW / My-Audi / MySkoda / MyCupra — de lo contrario el backend responde con 403.
+
+Roadmap actual y estado detallado: [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md)
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -12,7 +12,7 @@
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="../tests/"><img src="https://img.shields.io/badge/Tests-337%2F337-brightgreen?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
@@ -34,7 +34,21 @@ Je voulais contrôler mon Audi dans Home Assistant — complètement. Alors j'ai
 
 **VAG Connect** est une intégration Home Assistant autonome pour toutes les marques VAG. Aucune dépendance externe, aucun Docker, aucun service externe. Installez l'intégration, entrez vos identifiants, c'est prêt.
 
-Depuis v0.14.1, l'intégration parle **directement** à l'API CARIAD — client async propre, entièrement autonome.
+Depuis v0.14.1, l'intégration parle **directement** à l'API CARIAD — client async propre, entièrement autonome. Architecture cloud-polling, 80+ entités sur 10 plateformes, 14 services.
+
+> ✅ **Successeur multi-marque activement maintenu** de [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivé le 2025-10-29) et [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (déprécié le 2025-03-14). Une intégration pour Audi, VW, Škoda, SEAT, CUPRA, Porsche et VW US/CA — pas de plugin séparé par marque.
+
+## État actuel et limites honnêtes (v1.8.5)
+
+VAG Connect évolue activement. Pour que vous sachiez ce qui fonctionne et ce qui ne fonctionne pas :
+
+- **Capability-gating :** Actif actuellement uniquement pour les boutons flash et wake SEAT/CUPRA. Pour les autres marques, les entités sont créées sans vérification de capability — elles peuvent donc apparaître "indisponible" si votre modèle n'a pas la fonction. Déploiement marque par marque (Sessions 3B / 3C / 3S).
+- **Repli automatique CARIAD v1/v2 :** Actif actuellement uniquement pour 4 commandes set-value (cible de charge, température climatisation, mode de charge, SoC minimal). Cela débloque Audi RS e-tron GT et VW Passat 2025 depuis v1.8.5. Lock/unlock, climate start/stop et charging start/stop suivent en Session 3B.
+- **Plateforme image :** Aucune API officielle de rendu d'image n'existe dans le pipeline CARIAD. L'entité image est donc un placeholder et sera soit supprimée, soit basculée vers une URL fournie par l'utilisateur en v1.10.0.
+- **Plateforme PPC/PPE (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron) :** Ces modèles 2025+ utilisent la nouvelle architecture E³ 1.2. Aucun endpoint reverse-engineered n'est encore connu publiquement. VAG Connect détecte ces véhicules et n'instancie pas les entités de commande, plutôt que de produire des erreurs 404.
+- **Prérequis confidentialité :** La position GPS, l'état du véhicule et le préchauffage nécessitent **"Partager ma position"** activé dans votre app My-VW / My-Audi / MySkoda / MyCupra — sinon le backend répond avec 403.
+
+Roadmap actuelle et état détaillé : [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/Lizenz-Apache%202.0-blue.svg?style=for-the-badge" alt="Lizenz"></a>
   <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2024.1%2B-blue?style=for-the-badge" alt="Home Assistant"></a>
-  <a href="tests/"><img src="https://img.shields.io/badge/Tests-363%2F363-brightgreen?style=for-the-badge" alt="Tests"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
 </p>
 
@@ -31,7 +31,21 @@
 
 **VAG Connect** verbindet Home Assistant direkt mit deinem Fahrzeug — ohne Middleware, ohne Docker, ohne extra Dienst. App-Zugangsdaten eingeben, fertig.
 
-**80+ Entities** über **10 Plattformen**, **16 Services**. Alle 7 VAG-Marken in einer Integration — kein separates Plugin nötig.
+**80+ Entities** über **10 Plattformen**, **14 Services**. Alle 7 VAG-Marken in einer Integration — kein separates Plugin nötig.
+
+> ✅ **Aktiv gepflegter Multi-Brand-Nachfolger** für [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archiviert am 29.10.2025) und [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated am 14.03.2025). Eine Integration für Audi, VW, Škoda, SEAT, CUPRA, Porsche und VW US/CA — kein separates Plugin pro Marke.
+
+## Aktueller Stand & ehrliche Limits (v1.8.5)
+
+VAG Connect entwickelt sich aktiv weiter. Damit du weißt, was funktioniert und was nicht:
+
+- **Capability-Gating:** Aktuell nur für SEAT/CUPRA Flash- und Wake-Buttons aktiv. Für andere Marken werden Entities noch ohne Capability-Check angelegt — sie können also "unavailable" sein, wenn dein Modell die Funktion nicht hat. Wird marken-für-marken erweitert (Sessions 3B / 3C / 3S).
+- **CARIAD v1/v2 Auto-Fallback:** Aktuell nur für 4 Set-Value Commands (Ladziel, Klimatemperatur, Lademodus, Mindest-SoC) aktiv. Das löst Audi RS e-tron GT und VW Passat 2025 ab v1.8.5. Lock/Unlock, Climate Start/Stop und Charging Start/Stop folgen in Session 3B.
+- **Image-Plattform:** Es existiert kein offizielles Render-Image-API in der CARIAD-Pipeline. Die Image-Entity ist daher ein Platzhalter und wird in v1.10.0 entweder entfernt oder auf user-supplied URLs umgestellt.
+- **PPC/PPE-Plattform (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):** Diese 2025er Modelle nutzen die neue E³ 1.2 Architektur. Öffentlich gibt es noch keine reverse-engineerten Endpoints. VAG Connect erkennt diese Fahrzeuge und legt für sie keine Command-Entities an, statt 404-Fehler zu produzieren.
+- **Privacy-Voraussetzung:** Damit GPS-Position, Fahrzeugstatus und Standheizung funktionieren, muss in deiner My-VW / My-Audi / MySkoda / MyCupra-App **"Standort teilen"** aktiviert sein — sonst antwortet das Backend mit 403.
+
+Aktuelle Roadmap und Detailstand: [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
 
 ## Unterstützte Plattformen
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -12,7 +12,7 @@
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="../tests/"><img src="https://img.shields.io/badge/Tests-337%2F337-brightgreen?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
@@ -34,7 +34,21 @@ Ik wilde mijn Audi volledig in Home Assistant besturen. Dus bouwde ik dit.
 
 **VAG Connect** is een zelfstandige Home Assistant integratie voor alle VAG-merken. Geen externe afhankelijkheden, geen Docker, geen externe diensten.
 
-Vanaf v0.14.1 communiceert de integratie **rechtstreeks** met de CARIAD API — eigen async-client, volledig zelfstandig.
+Vanaf v0.14.1 communiceert de integratie **rechtstreeks** met de CARIAD API — eigen async-client, volledig zelfstandig. Cloud-polling architectuur, 80+ entities over 10 platforms, 14 services.
+
+> ✅ **Actief onderhouden multi-merk opvolger** van [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (gearchiveerd op 2025-10-29) en [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated op 2025-03-14). Eén integratie voor Audi, VW, Škoda, SEAT, CUPRA, Porsche en VW US/CA — geen aparte plugin per merk.
+
+## Huidige status & eerlijke beperkingen (v1.8.5)
+
+VAG Connect is in actieve ontwikkeling. Zodat je weet wat werkt en wat niet:
+
+- **Capability-gating:** Op dit moment alleen actief voor SEAT/CUPRA flash- en wake-knoppen. Voor andere merken worden entities nog zonder capability-controle aangemaakt — ze kunnen dus "niet beschikbaar" tonen als je model de functie niet heeft. Wordt merk-voor-merk uitgerold (Sessies 3B / 3C / 3S).
+- **CARIAD v1/v2 auto-fallback:** Op dit moment alleen actief voor 4 set-value commando's (laaddoel, klimaattemperatuur, laadmodus, minimale SoC). Dit deblokkeert Audi RS e-tron GT en VW Passat 2025 vanaf v1.8.5. Lock/unlock, climate start/stop en charging start/stop volgen in Sessie 3B.
+- **Image-platform:** Er is geen officiële render-image API in de CARIAD-pipeline. De image-entity is daarom een placeholder en wordt in v1.10.0 ofwel verwijderd ofwel omgezet naar door de gebruiker opgegeven URLs.
+- **PPC/PPE-platform (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):** Deze 2025+ modellen gebruiken de nieuwe E³ 1.2 architectuur. Er zijn nog geen openbaar gereverse-engineerde endpoints bekend. VAG Connect detecteert deze voertuigen en maakt geen command-entities aan, in plaats van 404-fouten te produceren.
+- **Privacy-vereiste:** GPS-positie, voertuigstatus en standkachel vereisen **"Locatie delen"** ingeschakeld in je My-VW / My-Audi / MySkoda / MyCupra app — anders antwoordt de backend met 403.
+
+Actuele roadmap en gedetailleerde status: [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md)
 
 ---
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -12,7 +12,7 @@
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="../tests/"><img src="https://img.shields.io/badge/Tests-337%2F337-brightgreen?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
@@ -34,7 +34,21 @@ Chciałem w pełni sterować moim Audi z poziomu Home Assistant. Więc to zbudow
 
 **VAG Connect** to samodzielna integracja Home Assistant dla wszystkich marek VAG. Bez zewnętrznych zależności, bez Dockera, bez zewnętrznych usług.
 
-Od v0.14.1 integracja **bezpośrednio** komunikuje się z API CARIAD — własny klient async, w pełni autonomiczny.
+Od v0.14.1 integracja **bezpośrednio** komunikuje się z API CARIAD — własny klient async, w pełni autonomiczny. Architektura cloud-polling, 80+ encji w 10 platformach, 14 usług.
+
+> ✅ **Aktywnie utrzymywany wieloprodukcyjny następca** projektów [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (zarchiwizowany 2025-10-29) i [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). Jedna integracja dla Audi, VW, Škoda, SEAT, CUPRA, Porsche i VW US/CA — bez osobnej wtyczki dla każdej marki.
+
+## Bieżący stan i uczciwe ograniczenia (v1.8.5)
+
+VAG Connect jest aktywnie rozwijany. Żebyś wiedział, co działa, a co nie:
+
+- **Capability-gating:** Obecnie aktywny tylko dla przycisków flash i wake SEAT/CUPRA. Dla innych marek encje są tworzone bez sprawdzania capability — mogą więc pokazywać "niedostępne", jeśli twój model nie ma danej funkcji. Wdrażanie marka po marce (Sesje 3B / 3C / 3S).
+- **Automatyczny fallback CARIAD v1/v2:** Obecnie aktywny tylko dla 4 komend set-value (cel ładowania, temperatura klimatyzacji, tryb ładowania, minimalny SoC). Odblokowuje to Audi RS e-tron GT i VW Passat 2025 od v1.8.5. Lock/unlock, climate start/stop i charging start/stop pojawią się w Sesji 3B.
+- **Platforma image:** Nie istnieje oficjalne API renderowania obrazów w pipeline CARIAD. Encja image jest więc placeholderem i w v1.10.0 zostanie albo usunięta, albo przełączona na URL-e dostarczane przez użytkownika.
+- **Platforma PPC/PPE (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):** Te modele 2025+ używają nowej architektury E³ 1.2. Żadne reverse-engineered endpointy nie są jeszcze publicznie znane. VAG Connect wykrywa te pojazdy i nie tworzy dla nich encji komend, zamiast generować błędy 404.
+- **Wymóg prywatności:** Pozycja GPS, status pojazdu i ogrzewanie postojowe wymagają włączonej opcji **"Udostępnij moją lokalizację"** w aplikacji My-VW / My-Audi / MySkoda / MyCupra — w przeciwnym razie backend odpowiada błędem 403.
+
+Aktualny roadmap i szczegółowy stan: [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md)
 
 ---
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -12,7 +12,7 @@
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="../tests/"><img src="https://img.shields.io/badge/Tests-337%2F337-brightgreen?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
@@ -34,7 +34,21 @@ Jag ville styra min Audi i Home Assistant — fullständigt. Så jag byggde dett
 
 **VAG Connect** är en fristående Home Assistant-integration för alla VAG-märken. Inga externa beroenden, ingen Docker, inga externa tjänster.
 
-Från v0.14.1 kommunicerar integrationen **direkt** med CARIAD API — egen async-klient, helt fristående.
+Från v0.14.1 kommunicerar integrationen **direkt** med CARIAD API — egen async-klient, helt fristående. Cloud-polling-arkitektur, 80+ entiteter över 10 plattformar, 14 tjänster.
+
+> ✅ **Aktivt underhållen multi-märkes-efterträdare** till [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (arkiverat 2025-10-29) och [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). En integration för Audi, VW, Škoda, SEAT, CUPRA, Porsche och VW US/CA — ingen separat plugin per märke.
+
+## Nuvarande status och ärliga begränsningar (v1.8.5)
+
+VAG Connect är under aktiv utveckling. För att du ska veta vad som fungerar och vad som inte gör det:
+
+- **Capability-gating:** Aktivt för närvarande endast för SEAT/CUPRA flash- och wake-knappar. För andra märken skapas entiteter fortfarande utan capability-kontroll — de kan visa "ej tillgänglig" om din modell saknar funktionen. Rullas ut märke för märke (Sessioner 3B / 3C / 3S).
+- **CARIAD v1/v2 auto-fallback:** Aktivt för närvarande endast för 4 set-value-kommandon (laddmål, klimattemperatur, laddningsläge, minimal SoC). Detta avblockerar Audi RS e-tron GT och VW Passat 2025 från v1.8.5. Lock/unlock, climate start/stop och charging start/stop följer i Session 3B.
+- **Image-plattform:** Det finns inget officiellt render-image-API i CARIAD-pipelinen. Image-entiteten är därför en placeholder och kommer i v1.10.0 antingen tas bort eller bytas ut mot användarspecificerade URL:er.
+- **PPC/PPE-plattform (Audi Q5 2025, Q6 e-tron, A5/S5, A6 e-tron):** Dessa 2025+-modeller använder den nya E³ 1.2-arkitekturen. Inga reverse-engineered endpoints är ännu publikt kända. VAG Connect upptäcker dessa fordon och skapar inga kommando-entiteter, istället för att producera 404-fel.
+- **Integritetskrav:** GPS-position, fordonsstatus och kupévärmare kräver **"Dela min position"** aktiverat i din My-VW / My-Audi / MySkoda / MyCupra-app — annars svarar backend med 403.
+
+Aktuell roadmap och detaljerad status: [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md)
 
 ---
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.8.5"
+  "version": "1.8.6"
 }

--- a/docs/AUDIT_2026-04-29.md
+++ b/docs/AUDIT_2026-04-29.md
@@ -1,0 +1,270 @@
+# VAG Connect — Code Audit 2026-04-29
+
+> Independent multi-source audit of the integration at `main` HEAD (v1.8.5).
+> Built from a 5-agent parallel research pass across:
+> - 5 CarConnectivity Brand Connectors (`tillsteinbach`, `acfischer42`, `zackcornelius`)
+> - 6 CarConnectivity Plugins + Tronity (MQTT, MQTT-HA, WebUI, ABRP, Homekit)
+> - 6 Reference HA integrations (mitch-dc/we_connect_id, skodaconnect/myskoda, audi_connect_ha, pycupra, volkswagencarnet)
+> - PPC/PPE platform reverse-engineering (Audi MediaCenter, evcc, davidgiga1993/AudiAPI)
+> - Cross-reference matrix across all 11+ repos
+
+**Methodological caveat:** All five research agents had `WebFetch` blocked in the
+sandbox and worked from search-engine snippets + verifiable repo URLs. Issue
+numbers and titles are confirmed; issue body details are reconstructed from
+snippets and should be re-verified before any single-issue implementation.
+Code-level findings (e.g. `pycupra/connection.py` endpoints,
+`audi_services.py` endpoint schema, `mitch-dc/volkswagen_we_connect_id`
+archive status) are repo-state facts, not snippet inferences.
+
+---
+
+## 1. Strategic context shift
+
+| Repo | Status | Date | Implication |
+|---|---|---|---|
+| `mitch-dc/volkswagen_we_connect_id` | **Archived (read-only)** | 2025-10-29 | Most popular HACS VW WeConnect ID integration is dead. Marketplace gap. |
+| `skodaconnect/homeassistant-skodaconnect` | **Deprecated** | 2025-03-14 | Successor: `homeassistant-myskoda`. |
+| `tillsteinbach/WeConnect-python`, `WeConnect-cli`, `WeConnect-MQTT` | **EOL announced 2026** | 2026 | Ecosystem migrating to multi-brand `CarConnectivity-*` framework. |
+
+**Consequence for this project:** vag-connect-ha is now structurally
+positioned as an active, multi-brand successor. README and HACS listing
+should reflect this — it is a measurable HACS-Default acceleration lever
+(Session 10 #13).
+
+---
+
+## 2. Hypothesis corrections (the most actionable findings)
+
+### 2.1 Škoda "Standby" vs "Offline" — NOT `connectionState.isActive`
+
+The original hypothesis (combine `connectionState.isActive` + `lastConnected`)
+is wrong. The Škoda Connect docs and `homeassistant-myskoda` both compute
+state from **`carCapturedTimestamp`** (returned on every status sub-object
+of `/v2/vehicles/{vin}/status`):
+
+```python
+def compute_connection_state(status_dict) -> Literal["online", "standby", "offline"]:
+    ts = status_dict.get("carCapturedTimestamp")
+    age = (datetime.now(UTC) - parse_iso(ts)).total_seconds()
+    if age < 1800:    return "online"     # < 30 min
+    if age < 86400:   return "standby"    # < 24 h, wakeable
+    return "offline"                       # > 24 h, 12V flat / underground / service
+```
+
+**Sources:** `skodaconnect/homeassistant-myskoda` issues #751, #731, #981 + `skoda-auto.com/connectivity` docs.
+**Verified locally:** `carCapturedTimestamp` appears as `field_options(alias=...)` in 9 myskoda model files (`air_conditioning.py`, `charging.py`, `status.py`, `driving_range.py`, `software_status.py`, `departure.py`, `auxiliary_heating.py`, `chargingprofiles.py`, plus the v2 air_conditioning variant). **Counter-check:** `lastConnected` returns zero hits in `skodaconnect/myskoda` — the original ChatGPT hypothesis (combine `lastConnected` + `connectionState.isActive`) is provably wrong; do not revisit.
+**Closes:** #54 (GitHobi).
+
+### 2.2 CUPRA missing door/window/range entities — NOT `/access/status`
+
+The original hypothesis (`/v1/vehicles/{vin}/access/status`) is wrong. The
+correct OLA endpoint, used by both `pycupra` and `evcc/cupra/api.go`, is:
+
+```
+/v5/users/{userID}/vehicles/{vin}/mycar
+```
+
+Requires `userID` — NOT VIN-only. Pull `userID` once from `/v1/users/me`
+after login and cache. Pycupra splits calls into 3 buckets:
+
+| Bucket | Endpoint(s) | Frequency |
+|---|---|---|
+| 1 — high-frequency | `/v5/users/{userID}/vehicles/{vin}/mycar` (doors/windows/range/charging/clima) | every coordinator tick |
+| 2 — mid-frequency | `/v1/vehicles/{vin}/mileage`, `/v1/vehicles/{vin}/parkingposition` | every 15 min |
+| 3 — low-frequency | `/v2/vehicles/{vin}/capabilities` | every 2 h |
+
+Fallback: on 404 from `/v5/...mycar`, retry against `/v2/vehicles/{vin}/status`
+(older Born models).
+
+**Sources:** `WulfgarW/pycupra/connection.py`, `evcc-io/evcc/vehicle/seat/cupra/api.go`, `WulfgarW/homeassistant-pycupra` #39.
+**Verified locally:** `pycupra/const.py:141` declares `API_MYCAR = '{baseurl}/v5/users/{userId}/vehicles/{vin}/mycar'` with comment `# Vehicle status report`. `API_POSITION` and `API_MILEAGE` confirmed at `const.py:152` and `:156` as `/v1/vehicles/{vin}/parkingposition` and `/v1/vehicles/{vin}/mileage`.
+**Closes (or substantially advances):** Gerhard's CUPRA Born missing 19 entities (post-#53 follow-up).
+
+### 2.3 Vehicle render image — there is NO official API
+
+Audit hypothesis that `volkswagen_we_connect_id` parses render images
+dynamically is **wrong**. The WeConnect API does not expose render images.
+What the apps display comes from un-authenticated marketing CDN URLs
+(`digitalrenderingservice.apps.emea.vwapps.io/...`). `tillsteinbach/WeConnect-python`'s
+`--pictures` option generates ASCII-art client-side via Pillow — not from API.
+
+**Implication:** the existing `image` platform in vag-connect-ha cannot be
+fed by an official endpoint. Options:
+- Remove `image` platform from default load + document why
+- Convert to user-supplied URL config option per vehicle
+- Mark as "Phase 2 / out of scope" in README
+
+This was noisy in the README ("80+ entities, 10 platforms") and contributes
+to the v1.8.6 truthfulness gap.
+
+---
+
+## 3. Cross-reference confidence matrix
+
+Patterns confirmed across multiple reference repos. Confidence reflects how
+many independent repos exhibit (or document) the pattern.
+
+| Pattern | we_connect_id | myskoda | audi_connect_ha | pycupra | CC-* | volkswagencarnet | Confidence | Action |
+|---|---|---|---|---|---|---|---|---|
+| 502/503 weekend outages — none have elegant backoff | #165, #166, #215 | #235, #731 | forum threads | #39 | seatcupra #49 | #683, #502 | **VERY HIGH** (6/6) | Coordinator-wide retry + 6h stale cache (v1.8.7) |
+| Token-refresh spiral → IP ban after repeated 401s | #143, #289 | #976 | "Audi Connect Nightmare" forum | — | CC-vw 0.10.2 fix | #683, #507 | **HIGH** (5/6) | Backoff layer in `auth/oauth.py`, max 3 refresh/h (v1.8.7) |
+| 12V battery drain via wake-on-poll | — | #612, #751, #762 | mentioned forum | "wake-up call" doc | — | indirect | **HIGH** (4/6) | Wake max 3/day, NEVER auto-trigger (Session 6) |
+| 404 ≠ auth-fail (capability missing for newer models) | — | — | #207 | — | seatcupra #49 | — | **HIGH** | Strict status-code discrimination (v1.8.7) |
+| Optimistic-update + state restore after set | — | #832 | — | — | — | — | MEDIUM (1/6) | Apply for lock/climate (Session 3B) |
+| 2h refresh for capabilities + render images | — | — | — | bucket pattern | — | — | MEDIUM | Bucket pattern (Session 3C) |
+| Stale-but-visible > unavailable on 5xx | — | #731 | — | — | — | — | MEDIUM | "Last good for 6h" pattern (v1.8.7) |
+| `carCapturedTimestamp` as authoritative staleness | — | #731, #751 | — | — | — | — | **CONFIRMED** | Adopt for Škoda first, then generalize |
+| PPC/PPE platform 404 on 2025+ models | — | — | forum | — | seatcupra #49 (Tavascan) | — | **MEDIUM** (3/6, public data thin) | Graceful degradation — NO endpoint guessing (Session 3B) |
+| EULA change → mass auth-fail | — | — | — | — | — | #467, #695 | MEDIUM | `ir.async_create_issue()` with login deeplink (v1.8.7) |
+| HA 255-char state limit blown by JSON-blob states | — | — | #113 | — | — | — | CONFIRMED | Coding convention: aggregate in state, JSON in attrs |
+| Render image API does not exist officially | — | — | — | — | — | — | CONFIRMED | Document, do not promise |
+
+---
+
+## 4. Direct-port code snippets (from confirmed sources)
+
+### 4.1 Centralised retry layer (v1.8.7 → `cariad/api/base.py`)
+
+```python
+# Source pattern: aiohttp + tenacity (replaces urllib3.Retry which is sync-only)
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+from aiohttp import ClientResponseError, ServerDisconnectedError
+
+@retry(
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=2, min=2, max=16),  # 2s/4s/8s/16s
+    retry=retry_if_exception_type((ServerDisconnectedError,)) |
+          retry_if_exception(lambda e: isinstance(e, ClientResponseError) and e.status in (429, 500, 502, 503, 504)),
+    reraise=True,
+)
+async def _request(self, method, url, **kw): ...
+```
+
+### 4.2 Stale-but-visible coordinator wrap (v1.8.7 → `coordinator.py`)
+
+```python
+# Source: myskoda #731 pattern
+try:
+    data = await self.api.refresh()
+    self._last_good_data = data
+    self._last_good_at = utcnow()
+    return data
+except (ServerError5xx, ClientConnectorError, asyncio.TimeoutError):
+    if self._last_good_data and (utcnow() - self._last_good_at) < timedelta(hours=6):
+        _LOGGER.warning("Backend unreachable, serving cached data from %s", self._last_good_at)
+        return self._last_good_data
+    raise UpdateFailed("Backend unavailable, no recent cache")
+```
+
+### 4.3 Audi Trip Statistics endpoint (Session 9 → new `cariad/api/trip_stats.py`)
+
+```
+GET {homeRegion}/api/bs/tripstatistics/v1/vehicles/{vin}/tripdata/{kind}
+    ?type=list&from=1970-01-01T00:00:00Z&to=<ISO_NOW>
+
+kind ∈ {"longTerm", "shortTerm"}   # "cyclic" exists in API spec but not used by audi_connect_ha
+
+Headers: X-App-Name: myAudi, X-App-Version, X-Client-ID, Authorization: Bearer ...
+```
+
+**Verified locally:** `audi_connect_ha/custom_components/audiconnect/audi_services.py:337` (URL template literal) and `audi_connect_account.py:1007/1010` (only `longTerm` + `shortTerm` actually called).
+
+Datamodel: `TripStatistics(kind, start_mileage, end_mileage, distance_km, avg_consumption, recent_trips: list[Trip])`.
+**State = numeric aggregate only.** Trip list in `extra_state_attributes["trips"]`, max 10.
+Cache 1h — trip stats change rarely.
+**Source:** `audi_connect_ha/audi_services.py` + issues #113, #162.
+
+---
+
+## 5. Anti-patterns observed (do NOT replicate)
+
+1. **Restart as refresh workaround** — CarConnectivity-plugin-mqtt `mqtt_homeassistant` documents "restart to resend topics". Use `RestoreEntity` + persistent state cache instead.
+2. **Endpoint guessing for PPC/PPE** — burns sessions, risks Audi account suspension. Wait for tillsteinbach SeatCupra #49 or `acfischer42/CC-audi` to surface URL.
+3. **Wake automatically in coordinator** — universal anti-pattern (myskoda #762). Wake stays a manual service action only.
+4. **JSON-blob as HA state** — sprengt 255-char limit (audi #113). Aggregate in state, JSON in attributes.
+5. **Generic `except Exception`** — swallows context (we_connect_id #289). Audit all `except` clauses.
+6. **Hardcoded library versions in `manifest.json`** (we_connect_id #261). Use `>=` ranges.
+7. **Reauth on 403** (audi #207) — 403 is permission/feature lock, not token expiry.
+8. **Reauth on transient `socket.gaierror` / `ClientConnectorError`** (we_connect_id #166) — these are `UpdateFailed`, not `ConfigEntryAuthFailed`.
+
+---
+
+## 6. Session map (revised)
+
+| Session | Version | Scope | Source patterns | Issues closed/advanced |
+|---|---|---|---|---|
+| **v1.8.6** Docs Truthfulness | v1.8.6 | README, GitHub About, image-platform clarification, archived-repo positioning, capability-gating scope statement, "Share my position" privacy note | tillsteinbach EOL, mitch-dc archived, pycupra "share my position" | #74 partial (expectation alignment) |
+| **v1.8.7** Defensive Programming | v1.8.7 | Centralised retry+backoff, stale-cache 6h, 3-failure tolerance, 401/403/404/5xx discrimination, EULA repair-issue, generic-except audit, manifest version ranges | we_connect_id #165/#166/#215/#289/#261, myskoda #731/#976, volkswagencarnet #467/#683/#695, audi #207, CC-seatcupra #49 | many small live-test bugs reduced |
+| **3B** | v1.8.8 | CARIAD v1/v2 fallback for `lock/unlock/climate_start/climate_stop/charging_start/charging_stop`; PPC/PPE graceful degradation (skip command entities, repair-issue); optimistic-update + state-restoration | myskoda #832, CC-seatcupra #49 (404 handling), Audi MediaCenter E³ 1.2 | #51, #74 commands |
+| **3C** _new_ | v1.8.9 | CUPRA `/v5/users/{userID}/vehicles/{vin}/mycar` for missing doors/windows/range; userID caching from `/v1/users/me`; pycupra bucket pattern (high/mid/low frequency); 404→`/v2/.../status` fallback | pycupra/connection.py, evcc/cupra/api.go | Gerhard's 19 missing entities |
+| **3S** _new_ | v1.8.10 | Škoda mysmob v3: `/v3/garage` fallback for `/v2/garage` 403; `compute_connection_state()` via `carCapturedTimestamp`; `binary_sensor.<vehicle>_connection`; `device_tracker` GPS retention during `vehicle_in_motion` | myskoda #751/#731/#981, #976 | #54, #75 |
+| **4** Diagnostics + Fixtures | v1.9.0-pre | Diagnostics dump with `last_good_at`/`last_error_type`/`consecutive_failures`/`capability_404_endpoints`/`command_profile`/`device_platform`; fixtures from we_connect_id #165, myskoda #751, CC-seatcupra #49; VIN/userID/GPS masking | original #62 + #58 | #62, #58 |
+| **5** Process & Governance | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 | #64 |
+| **6** Read-only + Smart-Wake | v1.9.0 | Read-only mode; wake counter persistent (max 3/day); `wake_count_today` sensor; smart-wake guarded by `connectionState != online` AND time-since-user-action; NEVER auto-wake from coordinator | myskoda #762 (wake limit), #751 (12V signal), pycupra "force refresh = wake" | #63, #55 |
+| **7** Push CUPRA/SEAT | v1.9.1 | Firebase FCM via `mqtt.messagehub.de` | #57 | #57 |
+| **8** Push Škoda | v1.9.2 | mysmob MQTT broker (myskoda-style; Škoda-only — NOT portable to other brands) | #57 | #57 |
+| **9** Trip Stats + Image refactor | v1.10.0 | Audi `tripstatistics/v1` schema 1:1 portable to `cariad/api/trip_stats.py`; `TripStatistics` dataclass; aggregate-in-state convention; image platform → user-supplied URL or remove | audi_services.py, audi #113, weconnect-python (image dead-end) | #24, #35, #37 partial |
+| **10** HACS Default + v2.0.0 | v2.0.0 | Live tests all brands, compatibility matrix, EU Data Act ready, position as multi-brand successor | strategic | #13, #59 |
+
+---
+
+## 7. Items deliberately not adopted
+
+- **myskoda MQTT-push architecture** — mysmob-broker is Škoda-only. Not portable to VW/Audi/Porsche/SEAT/CUPRA.
+- **pycupra 3-update-modes API surface 1:1** — concept yes (bucket frequency), implementation re-thought to fit our coordinator.
+- **CarConnectivity plugin-pattern with separate Webserver** — HA already provides Frontend/Repair flows.
+- **Vehicle render via official API** — does not exist.
+- **PPC/PPE endpoint guessing** — observe upstream (acfischer42/CC-audi, tillsteinbach SeatCupra #49) instead.
+- **HomeKit-specific protocol mappings** — out of scope, HA-native is the target.
+
+---
+
+## 7b. Bonus finding — EU Data Act ready code already exists in pycupra
+
+`pycupra` already ships an `EUDAConnection` class targeting the post-EU-Data-Act
+endpoint family:
+
+```
+EUDA_BASE_URL  = "https://eu-data-act.drivesomethinggreater.com"
+PROXY_API_PATH = "/proxy_api/vum/v2/users/me/relations/{vin}"
+```
+
+Files: `pycupra/const.py:219/228/239/247`, `pycupra/eudaconnection.py:1215`,
+`pycupra/__init__.py:8` (`from pycupra.eudaconnection import EUDAConnection`).
+
+**Implication for Session 10 (#59 EU Data Act ready):** when EU Data Act takes
+effect (Sep 2026), we don't need to reverse-engineer the new endpoint family
+from scratch. We have a working reference implementation. Materially
+de-risks Session 10.
+
+---
+
+## 8. Open questions deferred to Session 4
+
+1. Does VW Passat 2025 (B9 / MQB-Evo) share the SeatCupra #49 capability-404 pattern, or a different drift? Diagnostics will tell.
+2. Is T6 Multivan 2016 (#76) actually reachable via CARIAD BFF, or does it require the legacy MBB base (`mal-1a.prd.ece.vwg-connect.com`)? Need Tobias' logs before implementing LEGACY_MBB routing.
+3. Does the `/v3/garage` fallback work for Kodiaq Mk2 (#75), or is the entire mysmob v3 different?
+4. Does the same `userID`-based path scheme apply to SEAT (not just CUPRA), or is OLA-Cupra a special case?
+
+---
+
+## 9. Sources (verified URLs)
+
+- [mitch-dc/volkswagen_we_connect_id](https://github.com/mitch-dc/volkswagen_we_connect_id) (archived 2025-10-29) — issues #143, #165, #166, #210, #215, #261, #289
+- [skodaconnect/homeassistant-myskoda](https://github.com/skodaconnect/homeassistant-myskoda) — issues #612, #731, #748, #751, #762, #832, #976, #981
+- [skodaconnect/myskoda (Python lib)](https://github.com/skodaconnect/myskoda)
+- [audiconnect/audi_connect_ha](https://github.com/audiconnect/audi_connect_ha) — issues #94, #113, #162, #207
+- [WulfgarW/pycupra](https://github.com/WulfgarW/pycupra) — `connection.py`
+- [WulfgarW/homeassistant-pycupra](https://github.com/WulfgarW/homeassistant-pycupra) — issue #39
+- [robinostlund/homeassistant-volkswagencarnet](https://github.com/robinostlund/homeassistant-volkswagencarnet) — issues #467, #502, #683, #695, #704
+- [tillsteinbach/CarConnectivity-connector-volkswagen](https://github.com/tillsteinbach/CarConnectivity-connector-volkswagen) — releases 0.10.1/0.10.2/0.10.3
+- [tillsteinbach/CarConnectivity-connector-skoda](https://github.com/tillsteinbach/CarConnectivity-connector-skoda)
+- [tillsteinbach/CarConnectivity-connector-seatcupra](https://github.com/tillsteinbach/CarConnectivity-connector-seatcupra) — issue #49
+- [tillsteinbach/CarConnectivity-connector-tronity](https://github.com/tillsteinbach/CarConnectivity-connector-tronity)
+- [tillsteinbach/CarConnectivity-plugin-mqtt-homeassistant](https://github.com/tillsteinbach/CarConnectivity-plugin-mqtt_homeassistant)
+- [tillsteinbach/CarConnectivity-plugin-abrp](https://github.com/tillsteinbach/CarConnectivity-plugin-abrp)
+- [acfischer42/CarConnectivity-connector-audi](https://github.com/acfischer42/CarConnectivity-connector-audi)
+- [evcc-io/evcc cupra api.go](https://github.com/evcc-io/evcc/blob/master/vehicle/seat/cupra/api.go) — issues #15024, #16562
+- [Audi MediaCenter — E³ 1.2 architecture](https://www.audi-mediacenter.com/en/press-releases/the-new-audi-e3-12-electronic-architecture-brings-vorsprung-durch-technik-to-life-15925)
+- [Wikipedia — VW Premium Platform Combustion (PPC)](https://en.wikipedia.org/wiki/Volkswagen_Group_Premium_Platform_Combustion)
+- [Wikipedia — VW Premium Platform Electric (PPE)](https://en.wikipedia.org/wiki/Volkswagen_Group_Premium_Platform_Electric)

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -3,7 +3,7 @@
 > Living document. Updated at the start of every session so the next chat /
 > contributor / maintainer has a single page to read.
 
-Last updated: 2026-04-26 — Session 1 (v1.8.0 PR #65)
+Last updated: 2026-04-29 — post v1.8.5 (Session 3A merged), pre v1.8.6/v1.8.7 hotfixes
 
 ---
 
@@ -12,35 +12,43 @@ Last updated: 2026-04-26 — Session 1 (v1.8.0 PR #65)
 | What | Where |
 |---|---|
 | Current sessioned roadmap | [`docs/ROADMAP.md`](ROADMAP.md) (mirrors README) |
-| Code audit + status by P0/P1 finding | [`docs/AUDIT_2026-04-26.md`](AUDIT_2026-04-26.md) |
+| Latest multi-source audit + session map | [`docs/AUDIT_2026-04-29.md`](AUDIT_2026-04-29.md) |
+| Original P0/P1 audit (v1.8.0 baseline) | [`docs/AUDIT_2026-04-26.md`](AUDIT_2026-04-26.md) |
 | Active issues | https://github.com/its-me-prash/vag-connect-ha/issues |
-| Active PR | https://github.com/its-me-prash/vag-connect-ha/pull/65 |
 | Brand & API ecosystem map | [`research/VAG_GROUP_ECOSYSTEM.md`](research/VAG_GROUP_ECOSYSTEM.md) |
-| Image API | [`research/GRAPHQL_IMAGE_API.md`](research/GRAPHQL_IMAGE_API.md) |
+| Image API research (now known to be a dead-end officially) | [`research/GRAPHQL_IMAGE_API.md`](research/GRAPHQL_IMAGE_API.md) |
 | Why no Bentley/Lamborghini | [`research/LUXURY_BRANDS.md`](research/LUXURY_BRANDS.md) |
 
 ---
 
-## Current state — v1.8.0 (in PR #65)
+## Current state — v1.8.5 (merged on `main`)
 
 ```
-Branch:        claude/analyze-test-coverage-gG3d8
-Manifest:      version 1.8.0, iot_class cloud_polling
-Quality scale: cleaned (no more hardcoded numbers — CI publishes badges)
-Open issues:   #56–#64 (P1 work for Sessions 2–6) + user bugs #42, #51, #53, #54
+Branch:        main
+Manifest:      version 1.8.5, iot_class cloud_polling
+Quality scale: clean (CI publishes badges)
+Open PRs:      none
+Sessions done: 1 (v1.8.0), 2A/B/C (v1.8.1–v1.8.4), 3A (v1.8.5)
+Next up:       v1.8.6 Docs Truthfulness  →  v1.8.7 Defensive Pass  →  Session 3B/3C/3S
 ```
 
-### CI status (last run on commit `caf050a`)
+### What changed since AUDIT_2026-04-26
 
-| Check | Status |
+| Tag | What |
 |---|---|
-| Lint & Validate (ruff + mypy strict + manifest + JSON + CHANGELOG check) | ✅ green |
-| HA Hassfest | ✅ green |
-| HACS Validation | ✅ green |
-| CHANGELOG.md aktualisiert? | ✅ green |
-| Unit Tests + Coverage | 🔧 Two tests being fixed — `test_seat_commands` and `test_async_unlock_passes_spin` (both consequences of the v1.8.0 behaviour changes; tests now updated to match) |
+| v1.8.0 | Foundation Fix — 7 P0 release blockers (#60) |
+| v1.8.1 | Privacy & Auth Polish — VIN masking, ConfigEntryAuthFailed wiring |
+| v1.8.2 | Session 2A — error taxonomy + 3-state feature model + capabilities cache (#68) |
+| v1.8.3 | Session 2B — capability gating for SEAT/CUPRA flash + wake buttons |
+| v1.8.4 | Session 2C — SEAT/CUPRA SecToken lock fix (#53, #68) |
+| v1.8.5 | Session 3A — `CommandProfile` enum + CARIAD v1/v2 fallback (#51, #61, #74); 4 set-value commands ported |
 
-If Tests still fail after the next push, the `pytest-output` artifact uploaded by the workflow contains the full traceback.
+### Strategic context (new since 2026-04-29 audit)
+
+- `mitch-dc/volkswagen_we_connect_id` archived 2025-10-29 → marketplace gap
+- `skodaconnect/homeassistant-skodaconnect` deprecated 2025-03-14 → successor `homeassistant-myskoda`
+- tillsteinbach `WeConnect-*` → EOL 2026, ecosystem migrating to multi-brand `CarConnectivity-*`
+- **vag-connect-ha is now structurally positioned as the active multi-brand successor** — to be reflected in v1.8.6 README
 
 ---
 
@@ -50,24 +58,31 @@ If Tests still fail after the next push, the `pytest-output` artifact uploaded b
 custom_components/vag_connect/
   __init__.py          # PLATFORMS = 10 (sensor, binary_sensor, device_tracker,
                        # switch, button, climate, number, lock, image, select)
-  coordinator.py       # Poll loop, per-VIN vehicle_success tracking,
-                       #   ServiceValidationError on missing S-PIN,
-                       #   reverse-geocoding behind enable_reverse_geocoding opt-in
+                       # NOTE: image platform may be removed/refactored in v1.10.0 — no official render API exists
+  coordinator.py       # Poll loop, per-VIN vehicle_success, vehicle_capabilities
+                       # (24h TTL), feature_states, vehicle_command_profile (in-memory)
+                       # ServiceValidationError on missing S-PIN
+                       # Reverse-geocoding behind enable_reverse_geocoding opt-in
   entity_base.py       # available property = per-VIN poll success
-  config_flow.py       # Options flow now exposes enable_reverse_geocoding
+  config_flow.py       # Options flow exposes enable_reverse_geocoding
   cariad/
     auth/idk.py        # IDK PKCE — VW EU, Audi, Škoda (proprietary), SEAT, CUPRA, VW NA
     auth/porsche.py    # Auth0 PKCE — Porsche
-    api/base.py        # Abstract client; command_flash signature now accepts
-                       #   latitude/longitude kwargs (only SEAT/CUPRA use them)
-    api/vw_eu.py       # CARIAD BFF
-    api/audi.py        # CARIAD BFF + AZS token for vgql/render images
+    api/base.py        # Abstract client + per-VIN v1/v2 path memo
+                       # → v1.8.7 will add centralised retry/backoff layer
+    api/vw_eu.py       # CARIAD BFF + _post_command(vin, suffix) v1→v2 fallback
+    api/audi.py        # Inherits VW EU + AZS token for vgql/render images
     api/skoda.py       # mysmob + camelCase token + proprietary token exchange
+                       # → 3S will add /v3/garage fallback + carCapturedTimestamp
+                       # connection-state computation
     api/seat_cupra.py  # OLA + CUPRA client_secret + honk-and-flash with userPosition
+                       # SecToken-based lock/unlock (v1.8.4)
+                       # → 3C will add /v5/users/{userID}/vehicles/{vin}/mycar
+                       # for missing doors/windows/range entities
     api/porsche.py     # api.ppa.porsche.com
     api/vw_na.py       # VW US/CA UUID-based endpoints
-    api/graphql.py     # vgql GraphQL for vehicle render images (Audi confirmed)
-    exceptions.py      # APIError, AuthenticationError, RateLimitError, ...
+    api/graphql.py     # vgql GraphQL for vehicle render images (Audi)
+    exceptions.py      # APIError, AuthenticationError, RateLimitError, CommandProfile, ...
     models.py          # VehicleData, BrandConfig, TokenSet
 ```
 
@@ -76,53 +91,39 @@ Translation strings: English in `strings.json`, mirrored across
 
 ---
 
-## What changed in this session (v1.8.0 PR #65)
+## Sessioned roadmap (revised after 2026-04-29 audit)
 
-7 P0 release blockers identified by an independent audit, all fixed in one
-atomic PR. See [`docs/AUDIT_2026-04-26.md`](AUDIT_2026-04-26.md) for the
-full table. Highlights:
-
-- Per-VIN availability tracking (was: all vehicles flashed `success=True`)
-- S-PIN fail-fast with `ServiceValidationError(spin_required)`
-- Removed `max_charge_current`, `seat_heating_switch`, `auto_unlock_switch`
-  entities (they only logged or mutated internal state)
-- Reverse geocoding off by default — opt-in via `enable_reverse_geocoding`
-- `iot_class` corrected to `cloud_polling`
-- `image` and `select` platforms actually loaded now (and use
-  `entry.runtime_data` instead of the old `hass.data[DOMAIN]` lookup)
-
-Plus a bug fix for #53: CUPRA/SEAT honk-and-flash payload was wrong —
-needs `{"mode": "flash", "userPosition": {…}}`, not `{"mode": "FLASH_ONLY"}`.
-
----
-
-## Sessioned roadmap (next steps)
-
-| Session | Version | Scope |
-|---|---|---|
-| 1 — Foundation Fix | v1.8.0 | **Current** — PR #65 awaiting CI green + merge |
-| 2 — Capabilities | v1.8.1 | #56 — capability-gated entity creation |
-| 3 — Command Profile | v1.8.2 | #61 + #51 — fixes Audi RS e-tron GT 404 |
-| 4 — Diagnostics + Fixtures | v1.8.3 | #62 + #58 — anonymised diagnostics, regression tests |
-| 5 — Process & Governance | — | #64 — issue forms, brand captains, CODEOWNERS |
-| 6 — Read-only + Locking | v1.9.0 | #63 + #55 — read-only mode, command lock, smart wake-up |
-| 7 — Push CUPRA/SEAT | v1.9.1 | #57 — Firebase FCM via mqtt.messagehub.de |
-| 8 — Push Škoda | v1.9.2 | #57 — MQTT broker integration |
-| 9 — Feature batch | v1.10.0 | #24, #35, #26, #33, #31 — trip stats, charging history, etc. |
-| 10 — HACS Default + v2.0.0 | v2.0.0 | #13, #59 — live tests all brands, EU Data Act ready |
-
-> Strict order. Sessions 1–4 must merge before any new features land.
-
----
-
-## Known live issues (waiting on user verification with v1.8.0)
-
-| Issue | User | Brand / Model | What changed in v1.8.0 |
+| Session | Version | Scope | Issues |
 |---|---|---|---|
-| #54 | @GitHobi | Škoda | Per-VIN availability + JSON path fixes still in place |
-| #53 | @Gerhard2808 | CUPRA Born | `command_flash` payload fix → should work after one status poll caches GPS |
-| #42 | @migendi | CUPRA Formentor 2023 | Same v1.6.x auth fix + better repair messages |
-| #51 | G.S. (Facebook) | Audi RS e-tron GT | **Not yet fixed** — Session 3 (#61) command profile layer |
+| **v1.8.6** Docs Truthfulness | v1.8.6 | README + GitHub About truthful (`cloud_polling`, real entity count, fake-writables removed); position as successor to archived repos; clarify capability-gating + v1/v2 scope; image platform honest disclaimer; "Share my position" privacy note | partial #74 expectation alignment |
+| **v1.8.7** Defensive Programming Pass | v1.8.7 | Centralised retry+backoff (2s/4s/8s/16s for 429/5xx); 6h stale-cache; 3-failure tolerance before Unavailable; strict 401/403/404/5xx discrimination; EULA repair-issue; generic-except audit; manifest version `>=` ranges | reduces support volume across many issues |
+| **3B** | v1.8.8 | CARIAD v1/v2 fallback for `lock/unlock`, `climate_start/stop`, `charging_start/stop`; PPC/PPE graceful degradation (skip command entities, repair-issue, no endpoint guessing); optimistic-update + state-restoration | #51, #74 commands |
+| **3C** _new_ | v1.8.9 | CUPRA `/v5/users/{userID}/vehicles/{vin}/mycar` for missing doors/windows/range; userID caching from `/v1/users/me`; pycupra bucket pattern (high/mid/low frequency); 404 → `/v2/.../status` fallback | Gerhard's CUPRA Born 19 entities |
+| **3S** _new_ | v1.8.10 | Škoda mysmob v3: `/v3/garage` fallback for `/v2/garage` 403; `compute_connection_state()` via `carCapturedTimestamp` (`<30min` online / `<24h` standby / `>24h` offline); `binary_sensor.<vehicle>_connection`; GPS retention during `vehicle_in_motion` | #54, #75 |
+| **4** Diagnostics + Fixtures | v1.9.0-pre | Diagnostics dump with `last_good_at`, `last_error_type`, `consecutive_failures`, `capability_404_endpoints`, `command_profile`, `device_platform`; fixtures from we_connect_id #165, myskoda #751, CC-seatcupra #49; VIN/userID/GPS masking | #62, #58 |
+| **5** Process & Governance | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
+| **6** Read-only + Smart-Wake | v1.9.0 | Read-only mode; persistent wake counter (max 3/day); `wake_count_today` sensor; smart-wake guarded by `connectionState != online` AND time-since-user-action; **wake NEVER triggered automatically from coordinator** | #63, #55 |
+| **7** Push CUPRA/SEAT | v1.9.1 | Firebase FCM via `mqtt.messagehub.de` | #57 |
+| **8** Push Škoda | v1.9.2 | mysmob MQTT broker (Škoda-only — NOT portable to other brands) | #57 |
+| **9** Trip Stats + Image refactor | v1.10.0 | Audi `tripstatistics/v1` schema portable to `cariad/api/trip_stats.py`; `TripStatistics` dataclass; aggregate-in-state convention; image platform → user-supplied URL or removal | #24, #35, #37 partial |
+| **10** HACS Default + v2.0.0 | v2.0.0 | Live tests all brands, compatibility matrix, EU Data Act ready, multi-brand-successor positioning | #13, #59 |
+
+> Strict order. Hotfixes v1.8.6 + v1.8.7 must merge before Session 3B/3C/3S.
+
+---
+
+## Known live issues (waiting on user verification with v1.8.5)
+
+| Issue | User | Brand / Model | Status |
+|---|---|---|---|
+| #54 | @GitHobi | Škoda | **Pending Session 3S** — `carCapturedTimestamp` connection-state logic |
+| #53 | @Gerhard2808 | CUPRA Born | Lock/Unlock fixed v1.8.4; **missing 19 entities pending Session 3C** (`/v5/.../mycar`) |
+| #42 | @migendi | CUPRA Formentor 2023 | v1.6.x auth fix + better repair messages — verify on v1.8.5 |
+| #51 | G.S. (Facebook) | Audi RS e-tron GT | 4 set-value commands fixed v1.8.5; **lock/climate/charging pending Session 3B** |
+| #74 | @marcogrewe | VW Passat 2025 (B9) | Set-value commands fixed v1.8.5; status/clima/location debug pending Session 3B |
+| #75 | (Kodiaq Mk2 reporter) | Škoda Kodiaq 2 (Mk2) | `/v2/garage` 403 — **pending Session 3S** (try `/v3/garage`) |
+| #76 | @tobias-t6 | VW T6 Multivan 2016 | **Awaiting Tobias' logs** before any LEGACY_MBB routing — no speculative implementation |
+| #77 | — | Ford Explorer Electric | **Out of scope** — uses FordPass, not CARIAD. Documented. |
 
 ---
 
@@ -145,20 +146,47 @@ AZS_APP_API   = "app-api.live-my.audi.com"
 
 # Reverse geocoding (opt-in)
 NOMINATIM     = "https://nominatim.openstreetmap.org/reverse"
+
+# Session 3C — CUPRA OLA additional endpoints (verified in pycupra/connection.py)
+OLA_USER_ME      = f"{OLA_BASE}/v1/users/me"                # → userID, cache once
+OLA_MYCAR        = f"{OLA_BASE}/v5/users/{{user_id}}/vehicles/{{vin}}/mycar"
+OLA_MILEAGE      = f"{OLA_BASE}/v1/vehicles/{{vin}}/mileage"
+OLA_PARKING      = f"{OLA_BASE}/v1/vehicles/{{vin}}/parkingposition"
+
+# Session 9 — Audi Trip Statistics (verified in audi_connect_ha/audi_services.py:337)
+AUDI_TRIPSTATS = "{home_region}/api/bs/tripstatistics/v1/vehicles/{vin}/tripdata/{kind}"
+# kind ∈ {"longTerm", "shortTerm"}  — "cyclic" in API spec but not used by audi_connect_ha
+
+# Session 10 (#59 EU Data Act) — pycupra already has reference implementation
+EUDA_BASE = "https://eu-data-act.drivesomethinggreater.com"
+EUDA_RELATIONS = f"{EUDA_BASE}/proxy_api/vum/v2/users/me/relations/{{vin}}"
+# See pycupra/eudaconnection.py — saves us reverse-engineering when EU Data Act lands Sep 2026
+
+# Session 3S — Škoda connection state (verified in homeassistant-myskoda)
+# State derives from carCapturedTimestamp on every status sub-object:
+#   age < 1800   s   →  online
+#   age < 86400  s   →  standby
+#   age >= 86400 s   →  offline
 ```
 
 ---
 
 ## Reference projects (clean-room, MIT/Apache-2.0)
 
-| Project | Used for |
-|---|---|
-| arjenvrh/audi_connect_ha | AZS token exchange for Audi vgql |
-| robinostlund/homeassistant-volkswagencarnet | VW EU endpoints reference |
-| skodaconnect/myskoda | Škoda mysmob endpoints |
-| WulfgarW/pycupra | SEAT/CUPRA OLA endpoints + honk-and-flash payload |
-| CJNE/pyporscheconnectapi | Porsche Auth0 + PPA |
-| matpoulin/CarConnectivity-connector-volkswagen-na | VW US/CA endpoints |
+| Project | Status | Used for |
+|---|---|---|
+| arjenvrh/audi_connect_ha | Active fork | AZS token exchange for Audi vgql |
+| audiconnect/audi_connect_ha | Active | Trip statistics endpoint schema (Session 9) |
+| robinostlund/homeassistant-volkswagencarnet | Active | VW EU endpoints reference; EULA repair pattern |
+| skodaconnect/myskoda | Active | Škoda mysmob endpoints; `carCapturedTimestamp` logic |
+| skodaconnect/homeassistant-myskoda | Active | Stale-cache pattern, wake limits, optimistic update |
+| skodaconnect/homeassistant-skodaconnect | **Deprecated 2025-03** | Historical reference only |
+| WulfgarW/pycupra | Active | SEAT/CUPRA OLA endpoints incl. `/v5/.../mycar` bucket pattern |
+| WulfgarW/homeassistant-pycupra | Active | Live-test issue tracker |
+| CJNE/pyporscheconnectapi | Active | Porsche Auth0 + PPA |
+| matpoulin/CarConnectivity-connector-volkswagen-na | Active | VW US/CA endpoints |
+| mitch-dc/volkswagen_we_connect_id | **Archived 2025-10-29** | Historical issue forensics (we have inherited their userbase) |
+| tillsteinbach/CarConnectivity-* | Active | Multi-brand connector framework — ecosystem direction |
 
 ---
 
@@ -168,9 +196,14 @@ NOMINATIM     = "https://nominatim.openstreetmap.org/reverse"
 2. **Bilingual user-facing text** — contributor's language first, translation below.
 3. **README + 8 translations updated together** at every release.
 4. **CHANGELOG entry per version** — CI fails the PR otherwise.
-5. **VINs anonymised** — masked or example placeholders in code, docs, tests, fixtures.
+5. **VINs anonymised** — masked or example placeholders in code, docs, tests, fixtures. Same for userID and precise GPS.
 6. **Car-friendly translations** — "Lichthupe", "Klimaanlage", "Zentralverriegelung" — drivers' language, not API jargon.
 7. **Semver before bump** — patch = bug fix only, minor = new features, major = breaking change.
-8. **Do not guess API behaviour** — verify against pycupra / myskoda / audiconnect references and add the URL to the commit body.
+8. **Do not guess API behaviour** — verify against pycupra / myskoda / audi_connect_ha references and add the URL to the commit body.
 9. **Never expose tokens, S-PIN, account IDs, precise GPS** — in logs, diagnostics, fixtures, issue bodies.
-10. **Capability-first** — new entities check `capabilities` before being created (Session 2 #56 onwards).
+10. **Capability-first** — new entities check `capabilities` before being created.
+11. **404 ≠ auth-fail** — capability missing for newer models is the most common cause. Strict status-code discrimination.
+12. **Wake the car only on explicit user request** — never auto-trigger from coordinator. Persistent counter, max 3/day.
+13. **Aggregate in state, JSON in attributes** — HA state limit is 255 chars. JSON-blob states will be truncated and break dashboards.
+14. **Stale-but-visible > unavailable** on transient backend errors. 6h cache window.
+15. **Do not endpoint-guess for PPC/PPE** — wait for upstream (acfischer42/CC-audi, tillsteinbach SeatCupra #49) before any blind requests against E³ 1.2 backends. Risks Audi account suspension.


### PR DESCRIPTION
## Zusammenfassung (Deutsch)

Pure Docs-Release. Kein Code-Change, keine Verhaltensänderung. Bringt die README-Familie auf den realen v1.8.5-Stand und ergänzt die strategische Multi-Brand-Successor-Positionierung.

**Korrigiert:**
- `README.en.md` sagte "cloud-push architecture" — falsch seit v1.8.0 (`iot_class` ist `cloud_polling`).
- DE/EN Service-Count uneinheitlich (16 vs 14) → vereinheitlicht auf 14 (verifiziert in `services.yaml`).
- Hardcoded Test-Badge ("Tests-337/337" bzw "363/363") in 8 READMEs ersetzt durch dynamischen GitHub-Actions CI-Badge — driftet nicht mehr.

**Neu hinzugekommen (in allen 8 Sprachen):**
- **Successor-Box:** Aktiv gepflegter Multi-Brand-Nachfolger für `mitch-dc/volkswagen_we_connect_id` (archiviert 2025-10-29) und `skodaconnect/homeassistant-skodaconnect` (deprecated 2025-03-14).
- **"Aktueller Stand & ehrliche Limits (v1.8.5)" Section** mit 5 Disclaimern: Capability-Gating Scope, CARIAD v1/v2 Fallback Scope, Image-Plattform (kein offizielles API), PPC/PPE Graceful Degradation, Privacy "Standort teilen".

**Plus:** `docs/AUDIT_2026-04-29.md` (Multi-Source-Audit, 5 Recherche-Agents) und `docs/SESSION_HANDOFF.md` komplett auf v1.8.5+ aktualisiert.

## Summary (English)

Pure docs release. No code change, no behaviour change. Aligns the README family to the actual v1.8.5 state and adds the strategic multi-brand-successor positioning.

**Corrected:**
- `README.en.md` said "cloud-push architecture" — wrong since v1.8.0 (`iot_class` is `cloud_polling`).
- DE/EN service count inconsistent (16 vs 14) → unified to 14 (verified in `services.yaml`).
- Hardcoded test badge ("Tests-337/337" / "363/363") in 8 READMEs replaced by dynamic GitHub Actions CI badge — no more drift.

**Added (in all 8 languages):**
- **Successor box:** active multi-brand successor to `mitch-dc/volkswagen_we_connect_id` (archived 2025-10-29) and `skodaconnect/homeassistant-skodaconnect` (deprecated 2025-03-14).
- **"Current state & honest limits (v1.8.5)" section** with 5 disclaimers: capability-gating scope, CARIAD v1/v2 fallback scope, image platform (no official API), PPC/PPE graceful degradation, privacy "Share my position".

**Plus:** `docs/AUDIT_2026-04-29.md` (multi-source audit, 5 research agents) and `docs/SESSION_HANDOFF.md` fully refreshed to v1.8.5+.

## Test plan

- [ ] CI green: ruff, mypy strict, manifest, JSON, HACS, Hassfest, CHANGELOG check
- [ ] Unit tests unchanged (pure docs PR — no code touched)
- [ ] All 8 README files render correctly on GitHub (preview)
- [ ] Successor-box links to archived repos resolve
- [ ] Dynamic CI badge resolves to current main status (initially expected: green from Session 3A merge)
- [ ] `docs/AUDIT_2026-04-29.md` renders without broken anchors
- [ ] `docs/SESSION_HANDOFF.md` renders without broken anchors

## Stack ordering

This PR is **independent** of `claude/v1.8.7-defensive-programming` (next PR), but should ideally merge **first** to avoid a trivial `manifest.json` + `CHANGELOG.md` merge conflict. v1.8.7 takes manifest 1.8.5 → 1.8.7; this PR takes 1.8.5 → 1.8.6.