### PR TITLE
feat: v1.8.8 Session 3B — CARIAD v1/v2 for lock/climate/charging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,120 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.8.8] - 2026-04-29
+
+### Session 3B — CARIAD v1/v2 + combined/separate endpoint dispatch für Lock/Climate/Charging
+
+Erweitert das v1/v2-Fallback-Pattern aus Session 3A (4 Set-Value-Commands)
+auf die sechs verbleibenden Hauptkommandos: `lock`, `unlock`,
+`climate_start`, `climate_stop`, `charging_start`, `charging_stop`. Plus:
+schließt einen versteckten Bug aus dem Pre-1.8.8-Code, in dem `except
+Exception` Auth-Failures, Rate-Limits und 5xx-Errors als
+Endpoint-Mismatches fehlinterpretierte und still den Fallback-Pfad
+ansprach.
+
+**`cariad/api/vw_eu.py` — neuer Helper `_post_command_with_fallback_paths`:**
+
+Dispatcht in dieser Reihenfolge, jeder Aufruf via bestehendes
+`_post_command` (das schon v1→v2 Fallback macht):
+
+1. `primary_suffix` (combined endpoint) auf v1
+2. `primary_suffix` auf v2 (bei v1-404)
+3. `fallback_suffix` (separate endpoint) auf v1 (bei v2-404)
+4. `fallback_suffix` auf v2 (bei v1-404)
+
+**Kritische Verschärfung**: Fallback wird **nur** bei HTTP 404 ausgelöst.
+Auth-Failures (401), Permission-Errors (403), Rate-Limits (429),
+Backend-5xx und transiente Netzwerk-Fehler propagieren wie sie sollen
+und werden vom Coordinator über `classify_command_failure` korrekt
+klassifiziert.
+
+**Refactor — 6 Commands nutzen den Helper:**
+
+- `command_lock`: `access/lock-unlock` → `access/lock`
+- `command_unlock`: `access/lock-unlock` → `access/unlock` (S-PIN in
+  beiden Payloads, falls gesetzt)
+- `command_start_climate`: `climatisation/start-stop` →
+  `climatisation/start` (mit Default-Parametern wie vorher: 21°C,
+  Window-Heating, ohne externe Stromversorgung)
+- `command_stop_climate`: `climatisation/start-stop` →
+  `climatisation/stop`
+- `command_start_charging`: `charging/start-stop` → `charging/start`
+- `command_stop_charging`: `charging/start-stop` → `charging/stop`
+
+**`AudiClient` profitiert automatisch** über `VWEUClient`-Inheritance —
+keine separaten Audi-Änderungen.
+
+**Tests** (`tests/test_cariad.py::TestVWEUFallbackPaths`):
+
+- 4 neue Tests:
+  1. v1-Primary 404 → v2-Primary genutzt (kein Fallback-Endpoint
+     berührt)
+  2. Beide Primaries 404 → Fallback-Endpoint v1 genutzt
+  3. **Regressionstest**: 500 vom Primary löst KEINEN Fallback aus
+     (Hauptzweck dieser Session — vorheriger Code hätte still den
+     Fallback-Endpoint angefragt und einen Backend-Hiccup als
+     Endpoint-Mismatch maskiert)
+  4. `command_unlock` mit S-PIN passt PIN in alle drei Payloads
+     (combined v1, combined v2, separate v1)
+- Existing Smoke-Tests in `TestVWEUCommands` bleiben ohne Anpassung
+  pass — alle 6 Commands akzeptieren weiterhin 204 vom ersten Endpoint
+  und brauchen nie den Fallback-Pfad im Happy-Path-Test.
+
+**Bewusst NICHT in dieser Session enthalten** (Scope-Disziplin):
+
+- **PPC/PPE Graceful Degradation per VIN-Heuristik** (`devicePlatform`
+  Detection, Skip command-entities für E³-1.2-Vehicles): kommt in
+  v1.8.9 — eigener Scope mit Repair-Notice + Tracking-Issue.
+- **Optimistic-Update + State-Restoration** für lock/climate
+  (`skodaconnect/homeassistant-myskoda` #832 Pattern): braucht eigenen
+  Hotfix mit UI-Layer (entity availability state machine), nicht hier.
+- **LEGACY_MBB Routing** für ältere T6/MQB Vehicles: blockiert auf
+  T6-Logs von Tobias (#76); kein spekulatives Code-Schreiben.
+
+### Session 3B — CARIAD v1/v2 + Combined/Separate Endpoint Dispatch for Lock/Climate/Charging (English)
+
+Extends the v1/v2 fallback pattern from Session 3A (4 set-value commands)
+to the six remaining main commands: `lock`, `unlock`, `climate_start`,
+`climate_stop`, `charging_start`, `charging_stop`. Also: closes a
+hidden bug in pre-1.8.8 code where `except Exception` misclassified
+auth failures, rate limits and 5xx errors as endpoint mismatches and
+silently called the fallback path.
+
+**`cariad/api/vw_eu.py` — new helper `_post_command_with_fallback_paths`:**
+
+Dispatches in this order, each call via the existing `_post_command`
+(which already handles v1→v2 fallback):
+
+1. `primary_suffix` (combined endpoint) on v1
+2. `primary_suffix` on v2 (on v1-404)
+3. `fallback_suffix` (separate endpoint) on v1 (on v2-404)
+4. `fallback_suffix` on v2 (on v1-404)
+
+**Critical narrowing**: fallback fires **only** on HTTP 404. Auth
+failures (401), permission errors (403), rate limits (429), backend
+5xx and transient network errors propagate as they should and are
+correctly classified by the coordinator via `classify_command_failure`.
+
+**Refactor — 6 commands use the helper:** `command_lock`,
+`command_unlock`, `command_start_climate`, `command_stop_climate`,
+`command_start_charging`, `command_stop_charging`. `AudiClient` benefits
+automatically via `VWEUClient` inheritance.
+
+**Tests** (`tests/test_cariad.py::TestVWEUFallbackPaths`):
+
+4 new tests including the key regression test that a 500 on the
+primary endpoint must NOT trigger the fallback (the main purpose of
+this session — the previous code would have silently called the
+fallback and masked a backend hiccup as an endpoint mismatch).
+
+**Deliberately NOT in this session** (scope discipline):
+
+- PPC/PPE graceful degradation via VIN heuristic — v1.8.9.
+- Optimistic-update + state restoration for lock/climate (myskoda
+  #832) — needs its own UI-layer hotfix.
+- LEGACY_MBB routing for older T6/MQB — blocked on T6 logs from
+  Tobias (#76); no speculative code.
 ## [1.8.7] - 2026-04-29
 
 ### Defensive Programming Pass — Retry-Härtung + Stale-Cache + Token-Refresh-Schutz

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -134,87 +134,95 @@ class VWEUClient(CariadBaseClient):
         return self._parse_status(vin, raw, parking)
 
     async def command_lock(self, vin: str) -> None:
-        """Lock vehicle — tries combined endpoint, falls back to separate."""
-        try:
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/access/lock-unlock",
-                json={"action": "lock"},
-            )
-        except Exception:  # noqa: BLE001
-            await self._post(f"{_BASE}/vehicle/v1/vehicles/{vin}/access/lock", json={})
+        """Lock vehicle — combined endpoint with separate-endpoint fallback,
+        each tried on both /vehicle/v1/ and /vehicle/v2/ paths.
+
+        v1.8.8 (Session 3B): replaces the bare-except-then-fallback pattern
+        with HTTP-404-only fallback via ``_post_command_with_fallback_paths``.
+        Auth failures, rate limits and 5xx errors no longer mask as
+        endpoint-version mismatches and now propagate to the coordinator
+        for proper ``classify_command_failure`` handling.
+        """
+        await self._post_command_with_fallback_paths(
+            vin,
+            primary_suffix="access/lock-unlock",
+            primary_payload={"action": "lock"},
+            fallback_suffix="access/lock",
+            fallback_payload={},
+        )
 
     async def command_unlock(self, vin: str, spin: str = "") -> None:
-        """Unlock vehicle — S-PIN required if set."""
-        payload: dict[str, Any] = {"action": "unlock"}
+        """Unlock vehicle — S-PIN required if set.
+
+        Same v1/v2 + combined/separate dispatch as ``command_lock``.
+        S-PIN, when present, is included in *both* the combined-endpoint
+        payload and the separate-endpoint fallback payload (the legacy
+        unlock endpoint accepts the PIN in the body, the same way the
+        SecToken-using SEAT/CUPRA flow does in v1.8.4).
+        """
+        primary_payload: dict[str, Any] = {"action": "unlock"}
+        fallback_payload: dict[str, Any] = {}
         if spin or self._spin:
-            payload["spin"] = spin or self._spin
-        try:
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/access/lock-unlock",
-                json=payload,
-            )
-        except Exception:  # noqa: BLE001
-            unlock_payload: dict[str, Any] = {}
-            if spin or self._spin:
-                unlock_payload["spin"] = spin or self._spin
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/access/unlock",
-                json=unlock_payload,
-            )
+            primary_payload["spin"] = spin or self._spin
+            fallback_payload["spin"] = spin or self._spin
+        await self._post_command_with_fallback_paths(
+            vin,
+            primary_suffix="access/lock-unlock",
+            primary_payload=primary_payload,
+            fallback_suffix="access/unlock",
+            fallback_payload=fallback_payload,
+        )
 
     async def command_start_climate(self, vin: str) -> None:
-        """Start pre-conditioning — combined or separate endpoint."""
-        try:
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/climatisation/start-stop",
-                json={"action": "start"},
-            )
-        except Exception:  # noqa: BLE001
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/climatisation/start",
-                json={
-                    "targetTemperature": 21.0,
-                    "targetTemperatureUnit": "celsius",
-                    "climatisationWithoutExternalPower": True,
-                    "windowHeatingEnabled": True,
-                },
-            )
+        """Start pre-conditioning — combined endpoint with separate fallback,
+        each on v1/v2.
+
+        Default target temperature 21°C and window heating enabled match
+        the previous separate-endpoint payload — kept so behaviour does
+        not regress when the combined endpoint isn't available.
+        """
+        await self._post_command_with_fallback_paths(
+            vin,
+            primary_suffix="climatisation/start-stop",
+            primary_payload={"action": "start"},
+            fallback_suffix="climatisation/start",
+            fallback_payload={
+                "targetTemperature": 21.0,
+                "targetTemperatureUnit": "celsius",
+                "climatisationWithoutExternalPower": True,
+                "windowHeatingEnabled": True,
+            },
+        )
 
     async def command_stop_climate(self, vin: str) -> None:
