### PR TITLE
docs: User-Data Handling + [Inference] markers (post-#53 third-party review)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+### 📋 Doc-only — User-Data Handling + `[Inference]` Marker (2026-04-30, no version bump)
+
+Nach Third-Party-Privacy-Review zu Issue #53 dokumentiert:
+
+- 🔒 **`docs/SESSION_HANDOFF.md`** neue "User-Data Handling" Sektion + 2 neue Hard Rules (#18 Privacy-by-default, #19 `[Inference]` Marker für unverifizierte semantische Claims)
+- 📝 **`CONTRIBUTING.md`** neue "Privacy & data handling" Sektion mit Fixture-Redaction-Template + Consent-Anfrage-Template + Maintainer-Self-Check
+- ⚠️ **`cariad/api/seat_cupra.py:command_flash`** Docstring mit explizitem `[Inference]` Marker — `userPosition` Semantik ist gegen offizielle My SEAT/CUPRA-App nicht verifiziert (verifiziert nur gegen pycupra/myskoda)
+- ⚠️ **`coordinator.py:async_flash_lights`** Cross-Reference auf den Inference-Marker
+
+Hintergrund: pre-1.11.1 wurden zwei inhaltliche Ungenauigkeiten in #53 / #56 Comments gemacht:
+1. Pauschale "subscription expired" Diagnose obwohl Gerhard's Vertrag aktiv ist
+2. Behauptung `userPosition` macht es "wie die offizielle MyCupra-App" ohne App-Traffic-Verifikation
+
+Folge-Comments auf #53 + #56 mit Korrektur kommen separat. Diese Doc-PR codifiziert die Lessons damit es nicht wieder passiert.
+
 ## [1.11.1] - 2026-04-30 🐛💨 Golf 7 GTE Fuel-Range Fix (#96) + Optimistic UI (3B-Part-3)
 
 🐛 **Bug-Fix #96 — Golf 7 GTE / Passat GTE Fuel-Range erscheint endlich:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,92 @@ already redact these by default — if you paste a raw HA log, double-check.
 
 ---
 
+## Privacy & data handling (added 2026-04-30 after #53 review)
+
+This section is binding for **maintainers** and PR reviewers. Even when
+a tester pastes their own VIN/GPS/tokens publicly in an issue body, the
+maintainer-side rules below still apply.
+
+### What goes in the repo / fixtures / commits
+
+- ✅ Anonymised payload shapes — VIN replaced with placeholder, tokens
+  removed, GPS rounded to 1 decimal (~11 km bucket)
+- ✅ Issue / PR cross-references that name the contributor by
+  GitHub handle (which is already public)
+- ❌ Full VINs (17 chars), even from the tester's own car
+- ❌ Access / refresh / id-tokens, S-PIN values
+- ❌ User-IDs (UUIDs), account-IDs, email addresses
+- ❌ Exact GPS coordinates (more than 1 decimal place)
+- ❌ Home / parking address, license plates
+- ❌ Screenshots with personal data, even if the tester posted them
+- ❌ Raw HA logs without redaction
+
+### Fixture redaction template
+
+When converting a real-world payload into a regression fixture, save
+under `tests/fixtures/{brand}/{model}_{year}_{situation}_redacted.json`
+with this shape:
+
+```json
+{
+  "brand": "cupra",
+  "model": "born",
+  "model_year": 2023,
+  "region": "DE",
+  "subscription": "active",
+  "vin": "REDACTED_VIN",
+  "userId": "REDACTED_UUID",
+  "tokens": "REDACTED",
+  "location": {
+    "latitude": 48.0,
+    "longitude": 11.0,
+    "redacted": true,
+    "note": "rounded to 1 decimal"
+  }
+}
+```
+
+### Asking a tester for fixture consent
+
+```markdown
+Danke {Name} — deine Logs/Screenshots helfen sehr.
+
+Dürfen wir daraus eine vollständig anonymisierte Testfixture für
+{Brand} {Modell} erstellen? Wir entfernen vorher: VIN, Tokens,
+Account-IDs, E-Mail, exakte GPS, sonstige persönliche Daten.
+
+Die Fixture würde nur dazu dienen, künftige Regressionen zu
+verhindern — keine Weiterverwendung in Marketing oder anderen Kontexten.
+```
+
+### Self-check before posting on user issues
+
+1. **Diagnose vs. Annahme:** habe ich Beweise oder rate ich? Pauschale
+   "Abo abgelaufen" als generische 403-Antwort ist nicht OK wenn der
+   Tester seinen aktiven Vertrag erwähnt hat.
+2. **Verifiziert vs. spekulativ:** behauptungen über offizielle App-
+   Verhalten brauchen captured-traffic-Beweise oder `[Inference]` Marker.
+3. **Daten-Hygiene:** zitiere ich VIN/Token/GPS aus dem Issue? →
+   maskieren oder weglassen, auch wenn der User es selbst gepostet hat.
+
+### `[Inference]` marker für Code
+
+Wenn ein Code-Pfad pragmatisch funktioniert (Server akzeptiert Payload,
+Tests grün), aber semantische Korrektheit gegen offizielle App-Logik
+nicht verifiziert ist, dokumentiere das im Docstring + Code-Comment:
+
+```python
+# ⚠️ [Inference] — semantische Interpretation NICHT verifiziert gegen
+# official-app traffic. Pragmatischer Fix der Server-Validation
+# besteht; ob das semantisch der App-Logik entspricht, ist offen.
+```
+
+Beispiel im Repo: `cariad/api/seat_cupra.py:command_flash` — der OLA-
+Endpoint akzeptiert `userPosition = vehicle position`, aber wir wissen
+nicht ob die offizielle My CUPRA-App das gleich oder über phone-GPS macht.
+
+---
+
 ## Pull requests
 
 ```bash

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -638,12 +638,29 @@ class SeatCupraClient(CariadBaseClient):
         returns HTTP 400 "internal-error". Mode must be lowercase "flash"
         (not "FLASH_ONLY"). Coordinates are truncated to 4 decimals (~11 m).
 
-        Despite the field name, OLA expects the **vehicle's** last-known
-        position, not the user's phone GPS. Verified against pycupra
-        `vehicle.set_honkandflash` (uses `findCarResponse` lat/lon) and the
-        myskoda equivalent (sends `PositionType.VEHICLE`). The name is a
-        misnomer in the OLA contract — the field acts as a server-side
-        sanity token bound to the car's known location.
+        ⚠️ **[Inference] — semantic interpretation NOT verified against
+        official My SEAT / My CUPRA app traffic.**
+
+        We send the **vehicle's** last-known position rather than the
+        user's phone GPS, because:
+
+        - **Verified**: pycupra `vehicle.set_honkandflash` reads
+          `findCarResponse.lat/lon` (vehicle position).
+        - **Verified**: myskoda equivalent sends `PositionType.VEHICLE`.
+        - **NOT verified**: whether the official My SEAT/CUPRA mobile
+          apps populate the field from phone GPS or from the cached
+          last-known vehicle position. We have NOT captured app traffic
+          to confirm.
+
+        Pragmatically the OLA endpoint accepts vehicle coordinates
+        (verified live across multiple users on #53). The field name
+        ``userPosition`` is likely a misnomer in the OLA contract — it
+        appears to act as a server-side sanity token bound to *some*
+        recent location. If a future capture of My SEAT/CUPRA app
+        traffic shows it actually wants phone GPS, this needs revisiting.
+
+        Status: **WORKING** for OLA endpoint, **INFERENCE** for
+        semantic mapping to the official apps.
         """
         if latitude is None or longitude is None:
             raise APIError(

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1061,6 +1061,16 @@ class VagConnectCoordinator(DataUpdateCoordinator):
     async def async_flash_lights(self, vin: str) -> None:
         # SEAT/CUPRA require the user position in the honk-and-flash payload
         # (HTTP 400 otherwise). Other brands accept and ignore it.
+        #
+        # ⚠️ [Inference] We pass the **vehicle's** last-known position
+        # (cached from the most recent status poll) into the OLA
+        # ``userPosition`` field. This is verified to work on the OLA
+        # endpoint and matches the pycupra/myskoda implementations.
+        # It is NOT verified that the official My SEAT / My CUPRA mobile
+        # apps populate this field the same way (they may use phone GPS
+        # instead). See ``cariad/api/seat_cupra.py:command_flash`` for
+        # the full caveat. Pragmatic fix that passes server validation
+        # — semantic correctness against the official apps is unverified.
         vehicle = self.vehicles.get(vin, {})
         await self._cariad_cmd(
             vin,

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -211,6 +211,88 @@ custom_components/vag_connect/
 15. **Do not endpoint-guess for PPC/PPE** — wait for upstream (audi_connect_ha, acfischer42/CC-audi, tillsteinbach SeatCupra #49) before any blind requests against E³ 1.2 backends. Risks Audi account suspension.
 16. **CI explicit-check before merge** — `gh pr checks <num>` must show 0 non-SUCCESS conclusions. Don't trust `--watch` exit codes alone (lesson from v1.8.9 ship-with-failing-test).
 17. **Doc-only PRs without code change** — no manifest bump, but CHANGELOG.md change still triggers `changelog_check.yml` (since v1.8.12 workflow extension).
+18. **User-data privacy by default** — see "User-Data Handling" section below. Even when a tester pastes their VIN/GPS/tokens publicly in an issue, do NOT pull them into the repo, fixtures, or maintainer comments unredacted. Anonymise first, ask for explicit fixture consent, document the source.
+19. **`[Inference]` markers for unverified semantic claims** — when we choose a pragmatic implementation that passes server validation but isn't verified against official-app traffic, label it `[Inference]` in code comments + docstrings. The OLA `userPosition` field for SEAT/CUPRA honk-and-flash is the canonical example (vehicle position works, but whether the official My SEAT/My CUPRA app uses phone GPS is not verified).
+
+---
+
+## User-Data Handling (added after #53 third-party privacy review)
+
+When a community tester (Facebook group, GitHub issue, forum) shares debug data, follow this hierarchy:
+
+### What is OK to use
+
+- ✅ **Diagnose im Issue-Thread** — read VIN, logs, screenshots to identify root cause, payload, endpoint, capability, entity behaviour
+- ✅ **Code-Entscheidungen ableiten** — "CUPRA Born needs OLA payload + lowercase enum" is fine to deduce
+- ✅ **Anonymisierte Fixtures** — only after redaction (see below) AND ideally with explicit user consent
+
+### What is NOT OK
+
+- ❌ Vollständige VIN in Repo / Fixtures / Docs / Commits / Comments
+- ❌ Access-Tokens, Refresh-Tokens, JWTs, S-PIN
+- ❌ User-ID / Account-ID
+- ❌ E-Mail-Adresse
+- ❌ Exakte GPS-Koordinaten (>1 Dezimalstelle)
+- ❌ Heimat- / Parkadresse
+- ❌ Kennzeichen
+- ❌ Screenshots mit persönlichen Daten ungescrubbed
+- ❌ Vollständige Rohlogs ohne Redaction
+
+### Fixture redaction template
+
+When converting a tester's payload into a regression fixture:
+
+```json
+{
+  "brand": "cupra",
+  "model": "born",
+  "model_year": 2023,
+  "region": "DE",
+  "subscription": "active",
+  "vin": "REDACTED_VIN_LAST6_e.g.012345",
+  "userId": "REDACTED_UUID",
+  "tokens": "REDACTED",
+  "location": {
+    "latitude": 48.0,
+    "longitude": 11.0,
+    "redacted": true,
+    "note": "rounded to 1 decimal (~11 km bucket)"
+  },
+  "capabilities": {
+    "honk_and_flash": "missing-capability",
+    "wake": "missing-capability"
+  }
+}
+```
+
+Save under `tests/fixtures/{brand}/{model}_{year}_{situation}_redacted.json`.
+
+### Asking for fixture consent
+
+Use this template when proposing to convert a tester's data into a fixture:
+
+```markdown
+Danke {Name} — deine Logs/Screenshots helfen uns sehr.
+
+Dürfen wir daraus eine vollständig anonymisierte Testfixture für {Brand} {Modell} erstellen?
+Wir entfernen vorher: VIN, Tokens, Account-IDs, E-Mail, exakte GPS, sonstige persönliche Daten.
+
+Die Fixture würde nur dazu dienen, künftige {Brand}-{Modell}-Regressionen automatisch zu testen — keine Weiterverwendung in Marketing oder anderen Kontexten.
+```
+
+### Maintainer self-check before commenting on a user issue
+
+Before posting a diagnostic comment on a user-reported issue, verify:
+
+1. **Diagnose-Hypothese vs. Fakten:** habe ich tatsächlich Beweise für meine Vermutung, oder ist das eine pauschale Annahme? (Beispiel-Fail: pre-1.11.1 wurde `subscription_expired` als generische 403-Erklärung gepostet, obwohl Gerhard's Vertrag aktiv war — siehe #53.)
+2. **Verifiziert vs. spekulativ:** wenn ich eine Verhaltensbeschreibung mache ("die offizielle App macht es so"), habe ich App-Traffic captured? Sonst → `[Inference]` markieren oder weglassen.
+3. **Daten-Hygiene:** zitiere ich VIN / Token / GPS aus dem Issue-Body? Falls ja → maskieren oder weglassen, auch wenn der User es selbst geschrieben hat.
+
+### Why these rules
+
+- HACS / HA Community: Vertrauen kommt von Privacy-by-default. Tester teilen mehr, wenn sie sehen dass mit ihren Daten sauber umgegangen wird.
+- GitHub Issues sind public + permanent. Was du heute zitierst, ist auch in 5 Jahren noch indexiert.
+- Hard Rule #8 (no speculation) gilt auch für User-Communication, nicht nur Code.
 
 ---
 


### PR DESCRIPTION
## Summary

Doc-only PR nach unabhängiger Third-Party-Analyse der #53-Bearbeitung. Codifies die zwei strukturellen Lessons damit die gleichen Fehler nicht wieder passieren.

## Was war suboptimal in #53 / #56 Comments

1. **Pauschale "subscription_expired" Diagnose** in Maintainer-Comments — bei Gerhard inhaltlich falsch (sein CUPRA-Connect-Vertrag ist aktiv). Code (`classify_command_failure` body sniffing) ist technisch korrekt, aber die Maintainer-Comments waren zu pauschal in der Diagnose-Hypothese.
2. **"userPosition wie offizielle MyCupra-App"** behauptet ohne App-Traffic-Verifikation. Pragmatisch akzeptiert OLA die Vehicle-Position, aber semantisch ist nicht verifiziert ob die offizielle App Phone-GPS oder Vehicle-GPS sendet.

## Was diese PR ändert

**Code-Comments only — keine Logik-Änderung:**
- `cariad/api/seat_cupra.py:command_flash` Docstring strukturiert mit explizitem `[Inference]` Marker
- `coordinator.py:async_flash_lights` Cross-Reference auf den Marker

**Neue Doku-Sections:**
- `docs/SESSION_HANDOFF.md` Hard Rule #18 (Privacy-by-default) + Hard Rule #19 (`[Inference]` Marker) + neue "User-Data Handling" Sektion
- `CONTRIBUTING.md` neue "Privacy & data handling" Sektion mit Fixture-Template + Consent-Template + Maintainer-Self-Check

## Was diese PR NICHT macht

- Keine Code-Pfad-Änderung — alle Tests laufen unverändert
- Keine retroaktive Comment-Löschung auf #53 / #56 (folgt als separate Aktion: neue Korrektur-Comments)
- Keine User-Daten-Manipulation
- Kein Manifest-Bump (Doc-only)

## Test plan

- [x] CHANGELOG `[Unreleased]` Eintrag hinzugefügt → `changelog_check.yml` läuft grün
- [x] Keine Code-Tests beeinflusst (nur Docstrings + Comments)
- [x] Lint / Hassfest / HACS unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)