### PR TITLE
feat: v1.8.7 defensive programming (retry/stale-cache/auth guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,158 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.8.7] - 2026-04-29
+
+### Defensive Programming Pass — Retry-Härtung + Stale-Cache + Token-Refresh-Schutz
+
+Auswertung der unabhängigen Multi-Source-Audit (`docs/AUDIT_2026-04-29.md`):
+**Sechs von sechs untersuchten Reference-Repos** (we_connect_id, myskoda,
+audi_connect_ha, pycupra, volkswagencarnet, CarConnectivity-Connectors)
+haben dieselben Stabilitätsprobleme dokumentiert. v1.8.7 schließt vier
+davon zentral statt punktuell pro API-Client.
+
+**`cariad/api/base.py` — `_request()` Retry-Layer:**
+
+- **HTTP 504 Gateway Timeout** ist jetzt Teil der Retry-Liste (war vorher
+  fatal). Tritt regelmäßig auf der CARIAD BFF an Wochenenden auf
+  (Quelle: `mitch-dc/volkswagen_we_connect_id` #165).
+- **Server-Error Retries** auf 3 Versuche erhöht (war 2): 3s/6s/12s
+  exponential backoff für 500/502/503/504.
+- **Transiente Netzwerk-Fehler** werden jetzt mit demselben Backoff
+  gehandhabt: `ClientConnectorError` (DNS/Connection refused),
+  `ServerDisconnectedError` (Mid-Stream-Abbruch),
+  `ClientPayloadError`, `asyncio.TimeoutError`. Wurden vorher als fatal
+  raised und teilweise von oberen Schichten als Auth-Failure
+  fehlinterpretiert (Quelle: `mitch-dc/volkswagen_we_connect_id` #166).
+  Nach 4 erfolglosen Versuchen wird `APIError(0, ...)` mit prefix
+  `"transient: ..."` raised — eindeutig unterscheidbar von HTTP-Errors.
+
+**`cariad/api/base.py` — `_refresh_tokens()` Storm-Protection:**
+
+- **Maximal 3 Token-Refresh-Versuche pro rollender Stunde.** Sliding
+  Window mit `time.monotonic()`-Timestamps in `_refresh_history`. Bei
+  Überschreitung wird `AuthenticationError("Token refresh storm — please
+  reauthenticate")` raised; der Coordinator triggert daraufhin den
+  HA-Reauth-Flow statt weiter zu loopen. Verhindert das Spirale-Pattern
+  aus `skodaconnect/myskoda` #976 und
+  `robinostlund/homeassistant-volkswagencarnet` #683, bei dem das
+  Backend nach wiederholten Login-Versuchen die IP / das Konto temporär
+  sperrt.
+
+**`coordinator.py` — Failure-Tolerance + Stale-Cache:**
+
+- **`is_vehicle_available(vin)` toleriert jetzt bis zu 3 aufeinanderfolgende
+  Poll-Failures** bevor die Verfügbarkeit auf False kippt
+  (`_FAILURE_TOLERANCE = 3`, Pattern aus `mitch-dc/volkswagen_we_connect_id`
+  #215). Single-Poll-Hiccups auf der CARIAD BFF brechen Automatisierungen
+  nicht mehr ab.
+- **Stale-Cache-Window von 6 Stunden** (`_STALE_CACHE_WINDOW`):
+  selbst nach Überschreitung der Failure-Tolerance bleibt das Fahrzeug
+  verfügbar wenn der letzte erfolgreiche Poll innerhalb der letzten 6h
+  lag. Pattern aus `skodaconnect/homeassistant-myskoda` #731 — User
+  bevorzugen "alt aber sichtbar" über "unavailable", weil
+  Automatisierungen weiter funktionieren und `last_updated_at` die
+  Staleness signalisiert.
+- Neue per-VIN Tracking-Dicts: `vehicle_failure_count` (Reset auf 0 bei
+  jedem Erfolg) und `vehicle_last_good_at` (Timestamp letzter Erfolg —
+  später auch für Diagnostics in Session 4).
+- Lazy-Init mit `getattr(...)`-Fallback, damit Coordinators die vor
+  v1.8.7 ohne `__init__` instanziiert wurden (Tests, Reload nach
+  Upgrade) nicht crashen.
+
+**Tests:**
+
+- `tests/test_cariad.py::TestBaseClientHardening` — 5 neue Tests:
+  504-Retry, ClientConnectorError-Retry, persistente Transient → APIError(0),
+  Refresh-Storm-Protection, Refresh-Window-Pruning.
+- `tests/test_coordinator.py::TestVehicleAvailabilityTolerance` — 7 neue
+  Tests: Toleranz unter Schwelle, Verfügbarkeit über Schwelle ohne
+  Recent-Good, Stale-Window-Hit, Stale-Window-Miss, Legacy-Coord-Fallback.
+- `asyncio.sleep` wird in Retry-Tests gepatched, damit die Suite nicht
+  länger läuft — der existierende 500-Test wartete vorher 9s, jetzt
+  ohne Patch 21s; mit Patch in Sekundenbruchteilen.
+
+**Bewusst NICHT in dieser Session enthalten** (Scope-Disziplin):
+
+- EULA-Repair-Issue (`ir.async_create_issue` mit Direktlink): braucht
+  eigene Translation-Strings in 8 Sprachen, kommt in v1.8.8.
+- Generic-`except Exception` Audit quer durch alle API-Clients: größerer
+  Refactor, eigener Hotfix.
+
+### Defensive Programming Pass — Retry Hardening + Stale-Cache + Token-Refresh Guard (English)
+
+Synthesis of the independent multi-source audit
+(`docs/AUDIT_2026-04-29.md`): **six out of six reference repos**
+investigated (we_connect_id, myskoda, audi_connect_ha, pycupra,
+volkswagencarnet, CarConnectivity connectors) have documented the same
+stability issues. v1.8.7 closes four of them centrally instead of
+per-API-client.
+
+**`cariad/api/base.py` — `_request()` retry layer:**
+
+- **HTTP 504 Gateway Timeout** added to the retry list (was previously
+  fatal). Routine on the CARIAD BFF on weekends (source:
+  `mitch-dc/volkswagen_we_connect_id` #165).
+- **Server-error retries raised to 3 attempts** (was 2): 3s/6s/12s
+  exponential backoff for 500/502/503/504.
+- **Transient network errors** now retried with the same backoff:
+  `ClientConnectorError` (DNS / connection refused),
+  `ServerDisconnectedError` (mid-stream disconnect),
+  `ClientPayloadError`, `asyncio.TimeoutError`. Previously raised as
+  fatal and sometimes misclassified by upper layers as auth failure
+  (source: `mitch-dc/volkswagen_we_connect_id` #166). After 4 failed
+  attempts, surfaces as `APIError(0, ...)` with `"transient: ..."`
+  prefix — unambiguously distinguishable from HTTP errors.
+
+**`cariad/api/base.py` — `_refresh_tokens()` storm protection:**
+
+- **Maximum 3 token-refresh attempts per rolling hour.** Sliding window
+  using `time.monotonic()` timestamps in `_refresh_history`. Exceeding
+  raises `AuthenticationError("Token refresh storm — please
+  reauthenticate")`; the coordinator then triggers the HA reauth flow
+  instead of looping. Prevents the spiral pattern from
+  `skodaconnect/myskoda` #976 and
+  `robinostlund/homeassistant-volkswagencarnet` #683, where the backend
+  temporarily bans the IP / locks the account after repeated login
+  attempts.
+
+**`coordinator.py` — failure tolerance + stale-cache:**
+
+- **`is_vehicle_available(vin)` now tolerates up to 3 consecutive poll
+  failures** before flipping availability to False
+  (`_FAILURE_TOLERANCE = 3`, pattern from
+  `mitch-dc/volkswagen_we_connect_id` #215). Single-poll hiccups on the
+  CARIAD BFF no longer break automations.
+- **Stale-cache window of 6 hours** (`_STALE_CACHE_WINDOW`): even past
+  the failure tolerance, the vehicle stays available if the last
+  successful poll was within the last 6h. Pattern from
+  `skodaconnect/homeassistant-myskoda` #731 — users strongly prefer
+  "old but visible" over "unavailable", because automations keep
+  working and `last_updated_at` signals the staleness.
+- New per-VIN tracking dicts: `vehicle_failure_count` (reset to 0 on
+  each success) and `vehicle_last_good_at` (last-success timestamp,
+  also surfaced in diagnostics in Session 4).
+- Lazy-init with `getattr(...)` fallback so coordinators built before
+  v1.8.7 without `__init__` (tests, post-upgrade reload) don't crash.
+
+**Tests:**
+
+- `tests/test_cariad.py::TestBaseClientHardening` — 5 new tests:
+  504-retry, ClientConnectorError retry, persistent-transient →
+  APIError(0), refresh-storm protection, refresh-window pruning.
+- `tests/test_coordinator.py::TestVehicleAvailabilityTolerance` — 7 new
+  tests: tolerance under threshold, unavailable over threshold without
+  recent good, stale-window hit, stale-window miss, legacy coord fallback.
+- `asyncio.sleep` patched in retry tests so the suite doesn't slow down
+  — the existing 500 test previously waited 9s; without the patch now
+  21s; with the patch sub-second.
+
+**Deliberately NOT in this session** (scope discipline):
+
+- EULA repair issue (`ir.async_create_issue` with deeplink): needs its
+  own translation strings in 8 languages, ships in v1.8.8.
+- Generic-`except Exception` audit across all API clients: larger
+  refactor, its own hotfix.
 ## [1.8.6] - 2026-04-29
 
 ### Docs Truthfulness Hotfix — README + 8 translations + CI badge

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any
 
-from aiohttp import ClientSession, ClientTimeout
+from aiohttp import (
+    ClientConnectorError,
+    ClientPayloadError,
+    ClientSession,
+    ClientTimeout,
+    ServerDisconnectedError,
+)
 
 from ..auth.idk import IDKAuth
 from .graphql import VehicleImageFetcher, VehicleImageData
@@ -17,6 +24,32 @@ from ..models import BrandConfig, TokenSet, VehicleData
 _LOGGER = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = 60
+
+# Token-refresh storm protection (v1.8.7).
+# Capped at 3 successful-or-attempted refreshes per rolling hour. If the
+# CARIAD identity backend hands out short-lived tokens or returns transient
+# 401s, this prevents us from looping login → 401 → login until the IP gets
+# rate-limited or the account temporarily locked. Patterns from
+# `skodaconnect/myskoda` #976 and `robinostlund/homeassistant-volkswagencarnet`
+# #683 — both repos shipped fixes after users reported account suspensions
+# triggered by integrations refreshing tokens every poll cycle.
+_REFRESH_MAX_PER_HOUR = 3
+_REFRESH_WINDOW_S = 3600
+
+# Transient network exceptions that should be retried with the same
+# exponential backoff as 5xx server errors. Verified against:
+#   - `mitch-dc/volkswagen_we_connect_id` #166 (`socket.gaierror` /
+#     `ClientConnectorError` was being misclassified as auth failure)
+#   - `skodaconnect/homeassistant-myskoda` #731 ("server unavailable" UX)
+# DNS, connection refused, and mid-stream disconnects from the CARIAD BFF
+# happen routinely on weekends and during VAG maintenance windows. They are
+# not auth failures and must not trigger reauth.
+_TRANSIENT_NET_ERRORS: tuple[type[BaseException], ...] = (
+    ClientConnectorError,
+    ServerDisconnectedError,
+    ClientPayloadError,
+    asyncio.TimeoutError,
+)
 
 
 class CariadBaseClient:
@@ -42,6 +75,10 @@ class CariadBaseClient:
         self._tokens: TokenSet | None = None
         self._image_data: dict[str, VehicleImageData] = {}
         self._refresh_lock: asyncio.Lock | None = None
+        # Sliding window of token refresh attempt timestamps (monotonic seconds).
+        # Pruned to the last `_REFRESH_WINDOW_S` on every refresh attempt.
+        # Prevents the spiral documented in myskoda #976 / volkswagencarnet #683.
+        self._refresh_history: list[float] = []
         self._auth = IDKAuth(session, brand)
 
     @property
@@ -169,49 +206,99 @@ class CariadBaseClient:
     async def _request(
         self, method: str, url: str, retry: bool = True, _attempt: int = 0, **kwargs: Any
     ) -> Any:
-        """Execute an authenticated request with retry for transient errors."""
-        import asyncio as _aio  # noqa: PLC0415
+        """Execute an authenticated request with retry for transient errors.
 
+        Retry behaviour (v1.8.7 hardening):
+
+        - HTTP 401 → token refresh + 1 retry. Refresh itself is throttled
+          to ``_REFRESH_MAX_PER_HOUR`` per rolling hour (storm protection).
+        - HTTP 429 → exponential backoff up to 3 attempts (5s/10s/20s).
+        - HTTP 500/502/503/504 → exponential backoff up to 3 attempts
+          (3s/6s/12s). 504 added in v1.8.7 — Gateway Timeouts from the
+          CARIAD BFF are routine on weekends and were previously surfaced
+          as fatal API errors.
+        - Transient network errors (DNS / connection refused / mid-stream
+          disconnects / asyncio timeouts) → same backoff as server errors.
+          Verified pattern from we_connect_id #166 and myskoda #731.
+        """
         headers = kwargs.pop("headers", {})
         headers["Authorization"] = f"Bearer {self._access_token}"
         headers["Accept"] = "application/json"
         headers["Content-Type"] = headers.get("Content-Type", "application/json")
         headers["User-Agent"] = self._brand.user_agent
 
-        async with self._session.request(
-            method, url, headers=headers, timeout=ClientTimeout(total=_REQUEST_TIMEOUT), **kwargs
-        ) as resp:
-            if resp.status == 401 and retry:
-                await self._refresh_tokens()
-                return await self._request(method, url, retry=False, **kwargs)
-            if resp.status == 429 and _attempt < 3:
-                wait = (2 ** _attempt) * 5
-                _LOGGER.debug("Rate limited (429) — retrying in %ds", wait)
-                await _aio.sleep(wait)
-                return await self._request(method, url, retry=retry, _attempt=_attempt + 1, **kwargs)
-            if resp.status in (500, 502, 503) and _attempt < 2:
+        try:
+            async with self._session.request(
+                method, url, headers=headers, timeout=ClientTimeout(total=_REQUEST_TIMEOUT), **kwargs
+            ) as resp:
+                if resp.status == 401 and retry:
+                    await self._refresh_tokens()
+                    return await self._request(method, url, retry=False, **kwargs)
+                if resp.status == 429 and _attempt < 3:
+                    wait = (2 ** _attempt) * 5
+                    _LOGGER.debug("Rate limited (429) — retrying in %ds", wait)
+                    await asyncio.sleep(wait)
+                    return await self._request(method, url, retry=retry, _attempt=_attempt + 1, **kwargs)
+                if resp.status in (500, 502, 503, 504) and _attempt < 3:
+                    wait = (2 ** _attempt) * 3
+                    _LOGGER.debug("Server error %d — retrying in %ds", resp.status, wait)
+                    await asyncio.sleep(wait)
+                    return await self._request(method, url, retry=retry, _attempt=_attempt + 1, **kwargs)
+                if resp.status == 204:
+                    return None
+                if resp.status not in (200, 201, 202, 207):
+                    body = await resp.text()
+                    raise APIError(resp.status, url, body)
+                ct = resp.headers.get("Content-Type", "")
+                if "json" in ct:
+                    return await resp.json()
+                return await resp.text()
+        except _TRANSIENT_NET_ERRORS as err:
+            if _attempt < 3:
                 wait = (2 ** _attempt) * 3
-                _LOGGER.debug("Server error %d — retrying in %ds", resp.status, wait)
-                await _aio.sleep(wait)
-                return await self._request(method, url, retry=retry, _attempt=_attempt + 1, **kwargs)
-            if resp.status == 204:
-                return None
-            if resp.status not in (200, 201, 202, 207):
-                body = await resp.text()
-                raise APIError(resp.status, url, body)
-            ct = resp.headers.get("Content-Type", "")
-            if "json" in ct:
-                return await resp.json()
-            return await resp.text()
+                _LOGGER.debug(
+                    "Transient network error (%s) — retrying in %ds",
+                    type(err).__name__,
+                    wait,
+                )
+                await asyncio.sleep(wait)
+                return await self._request(
+                    method, url, retry=retry, _attempt=_attempt + 1, **kwargs
+                )
+            raise APIError(0, url, f"transient: {type(err).__name__}: {err}") from err
 
     async def _refresh_tokens(self) -> None:
         """Attempt token refresh; fall back to full re-login.
 
         Uses a lock to prevent concurrent refresh attempts from racing.
+
+        Storm protection (v1.8.7): if more than ``_REFRESH_MAX_PER_HOUR``
+        refresh attempts occur within ``_REFRESH_WINDOW_S`` seconds, raise
+        ``AuthenticationError`` to surface the problem instead of silently
+        looping. The coordinator catches this in its poll loop and triggers
+        the HA reauth flow — the user gets a UI prompt instead of a slowly
+        rate-limited account. Patterns from myskoda #976 and
+        volkswagencarnet #683.
         """
         if self._refresh_lock is None:
             self._refresh_lock = asyncio.Lock()
         async with self._refresh_lock:
+            now = time.monotonic()
+            cutoff = now - _REFRESH_WINDOW_S
+            self._refresh_history = [t for t in self._refresh_history if t > cutoff]
+            if len(self._refresh_history) >= _REFRESH_MAX_PER_HOUR:
+                _LOGGER.error(
+                    "Token refresh storm: %d attempts in last %ds for %s — pausing"
+                    " to prevent IP ban; please reauthenticate from the UI",
+                    len(self._refresh_history),
+                    _REFRESH_WINDOW_S,
+                    self._brand.name,
+                )
+                raise AuthenticationError(
+                    "Token refresh storm — please reauthenticate"
+                )
+            self._refresh_history.append(now)
+
             if self._tokens and self._tokens.refresh_token:
                 try:
                     self._tokens = await self._auth.refresh(self._tokens.refresh_token)

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -46,6 +46,24 @@ _CC_MIN_INTERVAL_S = 180
 # between picking up legitimate changes and avoiding unnecessary calls.
 _CAPABILITIES_TTL = timedelta(hours=24)
 
+# Per-VIN failure tolerance before marking the vehicle unavailable.
+# Pattern from `mitch-dc/volkswagen_we_connect_id` #215: a single failed
+# poll should not flip every entity on the vehicle to "unavailable" because
+# the VAG backend is intermittently flaky (especially weekends and during
+# software maintenance windows). Three consecutive failures is the same
+# threshold the official We Connect ID app uses before showing an offline
+# state to the user.
+_FAILURE_TOLERANCE = 3
+
+# Stale-cache window: even after exceeding the failure tolerance, keep
+# reporting the vehicle as available if we have data younger than this
+# window. Pattern from `skodaconnect/homeassistant-myskoda` #731: users
+# strongly prefer "old but visible" over "unavailable" — automations
+# triggered by the last known state are still useful, and the user can see
+# from `last_updated_at` that the data is stale. 6 hours covers normal
+# weekend backend outages without serving truly outdated data.
+_STALE_CACHE_WINDOW = timedelta(hours=6)
+
 
 @dataclass
 class FeatureState:
@@ -92,6 +110,19 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Per-VIN poll success tracking — entities use this for availability
         # so a single failing vehicle doesn't blank out the others.
         self.vehicle_success: dict[str, bool] = {}
+
+        # Per-VIN consecutive-failure counter (v1.8.7). Reset to 0 on every
+        # successful poll. Used by ``is_vehicle_available`` to apply
+        # ``_FAILURE_TOLERANCE`` before flipping availability — prevents
+        # single-poll flicker from breaking automations.
+        self.vehicle_failure_count: dict[str, int] = {}
+
+        # Per-VIN timestamp of the last successful poll (v1.8.7). Used by
+        # ``is_vehicle_available`` together with ``_STALE_CACHE_WINDOW`` to
+        # keep entities visible during transient backend outages. Also
+        # exposed in diagnostics so users can see how stale the cached
+        # state is.
+        self.vehicle_last_good_at: dict[str, datetime] = {}
 
         # Per-VIN capabilities cache. Hydrated best-effort during setup.
         # 2A foundation only — entity platforms don't read from this yet.
@@ -254,6 +285,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 )
                 fresh: dict[str, Any] = {}
                 any_success = False
+                # Lazy-initialise v1.8.7 tracking dicts so tests that bypass
+                # __init__ (and pre-1.8.7 instances reloaded after upgrade)
+                # still work.
+                if not hasattr(self, "vehicle_failure_count"):
+                    self.vehicle_failure_count = {}
+                if not hasattr(self, "vehicle_last_good_at"):
+                    self.vehicle_last_good_at = {}
                 for vin, result in zip(vins, results):
                     if isinstance(result, Exception):
                         _LOGGER.debug("Poll failed for %s: %s", mask_vin(vin), result)
@@ -261,6 +299,9 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         old["_poll_failed"] = True
                         fresh[vin] = old
                         self.vehicle_success[vin] = False
+                        self.vehicle_failure_count[vin] = (
+                            self.vehicle_failure_count.get(vin, 0) + 1
+                        )
                     elif isinstance(result, VehicleData):
                         data = result.to_dict()
                         data["_client"] = self._cariad_client
@@ -268,9 +309,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         fresh[vin] = await self._enrich(data)
                         any_success = True
                         self.vehicle_success[vin] = True
+                        self.vehicle_failure_count[vin] = 0
+                        self.vehicle_last_good_at[vin] = datetime.now(tz=timezone.utc)
                     else:
                         fresh[vin] = self.vehicles.get(vin, {})
                         self.vehicle_success[vin] = False
+                        self.vehicle_failure_count[vin] = (
+                            self.vehicle_failure_count.get(vin, 0) + 1
+                        )
                 with self._vehicles_lock:
                     self.vehicles.update(fresh)
                 await self._async_push_update(fresh, success=any_success)
@@ -285,9 +331,18 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 _LOGGER.error("VAG Connect poll error: %s", err)
                 if not hasattr(self, "vehicle_success"):
                     self.vehicle_success = {}
-                # Mark all known VINs as failed — avoids stale-as-fresh
+                if not hasattr(self, "vehicle_failure_count"):
+                    self.vehicle_failure_count = {}
+                # Mark all known VINs as failed — avoids stale-as-fresh.
+                # ``is_vehicle_available`` still tolerates this for up to
+                # ``_FAILURE_TOLERANCE`` consecutive failures and within
+                # ``_STALE_CACHE_WINDOW`` so single-poll backend hiccups
+                # don't ripple through every entity (we_connect_id #215).
                 for vin in list(self.vehicles.keys()):
                     self.vehicle_success[vin] = False
+                    self.vehicle_failure_count[vin] = (
+                        self.vehicle_failure_count.get(vin, 0) + 1
+                    )
                 await self._async_push_update({}, success=False)
 
     async def async_shutdown(self) -> None:
@@ -302,15 +357,36 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         return self._started
 
     def is_vehicle_available(self, vin: str) -> bool:
-        """Return True if the last poll for *vin* succeeded.
+        """Return True if *vin* should be reported available to entities.
 
-        Used by entities to expose per-VIN availability so a single failing
-        vehicle does not blank out entities of other vehicles in the same
-        account. Defaults to True for unknown VINs (covers initial setup).
+        Two-stage tolerance (v1.8.7):
+
+        1. Up to ``_FAILURE_TOLERANCE`` consecutive failed polls do not
+           flip the vehicle to unavailable. Single-poll backend hiccups
+           are common on the CARIAD BFF and would otherwise break
+           automations watching binary sensors (we_connect_id #215).
+        2. Even past the tolerance threshold, if we still have a recent
+           successful poll within ``_STALE_CACHE_WINDOW``, keep the
+           vehicle visible. The cached state is shown with its
+           ``last_updated_at`` so the user can tell it is stale; this
+           matches the UX preference documented in myskoda #731.
+
+        Defaults to True for unknown VINs (covers initial setup).
         """
-        # Lazy default so tests bypassing __init__ still work.
-        success: dict[str, bool] = getattr(self, "vehicle_success", {}) or {}
-        return bool(success.get(vin, True))
+        failures: dict[str, int] = getattr(self, "vehicle_failure_count", {}) or {}
+        count = failures.get(vin, 0)
+        if count < _FAILURE_TOLERANCE:
+            return True
+        last_good_map: dict[str, datetime] = (
+            getattr(self, "vehicle_last_good_at", {}) or {}
+        )
+        last_good = last_good_map.get(vin)
+        if last_good is not None:
+            age = datetime.now(tz=timezone.utc) - last_good
+            if age < _STALE_CACHE_WINDOW:
+                return True
+        # Truly unavailable — past tolerance and stale-cache window.
+        return False
 
     # ── Capabilities & feature-state plumbing (Session 2A foundation) ──────
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.8.6"
+  "version": "1.8.7"
 }

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -353,10 +353,14 @@ class TestBaseClient:
         client = VWEUClient(session, "u@t.de", "pw")
         client._tokens = TokenSet("acc", "ref", "id")
 
-        with pytest.raises(APIError) as exc:
-            asyncio.get_event_loop().run_until_complete(
-                client._request("GET", "https://example.com/api")
-            )
+        # v1.8.7: 500 is now retried up to 3 times (was 2). Patch sleep
+        # so the test finishes quickly instead of waiting 3+6+12 seconds.
+        with patch("custom_components.vag_connect.cariad.api.base.asyncio.sleep",
+                   new=AsyncMock(return_value=None)):
+            with pytest.raises(APIError) as exc:
+                asyncio.get_event_loop().run_until_complete(
+                    client._request("GET", "https://example.com/api")
+                )
         assert exc.value.status == 500
 
     def test_request_204_returns_none(self):
@@ -995,6 +999,142 @@ class TestBaseClientRefresh:
 
         asyncio.get_event_loop().run_until_complete(client.authenticate())
         assert client._tokens.access_token == "fresh_token"
+
+
+# ── v1.8.7 hardening: 504, transient network errors, refresh-storm guard ─────
+
+class TestBaseClientHardening:
+    """v1.8.7 — retry coverage extended to 504 + transient network errors,
+    plus token-refresh storm protection capped at 3/h."""
+
+    @staticmethod
+    def _resp(status: int, json_data=None, text: str = ""):
+        resp = AsyncMock()
+        resp.status = status
+        resp.headers = {"Content-Type": "application/json"}
+        resp.json = AsyncMock(return_value=json_data or {})
+        resp.text = AsyncMock(return_value=text)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    @staticmethod
+    def _client_with_session(session):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        from custom_components.vag_connect.cariad.models import TokenSet
+        client = VWEUClient(session, "u@t.de", "pw")
+        client._tokens = TokenSet("acc", "ref", "id")
+        return client
+
+    def test_request_retries_on_504_then_succeeds(self):
+        """504 Gateway Timeout is now retried (was previously fatal)."""
+        responses = [self._resp(504, text="GW timeout"),
+                     self._resp(200, json_data={"ok": True})]
+        idx = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal idx
+            r = responses[min(idx, len(responses) - 1)]
+            idx += 1
+            return r
+
+        session = MagicMock()
+        session.request = MagicMock(side_effect=side_effect)
+        client = self._client_with_session(session)
+        with patch("custom_components.vag_connect.cariad.api.base.asyncio.sleep",
+                   new=AsyncMock(return_value=None)):
+            result = asyncio.get_event_loop().run_until_complete(
+                client._request("GET", "https://example.com/api")
+            )
+        assert result == {"ok": True}
+        assert idx >= 2  # at least one retry happened
+
+    def test_request_retries_on_client_connector_error(self):
+        """ClientConnectorError (DNS / connection refused) is retried, not raised."""
+        from aiohttp import ClientConnectorError
+
+        # Build a ClientConnectorError using its real signature
+        connection_key = MagicMock()
+        os_error = OSError("nodename nor servname provided, or not known")
+        cc_err = ClientConnectorError(connection_key, os_error)
+
+        ok_resp = self._resp(200, json_data={"recovered": True})
+        responses_or_errors = [cc_err, ok_resp]
+        idx = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal idx
+            item = responses_or_errors[min(idx, len(responses_or_errors) - 1)]
+            idx += 1
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        session = MagicMock()
+        session.request = MagicMock(side_effect=side_effect)
+        client = self._client_with_session(session)
+        with patch("custom_components.vag_connect.cariad.api.base.asyncio.sleep",
+                   new=AsyncMock(return_value=None)):
+            result = asyncio.get_event_loop().run_until_complete(
+                client._request("GET", "https://example.com/api")
+            )
+        assert result == {"recovered": True}
+
+    def test_request_raises_api_error_after_persistent_transient(self):
+        """After 4 attempts at a transient error, surface APIError(0, ...)."""
+        from aiohttp import ServerDisconnectedError
+        from custom_components.vag_connect.cariad.exceptions import APIError
+
+        session = MagicMock()
+        session.request = MagicMock(side_effect=ServerDisconnectedError())
+        client = self._client_with_session(session)
+        with patch("custom_components.vag_connect.cariad.api.base.asyncio.sleep",
+                   new=AsyncMock(return_value=None)):
+            with pytest.raises(APIError) as exc:
+                asyncio.get_event_loop().run_until_complete(
+                    client._request("GET", "https://example.com/api")
+                )
+        assert exc.value.status == 0
+        assert "transient" in str(exc.value).lower()
+
+    def test_refresh_storm_protection_raises_after_threshold(self):
+        """More than 3 refresh attempts in 1h must raise AuthenticationError."""
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        from custom_components.vag_connect.cariad.models import TokenSet
+        from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+
+        client = VWEUClient(MagicMock(), "u@t.de", "pw")
+        client._tokens = TokenSet("acc", "ref", "id")
+        # Mock the inner refresh path so it always succeeds — we want to
+        # verify the storm guard, not the refresh logic itself.
+        client._auth.refresh = AsyncMock(return_value=TokenSet("acc2", "ref2", "id2"))
+
+        loop = asyncio.get_event_loop()
+        # First 3 refreshes succeed (within threshold)
+        for _ in range(3):
+            loop.run_until_complete(client._refresh_tokens())
+        # Fourth must raise
+        with pytest.raises(AuthenticationError, match="storm"):
+            loop.run_until_complete(client._refresh_tokens())
+
+    def test_refresh_storm_window_resets_after_age_out(self):
+        """Old refresh timestamps must be pruned out of the rolling window."""
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        from custom_components.vag_connect.cariad.models import TokenSet
+        import time as _time
+
+        client = VWEUClient(MagicMock(), "u@t.de", "pw")
+        client._tokens = TokenSet("acc", "ref", "id")
+        client._auth.refresh = AsyncMock(return_value=TokenSet("acc2", "ref2", "id2"))
+
+        # Plant 3 ancient (>1h old) timestamps and one recent — should NOT trip
+        old = _time.monotonic() - 7200  # 2h ago
+        client._refresh_history = [old, old, old, _time.monotonic() - 5]
+        # New refresh should succeed (only the recent one survives prune)
+        asyncio.get_event_loop().run_until_complete(client._refresh_tokens())
+        # History after prune should contain at most 2 entries (the recent
+        # one + the brand new one)
+        assert len(client._refresh_history) <= 2
 
 
 # ── Škoda get_status ──────────────────────────────────────────────────────────

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -395,3 +395,78 @@ class TestIsChargingReset:
         data = {"is_charging": False, "plug_connected": True, "latitude": None, "longitude": None}
         result = asyncio.get_event_loop().run_until_complete(coord._enrich(data))
         assert result["is_charging"] is False
+
+
+# ── v1.8.7 hardening: failure tolerance + stale-cache window ────────────────
+
+class TestVehicleAvailabilityTolerance:
+    """v1.8.7 — ``is_vehicle_available`` must tolerate up to 3 consecutive
+    failures and serve cached data for up to 6h after the last good poll
+    before flipping to unavailable. Patterns from we_connect_id #215 and
+    myskoda #731 — single-poll backend hiccups should not break automations.
+    """
+
+    def _make_coord(self):
+        coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        coord.vehicle_success = {}
+        coord.vehicle_failure_count = {}
+        coord.vehicle_last_good_at = {}
+        coord.vehicles = {}
+        return coord
+
+    def test_unknown_vin_defaults_to_available(self):
+        """Unknown VIN (not yet polled) returns True so initial setup
+        doesn't blank entities before the first poll."""
+        coord = self._make_coord()
+        assert coord.is_vehicle_available("WVWZZZAUZLW000001") is True
+
+    def test_one_failure_still_available(self):
+        """One failed poll is below the tolerance threshold (3)."""
+        coord = self._make_coord()
+        coord.vehicle_failure_count["VIN1"] = 1
+        assert coord.is_vehicle_available("VIN1") is True
+
+    def test_two_failures_still_available(self):
+        """Two failed polls is still below threshold."""
+        coord = self._make_coord()
+        coord.vehicle_failure_count["VIN1"] = 2
+        assert coord.is_vehicle_available("VIN1") is True
+
+    def test_three_failures_no_recent_good_unavailable(self):
+        """At threshold with no recent good data → unavailable."""
+        coord = self._make_coord()
+        coord.vehicle_failure_count["VIN1"] = 3
+        # No entry in vehicle_last_good_at
+        assert coord.is_vehicle_available("VIN1") is False
+
+    def test_past_threshold_with_recent_good_still_available(self):
+        """Even past tolerance, recent good poll within stale window
+        keeps the vehicle visible — myskoda #731 'old but visible' UX."""
+        from datetime import datetime, timezone, timedelta
+        coord = self._make_coord()
+        coord.vehicle_failure_count["VIN1"] = 10
+        # Last good poll was 1 hour ago — well within 6h window
+        coord.vehicle_last_good_at["VIN1"] = (
+            datetime.now(tz=timezone.utc) - timedelta(hours=1)
+        )
+        assert coord.is_vehicle_available("VIN1") is True
+
+    def test_past_threshold_and_past_stale_window_unavailable(self):
+        """Past tolerance AND past stale window → truly unavailable."""
+        from datetime import datetime, timezone, timedelta
+        coord = self._make_coord()
+        coord.vehicle_failure_count["VIN1"] = 10
+        # Last good poll was 7 hours ago — past 6h stale window
+        coord.vehicle_last_good_at["VIN1"] = (
+            datetime.now(tz=timezone.utc) - timedelta(hours=7)
+        )
+        assert coord.is_vehicle_available("VIN1") is False
+
+    def test_legacy_coord_without_v187_attrs_still_available(self):
+        """Coordinators upgraded from <1.8.7 may lack the new dicts —
+        defensive default of True must apply via getattr fallback."""
+        coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        # Deliberately do NOT set vehicle_failure_count / vehicle_last_good_at
+        # to simulate an instance constructed before the v1.8.7 __init__
+        # changes (e.g. tests bypassing __init__).
+        assert coord.is_vehicle_available("VIN1") is True


### PR DESCRIPTION
## Zusammenfassung (Deutsch)

Defensive Programming Pass — schließt 4 Stabilitätsprobleme zentral, die in 6 von 6 untersuchten Reference-Repos (`mitch-dc/volkswagen_we_connect_id`, `skodaconnect/myskoda`, `audi_connect_ha`, `pycupra`, `volkswagencarnet`, CarConnectivity-Connectors) dokumentiert sind. Quelle: `docs/AUDIT_2026-04-29.md`.

**`cariad/api/base.py` — `_request()` Retry-Layer:**
- HTTP **504 Gateway Timeout** zur Retry-Liste hinzugefügt (war fatal); 500/502/503/504 jetzt 3 Versuche (war 2)
- **Transiente Netzwerk-Fehler** (`ClientConnectorError`, `ServerDisconnectedError`, `ClientPayloadError`, `asyncio.TimeoutError`) werden mit selbem Backoff retried statt fatal — verhindert false-auth-fail-Klassifizierung (Pattern: we_connect_id #166)
- Nach 4 Versuchen: `APIError(0, "transient: ...")` — eindeutig vs HTTP-Errors

**`cariad/api/base.py` — `_refresh_tokens()` Storm-Protection:**
- Max **3 Refresh-Versuche pro rollender Stunde** (sliding window via `time.monotonic`)
- Bei Überschreitung: `AuthenticationError("Token refresh storm — please reauthenticate")` → Coordinator triggert HA-Reauth-Flow
- Verhindert IP-Bans aus myskoda #976 + volkswagencarnet #683

**`coordinator.py` — Failure-Tolerance + Stale-Cache:**
- `is_vehicle_available(vin)` toleriert bis zu **3 aufeinanderfolgende Failures** (we_connect_id #215)
- **6h Stale-Cache-Window**: selbst über Schwelle bleibt Vehicle verfügbar wenn letzter Erfolg <6h alt (myskoda #731 "alt aber sichtbar" UX)
- Neue per-VIN dicts: `vehicle_failure_count`, `vehicle_last_good_at`
- Lazy-init mit `getattr`-Fallback für Coordinator-Instanzen ohne `__init__`

**Tests (12 neu, 1 gepatcht):**
- `tests/test_cariad.py::TestBaseClientHardening` — 5 Tests (504-Retry, ClientConnectorError, persistent-transient, refresh-storm, refresh-window-pruning)
- `tests/test_coordinator.py::TestVehicleAvailabilityTolerance` — 7 Tests
- Existing `test_request_raises_api_error_on_500`: `asyncio.sleep` gepatched (war 9s, hätte ohne Patch jetzt 21s gedauert)

## Summary (English)

Defensive programming pass — closes 4 stability issues centrally that are documented in 6 of 6 reference repos investigated. Source: `docs/AUDIT_2026-04-29.md`.

**`cariad/api/base.py` — `_request()` retry layer:**
- HTTP **504 Gateway Timeout** added to retry list (was fatal); 500/502/503/504 now 3 attempts (was 2)
- **Transient network errors** (`ClientConnectorError`, `ServerDisconnectedError`, `ClientPayloadError`, `asyncio.TimeoutError`) retried with same backoff instead of fatal — prevents false-auth-fail classification (pattern: we_connect_id #166)
- After 4 attempts: `APIError(0, "transient: ...")` — unambiguous vs HTTP errors

**`cariad/api/base.py` — `_refresh_tokens()` storm protection:**
- Max **3 refresh attempts per rolling hour** (sliding window via `time.monotonic`)
- Exceeding: `AuthenticationError("Token refresh storm — please reauthenticate")` → coordinator triggers HA reauth flow
- Prevents IP bans from myskoda #976 + volkswagencarnet #683

**`coordinator.py` — failure tolerance + stale-cache:**
- `is_vehicle_available(vin)` tolerates up to **3 consecutive failures** (we_connect_id #215)
- **6h stale-cache window**: even past threshold, vehicle stays available if last good poll <6h ago (myskoda #731 "old but visible" UX)
- New per-VIN dicts: `vehicle_failure_count`, `vehicle_last_good_at`
- Lazy-init with `getattr` fallback for coordinator instances without `__init__`

**Tests (12 new, 1 patched):**
- `tests/test_cariad.py::TestBaseClientHardening` — 5 tests (504 retry, ClientConnectorError, persistent-transient, refresh-storm, refresh-window pruning)
- `tests/test_coordinator.py::TestVehicleAvailabilityTolerance` — 7 tests
- Existing `test_request_raises_api_error_on_500`: `asyncio.sleep` patched (was 9s, would now be 21s without patch)

## Test plan

- [ ] CI green: ruff, mypy strict, manifest, JSON, HACS, Hassfest, CHANGELOG check
- [ ] Unit tests pass — 12 new tests + 1 modified test
- [ ] Manual smoke: integration loads, polls succeed, simulated 504 doesn't crash entity
- [ ] Manual smoke: token refresh works normally (only 1 attempt per hour under normal load)
- [ ] Coverage threshold ≥65% maintained

## Bewusst NICHT enthalten / Deliberately NOT included

- **EULA-Repair-Issue** (`ir.async_create_issue` mit Direktlink) — braucht Translation-Strings in 8 Sprachen, kommt in v1.8.8
- **Generic-`except Exception` Audit** quer durch alle API-Clients — größerer Refactor, eigener Hotfix
- **Optimistic-Update + State-Restoration** für Lock/Climate (myskoda #832) — gehört zu Session 3B (CARIAD v1/v2 Lock/Climate fallback)

## Stack ordering

Stacked on top of `main` (NOT on `claude/v1.8.6-docs-truthfulness`). PR #79 (v1.8.6 docs hotfix) should ideally merge **first** to avoid a trivial `manifest.json` + `CHANGELOG.md` merge conflict — both PRs touch the version field and add a CHANGELOG section under `[Unreleased]`.

If this PR merges first instead, manifest.json will skip 1.8.6 (1.8.5 → 1.8.7); resolution is to rebase #79 onto new main and bump 1.8.6 entry in its CHANGELOG to land between 1.8.5 and 1.8.7.

## References (verified during multi-source audit)

- `mitch-dc/volkswagen_we_connect_id` — issues #165 (504), #166 (transient → false-auth-fail), #215 (failure tolerance)
- `skodaconnect/homeassistant-myskoda` — issues #731 (stale-cache UX), #976 (refresh storm)
- `robinostlund/homeassistant-volkswagencarnet` — issues #683 (refresh storm IP ban)
- Full audit: `docs/AUDIT_2026-04-29.md`