-        """Stop pre-conditioning."""
-        try:
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/climatisation/start-stop",
-                json={"action": "stop"},
-            )
-        except Exception:  # noqa: BLE001
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/climatisation/stop", json={},
-            )
+        """Stop pre-conditioning — combined endpoint with separate fallback."""
+        await self._post_command_with_fallback_paths(
+            vin,
+            primary_suffix="climatisation/start-stop",
+            primary_payload={"action": "stop"},
+            fallback_suffix="climatisation/stop",
+            fallback_payload={},
+        )
 
     async def command_start_charging(self, vin: str) -> None:
-        """Start charging."""
-        try:
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/charging/start-stop",
-                json={"action": "start"},
-            )
-        except Exception:  # noqa: BLE001
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/charging/start", json={},
-            )
+        """Start charging — combined endpoint with separate fallback."""
+        await self._post_command_with_fallback_paths(
+            vin,
+            primary_suffix="charging/start-stop",
+            primary_payload={"action": "start"},
+            fallback_suffix="charging/start",
+            fallback_payload={},
+        )
 
     async def command_stop_charging(self, vin: str) -> None:
-        """Stop charging."""
-        try:
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/charging/start-stop",
-                json={"action": "stop"},
-            )
-        except Exception:  # noqa: BLE001
-            await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/charging/stop", json={},
-            )
+        """Stop charging — combined endpoint with separate fallback."""
+        await self._post_command_with_fallback_paths(
+            vin,
+            primary_suffix="charging/start-stop",
+            primary_payload={"action": "stop"},
+            fallback_suffix="charging/stop",
+            fallback_payload={},
+        )
 
     async def command_flash(
         self,
@@ -284,6 +292,47 @@ class VWEUClient(CariadBaseClient):
             )
             self._mark_v2_active(vin)
             return result
