### PR TITLE
feat: v1.8.9 Session 3C — CUPRA/SEAT OLA status JSON paths fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,167 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.8.9] - 2026-04-29
+
+### Session 3C — CUPRA/SEAT OLA Status JSON-Pfade gefixt + Per-Window Entities + Live-API-Erkenntnisse
+
+**Bug-Fix-Bündel** für Gerhards 19 fehlende Entities (CUPRA Born) und alle
+SEAT/CUPRA-Modelle. Vor v1.8.9 las unser Parser aus
+`/v2/vehicles/{vin}/status` mit CARIAD-BFF-typischen flachen Feldnamen
+(`doorsOpenedCount`, `doorClosedLeftFront`, `trunk: "OPEN"` etc.). Diese
+Felder existieren auf dem OLA-Backend
+(`ola.prod.code.seat.cloud.vwgroup.com`) **nicht** — Konsequenz: Tür-,
+Fenster-, Kofferraum-, Motorhauben- und Schiebedach-Entities blieben
+permanent leer.
+
+**Methodik (wichtig):** Wo möglich nehmen wir Field-Namen aus echten
+Live-API-Responses (verifiziert via `tillsteinbach/CarConnectivity-connector-seatcupra`
+Issues #5, #8, #18, #21, #50, #51, #109) und stellen sie an die Spitze der
+`v(...) or v(...) or ...` Pfad-Listen. Die alten geratenen Pfade bleiben als
+defensiver Fallback.
+
+#### `cariad/api/seat_cupra.py` — `_parse_status` Status-Block neu geschrieben
+
+**Doors / Windows / Trunk / Hood / Sunroof** (verifiziert gegen
+`WulfgarW/pycupra/vehicle.py` ~Z. 3100-3325):
+
+- **Per-Door:** `status.doors.{frontLeft,frontRight,rearLeft,rearRight}.{locked,open}`
+  → `doors_individual` dict + abgeleitete `doors_open` und `doors_locked` aggregates
+- **Per-Window (NEU):** `status.windows.{frontLeft,...}` (string `"closed"`/`"open"`)
+  → `windows_individual` dict + `windows_open` aggregate
+- **Trunk:** `status.trunk.{open,locked}` als nested object (statt flat string)
+- **Hood:** `status.hood.open` (newer firmware)
+- **Sunroof:** dreifach-Pfad `status.sunRoof` (Großbuchstabe R, top-level —
+  CC-seatcupra **#5** verifiziert) ODER `status.sunroof` (pycupra) ODER
+  `status.windows.sunroof` (firmware variance)
+- **Engine (NEU):** top-level `status.engine: 'on'/'off'` (CC-seatcupra
+  **#50**) → setzt `is_driving=True` und `vehicle_state="DRIVING"` wenn
+  `engine='on'`. Behebt das verbreitete "vehicle_state immer parked"-Problem
+  (CC-seatcupra **#18**)
+
+**Defensiv:** Wenn keine der neuen Pfade Daten liefert, Fallback auf den
+pre-v1.8.9 CARIAD-BFF-style Code (für sehr alte Firmware oder zukünftige
+API-Änderungen).
+
+#### `cariad/api/seat_cupra.py` — Charging-Endpoint Live-Response Erkenntnisse (#109)
+
+**Methodik-Korrektur:** Reihenfolge der Pfad-Suche umgedreht — Rainer's
+verifizierte Live-Response-Felder zuerst, alte geratene Pfade als Fallback.
+
+OLA `/v1/vehicles/{vin}/charging` returns one of two shapes (live verifiziert):
+- **Shape A:** `{"status": ..., "currentPct": ..., "remainingTime": ...,
+  "chargeMode": ..., "preferredChargeMode": ..., "active": false}`
+- **Shape B:** `{"state": ..., "chargedPowerInKw": ...,
+  "remainingTimeInMinutes": ..., "type": ..., "mode": ...}`
+
+Field-Reihenfolge jetzt korrekt:
+- `charging_state`: `state` → `status` → `chargingState` (Legacy)
+- `charging_power_kw`: **`chargedPowerInKw` (mit "d", verified)** → `chargePowerInKw` (Legacy)
+- `remaining`: **`remainingTimeInMinutes` / `remainingTime` (verified)** → `remainingTimeToFullyChargedInMinutes` (Legacy)
+- `charging_type`: `type` → `chargeType` (Legacy)
+- `target_soc`: **`targetSoc_pct` (lowercase soc, verified)** → `targetSOC_pct` (Legacy uppercase)
+- `is_charging` jetzt case-insensitive (`charging` ODER `CHARGING`)
+- **`autoUnlockPlugWhenCharged: 'permanent'`** als 3. truthy-Wert (CC-seatcupra **#51** —
+  vorher nur `"on"` matched, `"permanent"` Konfiguration wurde fälschlich
+  als deaktiviert angezeigt)
+
+#### `cariad/api/seat_cupra.py` — Climate robustness (#8, #21)
+
+- `climatisation_state == "unsupported"` (CC-seatcupra **#21**) wird jetzt
+  korrekt als inaktiv behandelt — vorher leer (zufällig korrekt, aber
+  unklar dokumentiert)
+- `targetTemperatureCelsius` (Rainer #109 Variante ohne "In") als zusätzlicher
+  Pfad neben `targetTemperatureInCelsius`
+- `climatisation_active` False-Set erweitert auf `(None, "OFF", "off", "Off", "unsupported")`
+
+#### `cariad/models.py` — neues Field `windows_individual: dict[str, bool]`
+
+Mirror von `doors_individual`. Keys: `frontLeft` / `frontRight` / `rearLeft` /
+`rearRight`. Value `True` == Fenster geschlossen.
+
+#### `binary_sensor.py` — neuer `VagWindowSensor` + Setup-Hook
+
+Pro Fenster eine Binary-Sensor-Entity (`device_class=WINDOW`), Naming
+`Window Front Left` etc. Nur erstellt wenn `windows_individual` Daten enthält
+(SEAT/CUPRA initial; andere Marken folgen wenn deren API es liefert).
+
+#### Tests (12 neue) — `tests/test_cariad.py::TestSeatCupraGetStatus`
+
+1. `test_v189_status_parses_doors_per_position` — pycupra-Pfade door-Mapping
+2. `test_v189_status_parses_windows_per_position` — neuer windows_individual
+3. `test_v189_status_parses_trunk_hood_nested_objects` — nested {open, locked}
+4. `test_v189_status_sunroof_in_windows_subtree` — sunroof in windows.sunroof
+5. `test_v189_status_sunroof_top_level_camelCase` — `sunRoof` Großbuchstabe (#5)
+6. `test_v189_status_engine_on_implies_driving` — engine='on' → DRIVING (#50, #18)
+7. `test_v189_status_engine_off_does_not_force_driving` — engine='off' lässt vehicle_state in Ruhe
+8. `test_v189_charging_shape_b_chargedPowerInKw_remaining_minutes` — #109 Shape B
+9. `test_v189_charging_settings_targetSoc_pct_lowercase` — #109 lowercase variant
+10. `test_v189_auto_unlock_permanent_is_truthy` — `permanent` als truthy (#51)
+11. `test_v189_climatisation_trigger_unsupported_is_inactive` — `unsupported` → inaktiv (#21)
+12. `test_v189_status_legacy_flat_fallback_still_works` — defensiver Fallback intakt
+
+#### Bewusst NICHT in v1.8.9 enthalten (eigener Scope, geplant für v1.8.10+)
+
+Alles aus dem Deep-Dive der CC-seatcupra-Issues, was eigene Entities oder
+zusätzliche API-Calls braucht:
+
+- **Capability-Filter** (CC-seatcupra **#64**) — `capability.active &&
+  capability.user-enabled` vor Entity-Creation prüfen. Sehr wahrscheinlich
+  weiteres Stück für Gerhards 19 fehlende Entities. Eigene Session
+  (Erweiterung des bestehenden Capability-Cache).
+- **`/maintenance` Endpoint** (CC-seatcupra **#44**) — separater API-Call mit
+  4 neuen Sensoren (inspectionDueDays/Km, oilServiceDueDays/Km).
+- **Multi-Zone Klima** (CC-seatcupra **#10, #109**) — `zoneFrontLeftEnabled`,
+  `zoneFrontRightEnabled` als eigene Switches.
+- **Battery Care Mode** (CC-seatcupra **#20, #51**) —
+  `batteryCareModeEnabled`, `batteryCareTargetSocPercentage` als eigene
+  Switch + Number.
+- **`windowHeatingStatus[]` Array** (CC-seatcupra **#5, #8**) — strukturierter
+  Array `[{windowLocation, windowHeatingState}]` statt unsere flat
+  `windowHeatingStateFront/Rear` Pfade. Eigene Refactor-Session.
+- **`/ventilation/start|stop` Service** (CC-seatcupra **#43**) — neuer
+  HA-Service.
+- **Trip-Statistics** (CC-seatcupra **#22**, MasterTim17 fork hat Code) —
+  v1.10.x.
+- **Departure-Timer Toggle** (CC-seatcupra **#70**) — v1.9.x.
+- **`carCapturedTimestamp`-Freshness-Pattern** für CUPRA — wird in v1.8.10
+  zentral für Škoda eingeführt (Session 3S) und kann später auf CUPRA + Audi
+  expandiert werden.
+
+### Session 3C — CUPRA/SEAT OLA Status JSON Paths Fixed + Per-Window Entities + Live-API Findings (English)
+
+Bug-fix bundle for Gerhard's 19 missing entities (CUPRA Born) and all
+SEAT/CUPRA models. Pre-v1.8.9 read `/v2/vehicles/{vin}/status` using
+CARIAD-BFF-style flat field names that don't exist on the OLA backend.
+
+**Methodology:** real-world API field names (verified via tillsteinbach
+`CarConnectivity-connector-seatcupra` issues #5, #8, #18, #21, #50, #51,
+#109) are placed at the head of `v(...) or v(...) or ...` chains. Old
+inferred paths kept as defensive fallback.
+
+**`seat_cupra.py` `_parse_status`** — verified against pycupra source:
+per-door `status.doors.{position}.{locked,open}`, per-window
+`status.windows.{position}`, nested `status.trunk.{open,locked}` and
+`status.hood.open`, sunroof at THREE positions (`sunRoof` top-level from
+#5, plus pycupra paths), engine top-level → DRIVING inference (#50, #18).
+
+**Charging endpoint #109 paths reordered** — `chargedPowerInKw` (with "d"),
+`remainingTimeInMinutes`, `targetSoc_pct` (lowercase) now first;
+`auto_unlock_charge` recognises `"permanent"` (#51); climate handles
+`"unsupported"` state (#21).
+
+**`models.py`** — new `windows_individual` field. **`binary_sensor.py`** —
+new `VagWindowSensor` per-window entity.
+
+**12 new tests** in `TestSeatCupraGetStatus` covering both the new
+structured paths and all live-API-response findings.
+
+**Deliberately NOT in v1.8.9** (own scope): capability filter (#64),
+`/maintenance` endpoint (#44), multi-zone climate (#10, #109), battery
+care mode (#20, #51), `windowHeatingStatus[]` array (#5, #8),
+`/ventilation` service (#43), trip stats (#22), departure timer toggle
+(#70). All planned for v1.8.10+.
+
 ## [1.8.8] - 2026-04-29
 
 ### Session 3B — CARIAD v1/v2 + combined/separate endpoint dispatch für Lock/Climate/Charging

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -173,6 +173,13 @@ async def async_setup_entry(
     for vin, vehicle in coordinator.vehicles.items():
         await _async_setup_door_sensors(coordinator, vin, vehicle, entities)
 
+    # v1.8.9 (Session 3C) — per-window binary sensors. Currently only
+    # populated for SEAT/CUPRA via the corrected OLA status paths;
+    # other brands leave ``windows_individual`` empty so no entities
+    # are created for them.
+    for vin, vehicle in coordinator.vehicles.items():
+        await _async_setup_window_sensors(coordinator, vin, vehicle, entities)
+
     async_add_entities(entities)
 
 
@@ -236,3 +243,57 @@ async def _async_setup_door_sensors(
     doors = vehicle.get("doors_individual", {})
     for door_id in doors:
         entities.append(VagDoorSensor(coordinator, vin, door_id))
+
+
+# v1.8.9 (Session 3C) — per-window binary sensors.
+# Layout mirrors ``_DOOR_NAMES``; populated by SEAT/CUPRA OLA paths
+# (``status.windows.{position}``). State convention: ``True`` means
+# *open* (BinarySensorDeviceClass.WINDOW reports True for "the
+# detected event", i.e. open). Internally we store ``True`` for
+# *closed* in ``windows_individual`` (consistent with
+# ``doors_individual``), so ``is_on`` inverts that.
+
+_WINDOW_NAMES = {
+    "frontLeft":  "Window Front Left",
+    "frontRight": "Window Front Right",
+    "rearLeft":   "Window Rear Left",
+    "rearRight":  "Window Rear Right",
+}
+
+
+class VagWindowSensor(VagConnectEntity, BinarySensorEntity):
+    """Binary Sensor für ein einzelnes Fenster (CUPRA/SEAT initial)."""
+
+    _attr_device_class = BinarySensorDeviceClass.WINDOW
+
+    def __init__(
+        self,
+        coordinator: VagConnectCoordinator,
+        vin: str,
+        window_id: str,
+    ) -> None:
+        super().__init__(coordinator, vin, f"window_{window_id}")
+        self._window_id = window_id
+        self._attr_name = _WINDOW_NAMES.get(window_id, window_id)
+        self._attr_icon = "mdi:car-door"
+
+    @property
+    def is_on(self) -> bool | None:
+        windows = self._vehicle.get("windows_individual", {})
+        val = windows.get(self._window_id)
+        # Stored value: True == closed. is_on for WINDOW device_class
+        # means "open detected" — invert.
+        return (not val) if val is not None else None
+
+
+async def _async_setup_window_sensors(
+    coordinator: VagConnectCoordinator,
+    vin: str,
+    vehicle: dict,
+    entities: list,
+) -> None:
+    """Legt individuelle Fenster-Sensoren an, wenn die Fahrzeug-Antwort
+    sie liefert. Heute: SEAT/CUPRA OLA. Andere Marken: leer → keine Entities."""
+    windows = vehicle.get("windows_individual", {})
+    for window_id in windows:
+        entities.append(VagWindowSensor(coordinator, vin, window_id))

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -151,40 +151,223 @@ class SeatCupraClient(CariadBaseClient):
             d.adblue_range_km = v(ranges, "adBlueRange")
 
         # ── Detailed vehicle status (doors, windows, trunk) ──────────────────
+        # OLA `/v2/vehicles/{vin}/status` for SEAT/CUPRA returns a structured
+        # tree, NOT the flat ``doorsOpenedCount`` shape that CARIAD BFF uses.
+        # The real shape (verified against `WulfgarW/pycupra/vehicle.py` lines
+        # ~3100–3325, the pycupra dashboard reads identical paths):
+        #
+        #   status:
+        #     doors:
+        #       frontLeft:  { locked: bool, open: bool }
+        #       frontRight: { locked: bool, open: bool }
+        #       rearLeft:   { locked: bool, open: bool }
+        #       rearRight:  { locked: bool, open: bool }
+        #     windows:
+        #       frontLeft:  "closed" | "open"      # string state
+        #       frontRight: "closed" | "open"
+        #       rearLeft:   "closed" | "open"
+        #       rearRight:  "closed" | "open"
+        #       sunroof:    "closed" | "open"      # sometimes here, sometimes top-level
+        #     trunk:   { open: bool, locked?: bool }
+        #     hood:    { open: bool }              # newer firmware
+        #     sunroof: "closed" | "open"           # legacy/alternative position
+        #
+        # Pre-v1.8.9 used CARIAD-BFF flat keys (``doorsOpenedCount``,
+        # ``doorClosedLeftFront`` etc.) which do not exist on OLA — so for
+        # CUPRA Born / Formentor / Tavascan the door, window, trunk, hood
+        # and sunroof entities silently never populated. Fix verified via
+        # pycupra source — the legacy-flat fallback below stays in place
+        # for the rare model that sends the older shape.
         if isinstance(status, dict):
             access_s = v(status, "access") or status
-            d.doors_open = v(access_s, "doorsOpenedCount", default=0) > 0
-            d.windows_open = v(access_s, "windowsOpenedCount", default=0) > 0
-            d.trunk_open = v(access_s, "trunk") == "OPEN" or v(access_s, "trunkOpen") is True
-            d.trunk_locked = v(access_s, "trunkLocked") is True or v(access_s, "trunkStatus") == "LOCKED"
-            d.hood_open = v(access_s, "hood") == "OPEN" or v(access_s, "hoodOpen") is True
-            d.sunroof_open = v(access_s, "sunroof") == "OPEN" or v(access_s, "sunroofOpen") is True
+            doors_obj = v(status, "doors") or {}
+            windows_obj = v(status, "windows") or {}
+            trunk_obj = v(status, "trunk") or {}
+            hood_obj = v(status, "hood") or {}
 
-            doors = {}
-            for key in ("doorClosedLeftFront", "doorClosedRightFront", "doorClosedLeftBack", "doorClosedRightBack"):
-                val = v(access_s, key)
-                if val is not None:
-                    door_id = key.replace("doorClosed", "").replace("LeftFront", "frontLeft").replace("RightFront", "frontRight").replace("LeftBack", "rearLeft").replace("RightBack", "rearRight")
-                    doors[door_id] = not val
-            if doors:
-                d.doors_individual = doors
+            # Per-door (locked + open). Aggregate ``doors_open`` and
+            # ``doors_locked`` are derived once we have the dict.
+            door_individual: dict[str, bool] = {}
+            for pos in ("frontLeft", "frontRight", "rearLeft", "rearRight"):
+                door = v(doors_obj, pos) or {}
+                if not door:
+                    continue
+                # ``open`` may be bool or "open"/"closed" string — normalise
+                open_raw = door.get("open")
+                if isinstance(open_raw, bool):
+                    is_closed = not open_raw
+                elif isinstance(open_raw, str):
+                    is_closed = open_raw.lower() == "closed"
+                else:
+                    is_closed = None
+                if is_closed is not None:
+                    door_individual[pos] = is_closed
+            if door_individual:
+                d.doors_individual = door_individual
+                d.doors_open = any(not closed for closed in door_individual.values())
+                # ``doors_locked`` is True only when every position reports
+                # locked=True. If any position doesn't report (None),
+                # fall back to the access endpoint or stay False.
+                locked_states = []
+                for pos in ("frontLeft", "frontRight", "rearLeft", "rearRight"):
+                    door = v(doors_obj, pos) or {}
+                    locked = door.get("locked")
+                    if locked is not None:
+                        locked_states.append(bool(locked))
+                if locked_states:
+                    d.doors_locked = all(locked_states)
+
+            # Per-window (string-state). New ``windows_individual`` dict
+            # mirrors ``doors_individual`` so binary sensors can expose
+            # one entity per window.
+            window_individual: dict[str, bool] = {}
+            for pos in ("frontLeft", "frontRight", "rearLeft", "rearRight"):
+                wstate = v(windows_obj, pos)
+                if isinstance(wstate, str):
+                    window_individual[pos] = wstate.lower() == "closed"
+                elif isinstance(wstate, bool):
+                    # Some firmware returns bool. Convention: True == closed.
+                    window_individual[pos] = wstate
+            if window_individual:
+                d.windows_individual = window_individual
+                d.windows_open = any(not closed for closed in window_individual.values())
+
+            # Trunk + hood — both as nested {open, locked}. Sunroof can be
+            # at status.sunroof OR status.windows.sunroof (pycupra checks
+            # both due to firmware variance).
+            if trunk_obj:
+                trunk_open = trunk_obj.get("open")
+                if trunk_open is not None:
+                    d.trunk_open = bool(trunk_open) if isinstance(trunk_open, bool) else trunk_open == "open"
+                trunk_locked = trunk_obj.get("locked")
+                if trunk_locked is not None:
+                    d.trunk_locked = bool(trunk_locked)
+            if hood_obj:
+                hood_open = hood_obj.get("open")
+                if hood_open is not None:
+                    d.hood_open = bool(hood_open) if isinstance(hood_open, bool) else hood_open == "open"
+            # Sunroof can be at three different positions depending on
+            # firmware/model. Issue #5 (CC-seatcupra) confirms ``sunRoof``
+            # (camelCase with capital R) as a top-level field on Seat Leon
+            # KL — verified live. pycupra checks both ``sunroof`` and
+            # ``windows.sunroof`` due to firmware variance. Accept all three.
+            sunroof_state = (
+                v(status, "sunRoof")                # CC-seatcupra #5 — verified
+                or v(status, "sunroof")              # pycupra path
+                or v(windows_obj, "sunroof")         # pycupra alternative
+            )
+            if isinstance(sunroof_state, str):
+                d.sunroof_open = sunroof_state.lower() == "open"
+            elif isinstance(sunroof_state, bool):
+                d.sunroof_open = sunroof_state
+
+            # Engine state — top-level field on OLA `/v2/vehicles/{vin}/status`.
+            # CC-seatcupra issue #50 reports ``engine: 'on' | 'off'`` from
+            # multiple users (Seat Leon KL, Cupra Born). When 'on' the car
+            # is being driven; this is the only reliable signal for driving
+            # state because the official ``vehicle.state`` field stays at
+            # ``parked`` for many users (CC-seatcupra issue #18).
+            engine_state = v(status, "engine")
+            if isinstance(engine_state, str):
+                d.is_driving = engine_state.lower() == "on"
+                if d.is_driving:
+                    d.vehicle_state = "DRIVING"
+
+            # ── Legacy CARIAD-BFF-style flat fallback ────────────────────
+            # If the new structured paths produced nothing (older firmware,
+            # corrupted response, or a future OLA API change) fall back to
+            # the pre-v1.8.9 flat shape. Defensive only — should not fire
+            # for any current SEAT/CUPRA model verified against pycupra.
+            if not door_individual and not window_individual:
+                d.doors_open = v(access_s, "doorsOpenedCount", default=0) > 0
+                d.windows_open = v(access_s, "windowsOpenedCount", default=0) > 0
+                if d.trunk_open is None:
+                    d.trunk_open = v(access_s, "trunk") == "OPEN" or v(access_s, "trunkOpen") is True
+                if d.trunk_locked is None:
+                    d.trunk_locked = v(access_s, "trunkLocked") is True or v(access_s, "trunkStatus") == "LOCKED"
+                if d.hood_open is None:
+                    d.hood_open = v(access_s, "hood") == "OPEN" or v(access_s, "hoodOpen") is True
+                if d.sunroof_open is None:
+                    d.sunroof_open = v(access_s, "sunroof") == "OPEN" or v(access_s, "sunroofOpen") is True
+
+                doors_legacy: dict[str, bool] = {}
+                for key in ("doorClosedLeftFront", "doorClosedRightFront",
+                            "doorClosedLeftBack", "doorClosedRightBack"):
+                    val = v(access_s, key)
+                    if val is not None:
+                        door_id = (key.replace("doorClosed", "")
+                                   .replace("LeftFront", "frontLeft")
+                                   .replace("RightFront", "frontRight")
+                                   .replace("LeftBack", "rearLeft")
+                                   .replace("RightBack", "rearRight"))
+                        doors_legacy[door_id] = not val
+                if doors_legacy:
+                    d.doors_individual = doors_legacy
 
         # ── Charging status ──────────────────────────────────────────────────
+        # OLA charging endpoint field-name variance. Path order is now
+        # **real-world response first, legacy guesses last** (v1.8.9
+        # methodology fix): the older paths in this file were inferred
+        # from CARIAD-BFF / pycupra back when we had no live OLA dump.
+        # Now that we have a verified live CUPRA Born response from
+        # `tillsteinbach/CarConnectivity-connector-seatcupra` issue #109
+        # (user "Rainer", 2026-03-27 — same OLA host, same brand),
+        # those field names are known good and must be tried first so a
+        # vehicle that returns BOTH shapes doesn't accidentally pick a
+        # zero from a legacy field.
+        #
+        # /v1/vehicles/{vin}/charging — observed shapes:
+        #   Real-world (Rainer #109 shape B):
+        #     {"state": "notReadyForCharging", "chargedPowerInKw": 0.0,
+        #      "remainingTimeInMinutes": 0, "type": "invalid", "mode": "manual"}
+        #   Real-world (Rainer #109 shape A — same endpoint, alt firmware):
+        #     {"status": "NotReadyForCharging", "currentPct": 43,
+        #      "remainingTime": 0, "chargeMode": "manual",
+        #      "preferredChargeMode": "manual", "active": false}
+        #   Legacy (pre-v1.8.9 inferred, kept as defensive fallback):
+        #     {"chargingState": ..., "chargePowerInKw": ...,
+        #      "remainingTimeToFullyChargedInMinutes": ..., "chargeType": ...}
         if isinstance(charge_status, dict):
             bat = v(charge_status, "battery") or charge_status
             if d.battery_soc is None:
-                d.battery_soc = v(bat, "stateOfChargeInPercent") or v(bat, "currentSOC_pct")
+                d.battery_soc = (
+                    v(charge_status, "currentPct")  # Rainer #109 shape A — verified
+                    or v(bat, "stateOfChargeInPercent")
+                    or v(bat, "currentSOC_pct")
+                )
                 d.has_battery = d.battery_soc is not None
 
             chg = v(charge_status, "charging") or charge_status
-            d.charging_state = v(chg, "state") or v(chg, "chargingState")
-            d.is_charging = d.charging_state == "CHARGING"
-            d.charging_power_kw = v(chg, "chargePowerInKw") or v(chg, "chargePower_kW")
+            d.charging_state = (
+                v(chg, "state")             # Rainer #109 shape B — verified
+                or v(chg, "status")         # Rainer #109 shape A — verified
+                or v(chg, "chargingState")  # Legacy — inferred pre-v1.8.9
+            )
+            # Charging-state values are camelCase or PascalCase depending on
+            # firmware; treat case-insensitively.
+            d.is_charging = (
+                isinstance(d.charging_state, str)
+                and d.charging_state.lower() == "charging"
+            )
+            d.charging_power_kw = (
+                v(chg, "chargedPowerInKw")  # Rainer #109 shape B — verified
+                or v(chg, "chargePowerInKw")  # Legacy
+                or v(chg, "chargePower_kW")   # Legacy
+            )
             d.charging_rate_kmh = v(chg, "chargeRateInKmPerHour") or v(chg, "chargeRate_kmph")
-            remaining = v(chg, "remainingTimeToFullyChargedInMinutes") or v(chg, "remainingChargingTime")
+            remaining = (
+                v(chg, "remainingTimeInMinutes")  # Rainer #109 shape B — verified
+                or v(chg, "remainingTime")        # Rainer #109 shape A — verified
+                or v(chg, "remainingTimeToFullyChargedInMinutes")  # Legacy
+                or v(chg, "remainingChargingTime")                  # Legacy
+            )
             if remaining:
                 d.charge_complete_eta = datetime.now(tz=timezone.utc) + timedelta(minutes=int(remaining))
-            d.charging_type = v(chg, "chargeType") or v(chg, "chargingType")
+            d.charging_type = (
+                v(chg, "type")          # Rainer #109 shape B — verified
+                or v(chg, "chargeType")  # Legacy
+                or v(chg, "chargingType")  # Legacy
+            )
 
             plug = v(charge_status, "plug") or {}
             plug_state = v(plug, "connectionState") or v(plug, "plugConnectionState")
@@ -193,21 +376,52 @@ class SeatCupraClient(CariadBaseClient):
             d.connector_locked = v(plug, "lockState") == "LOCKED" or v(plug, "externalPower") == "READY"
 
         # ── Charging info (settings) ─────────────────────────────────────────
+        # OLA `/v2/vehicles/{vin}/charging/settings` field variance.
+        # Real-world (Rainer #109): {"targetSoc_pct": 80, "maxChargeCurrentAC":
+        # "maximum", "autoUnlockPlugWhenCharged": "off" | "on" | "permanent"}.
+        # The "permanent" value is documented in issue #51 and means the
+        # connector unlocks at any SoC, not just at full charge — so
+        # ``auto_unlock_charge`` is True for both "on" and "permanent".
         if isinstance(charge_info, dict):
-            d.target_soc = v(charge_info, "targetSOC_pct") or v(charge_info, "targetStateOfChargeInPercent")
+            d.target_soc = (
+                v(charge_info, "targetSoc_pct")  # Rainer #109 — verified
+                or v(charge_info, "targetSOC_pct")          # Legacy uppercase
+                or v(charge_info, "targetStateOfChargeInPercent")  # Legacy verbose
+            )
             d.max_charge_current = v(charge_info, "maxChargeCurrentAC") or v(charge_info, "maxChargeCurrent")
-            d.auto_unlock_charge = v(charge_info, "autoUnlockPlugWhenCharged") == "ON" or v(charge_info, "autoUnlockPlugWhenChargedAC") is True
+            auto_raw = v(charge_info, "autoUnlockPlugWhenCharged")
+            auto_str = auto_raw.lower() if isinstance(auto_raw, str) else None
+            d.auto_unlock_charge = (
+                # #51: "permanent" is also "yes, unlock". Only "off"/None means no.
+                auto_str in ("on", "permanent")
+                or v(charge_info, "autoUnlockPlugWhenChargedAC") is True
+            )
 
         # ── Climate ──────────────────────────────────────────────────────────
+        # CC-seatcupra issue #21 + #8 documented that ``climatisationTrigger``
+        # can return ``"unsupported"`` on older Born firmware; pre-v1.8.9
+        # treated this state as if the climate was off (since it didn't
+        # match "off"/"on" exactly), which still happened to be correct,
+        # but a bool ``is_climate_supported`` would let entity platforms
+        # hide controls cleanly. For v1.8.9 we keep ``climatisation_active``
+        # behaviour stable and just ensure ``"off"``, ``"OFF"``,
+        # ``"unsupported"``, and any ``None`` all evaluate to False.
         if isinstance(climate, dict):
             cs = v(climate, "status") or climate
             d.climatisation_state = v(cs, "climatisationState") or v(cs, "state")
-            d.climatisation_active = d.climatisation_state not in (None, "OFF", "off")
+            _inactive_states = (None, "OFF", "off", "Off", "unsupported")
+            d.climatisation_active = d.climatisation_state not in _inactive_states
             d.target_temperature = v(climate, "settings", "targetTemperature_K")
             if d.target_temperature:
                 d.target_temperature = round(float(d.target_temperature) - 273.15, 1)
             if not d.target_temperature:
-                d.target_temperature = v(climate, "settings", "targetTemperatureInCelsius")
+                # `targetTemperatureCelsius` (no "In") is the Rainer #109
+                # Live-response variant; `targetTemperatureInCelsius` is the
+                # newer settings-endpoint variant. Try both.
+                d.target_temperature = (
+                    v(climate, "settings", "targetTemperatureInCelsius")
+                    or v(cs, "targetTemperatureCelsius")  # Rainer #109
+                )
             d.outside_temp = v(cs, "outsideTemperature")
             if d.outside_temp and d.outside_temp > 100:
                 d.outside_temp = round(float(d.outside_temp) - 273.15, 1)

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -224,6 +224,11 @@ class VehicleData:
     doors_open: bool = False
     windows_open: bool = False
     doors_individual: dict[str, bool] = field(default_factory=dict)
+    # v1.8.9 (Session 3C) — per-window state, mirrors ``doors_individual``.
+    # Keys: frontLeft / frontRight / rearLeft / rearRight. Value True ==
+    # window closed, False == open. Populated by SEAT/CUPRA OLA paths
+    # (status.windows.{position}); other brands leave it empty for now.
+    windows_individual: dict[str, bool] = field(default_factory=dict)
 
     # Location
     latitude: float | None = None

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.8.8"
+  "version": "1.8.9"
 }

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -1397,6 +1397,250 @@ class TestSeatCupraGetStatus:
         vins = asyncio.get_event_loop().run_until_complete(client.get_vehicles())
         assert "VSSZZE1KZLR000001" in vins
 
+    # ── v1.8.9 Session 3C: OLA /v2/.../status JSON-paths ──────────────────
+
+    @staticmethod
+    def _resp(json_data):
+        resp = AsyncMock()
+        resp.status = 200
+        resp.headers = {"Content-Type": "application/json"}
+        resp.json = AsyncMock(return_value=json_data)
+        resp.text = AsyncMock(return_value="")
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    def _client_with_url_routing(self, brand: str, by_path: dict):
+        """Return a SeatCupraClient whose session.request routes by URL substring.
+        ``by_path`` maps URL substring → JSON body. Unknown URLs return ``{}``."""
+        from custom_components.vag_connect.cariad.api.seat_cupra import SeatCupraClient
+        from custom_components.vag_connect.cariad.models import TokenSet
+
+        empty = self._resp({})
+
+        def side_effect(method, url, **kwargs):
+            for pattern, body in by_path.items():
+                if pattern in url:
+                    return self._resp(body)
+            return empty
+
+        session = MagicMock()
+        session.request = MagicMock(side_effect=side_effect)
+        client = SeatCupraClient(session, brand, "u@t.de", "pw")
+        client._tokens = TokenSet("acc", "ref", "id")
+        client._user_id = "USER_TEST"
+        return client
+
+    def test_v189_status_parses_doors_per_position(self):
+        """v1.8.9 (Session 3C): pycupra-style ``status.doors.{position}.{locked,open}``
+        is parsed into ``doors_individual`` and aggregates ``doors_open`` /
+        ``doors_locked`` are derived correctly."""
+        status_body = {
+            "doors": {
+                "frontLeft":  {"locked": True, "open": False},
+                "frontRight": {"locked": True, "open": True},   # this one is open
+                "rearLeft":   {"locked": True, "open": False},
+                "rearRight":  {"locked": False, "open": False}, # this one not locked
+            },
+        }
+        client = self._client_with_url_routing("cupra", {"/v2/vehicles/": status_body})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000001"))
+
+        assert result.doors_individual == {
+            "frontLeft":  True,
+            "frontRight": False,  # open
+            "rearLeft":   True,
+            "rearRight":  True,
+        }
+        assert result.doors_open is True       # frontRight open → at least one
+        assert result.doors_locked is False    # rearRight not locked → not all
+
+    def test_v189_status_parses_windows_per_position(self):
+        """v1.8.9: pycupra-style ``status.windows.{position}`` (string state)
+        populates the new ``windows_individual`` dict and ``windows_open``."""
+        status_body = {
+            "windows": {
+                "frontLeft":  "closed",
+                "frontRight": "open",     # one open
+                "rearLeft":   "closed",
+                "rearRight":  "closed",
+            },
+        }
+        client = self._client_with_url_routing("cupra", {"/v2/vehicles/": status_body})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000002"))
+
+        assert result.windows_individual == {
+            "frontLeft":  True,
+            "frontRight": False,  # open
+            "rearLeft":   True,
+            "rearRight":  True,
+        }
+        assert result.windows_open is True
+
+    def test_v189_status_parses_trunk_hood_nested_objects(self):
+        """v1.8.9: ``status.trunk`` and ``status.hood`` are nested objects
+        with ``open`` (and optionally ``locked``), not flat strings."""
+        status_body = {
+            "trunk": {"open": False, "locked": True},
+            "hood":  {"open": True},
+        }
+        client = self._client_with_url_routing("cupra", {"/v2/vehicles/": status_body})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000003"))
+
+        assert result.trunk_open is False
+        assert result.trunk_locked is True
+        assert result.hood_open is True
+
+    def test_v189_status_sunroof_in_windows_subtree(self):
+        """v1.8.9: pycupra reads sunroof from BOTH ``status.sunroof`` and
+        ``status.windows.sunroof`` because firmware varies."""
+        status_body = {"windows": {"sunroof": "open"}}
+        client = self._client_with_url_routing("cupra", {"/v2/vehicles/": status_body})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000004"))
+        assert result.sunroof_open is True
+
+    def test_v189_charging_shape_b_chargedPowerInKw_remaining_minutes(self):
+        """v1.8.9 / Issue tillsteinbach/CarConnectivity-connector-seatcupra#109:
+        OLA `/v1/vehicles/{vin}/charging` returns `chargedPowerInKw` (with
+        the extra "d") and `remainingTimeInMinutes` on current CUPRA Born
+        firmware. Pre-v1.8.9 only knew variants without the "d", so power
+        and ETA never populated."""
+        charging_body = {
+            "state": "charging",
+            "chargedPowerInKw": 11.0,
+            "remainingTimeInMinutes": 75,
+            "type": "AC",
+            "mode": "manual",
+        }
+        client = self._client_with_url_routing("cupra", {
+            "/v1/vehicles/": charging_body,  # routes both /charging/status and others
+        })
+        # Disambiguate URL routing — only /charging/status URLs match
+        # because the helper picks substring; charging/info, mileage etc.
+        # also contain "/v1/vehicles/". For this focused test we only
+        # care that the field is parsed when present, not that other
+        # endpoints stay untouched. Status endpoint also gets this body
+        # but won't write into door fields because there's no `doors` key.
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000006"))
+
+        assert result.charging_power_kw == 11.0, "chargedPowerInKw not parsed"
+        assert result.charge_complete_eta is not None, "remainingTimeInMinutes not used for ETA"
+        assert result.charging_state == "charging"
+        assert result.is_charging is True
+        assert result.charging_type == "AC"
+
+    def test_v189_charging_settings_targetSoc_pct_lowercase(self):
+        """v1.8.9 / Issue #109: charging/settings uses `targetSoc_pct`
+        (lowercase "soc") on current Born firmware, not `targetSOC_pct`."""
+        # Route /charging/info to body with the lowercase variant
+        client = self._client_with_url_routing("cupra", {
+            "/v1/vehicles/": {"targetSoc_pct": 80, "maxChargeCurrentAC": "maximum"},
+        })
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000007"))
+        assert result.target_soc == 80, "targetSoc_pct (lowercase) not parsed"
+
+    def test_v189_status_sunroof_top_level_camelCase(self):
+        """v1.8.9 / CC-seatcupra issue #5: ``sunRoof`` (camelCase with capital R)
+        is a top-level field on Seat Leon KL — verified live in #5
+        comments. Pre-v1.8.9 only checked ``status.sunroof`` (lowercase) and
+        ``status.windows.sunroof``, so Leon owners never saw the entity."""
+        status_body = {"sunRoof": "open"}
+        client = self._client_with_url_routing("cupra", {"/v2/vehicles/": status_body})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000008"))
+        assert result.sunroof_open is True
+
+    def test_v189_status_engine_on_implies_driving(self):
+        """v1.8.9 / CC-seatcupra #50 + #18: ``engine: 'on'`` is the only
+        reliable signal that the car is being driven — official ``vehicle.state``
+        often stays at "parked" (issue #18). When engine='on', set
+        ``is_driving=True`` AND ``vehicle_state="DRIVING"``."""
+        status_body = {"engine": "on"}
+        client = self._client_with_url_routing("cupra", {"/v2/vehicles/": status_body})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000009"))
+        assert result.is_driving is True
+        assert result.vehicle_state == "DRIVING"
+
+    def test_v189_status_engine_off_does_not_force_driving(self):
+        """v1.8.9: ``engine: 'off'`` must NOT force ``vehicle_state``;
+        coordinator decides between PARKED/CHARGING/OFFLINE elsewhere."""
+        status_body = {"engine": "off"}
+        client = self._client_with_url_routing("cupra", {"/v2/vehicles/": status_body})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000010"))
+        assert result.is_driving is False
+        # vehicle_state may be None (default) — important is we don't
+        # accidentally set it to "DRIVING".
+        assert result.vehicle_state != "DRIVING"
+
+    def test_v189_auto_unlock_permanent_is_truthy(self):
+        """v1.8.9 / CC-seatcupra issue #51: ``autoUnlockPlugWhenCharged``
+        can be ``"permanent"`` (always unlocked) in addition to "on"/"off".
+        Pre-v1.8.9 only checked exact "ON" and missed "permanent" → user
+        couldn't see the actual config."""
+        client = self._client_with_url_routing("cupra", {
+            "/v1/vehicles/": {
+                "targetSoc_pct": 80,
+                "autoUnlockPlugWhenCharged": "permanent",
+            },
+        })
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000011"))
+        assert result.auto_unlock_charge is True
+
+    def test_v189_climatisation_trigger_unsupported_is_inactive(self):
+        """v1.8.9 / CC-seatcupra issues #21 + #8: ``climatisationState`` can
+        return ``"unsupported"`` on older Born firmware. Must be treated as
+        inactive (climate off), not as an error or 'on'."""
+        # Route /v2/vehicles/...climatisation to a body with unsupported state
+        client = self._client_with_url_routing("cupra", {
+            "climatisation": {"status": {"climatisationState": "unsupported"}},
+        })
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000012"))
+        assert result.climatisation_active is False
+
+    def test_v189_status_legacy_flat_fallback_still_works(self):
+        """v1.8.9: defensive — if a (rare/older) firmware sends the
+        pre-v1.8.9 flat CARIAD-BFF-style fields, the legacy fallback
+        path still populates doors_individual."""
+        status_body = {
+            "access": {
+                "doorClosedLeftFront":  False,  # → frontLeft open
+                "doorClosedRightFront": True,   # → frontRight closed
+                "doorClosedLeftBack":   True,
+                "doorClosedRightBack":  True,
+                "doorsOpenedCount":     1,
+                "windowsOpenedCount":   0,
+                "trunk":                "OPEN",
+                "trunkStatus":          "LOCKED",
+                "hoodOpen":             False,
+            },
+        }
+        client = self._client_with_url_routing("cupra", {"/v2/vehicles/": status_body})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_status("VSSZZE1KZLR000005"))
+
+        # New-shape parsing produces nothing → legacy fallback fires
+        assert result.doors_individual == {
+            "frontLeft":  False,  # open
+            "frontRight": True,
+            "rearLeft":   True,
+            "rearRight":  True,
+        }
+        assert result.doors_open is True
+        assert result.windows_open is False
+        assert result.trunk_open is True
+        assert result.trunk_locked is True
+        assert result.hood_open is False
+
     def test_fetch_user_id(self):
         from custom_components.vag_connect.cariad.api.seat_cupra import SeatCupraClient
         from custom_components.vag_connect.cariad.models import TokenSet


### PR DESCRIPTION
## Zusammenfassung (Deutsch)

**Bug-Fix-Bündel** für Gerhards 19 fehlende Entities (CUPRA Born) und alle SEAT/CUPRA-Modelle. Pre-v1.8.9 las `/v2/vehicles/{vin}/status` mit CARIAD-BFF-typischen flachen Feldnamen die auf dem OLA-Backend **nicht existieren** → Tür-, Fenster-, Kofferraum-, Motorhauben-, Schiebedach-Entities permanent leer.

**Methodik (wichtig):** Field-Namen aus echten Live-API-Responses (verifiziert via `tillsteinbach/CarConnectivity-connector-seatcupra` Issues **#5, #8, #18, #21, #50, #51, #109**) stehen jetzt am Anfang der `v(...) or v(...)` Pfad-Listen. Alte geratene Pfade als defensiver Fallback. Auf Reviewer-Frage "woher wissen wir dass unser Code richtig ist" → wir wissen es jetzt aus echten Live-Responses, nicht aus Vermutungen.

### `seat_cupra.py` — `_parse_status` Status-Block

- **Per-Door** (pycupra-verifiziert): `status.doors.{frontLeft,...}.{locked,open}` → `doors_individual` + aggregates
- **Per-Window** (NEU): `status.windows.{frontLeft,...}` → `windows_individual` + aggregate
- **Trunk/Hood:** nested `{open, locked}` (nicht flat string)
- **Sunroof DREIFACH:** `status.sunRoof` (camelCase R, top-level — **#5**) || `status.sunroof` (pycupra) || `status.windows.sunroof`
- **Engine** (NEU): top-level `status.engine: "on"/"off"` (**#50, #18**) → `is_driving=True` + `vehicle_state="DRIVING"` wenn engine='on'. Behebt das verbreitete "vehicle_state immer parked"-Problem.
- Defensiver Fallback auf pre-v1.8.9 CARIAD-BFF-Pfade

### `seat_cupra.py` — Charging-Endpoint Live-Response Erkenntnisse

- **Pfad-Reihenfolge umgedreht** (methodisch korrekt): Rainer's verifizierte Felder zuerst
- `chargedPowerInKw` (mit "d") FIRST, `chargePowerInKw` als Fallback
- `remainingTimeInMinutes` / `remainingTime` FIRST, `remainingTimeToFullyChargedInMinutes` als Fallback
- `targetSoc_pct` (lowercase) FIRST, `targetSOC_pct` als Fallback
- `is_charging` case-insensitive
- `autoUnlockPlugWhenCharged: "permanent"` als 3. truthy-Wert (**#51**)

### `seat_cupra.py` — Climate (#8, #21)

- `climatisationState=="unsupported"` korrekt als inaktiv behandelt
- `targetTemperatureCelsius` (Rainer #109 ohne "In") als zusätzlicher Pfad

### `models.py` + `binary_sensor.py`

- Neues Field `windows_individual: dict[str, bool]`
- Neuer `VagWindowSensor` (per-window WINDOW device_class)

### Tests (12 neue in `TestSeatCupraGetStatus`)

5 status structure + 2 driving-state (engine) + 2 charging #109 + 1 #51 permanent + 1 #21 unsupported + 1 legacy fallback intakt.

## Summary (English)

Bug-fix bundle for Gerhard's 19 missing entities (CUPRA Born). Pre-v1.8.9 used CARIAD-BFF-style flat field names that don't exist on the OLA backend.

**Methodology:** real-world API field names (from CC-seatcupra issues #5, #8, #18, #21, #50, #51, #109) placed at the head of `v(...) or v(...)` chains. Old inferred paths kept as defensive fallback.

`seat_cupra.py` `_parse_status` — verified against pycupra source: per-door, per-window (NEW), nested trunk/hood, sunroof at THREE positions, engine top-level → DRIVING inference.

Charging endpoint #109 paths reordered — `chargedPowerInKw`, `remainingTimeInMinutes`, `targetSoc_pct` now FIRST. `auto_unlock_charge` recognises `"permanent"` (#51). Climate handles `"unsupported"` (#21).

`models.py` — new `windows_individual` field. `binary_sensor.py` — new `VagWindowSensor` per-window entity.

12 new tests covering both new structured paths and live-API findings.

## Test plan

- [ ] CI green: ruff, mypy strict, manifest, JSON, HACS, Hassfest, CHANGELOG
- [ ] 12 new tests pass
- [ ] Existing 11 smoke tests in `TestSeatCupraGetStatus` unchanged → pass
- [ ] Manual smoke: CUPRA Born integration loads, doors/windows/trunk show correct states
- [ ] Manual smoke: `engine='on'` → `vehicle_state="DRIVING"` updates correctly during a drive

## Bewusst NICHT enthalten / Deliberately NOT included (eigener Scope für v1.8.10+)

Aus dem Deep-Dive der CC-seatcupra Issues, alles was eigene Entities oder zusätzliche API-Calls braucht:

- **Capability-Filter (#64)** — `capability.active && capability.user-enabled` vor Entity-Creation prüfen. Sehr wahrscheinlich weiteres Stück für Gerhards 19 fehlende Entities, aber **Coordinator-Layer**-Change (nicht `seat_cupra.py`)
- **`/maintenance` Endpoint (#44)** — separater API-Call mit 4 neuen Sensoren
- **Multi-Zone Klima (#10, #109)** — eigene Switches
- **Battery Care Mode (#20, #51)** — eigene Switch + Number
- **`windowHeatingStatus[]` Array (#5, #8)** — strukturierter Array statt flat Pfade
- **`/ventilation` Service (#43)** — neuer HA-Service
- **Trip-Statistics (#22, MasterTim17 fork)** — v1.10.x
- **Departure-Timer Toggle (#70)** — v1.9.x
- **`carCapturedTimestamp`-Freshness** — v1.8.10 (Session 3S für Skoda)

## References (verified during multi-source audit + deep-dive of CC-seatcupra issues)

- `WulfgarW/pycupra/vehicle.py` (~Z. 3100-3325) — verified live status path mapping
- `tillsteinbach/CarConnectivity-connector-seatcupra` issues #5, #8, #18, #21, #50, #51, #109 — real-world API responses from CUPRA Born / Seat Leon KL
- `docs/AUDIT_2026-04-29.md` Section 2.2 — original hypothesis correction