### PR TITLE
fix(v1.12.2): #107 Skoda Scout paths — first community Scout report (tritanium73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,40 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.12.2] - 2026-05-01 🌟🛰️ Erstes Community-Scout-Report (Skoda #107 von tritanium73)
+
+🌟 **Erste Live-Validation der v1.9.0 Reporter Pipeline durch einen Nicht-Maintainer-User!**
+
+User `tritanium73` hat heute einen Vehicle Data Scout Report für seine Skoda gefiltet (#107). 14 neue Felder über 4 mysmob-Endpoints — die volle 1-Klick Pipeline aus v1.9.0 funktioniert in der Wildbahn:
+
+1. Scout erkennt Drift bei Poll
+2. HA Repair-Notification erscheint bei tritanium73
+3. Klick auf "Mehr erfahren" → pre-filled GitHub Issue
+4. tritanium73 reicht das ein → wir fixen → 1.12.2 Release
+
+Genau dafür wurde v1.9.0 gebaut. **Riesigen Dank an tritanium73 für den ersten Community-Beitrag in dieser Form** 🙏
+
+🛰️ **EXPECTED_KEYS Registrierungen** (`cariad/_unexpected_keys.py`, alle skoda-only — SEAT/CUPRA und VW EU/Audi nicht betroffen):
+
+| Endpoint | Neue Pfade |
+|---|---|
+| `vehicle-status` | `renders.lightMode` + `renders.darkMode` (waren via 3-Segment-Wildcard nicht matched — Bug aus v1.9.1 catalog) |
+| `air-conditioning` | `runningRequests`, `steeringWheelPosition`, `windowHeatingState.unspecified`, `timers`, `outsideTemperature`, `errors` |
+| `driving-range` | `carType`, `primaryEngineRange` |
+| `maintenance` | `maintenanceReport.capturedAt`, `preferredServicePartner`, `predictiveMaintenance`, `customerService` |
+
+`carType` + `primaryEngineRange` sind besonders interessant — wahrscheinlich die mysmob-Variante zu CARIAD-BFFs `fuelStatus.rangeStatus.value.primaryEngine` aus v1.10.0. Wiring als Range-Source kommt in v1.13.0+ wenn wir verifizierte Live-Response-Shape sehen.
+
+🧪 **Tests:** 6 neue in `tests/test_v1122_107_skoda_scout.py` — verifizieren dass alle 14 Pfade jetzt registriert sind, plus Defensive-Test dass SEAT/CUPRA nicht versehentlich von der Skoda-Registrierung beeinflusst werden.
+
+📊 **Bonus-Audit aus Diagnostics-Datei (Audi 2 Vehicles, Prash):**
+
+- 4 unexpected findings sind bereits durch v1.12.1 registriert → silenced beim nächsten Poll ✅
+- 2 Error-Reporter Findings sind transiente 502 Bad Gateway → v1.8.7 retry-mechanism funktioniert wie designed (Backend war kurz down). Kein Code-Change nötig — same Pattern wie #108.
+
+**Closes:** #107.
+**Acknowledges:** #108 (transient 502, no fix needed — system working as designed).
+
 ## [1.12.1] - 2026-04-30 🛰️📚 Scout-Pfade #105/#106 + Gerhard's Born Fixture + FAQ #47
 
 🛰️ **Vehicle Data Scout Welle 4** (#105 VW EU 12 Felder + #106 Audi 8 Felder):

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -83,7 +83,13 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "overall.reliableLockStatus",
             "detail", "detail.sunroof", "detail.trunk", "detail.bonnet",
             "carCapturedTimestamp",
-            "renders", "renders.lightMode.*", "renders.darkMode.*",
+            # v1.12.2 (#107 — tritanium73's Skoda live test 2026-05-01,
+            # FIRST community Scout report from a non-maintainer!).
+            # The wildcards ``renders.lightMode.*`` only match 3-segment
+            # paths; the Scout reported ``renders.lightMode`` (2 segments)
+            # so the parent itself needs explicit registration too.
+            "renders", "renders.lightMode", "renders.lightMode.*",
+            "renders.darkMode", "renders.darkMode.*",
             "compositeRenders", "compositeRenders.*",
             "engine",
         },
@@ -106,6 +112,18 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "windowHeatingState", "windowHeatingState.front", "windowHeatingState.rear",
             "chargerConnectionState", "chargerLockState",
             "carCapturedTimestamp",
+            # v1.12.2 (#107 — tritanium73's Skoda 2026-05-01 Live-Test).
+            # Newer mysmob air-conditioning response includes additional
+            # status meta: list of in-flight requests, steering-wheel
+            # position (LEFT/RIGHT), windowHeatingState.unspecified
+            # (when state is INVALID), departure timer list, outside
+            # temperature block, and an errors[] array.
+            "runningRequests",
+            "steeringWheelPosition",
+            "windowHeatingState.unspecified",
+            "timers",
+            "outsideTemperature",
+            "errors",
         },
         "parking": {
             "parkingPosition", "parkingPosition.gpsCoordinates",
@@ -118,6 +136,15 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "totalRangeInKm", "electricRange", "electricRange.distanceInKm",
             "combustionRange", "adBlueRange", "adBlueRange.distanceInKm",
             "carCapturedTimestamp",
+            # v1.12.2 (#107) — Skoda mysmob now also publishes the
+            # high-level ``carType`` ("diesel"/"gasoline"/"electric"/
+            # "hybrid") at the top level + a ``primaryEngineRange``
+            # block (4 keys, similar to fuelStatus.primaryEngine on
+            # CARIAD-BFF). Registering silences the Scout — actually
+            # wiring these as fallback range sources is a v1.13.0+
+            # feature once we have a verified live response.
+            "carType",
+            "primaryEngineRange",
         },
         "maintenance": {
             "maintenanceReport", "maintenanceReport.mileageInKm",
@@ -126,6 +153,12 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "maintenanceReport.oilServiceDueInKm",
             "maintenanceReport.oilServiceDueInDays",
             "carCapturedTimestamp",
+            # v1.12.2 (#107) — Skoda mysmob v3 maintenance endpoint
+            # includes meta blocks alongside the report itself.
+            "maintenanceReport.capturedAt",
+            "preferredServicePartner",
+            "predictiveMaintenance",
+            "customerService",
         },
         "readiness": {
             "unreachable", "inMotion", "carCapturedTimestamp",

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.12.1"
+  "version": "1.12.2"
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,8 +5,9 @@
 > mirrors it for archive/historical purposes and links the active GitHub
 > issues for each session.
 
-**Last updated:** 2026-04-30 — post v1.12.1 (Scout-Pfade #105/#106 +
-Gerhard's Born Fixture mit consent + #47 FAQ). Komplette P0/P1/P2/P3
+**Last updated:** 2026-05-01 — post v1.12.2 (erstes Community-Scout-
+Report von tritanium73 für Skoda #107, Live-Validation der v1.9.0
+Pipeline durch Nicht-Maintainer-User). Komplette P0/P1/P2/P3
 Priorisierung in der "Sessioned Roadmap" Sektion unten.
 
 ---
@@ -50,6 +51,7 @@ Priorisierung in der "Sessioned Roadmap" Sektion unten.
 | **v1.11.1** | 🐛💨 **Golf 7 GTE Fuel-Range Fix (#96) + Optimistic UI (3B-Part-3)** — #96: VW Golf 7 GTE 2015 + Passat GTE B7/B8 zeigen endlich `fuel_level`/`combustion_range_km`/`total_range_km`. Root cause: `fuelStatus.rangeStatus = {error}` ließ Drivetrain-Detection False. Fix: 4 zusätzliche Pfade (`measurements.fuelLevelStatus.value.{primaryEngineType,secondaryEngineType}` + `carType="hybrid"` Substring) + `measurements.rangeStatus.value.totalRange_km` Fallback + engine-block `currentFuelLevel_pct` Fallback. Verifiziert via evcc-io/evcc#19045 + Audi Q4 + CarConnectivity Logs. 3B-Part-3: Optimistic UI (myskoda PR #832) — Lock/Climate/Charging/Window-Heating-Switches flippen sofort, revertieren bei Failure. (18 neue Tests) | **2026-04-30** |
 | **v1.12.0** | 🔋💡⚡🧯🔒 **5-in-1 Feature-Sprint** — Issue #23 (12V Voltage-Sensor + Low-Warnung bei <11.5V via lvBattery job), #91 Welle 3 (Per-Light Binary-Sensors aus `lights_individual` dict), #91 follow-up (writeable Max-Charge-Current Number + neuer `command_set_max_charge_current` Command), #55 (Smart-Wake Counter + Soft-Cap auf 3/Tag + UTC-midnight reset), #63 Phase 1 (Read-only Mode Option — skip lock/switch/button(non-refresh)/climate/number platforms; refresh-button bleibt). 8 Sprachen. (~25 neue Tests) | **2026-04-30** |
 | **v1.12.1** | 🛰️📚 **Scout-Pfade #105/#106 + Gerhard's Born Fixture (#53 consent) + #47 FAQ** — Welle 4 EXPECTED_KEYS Wildcards für `.error.*` + explizite `.value` Container. Erste Live-Validation des Privacy-Workflows aus PR #101: Gerhard hat Consent für Fixture gegeben, komplett redacted nach Hard Rule #18 + 7 Privacy-Audit-Tests. 6 Round-Trip-Tests verifizieren dass v1.10.2 Parser-Pfade aus der Fixture die Werte produzieren die Gerhard live sah. #47 FAQ-Sektion in CONTRIBUTING.md mit Subscription-vs-missing-capability-vs-spin-Diagnose-Tabelle. (19 neue Tests) | **2026-04-30** |
+| **v1.12.2** | 🌟🛰️ **Erstes Community-Scout-Report (Skoda #107 von tritanium73)** — User `tritanium73` reichte am 2026-05-01 den ersten Vehicle Data Scout Report von einem Nicht-Maintainer ein. 14 neue Skoda mysmob Pfade über 4 Endpoints (`renders.{lightMode,darkMode}` 2-segment fix, 6× `air-conditioning`, 2× `driving-range` mit `carType`+`primaryEngineRange`, 4× `maintenance` meta-blocks). Volle v1.9.0 Pipeline funktioniert in der Wildbahn. (6 neue Tests) | **2026-05-01** |
 
 **Sprint summary 2026-04-29:** 7 releases, ~50 new tests, branch
 protection activated, CHANGELOG split into human + technical, 4 parallel

--- a/tests/test_v1122_107_skoda_scout.py
+++ b/tests/test_v1122_107_skoda_scout.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""Tests for v1.12.2 — #107 Skoda Scout coverage (tritanium73's report).
+
+First community Scout report from a non-maintainer (tritanium73 on
+2026-05-01). 14 new paths reported across 4 endpoints. v1.12.2
+registers them in EXPECTED_KEYS["skoda"] so the Scout stops firing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestSkodaScout107:
+    def test_renders_lightmode_darkmode_registered_at_two_segments(self):
+        """v1.12.2 (#107) — wildcards `renders.lightMode.*` only matched
+        3-segment paths; tritanium73's report shows 2-segment
+        `renders.lightMode` was unmatched. Now both registered."""
+        from custom_components.vag_connect.cariad._unexpected_keys import (
+            EXPECTED_KEYS, _path_matches,
+        )
+        keys = EXPECTED_KEYS["skoda"]["vehicle-status"]
+        for path in ("renders.lightMode", "renders.darkMode"):
+            assert _path_matches(path, keys), f"missing: {path}"
+        # Wildcards still work for 3-segment children
+        assert _path_matches("renders.lightMode.MAIN_VIEW", keys)
+
+    def test_air_conditioning_six_new_paths(self):
+        from custom_components.vag_connect.cariad._unexpected_keys import (
+            EXPECTED_KEYS, _path_matches,
+        )
+        keys = EXPECTED_KEYS["skoda"]["air-conditioning"]
+        for path in (
+            "runningRequests",
+            "steeringWheelPosition",
+            "windowHeatingState.unspecified",
+            "timers",
+            "outsideTemperature",
+            "errors",
+        ):
+            assert _path_matches(path, keys), f"missing: {path}"
+
+    def test_driving_range_carType_and_primaryEngineRange(self):
+        from custom_components.vag_connect.cariad._unexpected_keys import (
+            EXPECTED_KEYS, _path_matches,
+        )
+        keys = EXPECTED_KEYS["skoda"]["driving-range"]
+        assert _path_matches("carType", keys)
+        assert _path_matches("primaryEngineRange", keys)
+
+    def test_maintenance_four_new_meta_blocks(self):
+        from custom_components.vag_connect.cariad._unexpected_keys import (
+            EXPECTED_KEYS, _path_matches,
+        )
+        keys = EXPECTED_KEYS["skoda"]["maintenance"]
+        for path in (
+            "maintenanceReport.capturedAt",
+            "preferredServicePartner",
+            "predictiveMaintenance",
+            "customerService",
+        ):
+            assert _path_matches(path, keys), f"missing: {path}"
+
+    def test_full_107_payload_silent(self):
+        """Replay verbatim Scout findings from #107. All 14 paths must
+        classify as expected — Scout returns empty per endpoint."""
+        from custom_components.vag_connect.cariad._unexpected_keys import (
+            detect_unexpected,
+        )
+
+        # vehicle-status — renders block
+        vs = {
+            "renders": {"lightMode": {}, "darkMode": {}},
+        }
+        assert list(detect_unexpected("skoda", "vehicle-status", vs)) == []
+
+        # air-conditioning — 6 new paths (use empty containers / scalars)
+        ac = {
+            "runningRequests": [],
+            "steeringWheelPosition": "LEFT",
+            "windowHeatingState": {"unspecified": "INVALID"},
+            "timers": [],
+            "outsideTemperature": {},
+            "errors": [],
+        }
+        assert list(detect_unexpected("skoda", "air-conditioning", ac)) == []
+
+        # driving-range — 2 new paths
+        dr = {"carType": "diesel", "primaryEngineRange": {}}
+        assert list(detect_unexpected("skoda", "driving-range", dr)) == []
+
+        # maintenance — 4 new paths
+        m = {
+            "maintenanceReport": {"capturedAt": "2026-04-30T17:10:52Z"},
+            "preferredServicePartner": {},
+            "predictiveMaintenance": {},
+            "customerService": {},
+        }
+        assert list(detect_unexpected("skoda", "maintenance", m)) == []
+
+    def test_seat_cupra_inheritance_NOT_affected(self):
+        """Defensive: SEAT/CUPRA share OLA endpoints, NOT Skoda's
+        mysmob endpoints. The new ``vehicle-status``/``air-conditioning``/
+        ``driving-range``/``maintenance`` registrations stay
+        Skoda-only."""
+        from custom_components.vag_connect.cariad._unexpected_keys import (
+            EXPECTED_KEYS,
+        )
+        # SEAT/CUPRA endpoints don't include any of these names
+        cupra_endpoints = set(EXPECTED_KEYS["cupra"].keys())
+        assert "vehicle-status" not in cupra_endpoints
+        assert "driving-range" not in cupra_endpoints
+        assert "maintenance" not in cupra_endpoints


### PR DESCRIPTION
## Summary

🌟 **Erste Live-Validation der v1.9.0 Reporter Pipeline durch einen Nicht-Maintainer-Community-User!**

User \`tritanium73\` reichte am 2026-05-01 den ersten Vehicle Data Scout Report (#107) für seine Skoda ein — die volle 1-Klick-Pipeline (Scout → Repair-Notification → pre-filled GitHub Issue → Maintainer-Fix) hat in der Wildbahn funktioniert.

Genau dafür wurde v1.9.0 gebaut.

## Closes #107 — 14 neue Skoda mysmob Pfade

| Endpoint | Neue Pfade |
|---|---|
| \`vehicle-status\` | \`renders.lightMode\` + \`renders.darkMode\` (2-segment fix für v1.9.1 wildcard-only registry) |
| \`air-conditioning\` | \`runningRequests\`, \`steeringWheelPosition\`, \`windowHeatingState.unspecified\`, \`timers\`, \`outsideTemperature\`, \`errors\` |
| \`driving-range\` | \`carType\`, \`primaryEngineRange\` |
| \`maintenance\` | \`maintenanceReport.capturedAt\`, \`preferredServicePartner\`, \`predictiveMaintenance\`, \`customerService\` |

\`carType\` + \`primaryEngineRange\` sind besonders interessant — wahrscheinlich die mysmob-Variante zu CARIAD-BFFs \`fuelStatus.rangeStatus.value.primaryEngine\` aus v1.10.0. Wiring als Range-Source kommt in v1.13.0+ wenn wir verifizierte Live-Response-Shape sehen.

## Bonus-Audit aus User-Diagnostics-Datei

Audi-User mit 2 Vehicles hat Diagnostics gepostet:
- 4 unexpected findings sind bereits durch v1.12.1 silenced (`.value` Container) → next poll cleanup ✅
- 2 Error-Reporter Findings (502 Bad Gateway × 2 VINs) — v1.8.7 retry mechanism handled sie. Same pattern wie #108 — system working as designed, no code change.

## Test plan

- [x] 6 neue Tests in \`tests/test_v1122_107_skoda_scout.py\`
- [x] Defensive Test: SEAT/CUPRA inheritance NOT affected
- [x] Verbatim #107 payload via detect_unexpected returnt empty
- [x] manifest 1.12.1 → 1.12.2 (PATCH)
- [x] CI 5/5 expected

## Acknowledges #108

Transient 502 Bad Gateway, retry mechanism (v1.8.7) handled it correctly. Kein Code-Change. Werde im Issue dazu kommentieren dass das die designte Behaviour ist — Error Reporter ist gewollt explizit (jeder echte Failure, auch wenn retry-recovered, wird logged für Pattern-Awareness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)