+
+    async def _post_command_with_fallback_paths(
+        self,
+        vin: str,
+        primary_suffix: str,
+        primary_payload: dict[str, Any],
+        fallback_suffix: str,
+        fallback_payload: dict[str, Any],
+    ) -> Any:
+        """POST a vehicle command with full v1/v2 + primary/fallback dispatch.
+
+        Used by lock/unlock and climate/charging start/stop where the
+        CARIAD BFF historically exposes both a combined endpoint
+        (e.g. ``/access/lock-unlock`` with ``{"action": "lock"}``) and
+        separate endpoints (e.g. ``/access/lock`` + ``/access/unlock``).
+
+        Order of attempts (each via ``_post_command``, so each carries its
+        own v1 → v2 fallback on 404):
+
+        1. ``primary_suffix`` (combined endpoint, the historically
+           preferred form on the older CARIAD BFF)
+        2. ``fallback_suffix`` (separate endpoint, what older firmware
+           and some current PPE/PPC vehicles still expect)
+
+        The previous implementation caught a bare ``except Exception`` and
+        always fell back, which masked auth failures, rate limits and
+        backend 500s as if they were endpoint mismatches. v1.8.8 narrows
+        the fallback trigger to HTTP 404 only — every other error
+        propagates so the coordinator's
+        ``classify_command_failure`` can see it.
+        """
+        try:
+            return await self._post_command(
+                vin, primary_suffix, json=primary_payload,
+            )
+        except APIError as err:
+            if getattr(err, "status", 0) != 404:
+                raise
+            return await self._post_command(
+                vin, fallback_suffix, json=fallback_payload,
+            )
 
     async def command_set_target_soc(self, vin: str, target: int) -> None:
         """Set charge target SoC. Tries v1 first, falls back to v2 on 404."""

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.8.7"
+  "version": "1.8.8"
 }

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -942,6 +942,128 @@ class TestVWEUCommands:
         client._session.request.assert_called()
 
 
+# ── v1.8.8 Session 3B: v1/v2 + combined/separate endpoint dispatch ──────────
+
+class TestVWEUFallbackPaths:
+    """v1.8.8 — lock/unlock and climate/charging start/stop now dispatch
+    through ``_post_command_with_fallback_paths``: try the combined
+    endpoint on v1, on 404 v2; if both 404, try the separate endpoint on
+    v1, on 404 v2. Critically, *only* HTTP 404 triggers the fallback —
+    auth failures, rate limits and 5xx errors propagate so the
+    coordinator can classify them correctly. The previous implementation
+    caught a bare ``except Exception`` and masked all of these as
+    endpoint-version mismatches.
+    """
+
+    @staticmethod
+    def _resp(status: int, json_data=None, text: str = ""):
+        resp = AsyncMock()
+        resp.status = status
+        resp.headers = {"Content-Type": "application/json"}
+        resp.json = AsyncMock(return_value=json_data or {})
+        resp.text = AsyncMock(return_value=text)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    def _client_with_responses(self, responses):
+        """Build a VWEUClient whose session.request returns the given
+        responses in order (last one is repeated if exhausted)."""
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        from custom_components.vag_connect.cariad.models import TokenSet
+        idx = {"i": 0}
+
+        def side_effect(*args, **kwargs):
+            r = responses[min(idx["i"], len(responses) - 1)]
+            idx["i"] += 1
+            return r
+
+        session = MagicMock()
+        session.request = MagicMock(side_effect=side_effect)
+        client = VWEUClient(session, "u@t.de", "pw")
+        client._tokens = TokenSet("acc", "ref", "id")
+        return client, session, idx
+
+    def test_404_on_v1_primary_falls_back_to_v2_primary(self):
+        """v1/access/lock-unlock → 404, v2/access/lock-unlock → 204.
+        Should call exactly two endpoints and not touch the separate
+        access/lock fallback at all."""
+        responses = [self._resp(404, text="not found"),
+                     self._resp(204)]
+        client, session, idx = self._client_with_responses(responses)
+        with patch("custom_components.vag_connect.cariad.api.base.asyncio.sleep",
+                   new=AsyncMock(return_value=None)):
+            asyncio.get_event_loop().run_until_complete(client.command_lock("VIN1"))
+        assert idx["i"] == 2
+        urls = [call.args[1] for call in session.request.call_args_list]
+        assert "/vehicle/v1/vehicles/VIN1/access/lock-unlock" in urls[0]
+        assert "/vehicle/v2/vehicles/VIN1/access/lock-unlock" in urls[1]
+
+    def test_404_on_both_primaries_falls_back_to_separate_endpoint(self):
+        """v1+v2 of combined endpoint both 404 → tries the separate
+        endpoint (v1/access/lock) which succeeds with 204."""
+        responses = [self._resp(404),  # v1 combined
+                     self._resp(404),  # v2 combined
+                     self._resp(204)]  # v1 separate
+        client, session, idx = self._client_with_responses(responses)
+        with patch("custom_components.vag_connect.cariad.api.base.asyncio.sleep",
+                   new=AsyncMock(return_value=None)):
+            asyncio.get_event_loop().run_until_complete(client.command_lock("VIN1"))
+        assert idx["i"] == 3
+        urls = [call.args[1] for call in session.request.call_args_list]
+        assert urls[0].endswith("/vehicle/v1/vehicles/VIN1/access/lock-unlock")
+        assert urls[1].endswith("/vehicle/v2/vehicles/VIN1/access/lock-unlock")
+        assert urls[2].endswith("/vehicle/v1/vehicles/VIN1/access/lock")
+
+    def test_500_on_primary_does_not_trigger_fallback(self):
+        """KEY REGRESSION TEST for v1.8.8: a 500 server error must
+        propagate as APIError(500), NOT trigger the combined→separate
+        fallback. The pre-v1.8.8 ``except Exception`` swallowed this
+        and silently called the wrong endpoint."""
+        from custom_components.vag_connect.cariad.exceptions import APIError
+
+        # 500 on v1 combined; if we accidentally fall back, we'd see
+        # additional requests. We give exactly one 500-response so any
+        # accidental retry would surface (StopIteration on next call).
+        responses = [self._resp(500, text="backend down")]
+        client, session, idx = self._client_with_responses(responses)
+        with patch("custom_components.vag_connect.cariad.api.base.asyncio.sleep",
+                   new=AsyncMock(return_value=None)):
+            with pytest.raises(APIError) as exc:
+                asyncio.get_event_loop().run_until_complete(client.command_lock("VIN1"))
+        assert exc.value.status == 500
+        # The 500 itself is retried 4 times (3 backoff retries inside
+        # _request) — that's the existing behaviour. What MUST NOT happen
+        # is a fall-through to the separate access/lock endpoint.
+        urls = [call.args[1] for call in session.request.call_args_list]
+        assert all("access/lock-unlock" in u for u in urls), (
+            f"Expected only combined-endpoint URLs (lock-unlock); got: {urls}"
+        )
+        assert not any(u.endswith("/access/lock") for u in urls), (
+            f"500 must NOT trigger fallback to separate /access/lock; got: {urls}"
+        )
+
+    def test_unlock_passes_spin_in_both_payloads(self):
+        """When falling back from combined to separate endpoint after a
+        404, the S-PIN must be present in *both* payloads — the legacy
+        separate /access/unlock endpoint accepts the PIN in the body."""
+        import json as _json
+        responses = [self._resp(404),  # v1 combined
+                     self._resp(404),  # v2 combined
+                     self._resp(204)]  # v1 separate succeeds
+        client, session, idx = self._client_with_responses(responses)
+        with patch("custom_components.vag_connect.cariad.api.base.asyncio.sleep",
+                   new=AsyncMock(return_value=None)):
+            asyncio.get_event_loop().run_until_complete(
+                client.command_unlock("VIN1", spin="1234")
+            )
+        # Inspect payloads: kwargs['json'] on each request
+        payloads = [call.kwargs.get("json") for call in session.request.call_args_list]
+        assert payloads[0] == {"action": "unlock", "spin": "1234"}, payloads[0]
+        assert payloads[1] == {"action": "unlock", "spin": "1234"}, payloads[1]
+        assert payloads[2] == {"spin": "1234"}, payloads[2]
+
+
 # ── BaseClient refresh logic ──────────────────────────────────────────────────
 
 class TestBaseClientRefresh:


### PR DESCRIPTION
## Zusammenfassung (Deutsch)

Session 3B — erweitert das v1/v2-Fallback-Pattern aus Session 3A (4 Set-Value-Commands) auf die **6 verbleibenden Hauptkommandos**: `lock`, `unlock`, `climate_start`, `climate_stop`, `charging_start`, `charging_stop`. Plus: schließt einen versteckten **Bug aus dem Pre-1.8.8-Code**, in dem `except Exception` Auth-Failures, Rate-Limits und 5xx-Errors als Endpoint-Mismatches fehlinterpretierte und still den Fallback-Pfad ansprach.

**`cariad/api/vw_eu.py` — neuer Helper `_post_command_with_fallback_paths`:**
Dispatcht in dieser Reihenfolge, jeder Aufruf via bestehendes `_post_command` (das schon v1→v2 Fallback macht):
1. `primary_suffix` (combined endpoint) auf v1
2. `primary_suffix` auf v2 (bei v1-404)
3. `fallback_suffix` (separate endpoint) auf v1 (bei v2-404)
4. `fallback_suffix` auf v2 (bei v1-404)

**Kritische Verschärfung**: Fallback wird **nur** bei HTTP 404 ausgelöst. Auth-Failures (401), Permission-Errors (403), Rate-Limits (429), Backend-5xx und transiente Netzwerk-Fehler propagieren wie sie sollen und werden vom Coordinator über `classify_command_failure` korrekt klassifiziert.

**6 Commands refactored:** `command_lock`, `command_unlock`, `command_start_climate`, `command_stop_climate`, `command_start_charging`, `command_stop_charging`. **`AudiClient` profitiert automatisch** über `VWEUClient`-Inheritance.

## Summary (English)

Session 3B — extends the v1/v2 fallback pattern from Session 3A (4 set-value commands) to the **6 remaining main commands**: `lock`, `unlock`, `climate_start`, `climate_stop`, `charging_start`, `charging_stop`. Plus: closes a hidden **bug in pre-1.8.8 code** where `except Exception` misclassified auth failures, rate limits and 5xx errors as endpoint mismatches and silently called the fallback path.

**`cariad/api/vw_eu.py` — new helper `_post_command_with_fallback_paths`** dispatches in order: v1/primary → v2/primary → v1/fallback → v2/fallback. **Critical narrowing**: fallback fires **only** on HTTP 404.

## Test plan

- [ ] CI green (5 checks): Lint+mypy strict, Unit Tests + Coverage, HACS, Hassfest, CHANGELOG
- [ ] 4 new tests in `TestVWEUFallbackPaths`:
  - [ ] v1-Primary 404 → v2-Primary used (no fallback endpoint touched)
  - [ ] Both primaries 404 → fallback endpoint v1 used
  - [ ] **KEY REGRESSION:** 500 on primary does NOT trigger combined→separate fallback
  - [ ] `command_unlock` with S-PIN passes PIN in all 3 payloads
- [ ] Existing 11 smoke tests in `TestVWEUCommands` unchanged → pass
- [ ] Manual smoke: lock → unlock → climate-start works on a v1-vehicle (no behaviour change in happy path)

## Bewusst NICHT in v1.8.8 / Deliberately NOT in v1.8.8 (eigener Scope / own scope)

- **PPC/PPE Graceful Degradation** per VIN-Heuristik (`devicePlatform` Detection, Skip command-entities für E³-1.2-Vehicles): kommt in v1.8.9 — eigener Scope mit Repair-Notice + Tracking-Issue
- **Optimistic-Update + State-Restoration** für lock/climate (`skodaconnect/homeassistant-myskoda` #832): braucht eigenen Hotfix mit UI-Layer (entity availability state machine)
- **LEGACY_MBB Routing** für ältere T6/MQB Vehicles: blockiert auf T6-Logs von Tobias (#76); kein spekulatives Code-Schreiben

## Stack ordering

This PR is rebased on top of main (post #79 + #80 merge). Linear manifest history: 1.8.5 → 1.8.6 → 1.8.7 → 1.8.8.

## References

- Session 3A foundation (PR #78, v1.8.5): `_post_command(vin, suffix)` helper with v1→v2 fallback for set-value commands
- Audit context: `docs/AUDIT_2026-04-29.md` Section 6 (Session 3B scope) and Section 5 anti-pattern #5 (`except Exception` audit)