### PR TITLE
docs: refresh all 8 READMEs to v1.12.3 + bi-lingual title convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Alle wesentlichen Änderungen werden hier dokumentiert.
 Format: [Keep a Changelog 1.0.0](https://keepachangelog.com/de/1.0.0/)  
 Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
+> 📖 **Bi-lingual title convention (ab v1.12.3 / since v1.12.3):** Section-Titles sind **DE / EN** geteilt durch ` / `. Body-Inhalt bleibt auf Deutsch (Audience ist primär die deutschsprachige VAG-HA-Community + DACH FB-Gruppen). Übersetzungen einzelner Body-Texte gibt es bei Bedarf via [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — dort wird das gleiche Pattern angewendet.
+
+## [Unreleased]
+
+### 📚 Documentation refresh / Doc-only refresh (2026-05-01, no version bump)
+
+- 🆕 **GitHub About-Section** auf v1.12.3-Stand aktualisiert (war veraltet auf "68 entities, cloud push") + 2 neue Topics (`vehicle-data-scout`, `phev`)
+- 🔄 **Master DE README + 7 Sprachen** "Aktueller Stand & ehrliche Limits" Sektion komplett refresht von v1.8.12 auf v1.12.3 — alle 12 LIVE-Features (Vehicle Data Scout, 12V, Optimistic UI, PHEV-Range-Triple, Read-only, etc.) + planned v1.13.0–v2.0.0 Sessions documented
+- 🔄 **Roadmap-Sektion in allen 8 READMEs** vereinfacht auf "Single Source of Truth" Pointer + Tabelle der letzten 9 Releases + nächste 5 Sessions
+- 📖 **Bi-lingual Title Convention** etabliert ab v1.12.3: Section-Titles `DE / EN`, Body bleibt deutsch
+- 📜 `docs/CHANGELOG_TECHNICAL.md` v1.12.2 + v1.12.3 entries nachgereicht (waren für die jeweiligen Releases vorhanden, hier dokumentiert)
+
 ## Semver-Regeln für dieses Projekt (pre-1.0.0)
 
 | Was | Version | Beispiel |
@@ -28,7 +40,7 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
-## [1.12.3] - 2026-05-01 🛰️ Scout-Pfade #111 (DnnsJp74) + #113 (Golf GTE) + #114 (Audi S6)
+## [1.12.3] - 2026-05-01 🛰️ Scout-Pfade #111 + #113 + #114 / Scout paths bundled with wildcard strategy
 
 🌟 **Drei Scout-Reports zusammen ausgeliefert.** #111 von DnnsJp74 (zweiter Community-User), plus #113+#114 von Prash auf seinen eigenen Vehicles (Golf GTE 14 Felder + Audi S6 C8 20 Felder) — alle drei zeigen denselben Pattern: `.value` Container haben Children die wir whack-a-mole jagen würden, wenn nicht Wildcards eingesetzt werden.
 
@@ -68,7 +80,7 @@ Plus alle 23 #111 paths unverändert eingeschlossen.
 
 **Closes:** #111, #113, #114.
 
-## [1.12.2] - 2026-05-01 🌟🛰️ Erstes Community-Scout-Report (Skoda #107 von tritanium73)
+## [1.12.2] - 2026-05-01 🌟🛰️ Erstes Community-Scout-Report (Skoda #107 von tritanium73) / First community Scout report
 
 🌟 **Erste Live-Validation der v1.9.0 Reporter Pipeline durch einen Nicht-Maintainer-User!**
 
@@ -102,7 +114,7 @@ Genau dafür wurde v1.9.0 gebaut. **Riesigen Dank an tritanium73 für den ersten
 **Closes:** #107.
 **Acknowledges:** #108 (transient 502, no fix needed — system working as designed).
 
-## [1.12.1] - 2026-04-30 🛰️📚 Scout-Pfade #105/#106 + Gerhard's Born Fixture + FAQ #47
+## [1.12.1] - 2026-04-30 🛰️📚 Scout-Pfade #105/#106 + Gerhard's Born Fixture + FAQ #47 / Scout paths + Born fixture + Subscription FAQ
 
 🛰️ **Vehicle Data Scout Welle 4** (#105 VW EU 12 Felder + #106 Audi 8 Felder):
 
@@ -144,7 +156,7 @@ Tabelle mit allen v1.9.1 `classify_command_failure` Markern + ihre Bedeutung. Ve
 
 **Closes:** #105, #106, #47.
 
-## [1.12.0] - 2026-04-30 🔋💡⚡🧯🔒 5-in-1 Feature-Sprint
+## [1.12.0] - 2026-04-30 🔋💡⚡🧯🔒 5-in-1 Feature-Sprint / Five features in one MINOR
 
 ✨ **Fünf neue Funktionen — alle in einer kohärenten "More Control + Diagnostics"-Theme:**
 

--- a/README.cs.md
+++ b/README.cs.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
@@ -38,60 +38,95 @@ Od v0.14.1 integrace **přímo** komunikuje s CARIAD API — vlastní async klie
 
 > ✅ **Aktivně udržovaný multi-značkový nástupce** projektů [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivováno 2025-10-29) a [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). Jedna integrace pro Audi, VW, Škoda, SEAT, CUPRA, Porsche a VW US/CA — bez samostatného pluginu pro každou značku.
 
-## Aktuální stav a upřímné limity (v1.8.12)
+## Aktuální stav a upřímné limity / Current Status & Honest Limits (v1.12.3)
+
+VAG Connect se aktivně vyvíjí. Abys věděl, co funguje a co přijde:
 
 ### ✅ Co funguje TEĎ (všech 7 značek)
 
-- 🟢🟡⚫ **Multi-Brand Connection-State sensor** — online / standby / offline pro všechny značky (v1.8.12).
-- 🛡️ **Defenzivní stabilita** — retry 504, retry přechodných síťových chyb, 6h stale-cache + tolerance 3 selhání (v1.8.7).
-- 🔓 **Příkazy Lock / Climate / Charging** pro Audi 2024+ a VW Passat 2025 — 10 příkazů s fallback CARIAD `/v1/` ↔ `/v2/` (v1.8.5 + v1.8.8).
-- 🚪 **CUPRA / SEAT kompletní entity** s ověřenými OLA JSON cestami + binary sensors na okno (v1.8.9).
-- 🚙 **Škoda** `detail` block + `reliableLockStatus` + `fullyChargedAt` (v1.8.11).
+**🛰️ Bug reporty a žádosti o funkce 1 kliknutím (LIVE od v1.9.0)**
 
-### 🔬 Brzy: Bug reporty 1 kliknutím & žádosti o funkce (v1.9.0)
+Dva diagnostické sensory se sdílenou reporter pipeline — **první skutečná live-validace komunitními uživateli** v v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) a v1.12.3 (DnnsJp74 / Audi):
 
-> **Pomáháš nám zlepšovat integraci — bez učení jediného slova GitHubu nebo Markdown.**
+- 🔬 **Vehicle Data Scout** — automaticky detekuje neznámá JSON pole v API tvého auta. Lokalizovaný per značku v 8 jazycích (DE: API-Beobachter, FR: Observateur d'API, etc.).
+- 🚨 **Error Reporter** — Ring-buffer posledních 20 chyb integrace s anonymizovaným kontextem (model, firmware, stack trace).
+- 🔘 **Reporter Pipeline:** oba sensory automaticky vytvářejí HA Repair notifikace s předvyplněným GitHub-Issue jako 1-klik linkem. Plus diagnostics-download se vším maskovaným pro fórum/Facebook.
+- 🔒 **Slib soukromí:** Nic neopustí tvou HA bez tvého explicitního kliknutí. VINy maskovány, GPS zaokrouhlené na 1 desetinné místo, JWT/UUID/e-maily odstraněny. GDPR-compliant.
 
-Dva nové diagnostické sensory v v1.9.0:
+**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
 
-| Sensor | Co dělá | Jak ti pomáhá |
-|---|---|---|
-| 🔬 **Detektor nových dat** | Automaticky detekuje nová pole v API tvého auta která ještě nezpracováváme | Pokud tvoje Audi A4 2017 nebo VW Golf 7 GTE vrací neznámá pole → přidáme je v další verzi |
-| 🛠️ **Reportér chyb** | Sbírá nedávné chyby s anonymizovaným kontextem (model, firmware, stack trace) | Místo fórového screenshotu bez info → strukturovaný bug report který okamžitě opravíme |
+Sensor `connection_state` (online / standby / offline) pro Audi, VW EU, Škoda, SEAT, CUPRA — první VAG integrace s centralizovaným stavem připojení. Brand-agnostický helper `compute_connection_state` s rekurzivním procházením `carCapturedTimestamp`.
 
-**1-klik workflow** (stejný pro oba sensory):
+**🔋 Monitoring 12V baterie + Smart-Wake (v1.12.0)**
 
-```
-1. HA zobrazí notifikaci když je detekováno něco nového
-2. Klikneš "Více info" → modal s anonymizovaným obsahem + 2 tlačítka:
+- Sensor `voltage_12v` (V) + binary `warning_12v_low` při <11.5V — zabraňuje tichým výpadkům API kvůli vybité startovací baterii
+- Sensor `wake_count_today` + soft-cap na 3 wakes/den (`_WAKE_BUDGET_PER_DAY`) chrání 12V před wake-loops, vyvolá `wake_budget_exhausted` PŘED API voláním
 
-   📤 Nahlásit na GitHub    ← otevře předvyplněný bug report
-   📋 Zkopírovat pro fórum/FB ← Markdown do schránky
+**💨 Optimistické UI pro Lock/Climate/Charging (v1.11.1)**
 
-3. Submit → hotovo za 30 sekund
-```
+Switche se přepínají okamžitě po kliknutí (vzor myskoda PR #832), API roundtrip na pozadí. Při selhání: revert + ServiceValidationError. 8 actuator metod převedeno.
 
-🔒 **Soukromí slib:** **Žádný auto-push.** Nic neopustí tvou HA instalaci bez tvého explicitního kliknutí. VINy, GPS, user-IDs anonymizovány. GDPR-compliant.
+**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up v v1.11.1)**
 
-🤝 **Proč to potřebujeme:** Jsme jediná aktivní VAG HA integrace pro všech 7 značek. Tvůj 1-klik příspěvek nám umožňuje objevovat rozdíly mezi modely v **dnech místo měsíců**.
+Tři explicitní range sensory: `electric_range_km`, `combustion_range_km`, `total_range_km`. Parser VW EU/Audi klasifikuje podle typu motoru (4 zdroje místo 2). Audi-diesel-fallback z `measurements.rangeStatus.value.dieselRange`. Ověřeno přes evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity logy.
 
-### ⚠️ Ještě v procesu
+**🔒 Read-only režim Fáze 1 (v1.12.0)**
 
-Capability filter fáze 2 (v1.9.1) · Defenzivní kódování fáze 2 (v1.9.2) · Optimistic Lock/Climate (v1.9.3) · Diagnostics + Smart-wake + ochrana drain 12V (v1.10.0) · Push updates (v1.10.x) · Trip stats + EU Data Act (v1.11.0 / v2.0.0).
+Toggle možností "Read-only Mode" → přeskočí lock/switch/button(non-refresh)/climate/number platformy pro privacy/safety-konzervativní vlastníky. Sensors + binary_sensors + device_tracker zůstávají.
 
-### 🚫 Vědomé limity
+**⚡ Zapisovatelné Max-Charge-Current Number (v1.12.0)**
 
-- **Image platforma:** neexistuje oficiální CARIAD render API. Bude odstraněna nebo přepnuta na URL od uživatele v v1.10.0.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — graceful degradation místo 404.
-- **Ford / značky mimo VAG:** mimo rozsah — viz [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass).
+Slider 6-32A místo pouze read-only sensoru. Nový `command_set_max_charge_current` POST chargingSettings.
+
+**💡 Per-Light Binary-Sensors (v1.12.0)**
+
+Dynamicky per typ světla z dict `lights_individual` + agregáty `lights_on` + `lights_count`.
+
+**🛠️ Defenzivní stabilita (v1.8.7 + v1.10.1)**
+
+- 504-retry, transient-network-error retry, 6h stale-cache + tolerance 3 selhání
+- Ochrana před token-refresh-storm (max 3/h) — zabraňuje IP banům
+- Helpery `safe_int` / `safe_float` / `safe_enum` — tolerují backend quirks
+
+**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhardova #53 první live-validace)**
+
+Field-name fallback řetězec: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerance pro `"connected"` / `"locked"`. Zpětná kompatibilita zachována.
+
+**🔓 Lock + Wake pro Audi/VW (v1.9.1, #92 Audi S6 C8)**
+
+`command_lock` posílá nyní S-PIN pro Audi/VW (CARIAD BFF odpovídal `403 spin_error`). `command_wake` používá v1→v2 fallback.
+
+**🛡️ Capability-Filter Fáze 2 (v1.9.1, #56)**
+
+Body-sniffing `classify_command_failure` pro `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error` markery. `_cariad_cmd` zapisuje každý výsledek do FeatureState. Command-bound entity (Lock/Climate/Switch/Buttons) jdou automaticky unavailable při definitivním "ne" backendu.
+
+### ⚠️ Ještě v procesu / What's still in progress (plánované sessions)
+
+- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Fáze 3 (`capability.active && user-enabled` PRE-vytvoření-entity, skrývá tlačítka jako MyCupra aplikace) + Read-only Fáze 2/3 (Command-Locking + oddělení služeb cloud_refresh vs wake_vehicle).
+- **v1.14.0 MINOR** — Trip Statistics z Audi `tripstatistics/v1` (#24, #35).
+- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26).
+- **v1.16.0 MINOR** — Lokalitně-specifický Cíl SoC nabíjení + nabíjecí profily (#25, #31).
+- **v1.17.0 MINOR** — Remote Start ICE (#28, vzor audi_connect_ha #717).
+- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) pro real-time updaty bez pollingu (#57, #27).
+- **v2.0.0 MAJOR** — HACS Default + Live-Tests všech značek + EU Data Act ready (pycupra `EUDAConnection` jako reference, deadline září 2026) (#13, #59).
+
+### 🚫 Vědomé limity / Conscious limits
+
+- **Image platforma:** neexistuje oficiální CARIAD render-image API. Image entita přejde v budoucí release na URL dodávané uživatelem.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nová architektura E³ 1.2, ještě veřejně reverse-engineered (ani v audi_connect_ha ani v CarConnectivity). VAG Connect tato vozidla detekuje a dělá **graceful degradation** místo 404 chyb.
+- **Ford / značky mimo VAG:** mimo rozsah — viz [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) pro Ford.
 
 ### 🔧 Předpoklad ochrany soukromí
 
-**"Sdílet mou polohu"** musí být aktivní v My-VW / My-Audi / MySkoda / MyCupra — jinak backend 403.
+Aby GPS poloha, stav vozidla a topení fungovaly, musí být **"Sdílet mou polohu"** aktivní v tvé aplikaci My-VW / My-Audi / MySkoda / MyCupra — jinak backend odpovídá 403.
 
-### 📚 Více informací
+### 📚 Více informací / More info
 
-- 🗺️ [`../docs/ROADMAP.md`](../docs/ROADMAP.md) · 📜 [`../docs/CHANGELOG_TECHNICAL.md`](../docs/CHANGELOG_TECHNICAL.md) · 🤝 [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md) · 🔬 [`../docs/RESEARCH_NOTES_2026-04-29.md`](../docs/RESEARCH_NOTES_2026-04-29.md)
+- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — kompletní P0/P1/P2/P3 priorizace všech otevřených issues
+- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + architektonické rozhodnutí + externí source-refs
+- 🤝 Session Handoff (pro přispěvatele a AI nástroje): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
+- 🔒 Pravidla soukromí a zacházení s daty: sekce [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
+- 📋 FAQ Subscription / Service Plus / diagnóza `missing-capability`: FAQ sekce v [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ---
 
@@ -185,41 +220,41 @@ Restartujte Home Assistant.
 
 ---
 
-## Plán
+## Plán / Roadmap
 
-### Dosaženo
+> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — kompletní P0/P1/P2/P3 priorizace se všemi ~20 otevřenými issues kategorizovanými.
 
-| Verze | Obsah | Stav |
+### Poslední releases / Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+
+| Verze | Obsah | Datum |
 |---|---|---|
-| v1.0–v1.5 | 9 platforem, 7 značek, opravy & audit entit | ✅ Hotovo |
-| v1.6.0 | SEAT/CUPRA 9 endpointů, Škoda oprava, Audi PPC, zámek, noční režim | ✅ Hotovo |
-| v1.7.0 | Kompletní přepis Škoda, automobilové překlady ve všech jazycích, spolehlivost | ✅ Hotovo |
+| v1.8.6–v1.8.12 | Foundation-Sprint: defenzivní stabilita, Capability-Filter Fáze 2, Multi-Brand Connection-State, všechny brand parsery na ověřených live API cestách | 2026-04-29 |
+| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
+| v1.9.1 | Audi/VW Lock + Wake hotfix (#92) + Capability-Filter Fáze 2 + Scout cesty #90/#91 | 2026-04-29 |
+| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Fáze 2 (#58), CUPRA Born 2026 firmware (#53 Gerhard) | 2026-04-29/30 |
+| v1.11.0–v1.11.1 | Closure Issue #91 (Light/Service/Number), Golf GTE Fuel-Range fix (#96), Optimistické UI (3B-Part-3) | 2026-04-30 |
+| v1.12.0 | 🔋💡⚡🧯🔒 5-v-1 Sprint: 12V (#23) + Per-Light + Zapisovatelné Number + Smart-Wake (#55) + Read-only Fáze 1 (#63) | 2026-04-30 |
+| v1.12.1 | Scout cesty #105/#106 + Gerhardova Born fixture (#53 se souhlasem) + #47 FAQ | 2026-04-30 |
+| v1.12.2 | 🌟 **První komunitní Scout-Report** (Skoda #107 od tritanium73) | 2026-05-01 |
+| **v1.12.3** | Scout cesty #111+#113+#114 sbalené s wildcard strategií (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
 
-### Plán sessions (P0 → P2)
+### Příští sessions / Next sessions
 
-| Session | Verze | Rozsah | Issues |
-|---|---|---|---|
-| **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN dostupnost, S-PIN fail-fast, falešné writable odstraněny, geokódování opt-in | **#60** |
-| **1.5 — Soukromí & Auth** | v1.8.1 | Maskování VIN v logu a diagnostice, ConfigEntryAuthFailed při neplatných údajích, dokumentace userPosition | — |
-| **2A — Capabilities Foundation** | v1.8.2 | Error taxonomy, 3-state model, capabilities cache (24h TTL) | #68 |
-| **2B — Button gating** | v1.8.3 | Skrýt flash/wake u SEAT/CUPRA dle capabilities | #56 |
-| **2C — Lock debug + userPosition** | v1.8.4 | Lock `internal-error` analyzovat + ověřit userPosition | #56 |
-| **3 — Command Profile** | v1.8.5 | Routing podle značky/regionu/platformy, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonymizované diagnostiky, regresní testy | #62, #58 |
-| **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
-| **6 — Read-only + Locking** | v1.9.0 | Read-only režim, command locking, cloud vs wake | #63, #55 |
-| **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |
-| **8 — Push Škoda** | v1.9.2 | MQTT broker integrace | #57 |
-| **9 — Feature batch** | v1.10.0 | Statistiky jízd, historie nabíjení, UI časovačů, alarm, profily nabíjení | #24, #35, #26, #33, #31 |
-| **10 — HACS Default + v2.0.0** | v2.0.0 | Live testy všech značek, compatibility matrix, EU Data Act | #13, #59 |
+| Verze | Rozsah | Issues |
+|---|---|---|
+| **v1.13.0** ⭐ MINOR | Anonymized Diagnostics-Export + Capability-Filter Fáze 3 + Read-only Fáze 2/3 | #62, #56 Fáze 3, #63 Fáze 2/3 |
+| **v1.14.0** MINOR | Trip Statistics z Audi `tripstatistics/v1` | #24, #35 |
+| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26) | various |
+| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
+| **v2.0.0** 🎉 MAJOR | HACS Default + Live-Tests všech značek + EU Data Act ready (deadline září 2026) | #13, #59 |
 
-> Striktní P0 → P1 → P2 pořadí. Sessions 1–4 jsou nezaměnitelné před přidáváním nových funkcí.
+> Pořadí je **striktně P0 → P1 → P2**. Bug-fixy mají vždy přednost před funkcemi.
 
 ---
 
 ## Licence
 
-Apache License 2.0 — [LICENSE](../LICENSE)
+Apache License 2.0 — [LICENSE](LICENSE)
 
 **VAG Connect™** je neregistrovaná ochranná známka (™, ne ®). Prosíme, nepoužívejte tento název ve forkách, abyste předešli záměně.
 

--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
@@ -38,66 +38,95 @@ Since v0.14.1, VAG Connect speaks **directly** to the CARIAD API via its own asy
 
 > ✅ **Active multi-brand successor** to [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archived 2025-10-29) and [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). One integration for Audi, VW, Škoda, SEAT, CUPRA, Porsche and VW US/CA — no separate plugin per brand.
 
-## Current state & honest limits (v1.8.12)
+## Current Status & Honest Limits (v1.12.3)
 
 VAG Connect is under active development. So you know what works and what's coming:
 
 ### ✅ What works NOW (all 7 brands)
 
-- 🟢🟡⚫ **Multi-brand connection-state sensor** — online / standby / offline for Audi, VW EU, Škoda, SEAT, CUPRA (v1.8.12). First VAG integration with centralized connection status across all brands.
-- 🛡️ **Defensive stability** — 504 retry, transient-network-error retry, 6h stale-cache + 3-failure tolerance (v1.8.7). Weekend backend hiccups no longer break automations.
-- 🔓 **Lock / Climate / Charging commands** for modern Audi 2024+ and VW Passat 2025 — 10 commands have automatic CARIAD `/v1/` ↔ `/v2/` fallback (v1.8.5 + v1.8.8).
-- 🚪 **CUPRA / SEAT complete door / window / trunk / sunroof entities** with verified OLA paths + per-window binary sensors (v1.8.9).
-- 🚙 **Škoda `detail.{sunroof,trunk,bonnet}`, `reliableLockStatus`, `fullyChargedAt`** (v1.8.11) from live API findings.
-- 🔐 **Token refresh storm protection** (max 3/h, v1.8.7) — prevents IP bans.
+**🛰️ 1-Click Bug Reports & Feature Requests (LIVE since v1.9.0)**
 
-### 🔬 Coming next: 1-click bug reports & feature requests (v1.9.0)
+Two diagnostic sensors with a shared reporter pipeline — **first real live-validation by community users** in v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) and v1.12.3 (DnnsJp74 / Audi):
 
-> **You help us improve the integration — without learning a single word of GitHub or Markdown.**
+- 🔬 **Vehicle Data Scout** — automatically detects unknown JSON fields in your car's API. Brand-localized in 8 languages (DE: API-Beobachter, FR: Observateur d'API, etc.).
+- 🚨 **Error Reporter** — Ring-buffer of the last 20 integration errors with anonymized context (model, firmware, stack trace).
+- 🔘 **Reporter Pipeline:** both sensors automatically create HA Repair notifications with a pre-filled GitHub issue as a 1-click link. Plus a diagnostics download with everything masked for forum/Facebook.
+- 🔒 **Privacy promise:** Nothing leaves your HA without your explicit click. VINs masked, GPS rounded to 1 decimal, JWTs/UUIDs/emails removed. GDPR-compliant.
 
-Two new diagnostic sensors in v1.9.0:
+**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
 
-| Sensor | What it does | How it helps you |
-|---|---|---|
-| 🔬 **Vehicle Data Scout** | Automatically detects new fields in your car's API that we don't parse yet | If your Audi A4 2017 or VW Golf 7 GTE returns fields we don't know → we add them in the next release |
-| 🛠️ **Error Reporter** | Collects recent errors with anonymised context (model, firmware, stack trace) | Instead of a forum screenshot without info → structured bug report we can fix immediately |
+`connection_state` sensor (online / standby / offline) for Audi, VW EU, Škoda, SEAT, CUPRA — first VAG integration with centralized connection status. Brand-agnostic helper `compute_connection_state` with recursive `carCapturedTimestamp` walk.
 
-**1-click workflow** (same for both sensors):
+**🔋 12V Battery Monitoring + Smart-Wake (v1.12.0)**
 
-```
-1. HA shows a notification when something new is detected
-2. You click "More info" → modal with anonymised content + 2 buttons:
+- `voltage_12v` sensor (V) + `warning_12v_low` binary at <11.5V — prevents silent API outages caused by an empty starter battery
+- `wake_count_today` sensor + soft-cap of 3 wakes/day (`_WAKE_BUDGET_PER_DAY`) protects 12V from wake-loops, raises `wake_budget_exhausted` BEFORE the API call
 
-   📤 Report on GitHub    ← opens pre-filled bug report
-   📋 Copy for forum/FB   ← Markdown to clipboard for Facebook group
+**💨 Optimistic UI for Lock/Climate/Charging (v1.11.1)**
 
-3. Submit → done in 30 seconds
-```
+Switches flip immediately on click (myskoda PR #832 pattern), API roundtrip in the background. On failure: revert + ServiceValidationError. 8 actuator methods migrated.
 
-🔒 **Privacy promise:** **No auto-push.** Nothing leaves your HA installation without your explicit click. VINs, GPS, user IDs are anonymised before display. GDPR-compliant, HACS-Default-compatible.
+**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up in v1.11.1)**
 
-🤝 **Why we need it:** We are the only active VAG HA integration for all 7 brands. Every new model returns slightly different API responses. With your 1-click contribution we discover these differences in **days instead of months**.
+Three explicit range sensors: `electric_range_km`, `combustion_range_km`, `total_range_km`. VW EU/Audi parser classifies by engine type (4 sources instead of 2). Audi diesel fallback from `measurements.rangeStatus.value.dieselRange`. Verified via evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity logs.
 
-### ⚠️ Still in progress
+**🔒 Read-only Mode Phase 1 (v1.12.0)**
 
-- **Capability filter phase 2** (v1.9.1) · **Defensive coding phase 2** (v1.9.2) · **Optimistic Lock/Climate** (v1.9.3) · **Diagnostics + Smart-wake + 12V drain protection** (v1.10.0) · **Push updates** (v1.10.x) · **Trip statistics + EU Data Act** (v1.11.0 / v2.0.0).
+Options toggle "Read-only Mode" → skip lock/switch/button(non-refresh)/climate/number platforms for privacy/safety-conservative owners. Sensors + binary_sensors + device_tracker remain.
+
+**⚡ Writeable Max-Charge-Current Number (v1.12.0)**
+
+Slider 6–32A instead of just a read-only sensor. New `command_set_max_charge_current` POST chargingSettings.
+
+**💡 Per-Light Binary-Sensors (v1.12.0)**
+
+Dynamically per light type from `lights_individual` dict + aggregate `lights_on` + `lights_count`.
+
+**🛠️ Defensive Stability (v1.8.7 + v1.10.1)**
+
+- 504-retry, transient-network-error retry, 6h stale-cache + 3-failure tolerance
+- Token-refresh-storm protection (max 3/h) — prevents IP bans
+- `safe_int` / `safe_float` / `safe_enum` helpers — tolerate backend quirks
+
+**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhard's #53 first live-validation)**
+
+Field-name fallback chain: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerance for `"connected"` / `"locked"`. Backwards compatibility preserved.
+
+**🔓 Lock + Wake for Audi/VW (v1.9.1, #92 Audi S6 C8)**
+
+`command_lock` now sends S-PIN for Audi/VW (CARIAD BFF answered `403 spin_error`). `command_wake` uses v1→v2 fallback.
+
+**🛡️ Capability-Filter Phase 2 (v1.9.1, #56)**
+
+`classify_command_failure` body-sniffing for `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error` markers. `_cariad_cmd` writes every outcome to FeatureState. Command-bound entities (Lock/Climate/Switch/Buttons) automatically go unavailable on a definitive backend "no".
+
+### ⚠️ Still in progress / What's still planned (planned sessions)
+
+- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Phase 3 (`capability.active && user-enabled` PRE-entity-creation, hides buttons like the MyCupra app) + Read-only Phase 2/3 (Command-Locking + cloud_refresh vs wake_vehicle service separation).
+- **v1.14.0 MINOR** — Trip Statistics from Audi `tripstatistics/v1` (#24, #35).
+- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26).
+- **v1.16.0 MINOR** — Location-specific Charge-Target SoC + Charge profiles (#25, #31).
+- **v1.17.0 MINOR** — Remote Start ICE (#28, audi_connect_ha #717 pattern).
+- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) for real-time updates without polling (#57, #27).
+- **v2.0.0 MAJOR** — HACS Default + Live tests all brands + EU Data Act ready (pycupra `EUDAConnection` as reference, September 2026 deadline) (#13, #59).
 
 ### 🚫 Conscious limits
 
-- **Image platform:** no official CARIAD render-image API exists. Will be removed or replaced with user-supplied URLs in v1.10.0.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — new E³ 1.2 architecture, not publicly reverse-engineered. **Graceful degradation** instead of 404 errors.
+- **Image platform:** no official CARIAD render-image API exists. The image entity will switch to user-supplied URLs in a future release.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — new E³ 1.2 architecture, not yet publicly reverse-engineered (not even in audi_connect_ha or CarConnectivity). VAG Connect detects these vehicles and does **graceful degradation** instead of 404 errors.
 - **Ford / non-VAG brands:** out of scope — see [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) for Ford.
 
 ### 🔧 Privacy prerequisite
 
-GPS position, vehicle status and pre-heating require **"Share my position"** enabled in your My-VW / My-Audi / MySkoda / MyCupra app — otherwise the backend responds with 403.
+For GPS position, vehicle status and pre-heating to work, **"Share my position"** must be enabled in your My-VW / My-Audi / MySkoda / MyCupra app — otherwise the backend responds with 403.
 
 ### 📚 More info
 
-- 🗺️ Roadmap: [`../docs/ROADMAP.md`](../docs/ROADMAP.md)
-- 📜 Tech changelog: [`../docs/CHANGELOG_TECHNICAL.md`](../docs/CHANGELOG_TECHNICAL.md)
-- 🤝 Session handoff (for contributors & AI tools): [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md)
-- 🔬 Verified API paths: [`../docs/RESEARCH_NOTES_2026-04-29.md`](../docs/RESEARCH_NOTES_2026-04-29.md)
+- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — complete P0/P1/P2/P3 prioritization of all open issues
+- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release field mappings + architecture decisions + external source refs
+- 🤝 Session Handoff (for contributors & AI tools): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
+- 🔒 Privacy & data handling rules: [`CONTRIBUTING.md`](CONTRIBUTING.md) section (post-#53 third-party review)
+- 📋 FAQ Subscription / Service Plus / `missing-capability` diagnosis: [`CONTRIBUTING.md`](CONTRIBUTING.md) FAQ section
 
 ## Supported Brands
 
@@ -192,39 +221,39 @@ Restart Home Assistant.
 
 ## Roadmap
 
-### Achieved so far
+> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — complete P0/P1/P2/P3 prioritization with all ~20 open issues categorized.
 
-| Version | Content | Status |
+### Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+
+| Version | Content | Date |
 |---|---|---|
-| v1.0–v1.5 | 9 platforms, 7 brands, bugs & entity audit | ✅ Done |
-| v1.6.0 | SEAT/CUPRA 9 endpoints, Škoda fix, Audi PPC, Lock, nightly reduction | ✅ Done |
-| v1.7.0 | Complete Škoda rewrite, car-friendly translations all languages, reliability | ✅ Done |
+| v1.8.6–v1.8.12 | Foundation Sprint: defensive stability, Capability-Filter Phase 2, Multi-Brand Connection-State, all brand parsers on verified live API paths | 2026-04-29 |
+| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
+| v1.9.1 | Audi/VW Lock + Wake hotfix (#92) + Capability-Filter Phase 2 + Scout paths #90/#91 | 2026-04-29 |
+| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Phase 2 (#58), CUPRA Born 2026 firmware (#53 Gerhard) | 2026-04-29/30 |
+| v1.11.0–v1.11.1 | Issue #91 closure (Light/Service/Number), Golf GTE fuel-range fix (#96), Optimistic UI (3B-Part-3) | 2026-04-30 |
+| v1.12.0 | 🔋💡⚡🧯🔒 5-in-1 Sprint: 12V (#23) + Per-Light + Writeable Number + Smart-Wake (#55) + Read-only Phase 1 (#63) | 2026-04-30 |
+| v1.12.1 | Scout paths #105/#106 + Gerhard's Born fixture (#53 with consent) + #47 FAQ | 2026-04-30 |
+| v1.12.2 | 🌟 **First community Scout report** (Skoda #107 from tritanium73) | 2026-05-01 |
+| **v1.12.3** | Scout paths #111+#113+#114 bundled with wildcard strategy (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
 
-### Session plan (P0 → P2)
+### Next sessions
 
-| Session | Version | Scope | Issues |
-|---|---|---|---|
-| **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN availability, S-PIN fail-fast, fake writables removed, geocoding opt-in, platforms sync | **#60** |
-| **1.5 — Privacy & Auth Polish** | v1.8.1 | VIN masking in logs/diagnostics, ConfigEntryAuthFailed on stale credentials, userPosition documentation | — |
-| **2A — Capabilities Foundation** | v1.8.2 | Error taxonomy, 3-state feature model, capabilities cache (24h TTL) | #68 |
-| **2B — Button gating** | v1.8.3 | Hide flash/wake on SEAT/CUPRA when capabilities say no | #56 |
-| **2C — Lock debug + userPosition** | v1.8.4 | Investigate lock `internal-error` + verify userPosition semantics | #56 |
-| **3 — Command Profile** | v1.8.5 | Brand/region/platform routing, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonymized diagnostics, regression tests | #62, #58 |
-| **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
-| **6 — Read-only + Locking** | v1.9.0 | Read-only mode, command locking, cloud vs wake | #63, #55 |
-| **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |
-| **8 — Push Škoda** | v1.9.2 | MQTT broker integration | #57 |
-| **9 — Feature batch** | v1.10.0 | Trip stats, charging history, departure timer UI, alarm, charge profiles | #24, #35, #26, #33, #31 |
-| **10 — HACS Default + v2.0.0** | v2.0.0 | Live tests all brands, compatibility matrix, EU Data Act ready | #13, #59 |
+| Version | Scope | Issues |
+|---|---|---|
+| **v1.13.0** ⭐ MINOR | Anonymized Diagnostics-Export + Capability-Filter Phase 3 + Read-only Phase 2/3 | #62, #56 Phase 3, #63 Phase 2/3 |
+| **v1.14.0** MINOR | Trip Statistics from Audi `tripstatistics/v1` | #24, #35 |
+| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26) | various |
+| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
+| **v2.0.0** 🎉 MAJOR | HACS Default + Live tests all brands + EU Data Act ready (Sept 2026 deadline) | #13, #59 |
 
-> Strict P0 → P1 → P2 order. Sessions 1–4 are non-negotiable before any new features land.
+> Order is **strictly P0 → P1 → P2**. Bug fixes always take priority over features.
 
 ---
 
 ## License
 
-Apache License 2.0 — [LICENSE](../LICENSE)
+Apache License 2.0 — [LICENSE](LICENSE)
 
 **VAG Connect™** is an unregistered trademark (™, not ®). Please do not use this name in forks to avoid confusion.
 

--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
@@ -38,60 +38,95 @@ Desde v0.14.1, la integración habla **directamente** con la API CARIAD — clie
 
 > ✅ **Sucesor multi-marca mantenido activamente** de [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivado el 2025-10-29) y [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (obsoleto el 2025-03-14). Una integración para Audi, VW, Škoda, SEAT, CUPRA, Porsche y VW US/CA — sin plugin separado por marca.
 
-## Estado actual y límites honestos (v1.8.12)
+## Estado actual y límites honestos / Current Status & Honest Limits (v1.12.3)
+
+VAG Connect se desarrolla activamente. Para que sepas qué funciona y qué viene:
 
 ### ✅ Qué funciona AHORA (todas las 7 marcas)
 
-- 🟢🟡⚫ **Sensor Multi-Brand Connection-State** — online / standby / offline para todas las marcas (v1.8.12).
-- 🛡️ **Estabilidad defensiva** — retry 504, retry errores de red transitorios, cache 6h + tolerancia 3 fallos (v1.8.7).
-- 🔓 **Comandos Lock / Climate / Charging** para Audi 2024+ y VW Passat 2025 — 10 comandos con fallback CARIAD `/v1/` ↔ `/v2/` (v1.8.5 + v1.8.8).
-- 🚪 **CUPRA / SEAT entidades completas** con rutas JSON OLA verificadas + binary sensors por ventana (v1.8.9).
-- 🚙 **Škoda** `detail` block + `reliableLockStatus` + `fullyChargedAt` (v1.8.11).
+**🛰️ Bug-Reports y solicitudes de features en 1 clic (LIVE desde v1.9.0)**
 
-### 🔬 Próximamente: Bug reports en 1 clic & solicitudes de features (v1.9.0)
+Dos sensores de diagnóstico con una pipeline reporter compartida — **primera validación live real por usuarios de la comunidad** en v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) y v1.12.3 (DnnsJp74 / Audi):
 
-> **Nos ayudas a mejorar la integración — sin aprender ni una palabra de GitHub o Markdown.**
+- 🔬 **Vehicle Data Scout** — detecta automáticamente campos JSON desconocidos en la API de tu coche. Localizado por marca en 8 idiomas (DE: API-Beobachter, FR: Observateur d'API, etc.).
+- 🚨 **Error Reporter** — Ring-buffer de los últimos 20 errores de integración con contexto anonimizado (modelo, firmware, stack trace).
+- 🔘 **Reporter Pipeline:** ambos sensores crean automáticamente notificaciones HA Repair con un GitHub-Issue prerellenado como enlace de 1 clic. Más una descarga de diagnostics con todo enmascarado para foro/Facebook.
+- 🔒 **Promesa de privacidad:** Nada sale de tu HA sin tu clic explícito. VINs enmascarados, GPS redondeado a 1 decimal, JWTs/UUIDs/emails eliminados. Cumple GDPR.
 
-Dos nuevos sensores de diagnóstico en v1.9.0:
+**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
 
-| Sensor | Qué hace | Cómo te ayuda |
-|---|---|---|
-| 🔬 **Detector de datos nuevos** | Detecta automáticamente nuevos campos en la API de tu coche que aún no procesamos | Si tu Audi A4 2017 o VW Golf 7 GTE devuelve campos desconocidos → los añadimos en la próxima versión |
-| 🛠️ **Reportador de errores** | Recoge errores recientes con contexto anonimizado (modelo, firmware, stack trace) | En vez de captura del foro sin info → bug report estructurado que arreglamos ya |
+Sensor `connection_state` (online / standby / offline) para Audi, VW EU, Škoda, SEAT, CUPRA — primera integración VAG con estado de conexión centralizado. Helper agnóstico de marca `compute_connection_state` con recorrido recursivo `carCapturedTimestamp`.
 
-**Workflow 1 clic** (igual para ambos sensores):
+**🔋 Monitorización batería 12V + Smart-Wake (v1.12.0)**
 
-```
-1. HA muestra una notificación cuando se detecta algo nuevo
-2. Haz clic en "Más info" → modal con contenido anonimizado + 2 botones:
+- Sensor `voltage_12v` (V) + binary `warning_12v_low` por debajo de 11.5V — evita caídas silenciosas de la API por batería de arranque vacía
+- Sensor `wake_count_today` + soft-cap a 3 wakes/día (`_WAKE_BUDGET_PER_DAY`) protege la 12V de wake-loops, lanza `wake_budget_exhausted` ANTES de la llamada API
 
-   📤 Reportar en GitHub    ← abre bug report pre-rellenado
-   📋 Copiar para foro/FB   ← Markdown al portapapeles
+**💨 UI optimista para Lock/Climate/Charging (v1.11.1)**
 
-3. Submit → listo en 30 segundos
-```
+Los switches cambian inmediatamente al hacer clic (patrón myskoda PR #832), roundtrip API en segundo plano. En caso de fallo: revert + ServiceValidationError. 8 métodos actuator migrados.
 
-🔒 **Promesa de privacidad:** **Sin auto-push.** Nada sale de tu instalación HA sin tu clic explícito. VINs, GPS, user-IDs anonimizados. GDPR-compliant.
+**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up en v1.11.1)**
 
-🤝 **Por qué lo necesitamos:** Somos la única integración HA VAG activa para las 7 marcas. Con tu contribución de 1 clic descubrimos diferencias entre modelos en **días en lugar de meses**.
+Tres sensores de autonomía explícitos: `electric_range_km`, `combustion_range_km`, `total_range_km`. El parser VW EU/Audi clasifica por tipo de motor (4 fuentes en lugar de 2). Fallback Audi diésel desde `measurements.rangeStatus.value.dieselRange`. Verificado vía evcc-io/evcc#19045 + sample Audi Q4 + logs CarConnectivity.
 
-### ⚠️ Aún en progreso
+**🔒 Modo Read-only Fase 1 (v1.12.0)**
 
-Capability filter fase 2 (v1.9.1) · Defensive coding fase 2 (v1.9.2) · Optimistic Lock/Climate (v1.9.3) · Diagnostics + Smart-wake + protección 12V (v1.10.0) · Push updates (v1.10.x) · Trip stats + EU Data Act (v1.11.0 / v2.0.0).
+Toggle de opciones "Read-only Mode" → omite plataformas lock/switch/button(non-refresh)/climate/number para propietarios conservadores con privacidad/seguridad. Sensors + binary_sensors + device_tracker permanecen.
 
-### 🚫 Límites conscientes
+**⚡ Number Max-Charge-Current escribible (v1.12.0)**
 
-- **Plataforma image:** no existe API CARIAD render oficial. Será eliminada o cambiada a URLs de usuario en v1.10.0.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — graceful degradation en lugar de 404.
-- **Ford / marcas no-VAG:** fuera de alcance — ver [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass).
+Slider 6-32A en lugar de un sensor solo de lectura. Nuevo `command_set_max_charge_current` POST chargingSettings.
+
+**💡 Binary-Sensors por luz (v1.12.0)**
+
+Dinámicamente por tipo de luz desde el dict `lights_individual` + agregados `lights_on` + `lights_count`.
+
+**🛠️ Estabilidad defensiva (v1.8.7 + v1.10.1)**
+
+- Retry 504, retry errores de red transitorios, cache 6h + tolerancia 3 fallos
+- Protección token-refresh-storm (max 3/h) — evita bans de IP
+- Helpers `safe_int` / `safe_float` / `safe_enum` — toleran rarezas del backend
+
+**🚪 Firmware-Shapes CUPRA Born 2026 (v1.10.2 — primera validación live de Gerhard #53)**
+
+Cadena de fallback de nombres de campos: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Tolerancia enum minúsculas para `"connected"` / `"locked"`. Compatibilidad hacia atrás preservada.
+
+**🔓 Lock + Wake para Audi/VW (v1.9.1, #92 Audi S6 C8)**
+
+`command_lock` ahora envía S-PIN para Audi/VW (CARIAD BFF respondía `403 spin_error`). `command_wake` usa fallback v1→v2.
+
+**🛡️ Capability-Filter Fase 2 (v1.9.1, #56)**
+
+Body-sniffing `classify_command_failure` para marcadores `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error`. `_cariad_cmd` escribe cada resultado en FeatureState. Las entidades ligadas a comandos (Lock/Climate/Switch/Buttons) pasan automáticamente a unavailable cuando el backend dice "no" definitivo.
+
+### ⚠️ Aún en progreso / What's still in progress (sesiones planificadas)
+
+- **v1.13.0 MINOR** — Export de diagnostics anonimizado (#62) + Capability-Filter Fase 3 (`capability.active && user-enabled` PRE-creación-de-entidad, oculta botones como la app MyCupra) + Read-only Fase 2/3 (Command-Locking + separación de servicios cloud_refresh vs wake_vehicle).
+- **v1.14.0 MINOR** — Trip Statistics desde Audi `tripstatistics/v1` (#24, #35).
+- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), UI timer Climate (#26).
+- **v1.16.0 MINOR** — SoC objetivo de carga específico por ubicación + perfiles de carga (#25, #31).
+- **v1.17.0 MINOR** — Remote Start ICE (#28, patrón audi_connect_ha #717).
+- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) para actualizaciones en tiempo real sin polling (#57, #27).
+- **v2.0.0 MAJOR** — HACS Default + Live-Tests todas las marcas + EU Data Act ready (pycupra `EUDAConnection` como referencia, deadline septiembre 2026) (#13, #59).
+
+### 🚫 Límites conscientes / Conscious limits
+
+- **Plataforma image:** no existe API CARIAD render-image oficial. La entidad image cambiará a URLs proporcionadas por el usuario en una futura release.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nueva arquitectura E³ 1.2, aún no reverse-engineereada públicamente (ni en audi_connect_ha ni en CarConnectivity). VAG Connect detecta estos vehículos y hace **graceful degradation** en lugar de errores 404.
+- **Ford / marcas no-VAG:** fuera de alcance — ver [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) para Ford.
 
 ### 🔧 Requisito de privacidad
 
-**"Compartir mi posición"** debe estar activado en My-VW / My-Audi / MySkoda / MyCupra — sino backend 403.
+Para que la posición GPS, el estado del vehículo y la calefacción estacionaria funcionen, **"Compartir mi posición"** debe estar activado en tu app My-VW / My-Audi / MySkoda / MyCupra — de lo contrario el backend responde con 403.
 
-### 📚 Más información
+### 📚 Más información / More info
 
-- 🗺️ [`../docs/ROADMAP.md`](../docs/ROADMAP.md) · 📜 [`../docs/CHANGELOG_TECHNICAL.md`](../docs/CHANGELOG_TECHNICAL.md) · 🤝 [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md) · 🔬 [`../docs/RESEARCH_NOTES_2026-04-29.md`](../docs/RESEARCH_NOTES_2026-04-29.md)
+- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — priorización P0/P1/P2/P3 completa de todos los issues abiertos
+- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — por release: mapeos de campos + decisiones de arquitectura + refs a fuentes externas
+- 🤝 Session Handoff (para colaboradores y herramientas IA): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
+- 🔒 Reglas de privacidad y manejo de datos: sección [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
+- 📋 FAQ Subscription / Service Plus / diagnóstico `missing-capability`: sección FAQ de [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ---
 
@@ -185,41 +220,41 @@ Reinicia Home Assistant.
 
 ---
 
-## Hoja de Ruta
+## Hoja de Ruta / Roadmap
 
-### Logrado hasta ahora
+> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — priorización P0/P1/P2/P3 completa con todos los ~20 issues abiertos categorizados.
 
-| Versión | Contenido | Estado |
+### Últimas releases / Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+
+| Versión | Contenido | Fecha |
 |---|---|---|
-| v1.0–v1.5 | 9 plataformas, 7 marcas, correcciones & auditoría de entidades | ✅ Listo |
-| v1.6.0 | SEAT/CUPRA 9 endpoints, corrección Škoda, Audi PPC, cerradura, modo nocturno | ✅ Listo |
-| v1.7.0 | Reescritura completa Škoda, traducciones automovilísticas en todos los idiomas, fiabilidad | ✅ Listo |
+| v1.8.6–v1.8.12 | Foundation-Sprint: estabilidad defensiva, Capability-Filter Fase 2, Multi-Brand Connection-State, todos los parsers de marca sobre rutas API live verificadas | 2026-04-29 |
+| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
+| v1.9.1 | Hotfix Audi/VW Lock + Wake (#92) + Capability-Filter Fase 2 + rutas Scout #90/#91 | 2026-04-29 |
+| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Fase 2 (#58), firmware CUPRA Born 2026 (#53 Gerhard) | 2026-04-29/30 |
+| v1.11.0–v1.11.1 | Cierre Issue #91 (Light/Service/Number), fix Golf GTE Fuel-Range (#96), UI optimista (3B-Part-3) | 2026-04-30 |
+| v1.12.0 | 🔋💡⚡🧯🔒 Sprint 5-en-1: 12V (#23) + Per-Light + Number escribible + Smart-Wake (#55) + Read-only Fase 1 (#63) | 2026-04-30 |
+| v1.12.1 | Rutas Scout #105/#106 + fixture Born de Gerhard (#53 con consentimiento) + FAQ #47 | 2026-04-30 |
+| v1.12.2 | 🌟 **Primer Scout-Report comunitario** (Skoda #107 de tritanium73) | 2026-05-01 |
+| **v1.12.3** | Rutas Scout #111+#113+#114 agrupadas con estrategia wildcard (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
 
-### Plan de sesiones (P0 → P2)
+### Próximas sesiones / Next sessions
 
-| Sesión | Versión | Alcance | Issues |
-|---|---|---|---|
-| **1 — Foundation Fix** | v1.8.0 | iot_class, disponibilidad por VIN, S-PIN fail-fast, writables falsos eliminados | **#60** |
-| **1.5 — Privacidad & Auth** | v1.8.1 | Enmascarado de VIN en logs/diagnósticos, ConfigEntryAuthFailed con credenciales obsoletas, documentación userPosition | — |
-| **2A — Capabilities Foundation** | v1.8.2 | Taxonomía de errores, modelo 3-estados, caché capabilities (TTL 24h) | #68 |
-| **2B — Button gating** | v1.8.3 | Ocultar flash/wake en SEAT/CUPRA según capabilities | #56 |
-| **2C — Lock debug + userPosition** | v1.8.4 | Investigar `internal-error` de lock + verificar userPosition | #56 |
-| **3 — Command Profile** | v1.8.5 | Routing por marca/región/plataforma, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.6 | Diagnósticos anonimizados, tests de regresión | #62, #58 |
-| **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, guía de privacidad | #64 |
-| **6 — Read-only + Locking** | v1.9.0 | Modo read-only, command locking, cloud vs wake | #63, #55 |
-| **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM vía mqtt.messagehub.de | #57 |
-| **8 — Push Škoda** | v1.9.2 | Integración broker MQTT | #57 |
-| **9 — Feature batch** | v1.10.0 | Estadísticas, historial carga, UI timers, alarma, perfiles carga | #24, #35, #26, #33, #31 |
-| **10 — HACS Default + v2.0.0** | v2.0.0 | Tests live todas las marcas, compatibility matrix, EU Data Act | #13, #59 |
+| Versión | Alcance | Issues |
+|---|---|---|
+| **v1.13.0** ⭐ MINOR | Export de diagnostics anonimizado + Capability-Filter Fase 3 + Read-only Fase 2/3 | #62, #56 Fase 3, #63 Fase 2/3 |
+| **v1.14.0** MINOR | Trip Statistics desde Audi `tripstatistics/v1` | #24, #35 |
+| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), UI timer Climate (#26) | various |
+| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
+| **v2.0.0** 🎉 MAJOR | HACS Default + Live-Tests todas las marcas + EU Data Act ready (deadline sept. 2026) | #13, #59 |
 
-> Orden estricto P0 → P1 → P2. Sesiones 1–4 son innegociables antes de añadir nuevas funcionalidades.
+> El orden es **estrictamente P0 → P1 → P2**. Las correcciones de bugs siempre tienen prioridad sobre las features.
 
 ---
 
 ## Licencia
 
-Apache License 2.0 — [LICENSE](../LICENSE)
+Apache License 2.0 — [LICENSE](LICENSE)
 
 **VAG Connect™** es una marca no registrada (™, no ®). Por favor no uses este nombre en forks para evitar confusión.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
@@ -38,60 +38,95 @@ Depuis v0.14.1, l'intégration parle **directement** à l'API CARIAD — client 
 
 > ✅ **Successeur multi-marque activement maintenu** de [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivé le 2025-10-29) et [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (déprécié le 2025-03-14). Une intégration pour Audi, VW, Škoda, SEAT, CUPRA, Porsche et VW US/CA — pas de plugin séparé par marque.
 
-## État actuel et limites honnêtes (v1.8.12)
+## État actuel et limites honnêtes / Current Status & Honest Limits (v1.12.3)
+
+VAG Connect évolue activement. Pour que tu saches ce qui fonctionne et ce qui arrive :
 
 ### ✅ Ce qui FONCTIONNE maintenant (toutes les 7 marques)
 
-- 🟢🟡⚫ **Capteur Multi-Brand Connection-State** — online / standby / offline pour toutes les marques (v1.8.12).
-- 🛡️ **Stabilité défensive** — retry 504, retry erreurs réseau transitoires, cache 6h + tolérance 3 échecs (v1.8.7).
-- 🔓 **Commandes Lock / Climate / Charging** pour Audi 2024+ et VW Passat 2025 — 10 commandes avec fallback CARIAD `/v1/` ↔ `/v2/` (v1.8.5 + v1.8.8).
-- 🚪 **CUPRA / SEAT entités complètes** avec chemins JSON OLA vérifiés + binary sensors par fenêtre (v1.8.9).
-- 🚙 **Škoda** `detail` block + `reliableLockStatus` + `fullyChargedAt` (v1.8.11).
+**🛰️ Rapports de bugs & demandes de fonctionnalités en 1-clic (LIVE depuis v1.9.0)**
 
-### 🔬 Bientôt : Rapports de bugs en 1-clic & demandes de fonctionnalités (v1.9.0)
+Deux capteurs de diagnostic avec une pipeline reporter commune — **première vraie validation live par des utilisateurs de la communauté** en v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) et v1.12.3 (DnnsJp74 / Audi) :
 
-> **Tu nous aides à améliorer l'intégration — sans apprendre un seul mot de GitHub ou Markdown.**
+- 🔬 **Vehicle Data Scout** — détecte automatiquement les champs JSON inconnus dans l'API de ta voiture. Localisé par marque dans 8 langues (DE : API-Beobachter, FR : Observateur d'API, etc.).
+- 🚨 **Error Reporter** — Ring-buffer des 20 dernières erreurs d'intégration avec contexte anonymisé (modèle, firmware, stack trace).
+- 🔘 **Reporter Pipeline :** les deux capteurs créent automatiquement des notifications HA Repair avec un GitHub-Issue pré-rempli en lien 1-clic. Plus un téléchargement de diagnostics avec tout masqué pour le forum/Facebook.
+- 🔒 **Promesse confidentialité :** Rien ne quitte ton HA sans ton clic explicite. VIN masqués, GPS arrondi à 1 décimale, JWT/UUID/emails supprimés. Conforme RGPD.
 
-Deux nouveaux capteurs de diagnostic dans v1.9.0 :
+**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
 
-| Capteur | Ce qu'il fait | Comment il t'aide |
-|---|---|---|
-| 🔬 **Détecteur de nouvelles données** | Détecte automatiquement les nouveaux champs dans l'API de ta voiture que nous ne traitons pas encore | Si ton Audi A4 2017 ou VW Golf 7 GTE renvoie des champs que nous ne connaissons pas → nous les ajoutons à la prochaine version |
-| 🛠️ **Rapporteur d'erreurs** | Collecte les erreurs récentes avec contexte anonymisé (modèle, firmware, stack trace) | Au lieu d'une capture forum sans info → rapport de bug structuré que nous corrigeons immédiatement |
+Capteur `connection_state` (online / standby / offline) pour Audi, VW EU, Škoda, SEAT, CUPRA — première intégration VAG avec statut de connexion centralisé. Helper brand-agnostic `compute_connection_state` avec parcours récursif `carCapturedTimestamp`.
 
-**Workflow en 1-clic** (identique pour les deux capteurs) :
+**🔋 Surveillance batterie 12V + Smart-Wake (v1.12.0)**
 
-```
-1. HA affiche une notification quand quelque chose de nouveau est détecté
-2. Tu cliques "Plus d'info" → modal avec contenu anonymisé + 2 boutons :
+- Capteur `voltage_12v` (V) + binary `warning_12v_low` à <11.5V — empêche les pannes silencieuses de l'API dues à une batterie de démarrage vide
+- Capteur `wake_count_today` + soft-cap à 3 wakes/jour (`_WAKE_BUDGET_PER_DAY`) protège la 12V des wake-loops, lève `wake_budget_exhausted` AVANT l'appel API
 
-   📤 Signaler sur GitHub    ← ouvre un rapport pré-rempli
-   📋 Copier pour forum/FB   ← Markdown dans le presse-papiers
+**💨 UI optimiste pour Lock/Climate/Charging (v1.11.1)**
 
-3. Submit → terminé en 30 secondes
-```
+Les switches basculent immédiatement au clic (pattern myskoda PR #832), aller-retour API en arrière-plan. En cas d'échec : revert + ServiceValidationError. 8 méthodes actuator migrées.
 
-🔒 **Promesse confidentialité :** **Pas d'auto-push.** Rien ne quitte ton installation HA sans ton clic explicite. VIN, GPS, user-IDs sont anonymisés avant affichage. GDPR-compatible.
+**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up en v1.11.1)**
 
-🤝 **Pourquoi on en a besoin :** Nous sommes la seule intégration HA VAG active pour les 7 marques. Avec ta contribution en 1-clic, nous découvrons les différences entre modèles en **jours au lieu de mois**.
+Trois capteurs d'autonomie explicites : `electric_range_km`, `combustion_range_km`, `total_range_km`. Le parser VW EU/Audi classifie par type de motorisation (4 sources au lieu de 2). Fallback diesel Audi depuis `measurements.rangeStatus.value.dieselRange`. Vérifié via evcc-io/evcc#19045 + sample Audi Q4 + logs CarConnectivity.
 
-### ⚠️ Encore en cours
+**🔒 Mode Read-only Phase 1 (v1.12.0)**
 
-Capability filter phase 2 (v1.9.1) · Defensive coding phase 2 (v1.9.2) · Optimistic Lock/Climate (v1.9.3) · Diagnostics + Smart-wake + protection 12V (v1.10.0) · Push updates (v1.10.x) · Trip stats + EU Data Act (v1.11.0 / v2.0.0).
+Toggle d'options "Read-only Mode" → ignore les plateformes lock/switch/button(non-refresh)/climate/number pour les propriétaires soucieux de confidentialité/sécurité. Sensors + binary_sensors + device_tracker restent.
 
-### 🚫 Limites conscientes
+**⚡ Number Max-Charge-Current modifiable (v1.12.0)**
 
-- **Plateforme image :** aucune API CARIAD render officielle. À supprimer ou basculer vers URLs utilisateur en v1.10.0.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — graceful degradation au lieu de 404.
-- **Ford / marques non-VAG :** hors périmètre — voir [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass).
+Slider 6-32A au lieu d'un capteur read-only seul. Nouveau `command_set_max_charge_current` POST chargingSettings.
+
+**💡 Binary-Sensors par feu (v1.12.0)**
+
+Dynamiquement par type de feu depuis le dict `lights_individual` + agrégats `lights_on` + `lights_count`.
+
+**🛠️ Stabilité défensive (v1.8.7 + v1.10.1)**
+
+- Retry 504, retry erreurs réseau transitoires, cache 6h + tolérance 3 échecs
+- Protection token-refresh-storm (max 3/h) — empêche les bans IP
+- Helpers `safe_int` / `safe_float` / `safe_enum` — tolèrent les bizarreries du backend
+
+**🚪 Firmware-Shapes CUPRA Born 2026 (v1.10.2 — première validation live de Gerhard #53)**
+
+Chaîne de fallback de noms de champs : `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Tolérance enum lowercase pour `"connected"` / `"locked"`. Compatibilité ascendante préservée.
+
+**🔓 Lock + Wake pour Audi/VW (v1.9.1, #92 Audi S6 C8)**
+
+`command_lock` envoie maintenant le S-PIN pour Audi/VW (CARIAD BFF répondait `403 spin_error`). `command_wake` utilise le fallback v1→v2.
+
+**🛡️ Capability-Filter Phase 2 (v1.9.1, #56)**
+
+Body-sniffing `classify_command_failure` pour les marqueurs `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error`. `_cariad_cmd` écrit chaque résultat dans FeatureState. Les entités liées aux commandes (Lock/Climate/Switch/Buttons) deviennent automatiquement unavailable sur un "non" définitif du backend.
+
+### ⚠️ Encore en cours / What's still in progress (sessions planifiées)
+
+- **v1.13.0 MINOR** — Export de diagnostics anonymisés (#62) + Capability-Filter Phase 3 (`capability.active && user-enabled` PRE-création-d'entité, masque les boutons comme l'app MyCupra) + Read-only Phase 2/3 (Command-Locking + séparation des services cloud_refresh vs wake_vehicle).
+- **v1.14.0 MINOR** — Statistiques de trajets depuis Audi `tripstatistics/v1` (#24, #35).
+- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), UI minuteur Climate (#26).
+- **v1.16.0 MINOR** — SoC cible de charge spécifique au lieu + profils de charge (#25, #31).
+- **v1.17.0 MINOR** — Remote Start ICE (#28, pattern audi_connect_ha #717).
+- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) pour des mises à jour en temps réel sans polling (#57, #27).
+- **v2.0.0 MAJOR** — HACS Default + Live-Tests toutes marques + EU Data Act ready (pycupra `EUDAConnection` comme référence, deadline septembre 2026) (#13, #59).
+
+### 🚫 Limites conscientes / Conscious limits
+
+- **Plateforme image :** aucune API CARIAD render-image officielle n'existe. L'entité image basculera vers des URL fournies par l'utilisateur dans une future release.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nouvelle architecture E³ 1.2, pas encore reverse-engineerée publiquement (même pas dans audi_connect_ha ou CarConnectivity). VAG Connect détecte ces véhicules et fait du **graceful degradation** au lieu d'erreurs 404.
+- **Ford / marques non-VAG :** hors périmètre — voir [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) pour Ford.
 
 ### 🔧 Prérequis confidentialité
 
-**"Partager ma position"** doit être activé dans My-VW / My-Audi / MySkoda / MyCupra — sinon backend 403.
+Pour que la position GPS, le statut véhicule et le préchauffage fonctionnent, **"Partager ma position"** doit être activé dans ton app My-VW / My-Audi / MySkoda / MyCupra — sinon le backend répond avec 403.
 
-### 📚 Plus d'infos
+### 📚 Plus d'infos / More info
 
-- 🗺️ [`../docs/ROADMAP.md`](../docs/ROADMAP.md) · 📜 [`../docs/CHANGELOG_TECHNICAL.md`](../docs/CHANGELOG_TECHNICAL.md) · 🤝 [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md) · 🔬 [`../docs/RESEARCH_NOTES_2026-04-29.md`](../docs/RESEARCH_NOTES_2026-04-29.md)
+- 🗺️ Roadmap : [`docs/ROADMAP.md`](docs/ROADMAP.md) — priorisation P0/P1/P2/P3 complète de tous les issues ouverts
+- 📜 Tech Changelog : [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — par release : mappings de champs + décisions d'architecture + refs sources externes
+- 🤝 Session Handoff (pour contributeurs & outils IA) : [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
+- 🔒 Règles de confidentialité & gestion des données : section [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
+- 📋 FAQ Subscription / Service Plus / diagnostic `missing-capability` : section FAQ de [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ---
 
@@ -185,41 +220,41 @@ Redémarrez Home Assistant.
 
 ---
 
-## Feuille de Route
+## Feuille de Route / Roadmap
 
-### Acquis
+> 📍 **Single Source of Truth :** [`docs/ROADMAP.md`](docs/ROADMAP.md) — priorisation P0/P1/P2/P3 complète avec tous les ~20 issues ouverts catégorisés.
 
-| Version | Contenu | Statut |
+### Dernières releases / Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+
+| Version | Contenu | Date |
 |---|---|---|
-| v1.0–v1.5 | 9 plateformes, 7 marques, corrections & audit des entités | ✅ Fait |
-| v1.6.0 | SEAT/CUPRA 9 endpoints, correction Škoda, Audi PPC, verrouillage, mode nuit | ✅ Fait |
-| v1.7.0 | Réécriture complète Škoda, traductions automobiles dans toutes les langues, fiabilité | ✅ Fait |
+| v1.8.6–v1.8.12 | Foundation-Sprint : stabilité défensive, Capability-Filter Phase 2, Multi-Brand Connection-State, tous les parsers de marque sur des chemins API live vérifiés | 2026-04-29 |
+| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
+| v1.9.1 | Hotfix Audi/VW Lock + Wake (#92) + Capability-Filter Phase 2 + chemins Scout #90/#91 | 2026-04-29 |
+| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Phase 2 (#58), firmware CUPRA Born 2026 (#53 Gerhard) | 2026-04-29/30 |
+| v1.11.0–v1.11.1 | Closure Issue #91 (Light/Service/Number), fix Golf GTE Fuel-Range (#96), UI optimiste (3B-Part-3) | 2026-04-30 |
+| v1.12.0 | 🔋💡⚡🧯🔒 Sprint 5-en-1 : 12V (#23) + Per-Light + Number modifiable + Smart-Wake (#55) + Read-only Phase 1 (#63) | 2026-04-30 |
+| v1.12.1 | Chemins Scout #105/#106 + fixture Born de Gerhard (#53 avec consentement) + FAQ #47 | 2026-04-30 |
+| v1.12.2 | 🌟 **Premier Scout-Report communautaire** (Skoda #107 par tritanium73) | 2026-05-01 |
+| **v1.12.3** | Chemins Scout #111+#113+#114 bundlés avec stratégie wildcard (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
 
-### Plan de sessions (P0 → P2)
+### Prochaines sessions / Next sessions
 
-| Session | Version | Portée | Issues |
-|---|---|---|---|
-| **1 — Foundation Fix** | v1.8.0 | iot_class, disponibilité par VIN, S-PIN fail-fast, writables fictifs supprimés | **#60** |
-| **1.5 — Confidentialité & Auth** | v1.8.1 | Masquage VIN dans logs/diagnostics, ConfigEntryAuthFailed sur credentials périmés, documentation userPosition | — |
-| **2A — Capabilities Foundation** | v1.8.2 | Taxonomie d'erreurs, modèle 3 états, cache capabilities (TTL 24h) | #68 |
-| **2B — Button gating** | v1.8.3 | Masquer flash/wake sur SEAT/CUPRA selon capabilities | #56 |
-| **2C — Lock debug + userPosition** | v1.8.4 | Analyser `internal-error` lock + vérifier userPosition | #56 |
-| **3 — Command Profile** | v1.8.5 | Routing marque/région/plateforme, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.6 | Diagnostics anonymisés, tests de régression | #62, #58 |
-| **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, guide vie privée | #64 |
-| **6 — Read-only + Locking** | v1.9.0 | Mode read-only, command locking, cloud vs wake | #63, #55 |
-| **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |
-| **8 — Push Škoda** | v1.9.2 | Intégration broker MQTT | #57 |
-| **9 — Feature batch** | v1.10.0 | Statistiques, historique charge, UI minuteurs, alarme, profils charge | #24, #35, #26, #33, #31 |
-| **10 — HACS Default + v2.0.0** | v2.0.0 | Tests live toutes marques, matrice compatibilité, EU Data Act | #13, #59 |
+| Version | Portée | Issues |
+|---|---|---|
+| **v1.13.0** ⭐ MINOR | Export de diagnostics anonymisés + Capability-Filter Phase 3 + Read-only Phase 2/3 | #62, #56 Phase 3, #63 Phase 2/3 |
+| **v1.14.0** MINOR | Statistiques de trajets depuis Audi `tripstatistics/v1` | #24, #35 |
+| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), UI minuteur Climate (#26) | various |
+| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
+| **v2.0.0** 🎉 MAJOR | HACS Default + Live-Tests toutes marques + EU Data Act ready (deadline sept. 2026) | #13, #59 |
 
-> Ordre strict P0 → P1 → P2. Sessions 1–4 non-négociables avant tout ajout de fonctionnalité.
+> L'ordre est **strictement P0 → P1 → P2**. Les corrections de bugs ont toujours la priorité sur les fonctionnalités.
 
 ---
 
 ## Licence
 
-Apache License 2.0 — [LICENSE](../LICENSE)
+Apache License 2.0 — [LICENSE](LICENSE)
 
 **VAG Connect™** est une marque non déposée (™, pas ®). Veuillez ne pas utiliser ce nom dans les forks afin d'éviter toute confusion.
 

--- a/README.md
+++ b/README.md
@@ -35,58 +35,81 @@
 
 > ✅ **Aktiv gepflegter Multi-Brand-Nachfolger** für [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archiviert am 29.10.2025) und [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated am 14.03.2025). Eine Integration für Audi, VW, Škoda, SEAT, CUPRA, Porsche und VW US/CA — kein separates Plugin pro Marke.
 
-## Aktueller Stand & ehrliche Limits (v1.8.12)
+## Aktueller Stand & ehrliche Limits / Current Status & Honest Limits (v1.12.3)
 
 VAG Connect entwickelt sich aktiv weiter. Damit du weißt, was funktioniert und was kommt:
 
 ### ✅ Was JETZT funktioniert (alle 7 Marken)
 
-- 🟢🟡⚫ **Multi-Brand Connection-State Sensor** — online / standby / offline für Audi, VW EU, Škoda, SEAT, CUPRA (v1.8.12). Erste VAG-Integration mit centralisiertem Verbindungsstatus für alle Marken.
-- 🛡️ **Defensive Stabilität** — 504 Gateway-Timeout-Retry, transient-network-error retry, 6h Stale-Cache + 3-Failure-Tolerance (v1.8.7). Wochenend-Backend-Hiccups kippen keine Automatisierungen mehr.
-- 🔓 **Lock / Climate / Charging Commands** für moderne Audi 2024+ (RS e-tron GT etc.) und VW Passat 2025 — 10 Commands haben automatisches CARIAD `/v1/` ↔ `/v2/` Fallback (v1.8.5 + v1.8.8).
-- 🚪 **CUPRA / SEAT vollständige Tür-, Fenster-, Kofferraum-, Schiebedach-Entities** mit verifizierten OLA-JSON-Pfaden + per-window Binary-Sensors (v1.8.9).
-- 🚙 **Škoda `detail.{sunroof,trunk,bonnet}`, `reliableLockStatus`, `fullyChargedAt`** (v1.8.11) aus Live-API-Erkenntnissen.
-- 🔐 **Token-Refresh-Storm-Schutz** (max 3/h, v1.8.7) — verhindert IP-Bans durch Backend-Spirale.
+**🛰️ 1-Klick Bug-Reports & Feature-Wünsche (LIVE seit v1.9.0)**
 
-### 🔬 Bald: 1-Klick Bug-Reports & Feature-Wünsche (v1.9.0)
+Zwei diagnostische Sensoren mit gemeinsamer Reporter-Pipeline — **erste echte Live-Validation durch Community-User** in v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) und v1.12.3 (DnnsJp74 / Audi):
 
-> **Du hilfst uns die Integration besser zu machen — ohne ein einziges Wort GitHub oder Markdown lernen zu müssen.**
+- 🔬 **Vehicle Data Scout** — erkennt automatisch unbekannte JSON-Felder in der API deines Autos. Brand-lokalisiert in 8 Sprachen (DE: API-Beobachter, FR: Observateur d'API, etc.).
+- 🚨 **Error Reporter** — Ring-Buffer der letzten 20 Integration-Fehler mit anonymisiertem Kontext (Modell, Firmware, Stack-Trace).
+- 🔘 **Reporter Pipeline:** beide Sensoren erstellen automatisch HA Repair-Notifications mit pre-filled GitHub-Issue als 1-Klick-Link. Plus Diagnostics-Download mit allem maskiert für Forum/Facebook.
+- 🔒 **Privacy-Versprechen:** Nichts verlässt deine HA ohne deinen expliziten Klick. VINs maskiert, GPS auf 1 Dezimalstelle gerundet, JWTs/UUIDs/Emails entfernt. GDPR-konform.
 
-Zwei neue Diagnose-Sensoren in v1.9.0:
+**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
 
-| Sensor | Was er macht | Wie er dir hilft |
-|---|---|---|
-| 🔬 **API-Beobachter** | Erkennt automatisch neue Felder in der API deines Autos die wir noch nicht auswerten | Wenn dein Audi A4 2017 oder VW Golf 7 GTE Felder liefert die wir nicht kennen → wir bauen sie in der nächsten Version ein |
-| 🛠️ **Fehler-Berichter** | Sammelt die letzten Fehler mit anonymisiertem Kontext (Modell, Firmware, Stack-Trace) | Statt Forum-Screenshot ohne Info → strukturierter Bug-Report den wir sofort fixen können |
+Sensor `connection_state` (online / standby / offline) für Audi, VW EU, Škoda, SEAT, CUPRA — erste VAG-Integration mit centralisiertem Verbindungsstatus. Brand-agnostic Helper `compute_connection_state` mit recursive `carCapturedTimestamp` Walk.
 
-**1-Klick-Workflow** (für beide Sensoren gleich):
+**🔋 12V-Batterie Monitoring + Smart-Wake (v1.12.0)**
 
-```
-1. HA zeigt eine Benachrichtigung wenn was Neues entdeckt wird
-2. Du klickst "Mehr Info" → Modal mit anonymisiertem Inhalt + 2 Buttons:
+- `voltage_12v` Sensor (V) + `warning_12v_low` Binary bei <11.5V — verhindert silent API-Outages durch leere Starterbatterie
+- `wake_count_today` Sensor + Soft-Cap auf 3 Wakes/Tag (`_WAKE_BUDGET_PER_DAY`) schützt 12V vor Wake-Loops, raised `wake_budget_exhausted` BEVOR API-Call
 
-   📤 Auf GitHub melden    ← öffnet pre-fertigen Bug-Report
-   📋 Copy für Forum/FB    ← Markdown ins Clipboard für Facebook-Gruppe
+**💨 Optimistic UI für Lock/Climate/Charging (v1.11.1)**
 
-3. Submit klicken → fertig in 30 Sekunden
-```
+Switches flippen sofort beim Klick (myskoda PR #832 Pattern), API-Roundtrip im Hintergrund. Bei Failure: revert + ServiceValidationError. 8 Actuator-Methoden umgestellt.
 
-🔒 **Privacy-Versprechen:** **Kein Auto-Push.** Nichts verlässt deine HA-Installation ohne deinen expliziten Klick. VINs, GPS, User-IDs werden vor dem Anzeigen anonymisiert. GDPR-konform, HACS-Default-kompatibel.
+**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up in v1.11.1)**
 
-🤝 **Warum wir das brauchen:** Wir sind die einzige aktive VAG-HA-Integration für alle 7 Marken. Jedes neue Modell liefert minimal andere API-Antworten. Mit deinem 1-Klick-Beitrag entdecken wir diese Unterschiede in **Tagen statt Monaten**.
+Drei explizite Range-Sensoren: `electric_range_km`, `combustion_range_km`, `total_range_km`. VW EU/Audi Parser klassifiziert nach Engine-Typ (4 Quellen statt 2). Audi-Diesel-Fallback aus `measurements.rangeStatus.value.dieselRange`. Verifiziert via evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity Logs.
 
-### ⚠️ Was noch in Arbeit ist (geplante Sessions)
+**🔒 Read-only Mode Phase 1 (v1.12.0)**
 
-- **Capability-Filter Phase 2** (v1.9.1) — Entities werden VOR dem Anlegen gegen `capability.active && user-enabled` geprüft.
-- **Defensive Coding Phase 2** (v1.9.2) — Generic-Exception-Audit + Enum-Tolerance (`CHARGING_INTERRUPTED`, `NOT_ACTIVATED` etc.).
-- **Optimistic Lock/Climate** (v1.9.3) — myskoda #832 Pattern für sofortige UI-Reaktion.
-- **Anonymisierte Diagnostics + Smart-Wake + 12V-Drain-Schutz** (v1.10.0) — verhindert dass Auto-Wakeups die Batterie leersaugen.
-- **Push-Updates** (v1.10.x) — Firebase FCM für CUPRA/SEAT, mysmob MQTT für Skoda.
-- **Trip-Statistics + EU Data Act ready** (v1.11.0 / v2.0.0).
+Options-Toggle "Read-only Mode" → skip lock/switch/button(non-refresh)/climate/number Plattformen für Privacy/Safety-konservative Owner. Sensors + binary_sensors + device_tracker bleiben.
 
-### 🚫 Bewusste Limits (funktioniert nicht und wird nicht funktionieren)
+**⚡ Writeable Max-Charge-Current Number (v1.12.0)**
 
-- **Image-Plattform:** Kein offizielles CARIAD Render-Image-API existiert. Image-Entity ist Platzhalter, wird in v1.10.0 entfernt oder auf user-supplied URLs umgestellt.
+Slider 6-32A statt nur Read-only-Sensor. Neuer `command_set_max_charge_current` POST chargingSettings.
+
+**💡 Per-Light Binary-Sensors (v1.12.0)**
+
+Dynamisch pro Lichttyp aus `lights_individual` dict + Aggregate `lights_on` + `lights_count`.
+
+**🛠️ Defensive Stabilität (v1.8.7 + v1.10.1)**
+
+- 504-Retry, transient-network-error retry, 6h Stale-Cache + 3-Failure-Tolerance
+- Token-Refresh-Storm-Schutz (max 3/h) — verhindert IP-Bans
+- `safe_int` / `safe_float` / `safe_enum` Helper — toleriert Backend-Quirks
+
+**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhard's #53 erste Live-Validation)**
+
+Field-Name-Fallback-Kette: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerance für `"connected"`/`"locked"`. Backwards-compat erhalten.
+
+**🔓 Lock + Wake für Audi/VW (v1.9.1, #92 Audi S6 C8)**
+
+`command_lock` schickt jetzt S-PIN für Audi/VW (CARIAD BFF antwortete `403 spin_error`). `command_wake` nutzt v1→v2 Fallback.
+
+**🛡️ Capability-Filter Phase 2 (v1.9.1, #56)**
+
+`classify_command_failure` body-sniffing für `missing-capability`/`subscription_expired`/`not_entitled`/`spin_error` Marker. `_cariad_cmd` schreibt jedes Outcome in FeatureState. Command-bound Entities (Lock/Climate/Switch/Buttons) gehen automatisch unavailable bei definitivem Backend-No.
+
+### ⚠️ Was noch in Arbeit ist / What's still in progress (geplante Sessions)
+
+- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Phase 3 (`capability.active && user-enabled` PRE-Entity-Creation, versteckt Buttons wie MyCupra-App) + Read-only Phase 2/3 (Command-Locking + cloud_refresh vs wake_vehicle Service-Trennung).
+- **v1.14.0 MINOR** — Trip Statistics aus Audi `tripstatistics/v1` (#24, #35).
+- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Klima-Timer UI (#26).
+- **v1.16.0 MINOR** — Standort-spezifischer Ladeziel-SoC + Ladeprofile (#25, #31).
+- **v1.17.0 MINOR** — Remote Start ICE (#28, audi_connect_ha #717 Pattern).
+- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) für Real-Time-Updates ohne Polling (#57, #27).
+- **v2.0.0 MAJOR** — HACS Default + Live-Tests alle Marken + EU Data Act ready (pycupra `EUDAConnection` als Reference, September 2026 Deadline) (#13, #59).
+
+### 🚫 Bewusste Limits / Conscious limits
+
+- **Image-Plattform:** Kein offizielles CARIAD Render-Image-API existiert. Image-Entity wird in einer zukünftigen Release auf user-supplied URLs umgestellt.
 - **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — neue E³ 1.2 Architektur, öffentlich noch nicht reverse-engineered (auch nicht in audi_connect_ha oder CarConnectivity). VAG Connect erkennt diese Fahrzeuge und macht **graceful degradation** statt 404-Fehler.
 - **Ford / nicht-VAG Marken:** Out of scope — siehe [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) für Ford.
 
@@ -94,12 +117,13 @@ Zwei neue Diagnose-Sensoren in v1.9.0:
 
 Damit GPS-Position, Fahrzeugstatus und Standheizung funktionieren, muss in deiner My-VW / My-Audi / MySkoda / MyCupra-App **"Standort teilen"** aktiviert sein — sonst antwortet das Backend mit 403.
 
-### 📚 Mehr Infos
+### 📚 Mehr Infos / More info
 
-- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md)
-- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md)
+- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — komplette P0/P1/P2/P3 Priorisierung aller offenen Issues
+- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — pro Release Field-Mappings + Architektur-Entscheidungen + externe Source-Refs
 - 🤝 Session Handoff (für Mitwirkende & AI-Tools): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔬 Verifizierte API-Pfade: [`docs/RESEARCH_NOTES_2026-04-29.md`](docs/RESEARCH_NOTES_2026-04-29.md)
+- 🔒 Privacy & data handling Rules: [`CONTRIBUTING.md`](CONTRIBUTING.md) Sektion (post-#53 third-party-review)
+- 📋 FAQ Subscription / Service Plus / `missing-capability` Diagnose: [`CONTRIBUTING.md`](CONTRIBUTING.md) FAQ-Sektion
 
 ## Unterstützte Plattformen
 
@@ -362,33 +386,33 @@ cariad/
 
 ## Roadmap
 
-### Bisher erreicht
+> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — komplette P0/P1/P2/P3 Priorisierung mit allen ~20 offenen Issues kategorisiert.
 
-| Version | Inhalt | Status |
+### Letzte Releases / Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+
+| Version | Inhalt | Date |
 |---|---|---|
-| v1.0–v1.5 | 9 Plattformen, 7 Marken, Bugs & Entity-Audit | ✅ Done |
-| v1.6.0 | SEAT/CUPRA 9 Endpoints, Škoda Fix, Audi PPC, Lock, Nachtabsenkung | ✅ Done |
-| v1.7.0 | Škoda Komplett-Rewrite, Auto-Fachwörter alle Sprachen, Zuverlässigkeit | ✅ Done |
+| v1.8.6–v1.8.12 | Foundation-Sprint: Defensive Stabilität, Capability-Filter Phase 2, Multi-Brand Connection-State, alle Brand-Parser auf verifizierten Live-API-Pfaden | 2026-04-29 |
+| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
+| v1.9.1 | Audi/VW Lock + Wake Hotfix (#92) + Capability-Filter Phase 2 + Scout-Pfade #90/#91 | 2026-04-29 |
+| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Phase 2 (#58), CUPRA Born 2026 Firmware (#53 Gerhard) | 2026-04-29/30 |
+| v1.11.0–v1.11.1 | Issue #91 Closure (Light/Service/Number), Golf GTE Fuel-Range Fix (#96), Optimistic UI (3B-Part-3) | 2026-04-30 |
+| v1.12.0 | 🔋💡⚡🧯🔒 5-in-1 Sprint: 12V (#23) + Per-Light + Writeable Number + Smart-Wake (#55) + Read-only Phase 1 (#63) | 2026-04-30 |
+| v1.12.1 | Scout-Pfade #105/#106 + Gerhard's Born Fixture (#53 mit Consent) + #47 FAQ | 2026-04-30 |
+| v1.12.2 | 🌟 **Erstes Community-Scout-Report** (Skoda #107 von tritanium73) | 2026-05-01 |
+| **v1.12.3** | Scout-Pfade #111+#113+#114 bundled mit Wildcard-Strategie (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
 
-### Sessions-Plan (P0 → P2)
+### Nächste Sessions / Next sessions
 
-| Session | Version | Scope | Issues |
-|---|---|---|---|
-| **1 — Foundation Fix** | v1.8.0 | iot_class, per-VIN availability, S-PIN fail-fast, fake writables entfernt, Geocoding opt-in, Platforms-Sync | **#60** |
-| **1.5 — Privacy & Auth Polish** | v1.8.1 | VIN-Maskierung in Logs/Diagnostics, ConfigEntryAuthFailed bei verlorenen Credentials, userPosition-Doku | — |
-| **2A — Capabilities Foundation** | v1.8.2 | Error-Taxonomy, 3-State-Feature-Modell, Capabilities-Cache (24h TTL) | #68 |
-| **2B — Button-Gating** | v1.8.3 | Flash/Wake auf SEAT/CUPRA capability-aware ausblenden | #56 |
-| **2C — Lock-Debug + userPosition** | v1.8.4 | Lock `internal-error` analysieren + userPosition-Semantik verifizieren | #56 |
-| **3 — Command Profile** | v1.8.5 | Brand/Region/Plattform-Routing, RS e-tron GT Fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonymisierte Diagnostics, Regression-Tests | #62, #58 |
-| **5 — Process & Governance** | — | Issue Forms, Brand Captains, CODEOWNERS, Privacy Guide | #64 |
-| **6 — Read-only + Locking** | v1.9.0 | Read-only Modus, Command Locking, Cloud vs Wake | #63, #55 |
-| **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |
-| **8 — Push Škoda** | v1.9.2 | MQTT Broker Integration | #57 |
-| **9 — Feature Batch** | v1.10.0 | Verbrauchsdaten, Ladehistorie, Abfahrtstimer-UI, Alarm, Ladeprofile | #24, #35, #26, #33, #31 |
-| **10 — HACS Default + v2.0.0** | v2.0.0 | Live-Tests alle Marken, Compatibility Matrix, EU Data Act ready | #13, #59 |
+| Version | Scope | Issues |
+|---|---|---|
+| **v1.13.0** ⭐ MINOR | Anonymized Diagnostics-Export + Capability-Filter Phase 3 + Read-only Phase 2/3 | #62, #56 Phase 3, #63 Phase 2/3 |
+| **v1.14.0** MINOR | Trip Statistics aus Audi `tripstatistics/v1` | #24, #35 |
+| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), Klima-Timer UI (#26) | various |
+| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
+| **v2.0.0** 🎉 MAJOR | HACS Default + Live-Tests alle Marken + EU Data Act ready (Sept 2026 Deadline) | #13, #59 |
 
-> Reihenfolge ist **strikt P0 → P1 → P2**. Sessions 1–4 sind nicht-verhandelbar bevor neue Features kommen.
+> Reihenfolge ist **strikt P0 → P1 → P2**. Bug-Fixes haben immer Vorrang vor Features.
 
 ---
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
@@ -38,60 +38,95 @@ Vanaf v0.14.1 communiceert de integratie **rechtstreeks** met de CARIAD API — 
 
 > ✅ **Actief onderhouden multi-merk opvolger** van [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (gearchiveerd op 2025-10-29) en [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated op 2025-03-14). Eén integratie voor Audi, VW, Škoda, SEAT, CUPRA, Porsche en VW US/CA — geen aparte plugin per merk.
 
-## Huidige status & eerlijke beperkingen (v1.8.12)
+## Huidige status & eerlijke beperkingen / Current Status & Honest Limits (v1.12.3)
+
+VAG Connect ontwikkelt zich actief verder. Zodat je weet wat werkt en wat eraan komt:
 
 ### ✅ Wat NU werkt (alle 7 merken)
 
-- 🟢🟡⚫ **Multi-Brand Connection-State sensor** — online / standby / offline voor alle merken (v1.8.12).
-- 🛡️ **Defensieve stabiliteit** — 504 retry, transient-network-error retry, 6h stale-cache + 3-fail tolerance (v1.8.7).
-- 🔓 **Lock / Climate / Charging commando's** voor Audi 2024+ en VW Passat 2025 — 10 commando's met CARIAD `/v1/` ↔ `/v2/` fallback (v1.8.5 + v1.8.8).
-- 🚪 **CUPRA / SEAT volledige entities** met geverifieerde OLA JSON paden + binary sensors per venster (v1.8.9).
-- 🚙 **Škoda** `detail` block + `reliableLockStatus` + `fullyChargedAt` (v1.8.11).
+**🛰️ 1-klik bug reports & feature requests (LIVE sinds v1.9.0)**
 
-### 🔬 Binnenkort: 1-klik bug reports & feature requests (v1.9.0)
+Twee diagnose-sensoren met een gedeelde reporter-pipeline — **eerste echte live-validatie door community-gebruikers** in v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) en v1.12.3 (DnnsJp74 / Audi):
 
-> **Jij helpt ons de integratie te verbeteren — zonder een woord GitHub of Markdown te leren.**
+- 🔬 **Vehicle Data Scout** — detecteert automatisch onbekende JSON-velden in de API van je auto. Per merk gelokaliseerd in 8 talen (DE: API-Beobachter, FR: Observateur d'API, etc.).
+- 🚨 **Error Reporter** — Ring-buffer van de laatste 20 integratie-fouten met geanonimiseerde context (model, firmware, stack trace).
+- 🔘 **Reporter Pipeline:** beide sensoren maken automatisch HA Repair-notificaties met een vooringevuld GitHub-Issue als 1-klik link. Plus een diagnostics-download met alles gemaskeerd voor forum/Facebook.
+- 🔒 **Privacy-belofte:** Niets verlaat je HA zonder jouw expliciete klik. VINs gemaskeerd, GPS afgerond op 1 decimaal, JWT's/UUID's/e-mails verwijderd. AVG/GDPR-compliant.
 
-Twee nieuwe diagnose-sensoren in v1.9.0:
+**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
 
-| Sensor | Wat het doet | Hoe het je helpt |
-|---|---|---|
-| 🔬 **Voertuigdata-verkenner** | Detecteert automatisch nieuwe velden in de API van je auto die we nog niet uitlezen | Als je Audi A4 2017 of VW Golf 7 GTE velden levert die we niet kennen → we voegen ze toe in de volgende versie |
-| 🛠️ **Foutrapport** | Verzamelt recente fouten met geanonimiseerde context (model, firmware, stack trace) | In plaats van forum-screenshot zonder info → gestructureerd bug report dat we direct kunnen fixen |
+Sensor `connection_state` (online / standby / offline) voor Audi, VW EU, Škoda, SEAT, CUPRA — eerste VAG-integratie met gecentraliseerde verbindingsstatus. Brand-agnostische helper `compute_connection_state` met recursieve `carCapturedTimestamp` walk.
 
-**1-klik workflow** (gelijk voor beide sensoren):
+**🔋 12V-Accu monitoring + Smart-Wake (v1.12.0)**
 
-```
-1. HA toont een notificatie wanneer iets nieuws gedetecteerd wordt
-2. Klik "Meer info" → modal met geanonimiseerde inhoud + 2 knoppen:
+- `voltage_12v` sensor (V) + `warning_12v_low` binary bij <11.5V — voorkomt stille API-uitval door lege startaccu
+- `wake_count_today` sensor + soft-cap op 3 wakes/dag (`_WAKE_BUDGET_PER_DAY`) beschermt 12V tegen wake-loops, raised `wake_budget_exhausted` VOOR de API-call
 
-   📤 Op GitHub melden    ← opent vooringevuld bug report
-   📋 Kopiëren voor forum/FB ← Markdown naar clipboard
+**💨 Optimistische UI voor Lock/Climate/Charging (v1.11.1)**
 
-3. Submit → klaar in 30 seconden
-```
+Switches schakelen direct bij klik (myskoda PR #832 patroon), API-roundtrip op de achtergrond. Bij failure: revert + ServiceValidationError. 8 actuator-methodes overgezet.
 
-🔒 **Privacy-belofte:** **Geen auto-push.** Niets verlaat je HA-installatie zonder jouw expliciete klik. VINs, GPS, user-IDs anoniem. GDPR-compliant.
+**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up in v1.11.1)**
 
-🤝 **Waarom we dit nodig hebben:** We zijn de enige actieve VAG HA-integratie voor alle 7 merken. Met jouw 1-klik bijdrage ontdekken we verschillen tussen modellen in **dagen in plaats van maanden**.
+Drie expliciete range-sensoren: `electric_range_km`, `combustion_range_km`, `total_range_km`. VW EU/Audi parser classificeert op motortype (4 bronnen in plaats van 2). Audi-diesel-fallback uit `measurements.rangeStatus.value.dieselRange`. Geverifieerd via evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity logs.
 
-### ⚠️ Nog in uitvoering
+**🔒 Read-only Modus Fase 1 (v1.12.0)**
 
-Capability filter fase 2 (v1.9.1) · Defensive coding fase 2 (v1.9.2) · Optimistic Lock/Climate (v1.9.3) · Diagnostics + Smart-wake + 12V drain bescherming (v1.10.0) · Push updates (v1.10.x) · Trip stats + EU Data Act (v1.11.0 / v2.0.0).
+Options-toggle "Read-only Mode" → skip lock/switch/button(non-refresh)/climate/number platformen voor privacy/safety-conservatieve eigenaren. Sensors + binary_sensors + device_tracker blijven.
 
-### 🚫 Bewuste beperkingen
+**⚡ Schrijfbare Max-Charge-Current Number (v1.12.0)**
 
-- **Image-platform:** geen officiële CARIAD render API. Wordt verwijderd of omgezet naar gebruiker-URLs in v1.10.0.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — graceful degradation in plaats van 404.
-- **Ford / niet-VAG merken:** buiten scope — zie [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass).
+Slider 6-32A in plaats van alleen een read-only sensor. Nieuwe `command_set_max_charge_current` POST chargingSettings.
+
+**💡 Per-Light Binary-Sensors (v1.12.0)**
+
+Dynamisch per lichttype uit `lights_individual` dict + aggregaten `lights_on` + `lights_count`.
+
+**🛠️ Defensieve stabiliteit (v1.8.7 + v1.10.1)**
+
+- 504-retry, transient-network-error retry, 6h stale-cache + 3-failure tolerance
+- Token-refresh-storm bescherming (max 3/h) — voorkomt IP-bans
+- `safe_int` / `safe_float` / `safe_enum` helpers — toleranter voor backend-quirks
+
+**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhard's #53 eerste live-validatie)**
+
+Field-name fallback-keten: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerantie voor `"connected"` / `"locked"`. Backwards-compat behouden.
+
+**🔓 Lock + Wake voor Audi/VW (v1.9.1, #92 Audi S6 C8)**
+
+`command_lock` stuurt nu S-PIN voor Audi/VW (CARIAD BFF antwoordde `403 spin_error`). `command_wake` gebruikt v1→v2 fallback.
+
+**🛡️ Capability-Filter Fase 2 (v1.9.1, #56)**
+
+`classify_command_failure` body-sniffing voor `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error` markers. `_cariad_cmd` schrijft elke uitkomst naar FeatureState. Command-gebonden entities (Lock/Climate/Switch/Buttons) gaan automatisch unavailable bij definitieve backend-"nee".
+
+### ⚠️ Nog in uitvoering / What's still in progress (geplande sessies)
+
+- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Fase 3 (`capability.active && user-enabled` PRE-entity-creation, verbergt knoppen zoals de MyCupra-app) + Read-only Fase 2/3 (Command-Locking + cloud_refresh vs wake_vehicle service-scheiding).
+- **v1.14.0 MINOR** — Trip Statistics uit Audi `tripstatistics/v1` (#24, #35).
+- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26).
+- **v1.16.0 MINOR** — Locatie-specifieke laaddoel-SoC + laadprofielen (#25, #31).
+- **v1.17.0 MINOR** — Remote Start ICE (#28, audi_connect_ha #717 patroon).
+- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) voor real-time updates zonder polling (#57, #27).
+- **v2.0.0 MAJOR** — HACS Default + Live-Tests alle merken + EU Data Act ready (pycupra `EUDAConnection` als referentie, deadline september 2026) (#13, #59).
+
+### 🚫 Bewuste beperkingen / Conscious limits
+
+- **Image-platform:** geen officiële CARIAD render-image API. De image-entity zal in een toekomstige release overgaan naar door gebruiker geleverde URLs.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nieuwe E³ 1.2 architectuur, nog niet publiek reverse-engineered (ook niet in audi_connect_ha of CarConnectivity). VAG Connect detecteert deze voertuigen en doet **graceful degradation** in plaats van 404-fouten.
+- **Ford / niet-VAG merken:** buiten scope — zie [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) voor Ford.
 
 ### 🔧 Privacy-vereiste
 
-**"Locatie delen"** moet ingeschakeld zijn in My-VW / My-Audi / MySkoda / MyCupra — anders backend 403.
+Voor GPS-positie, voertuigstatus en standkachel moet **"Locatie delen"** ingeschakeld zijn in je My-VW / My-Audi / MySkoda / MyCupra app — anders antwoordt de backend met 403.
 
-### 📚 Meer info
+### 📚 Meer info / More info
 
-- 🗺️ [`../docs/ROADMAP.md`](../docs/ROADMAP.md) · 📜 [`../docs/CHANGELOG_TECHNICAL.md`](../docs/CHANGELOG_TECHNICAL.md) · 🤝 [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md) · 🔬 [`../docs/RESEARCH_NOTES_2026-04-29.md`](../docs/RESEARCH_NOTES_2026-04-29.md)
+- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — volledige P0/P1/P2/P3 prioritisering van alle openstaande issues
+- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + architectuur-beslissingen + externe source-refs
+- 🤝 Session Handoff (voor bijdragers & AI-tools): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
+- 🔒 Privacy & data handling regels: [`CONTRIBUTING.md`](CONTRIBUTING.md) sectie (post-#53 third-party review)
+- 📋 FAQ Subscription / Service Plus / `missing-capability` diagnose: [`CONTRIBUTING.md`](CONTRIBUTING.md) FAQ-sectie
 
 ---
 
@@ -187,39 +222,39 @@ Herstart Home Assistant.
 
 ## Roadmap
 
-### Tot nu toe bereikt
+> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — volledige P0/P1/P2/P3 prioritisering met alle ~20 openstaande issues gecategoriseerd.
 
-| Versie | Inhoud | Status |
+### Recente releases / Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+
+| Versie | Inhoud | Datum |
 |---|---|---|
-| v1.0–v1.5 | 9 platformen, 7 merken, bugfixes & entiteit-audit | ✅ Klaar |
-| v1.6.0 | SEAT/CUPRA 9 endpoints, Škoda fix, Audi PPC, vergrendeling, nachtmodus | ✅ Klaar |
-| v1.7.0 | Complete Škoda herschrijving, autovriendelijke vertalingen alle talen, betrouwbaarheid | ✅ Klaar |
+| v1.8.6–v1.8.12 | Foundation-Sprint: defensieve stabiliteit, Capability-Filter Fase 2, Multi-Brand Connection-State, alle merk-parsers op geverifieerde live-API-paden | 2026-04-29 |
+| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
+| v1.9.1 | Audi/VW Lock + Wake hotfix (#92) + Capability-Filter Fase 2 + Scout-paden #90/#91 | 2026-04-29 |
+| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Fase 2 (#58), CUPRA Born 2026 firmware (#53 Gerhard) | 2026-04-29/30 |
+| v1.11.0–v1.11.1 | Issue #91 closure (Light/Service/Number), Golf GTE Fuel-Range fix (#96), Optimistische UI (3B-Part-3) | 2026-04-30 |
+| v1.12.0 | 🔋💡⚡🧯🔒 5-in-1 Sprint: 12V (#23) + Per-Light + Schrijfbare Number + Smart-Wake (#55) + Read-only Fase 1 (#63) | 2026-04-30 |
+| v1.12.1 | Scout-paden #105/#106 + Gerhard's Born fixture (#53 met toestemming) + #47 FAQ | 2026-04-30 |
+| v1.12.2 | 🌟 **Eerste community-Scout-rapport** (Skoda #107 van tritanium73) | 2026-05-01 |
+| **v1.12.3** | Scout-paden #111+#113+#114 gebundeld met wildcard-strategie (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
 
-### Sessieplan (P0 → P2)
+### Volgende sessies / Next sessions
 
-| Sessie | Versie | Scope | Issues |
-|---|---|---|---|
-| **1 — Foundation Fix** | v1.8.0 | iot_class, beschikbaarheid per VIN, S-PIN fail-fast, neppe writables verwijderd | **#60** |
-| **1.5 — Privacy & Auth** | v1.8.1 | VIN-masking in logs/diagnostics, ConfigEntryAuthFailed bij verouderde credentials, userPosition-documentatie | — |
-| **2A — Capabilities Foundation** | v1.8.2 | Error-taxonomie, 3-state model, capabilities-cache (24h TTL) | #68 |
-| **2B — Button gating** | v1.8.3 | Flash/wake op SEAT/CUPRA verbergen volgens capabilities | #56 |
-| **2C — Lock debug + userPosition** | v1.8.4 | Lock `internal-error` onderzoeken + userPosition verifiëren | #56 |
-| **3 — Command Profile** | v1.8.5 | Merk/regio/platform routing, RS e-tron GT fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.6 | Geanonimiseerde diagnostics, regressietests | #62, #58 |
-| **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, privacy guide | #64 |
-| **6 — Read-only + Locking** | v1.9.0 | Read-only modus, command locking, cloud vs wake | #63, #55 |
-| **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |
-| **8 — Push Škoda** | v1.9.2 | MQTT broker integratie | #57 |
-| **9 — Feature batch** | v1.10.0 | Ritstats, laadgeschiedenis, vertrektimer-UI, alarm, laadprofielen | #24, #35, #26, #33, #31 |
-| **10 — HACS Default + v2.0.0** | v2.0.0 | Live tests alle merken, compatibility matrix, EU Data Act | #13, #59 |
+| Versie | Scope | Issues |
+|---|---|---|
+| **v1.13.0** ⭐ MINOR | Anonymized Diagnostics-Export + Capability-Filter Fase 3 + Read-only Fase 2/3 | #62, #56 Fase 3, #63 Fase 2/3 |
+| **v1.14.0** MINOR | Trip Statistics uit Audi `tripstatistics/v1` | #24, #35 |
+| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26) | various |
+| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
+| **v2.0.0** 🎉 MAJOR | HACS Default + Live-Tests alle merken + EU Data Act ready (sept. 2026 deadline) | #13, #59 |
 
-> Strikte P0 → P1 → P2 volgorde. Sessies 1–4 zijn niet onderhandelbaar voor nieuwe features.
+> De volgorde is **strikt P0 → P1 → P2**. Bug-fixes hebben altijd voorrang op features.
 
 ---
 
 ## Licentie
 
-Apache License 2.0 — [LICENSE](../LICENSE)
+Apache License 2.0 — [LICENSE](LICENSE)
 
 **VAG Connect™** is een niet-geregistreerd handelsmerk (™, niet ®). Gebruik deze naam niet in forks om verwarring te voorkomen.
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
@@ -38,60 +38,95 @@ Od v0.14.1 integracja **bezpośrednio** komunikuje się z API CARIAD — własny
 
 > ✅ **Aktywnie utrzymywany wieloprodukcyjny następca** projektów [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (zarchiwizowany 2025-10-29) i [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). Jedna integracja dla Audi, VW, Škoda, SEAT, CUPRA, Porsche i VW US/CA — bez osobnej wtyczki dla każdej marki.
 
-## Bieżący stan i uczciwe ograniczenia (v1.8.12)
+## Bieżący stan i uczciwe ograniczenia / Current Status & Honest Limits (v1.12.3)
+
+VAG Connect aktywnie się rozwija. Abyś wiedział, co działa i co nadchodzi:
 
 ### ✅ Co działa TERAZ (wszystkie 7 marek)
 
-- 🟢🟡⚫ **Multi-Brand Connection-State sensor** — online / standby / offline dla wszystkich marek (v1.8.12).
-- 🛡️ **Defensywna stabilność** — retry 504, retry przejściowych błędów sieci, cache 6h + tolerancja 3 błędów (v1.8.7).
-- 🔓 **Komendy Lock / Climate / Charging** dla Audi 2024+ i VW Passat 2025 — 10 komend z fallback CARIAD `/v1/` ↔ `/v2/` (v1.8.5 + v1.8.8).
-- 🚪 **CUPRA / SEAT pełne encje** ze zweryfikowanymi ścieżkami JSON OLA + binary sensors na okno (v1.8.9).
-- 🚙 **Škoda** `detail` block + `reliableLockStatus` + `fullyChargedAt` (v1.8.11).
+**🛰️ Bug reporty i prośby o funkcje 1-kliknięciem (LIVE od v1.9.0)**
 
-### 🔬 Wkrótce: Bug reporty 1-kliknięciem & prośby o funkcje (v1.9.0)
+Dwa sensory diagnostyczne ze wspólną pipeline reportera — **pierwsza prawdziwa walidacja live przez użytkowników społeczności** w v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) i v1.12.3 (DnnsJp74 / Audi):
 
-> **Pomagasz nam ulepszać integrację — bez uczenia się ani słowa GitHuba czy Markdown.**
+- 🔬 **Vehicle Data Scout** — wykrywa automatycznie nieznane pola JSON w API twojego auta. Lokalizowany per marka w 8 językach (DE: API-Beobachter, FR: Observateur d'API, etc.).
+- 🚨 **Error Reporter** — Ring-buffer ostatnich 20 błędów integracji z anonimizowanym kontekstem (model, firmware, stack trace).
+- 🔘 **Reporter Pipeline:** oba sensory tworzą automatycznie powiadomienia HA Repair z prefilled GitHub-Issue jako linkiem 1-kliknięciem. Plus pobranie diagnostics ze wszystkim zamaskowanym dla forum/Facebooka.
+- 🔒 **Obietnica prywatności:** Nic nie opuszcza twojego HA bez twojego wyraźnego kliknięcia. VIN-y zamaskowane, GPS zaokrąglone do 1 miejsca po przecinku, JWT/UUID/e-maile usunięte. Zgodne z RODO/GDPR.
 
-Dwa nowe sensory diagnostyczne w v1.9.0:
+**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
 
-| Sensor | Co robi | Jak ci pomaga |
-|---|---|---|
-| 🔬 **Wykrywacz nowych danych** | Wykrywa automatycznie nowe pola w API twojego auta których jeszcze nie parsujemy | Jeśli twoje Audi A4 2017 lub VW Golf 7 GTE zwraca nieznane pola → dodajemy je w następnej wersji |
-| 🛠️ **Reporter błędów** | Zbiera ostatnie błędy z anonimizowanym kontekstem (model, firmware, stack trace) | Zamiast screenshota z forum bez info → strukturalny bug report który od razu naprawiamy |
+Sensor `connection_state` (online / standby / offline) dla Audi, VW EU, Škoda, SEAT, CUPRA — pierwsza integracja VAG ze scentralizowanym statusem połączenia. Brand-agnostyczny helper `compute_connection_state` z rekursywnym przejściem `carCapturedTimestamp`.
 
-**Workflow 1-kliknięciem** (jednakowy dla obu sensorów):
+**🔋 Monitoring akumulatora 12V + Smart-Wake (v1.12.0)**
 
-```
-1. HA pokazuje powiadomienie gdy coś nowego zostanie wykryte
-2. Klikasz "Więcej info" → modal z anonimizowaną zawartością + 2 przyciski:
+- Sensor `voltage_12v` (V) + binary `warning_12v_low` przy <11.5V — zapobiega cichym awariom API spowodowanym pustym akumulatorem rozruchowym
+- Sensor `wake_count_today` + soft-cap na 3 wakes/dzień (`_WAKE_BUDGET_PER_DAY`) chroni 12V przed wake-loops, podnosi `wake_budget_exhausted` PRZED wywołaniem API
 
-   📤 Zgłoś na GitHub    ← otwiera prefilled bug report
-   📋 Kopiuj dla forum/FB ← Markdown do schowka
+**💨 Optymistyczne UI dla Lock/Climate/Charging (v1.11.1)**
 
-3. Submit → gotowe w 30 sekund
-```
+Switche przełączają się natychmiast po kliknięciu (wzorzec myskoda PR #832), roundtrip API w tle. Przy niepowodzeniu: revert + ServiceValidationError. 8 metod actuator przeniesionych.
 
-🔒 **Obietnica prywatności:** **Bez auto-push.** Nic nie opuszcza twojej instalacji HA bez twojego kliknięcia. VINy, GPS, user-IDy anonimizowane. GDPR-compliant.
+**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up w v1.11.1)**
 
-🤝 **Dlaczego tego potrzebujemy:** Jesteśmy jedyną aktywną integracją HA VAG dla wszystkich 7 marek. Twój 1-kliknięcie wkład pomaga nam odkrywać różnice między modelami w **dniach zamiast miesięcy**.
+Trzy jawne sensory zasięgu: `electric_range_km`, `combustion_range_km`, `total_range_km`. Parser VW EU/Audi klasyfikuje wg typu silnika (4 źródła zamiast 2). Fallback diesel Audi z `measurements.rangeStatus.value.dieselRange`. Zweryfikowany przez evcc-io/evcc#19045 + sample Audi Q4 + logi CarConnectivity.
 
-### ⚠️ Jeszcze w toku
+**🔒 Tryb Read-only Faza 1 (v1.12.0)**
 
-Capability filter faza 2 (v1.9.1) · Defensive coding faza 2 (v1.9.2) · Optimistic Lock/Climate (v1.9.3) · Diagnostics + Smart-wake + ochrona drain 12V (v1.10.0) · Push updates (v1.10.x) · Trip stats + EU Data Act (v1.11.0 / v2.0.0).
+Toggle opcji "Read-only Mode" → pomija platformy lock/switch/button(non-refresh)/climate/number dla właścicieli ostrożnych w kwestii prywatności/bezpieczeństwa. Sensors + binary_sensors + device_tracker pozostają.
 
-### 🚫 Świadome ograniczenia
+**⚡ Zapisywalny Number Max-Charge-Current (v1.12.0)**
 
-- **Platforma image:** nie istnieje oficjalne CARIAD render API. Zostanie usunięta lub przełączona na URL-e użytkownika w v1.10.0.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — graceful degradation zamiast 404.
-- **Ford / marki spoza VAG:** poza zakresem — patrz [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass).
+Slider 6-32A zamiast tylko sensora read-only. Nowy `command_set_max_charge_current` POST chargingSettings.
+
+**💡 Per-Light Binary-Sensors (v1.12.0)**
+
+Dynamicznie per typ światła z dict `lights_individual` + agregaty `lights_on` + `lights_count`.
+
+**🛠️ Defensywna stabilność (v1.8.7 + v1.10.1)**
+
+- Retry 504, retry przejściowych błędów sieci, cache 6h + tolerancja 3 błędów
+- Ochrona przed token-refresh-storm (max 3/h) — zapobiega banom IP
+- Helpery `safe_int` / `safe_float` / `safe_enum` — tolerują dziwactwa backendu
+
+**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — pierwsza walidacja live Gerharda #53)**
+
+Łańcuch fallback nazw pól: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Tolerancja enum lowercase dla `"connected"` / `"locked"`. Wsteczna kompatybilność zachowana.
+
+**🔓 Lock + Wake dla Audi/VW (v1.9.1, #92 Audi S6 C8)**
+
+`command_lock` wysyła teraz S-PIN dla Audi/VW (CARIAD BFF odpowiadał `403 spin_error`). `command_wake` używa fallback v1→v2.
+
+**🛡️ Capability-Filter Faza 2 (v1.9.1, #56)**
+
+Body-sniffing `classify_command_failure` dla markerów `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error`. `_cariad_cmd` zapisuje każdy wynik do FeatureState. Encje powiązane z komendami (Lock/Climate/Switch/Buttons) automatycznie stają się unavailable przy ostatecznym "nie" backendu.
+
+### ⚠️ Jeszcze w toku / What's still in progress (zaplanowane sesje)
+
+- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Faza 3 (`capability.active && user-enabled` PRE-tworzenie-encji, ukrywa przyciski jak aplikacja MyCupra) + Read-only Faza 2/3 (Command-Locking + rozdzielenie usług cloud_refresh vs wake_vehicle).
+- **v1.14.0 MINOR** — Trip Statistics z Audi `tripstatistics/v1` (#24, #35).
+- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), UI timera Climate (#26).
+- **v1.16.0 MINOR** — Specyficzne dla lokalizacji SoC docelowy ładowania + profile ładowania (#25, #31).
+- **v1.17.0 MINOR** — Remote Start ICE (#28, wzorzec audi_connect_ha #717).
+- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) dla aktualizacji w czasie rzeczywistym bez pollingu (#57, #27).
+- **v2.0.0 MAJOR** — HACS Default + Live-Tests wszystkich marek + EU Data Act ready (pycupra `EUDAConnection` jako referencja, deadline wrzesień 2026) (#13, #59).
+
+### 🚫 Świadome ograniczenia / Conscious limits
+
+- **Platforma image:** nie istnieje oficjalne API CARIAD render-image. Encja image przejdzie na URL-e dostarczone przez użytkownika w przyszłej release.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nowa architektura E³ 1.2, jeszcze nie zreverse-engineered publicznie (nawet w audi_connect_ha ani CarConnectivity). VAG Connect wykrywa te pojazdy i robi **graceful degradation** zamiast błędów 404.
+- **Ford / marki spoza VAG:** poza zakresem — patrz [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) dla Forda.
 
 ### 🔧 Wymóg prywatności
 
-**"Udostępnij moją lokalizację"** musi być włączone w My-VW / My-Audi / MySkoda / MyCupra — inaczej backend 403.
+Aby pozycja GPS, status pojazdu i ogrzewanie postojowe działały, **"Udostępnij moją lokalizację"** musi być włączone w twojej aplikacji My-VW / My-Audi / MySkoda / MyCupra — inaczej backend odpowiada 403.
 
-### 📚 Więcej informacji
+### 📚 Więcej informacji / More info
 
-- 🗺️ [`../docs/ROADMAP.md`](../docs/ROADMAP.md) · 📜 [`../docs/CHANGELOG_TECHNICAL.md`](../docs/CHANGELOG_TECHNICAL.md) · 🤝 [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md) · 🔬 [`../docs/RESEARCH_NOTES_2026-04-29.md`](../docs/RESEARCH_NOTES_2026-04-29.md)
+- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — pełna priorytyzacja P0/P1/P2/P3 wszystkich otwartych issues
+- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: mapowania pól + decyzje architektoniczne + refy do zewnętrznych źródeł
+- 🤝 Session Handoff (dla współtwórców i narzędzi AI): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
+- 🔒 Zasady prywatności i obsługi danych: sekcja [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
+- 📋 FAQ Subscription / Service Plus / diagnoza `missing-capability`: sekcja FAQ w [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ---
 
@@ -185,41 +220,41 @@ Uruchom ponownie Home Assistant.
 
 ---
 
-## Mapa Drogowa
+## Mapa Drogowa / Roadmap
 
-### Osiągnięte
+> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — pełna priorytyzacja P0/P1/P2/P3 ze wszystkimi ~20 otwartymi issues skategoryzowanymi.
 
-| Wersja | Zawartość | Status |
+### Ostatnie release / Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+
+| Wersja | Zawartość | Data |
 |---|---|---|
-| v1.0–v1.5 | 9 platform, 7 marek, poprawki & audyt encji | ✅ Gotowe |
-| v1.6.0 | SEAT/CUPRA 9 endpointów, poprawka Škoda, Audi PPC, zamek, tryb nocny | ✅ Gotowe |
-| v1.7.0 | Kompletne przepisanie Škoda, motoryzacyjne tłumaczenia we wszystkich językach, niezawodność | ✅ Gotowe |
+| v1.8.6–v1.8.12 | Foundation-Sprint: defensywna stabilność, Capability-Filter Faza 2, Multi-Brand Connection-State, wszystkie parsery marek na zweryfikowanych ścieżkach API live | 2026-04-29 |
+| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
+| v1.9.1 | Hotfix Audi/VW Lock + Wake (#92) + Capability-Filter Faza 2 + ścieżki Scout #90/#91 | 2026-04-29 |
+| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Faza 2 (#58), firmware CUPRA Born 2026 (#53 Gerhard) | 2026-04-29/30 |
+| v1.11.0–v1.11.1 | Closure Issue #91 (Light/Service/Number), fix Golf GTE Fuel-Range (#96), Optymistyczne UI (3B-Part-3) | 2026-04-30 |
+| v1.12.0 | 🔋💡⚡🧯🔒 Sprint 5-w-1: 12V (#23) + Per-Light + Zapisywalny Number + Smart-Wake (#55) + Read-only Faza 1 (#63) | 2026-04-30 |
+| v1.12.1 | Ścieżki Scout #105/#106 + fixture Born Gerharda (#53 za zgodą) + FAQ #47 | 2026-04-30 |
+| v1.12.2 | 🌟 **Pierwszy Scout-Report od społeczności** (Skoda #107 od tritanium73) | 2026-05-01 |
+| **v1.12.3** | Ścieżki Scout #111+#113+#114 zbundlowane ze strategią wildcard (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
 
-### Plan sesji (P0 → P2)
+### Następne sesje / Next sessions
 
-| Sesja | Wersja | Zakres | Issues |
-|---|---|---|---|
-| **1 — Foundation Fix** | v1.8.0 | iot_class, dostępność per VIN, S-PIN fail-fast, fałszywe writable usunięte | **#60** |
-| **1.5 — Prywatność & Auth** | v1.8.1 | Maskowanie VIN w logach/diagnostyce, ConfigEntryAuthFailed przy nieaktualnych poświadczeniach, dokumentacja userPosition | — |
-| **2A — Capabilities Foundation** | v1.8.2 | Taksonomia błędów, model 3-stanów, cache capabilities (TTL 24h) | #68 |
-| **2B — Button gating** | v1.8.3 | Ukrywanie flash/wake na SEAT/CUPRA wg capabilities | #56 |
-| **2C — Lock debug + userPosition** | v1.8.4 | Analiza lock `internal-error` + weryfikacja userPosition | #56 |
-| **3 — Command Profile** | v1.8.5 | Routing marka/region/platforma, fix RS e-tron GT | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonimizowane diagnostyki, testy regresji | #62, #58 |
-| **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, przewodnik prywatności | #64 |
-| **6 — Read-only + Locking** | v1.9.0 | Tryb read-only, command locking, cloud vs wake | #63, #55 |
-| **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |
-| **8 — Push Škoda** | v1.9.2 | Integracja brokera MQTT | #57 |
-| **9 — Feature batch** | v1.10.0 | Statystyki, historia ładowania, UI timerów, alarm, profile ładowania | #24, #35, #26, #33, #31 |
-| **10 — HACS Default + v2.0.0** | v2.0.0 | Live testy wszystkich marek, compatibility matrix, EU Data Act | #13, #59 |
+| Wersja | Zakres | Issues |
+|---|---|---|
+| **v1.13.0** ⭐ MINOR | Anonymized Diagnostics-Export + Capability-Filter Faza 3 + Read-only Faza 2/3 | #62, #56 Faza 3, #63 Faza 2/3 |
+| **v1.14.0** MINOR | Trip Statistics z Audi `tripstatistics/v1` | #24, #35 |
+| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), UI timera Climate (#26) | various |
+| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
+| **v2.0.0** 🎉 MAJOR | HACS Default + Live-Tests wszystkich marek + EU Data Act ready (deadline wrz. 2026) | #13, #59 |
 
-> Ścisła kolejność P0 → P1 → P2. Sesje 1–4 są nienegocjowalne przed nowymi funkcjami.
+> Kolejność jest **ściśle P0 → P1 → P2**. Bug-fixy zawsze mają pierwszeństwo przed funkcjami.
 
 ---
 
 ## Licencja
 
-Apache License 2.0 — [LICENSE](../LICENSE)
+Apache License 2.0 — [LICENSE](LICENSE)
 
 **VAG Connect™** jest niezastrzeżonym znakiem towarowym (™, nie ®). Prosimy nie używać tej nazwy w forkach, aby uniknąć nieporozumień.
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
-  <a href="../LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
   <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
@@ -38,60 +38,95 @@ Från v0.14.1 kommunicerar integrationen **direkt** med CARIAD API — egen asyn
 
 > ✅ **Aktivt underhållen multi-märkes-efterträdare** till [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (arkiverat 2025-10-29) och [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). En integration för Audi, VW, Škoda, SEAT, CUPRA, Porsche och VW US/CA — ingen separat plugin per märke.
 
-## Nuvarande status och ärliga begränsningar (v1.8.12)
+## Nuvarande status och ärliga begränsningar / Current Status & Honest Limits (v1.12.3)
+
+VAG Connect utvecklas aktivt vidare. Så att du vet vad som fungerar och vad som kommer:
 
 ### ✅ Vad som fungerar NU (alla 7 märken)
 
-- 🟢🟡⚫ **Multi-Brand Connection-State sensor** — online / standby / offline för alla märken (v1.8.12).
-- 🛡️ **Defensiv stabilitet** — 504 retry, transient-network-error retry, 6h stale-cache + 3-fail tolerance (v1.8.7).
-- 🔓 **Lock / Climate / Charging-kommandon** för Audi 2024+ och VW Passat 2025 — 10 kommandon med CARIAD `/v1/` ↔ `/v2/` fallback (v1.8.5 + v1.8.8).
-- 🚪 **CUPRA / SEAT fullständiga entiteter** med verifierade OLA JSON-vägar + binary sensors per fönster (v1.8.9).
-- 🚙 **Škoda** `detail` block + `reliableLockStatus` + `fullyChargedAt` (v1.8.11).
+**🛰️ 1-klick bug rapporter & feature-önskemål (LIVE sedan v1.9.0)**
 
-### 🔬 Kommer snart: 1-klick bug rapporter & feature-önskemål (v1.9.0)
+Två diagnostiska sensorer med en gemensam reporter pipeline — **första riktiga live-validering av community-användare** i v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) och v1.12.3 (DnnsJp74 / Audi):
 
-> **Du hjälper oss att förbättra integrationen — utan att lära dig ett enda ord GitHub eller Markdown.**
+- 🔬 **Vehicle Data Scout** — upptäcker automatiskt okända JSON-fält i din bils API. Märkes-lokaliserad på 8 språk (DE: API-Beobachter, FR: Observateur d'API, etc.).
+- 🚨 **Error Reporter** — Ring-buffer av de senaste 20 integrationsfelen med anonymiserad kontext (modell, firmware, stack trace).
+- 🔘 **Reporter Pipeline:** båda sensorerna skapar automatiskt HA Repair-notifikationer med ett förifyllt GitHub-Issue som 1-klicks länk. Plus en diagnostics-nedladdning med allt maskerat för forum/Facebook.
+- 🔒 **Integritetslöfte:** Inget lämnar din HA utan din explicita klick. VIN maskerade, GPS avrundad till 1 decimal, JWT/UUID/e-post borttagna. GDPR-compliant.
 
-Två nya diagnostiska sensorer i v1.9.0:
+**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
 
-| Sensor | Vad den gör | Hur den hjälper dig |
-|---|---|---|
-| 🔬 **Fordonsdata-spårare** | Upptäcker automatiskt nya fält i din bils API som vi inte parsar än | Om din Audi A4 2017 eller VW Golf 7 GTE returnerar okända fält → vi lägger till dem i nästa version |
-| 🛠️ **Fel-rapportör** | Samlar in senaste fel med anonymiserad kontext (modell, firmware, stack trace) | Istället för forum-skärmdump utan info → strukturerad bug report vi kan fixa direkt |
+Sensor `connection_state` (online / standby / offline) för Audi, VW EU, Škoda, SEAT, CUPRA — första VAG-integration med centraliserad anslutningsstatus. Brand-agnostisk helper `compute_connection_state` med rekursiv `carCapturedTimestamp` walk.
 
-**1-klick workflow** (samma för båda sensorer):
+**🔋 12V-batteri-övervakning + Smart-Wake (v1.12.0)**
 
-```
-1. HA visar en notifikation när något nytt upptäcks
-2. Klicka "Mer info" → modal med anonymiserat innehåll + 2 knappar:
+- Sensor `voltage_12v` (V) + binary `warning_12v_low` vid <11.5V — förhindrar tysta API-avbrott orsakade av tomt startbatteri
+- Sensor `wake_count_today` + soft-cap på 3 wakes/dag (`_WAKE_BUDGET_PER_DAY`) skyddar 12V mot wake-loops, höjer `wake_budget_exhausted` INNAN API-anrop
 
-   📤 Rapportera på GitHub  ← öppnar förifyllt bug report
-   📋 Kopiera för forum/FB  ← Markdown till urklipp
+**💨 Optimistisk UI för Lock/Climate/Charging (v1.11.1)**
 
-3. Submit → klart på 30 sekunder
-```
+Switches växlar omedelbart vid klick (myskoda PR #832 mönster), API-roundtrip i bakgrunden. Vid misslyckande: revert + ServiceValidationError. 8 actuator-metoder migrerade.
 
-🔒 **Integritetslöfte:** **Ingen auto-push.** Inget lämnar din HA-installation utan din explicita klick. VINs, GPS, user-IDs anonymiseras. GDPR-compliant.
+**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up i v1.11.1)**
 
-🤝 **Varför vi behöver det:** Vi är den enda aktiva VAG HA-integrationen för alla 7 märken. Med ditt 1-klick bidrag upptäcker vi skillnader mellan modeller på **dagar istället för månader**.
+Tre explicita räckviddssensorer: `electric_range_km`, `combustion_range_km`, `total_range_km`. VW EU/Audi-parser klassificerar efter motortyp (4 källor istället för 2). Audi-diesel-fallback från `measurements.rangeStatus.value.dieselRange`. Verifierat via evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity-loggar.
 
-### ⚠️ Fortfarande pågår
+**🔒 Read-only-läge Fas 1 (v1.12.0)**
 
-Capability filter fas 2 (v1.9.1) · Defensiv kodning fas 2 (v1.9.2) · Optimistic Lock/Climate (v1.9.3) · Diagnostics + Smart-wake + 12V drain-skydd (v1.10.0) · Push updates (v1.10.x) · Trip stats + EU Data Act (v1.11.0 / v2.0.0).
+Options-toggle "Read-only Mode" → hoppa över lock/switch/button(non-refresh)/climate/number-plattformar för privacy/safety-konservativa ägare. Sensors + binary_sensors + device_tracker stannar.
 
-### 🚫 Medvetna begränsningar
+**⚡ Skrivbar Max-Charge-Current Number (v1.12.0)**
 
-- **Image-plattform:** inget officiellt CARIAD render API. Tas bort eller byts mot användar-URL:er i v1.10.0.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — graceful degradation istället för 404.
-- **Ford / icke-VAG-märken:** utanför scope — se [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass).
+Slider 6-32A istället för bara en read-only-sensor. Ny `command_set_max_charge_current` POST chargingSettings.
+
+**💡 Per-Light Binary-Sensors (v1.12.0)**
+
+Dynamiskt per ljustyp från `lights_individual` dict + aggregat `lights_on` + `lights_count`.
+
+**🛠️ Defensiv stabilitet (v1.8.7 + v1.10.1)**
+
+- 504-retry, transient-network-error retry, 6h stale-cache + 3-failure tolerance
+- Token-refresh-storm-skydd (max 3/h) — förhindrar IP-bans
+- Helpers `safe_int` / `safe_float` / `safe_enum` — tolererar backend-quirks
+
+**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhards #53 första live-validering)**
+
+Field-name fallback-kedja: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerance för `"connected"` / `"locked"`. Bakåtkompatibilitet bevarad.
+
+**🔓 Lock + Wake för Audi/VW (v1.9.1, #92 Audi S6 C8)**
+
+`command_lock` skickar nu S-PIN för Audi/VW (CARIAD BFF svarade `403 spin_error`). `command_wake` använder v1→v2 fallback.
+
+**🛡️ Capability-Filter Fas 2 (v1.9.1, #56)**
+
+Body-sniffing `classify_command_failure` för `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error` markörer. `_cariad_cmd` skriver varje resultat till FeatureState. Command-bundna entiteter (Lock/Climate/Switch/Buttons) går automatiskt unavailable vid definitivt "nej" från backend.
+
+### ⚠️ Fortfarande pågår / What's still in progress (planerade sessioner)
+
+- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Fas 3 (`capability.active && user-enabled` PRE-entity-creation, döljer knappar som MyCupra-appen) + Read-only Fas 2/3 (Command-Locking + cloud_refresh vs wake_vehicle service-separation).
+- **v1.14.0 MINOR** — Trip Statistics från Audi `tripstatistics/v1` (#24, #35).
+- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26).
+- **v1.16.0 MINOR** — Platsspecifik laddmål-SoC + laddprofiler (#25, #31).
+- **v1.17.0 MINOR** — Remote Start ICE (#28, audi_connect_ha #717-mönster).
+- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) för realtidsuppdateringar utan polling (#57, #27).
+- **v2.0.0 MAJOR** — HACS Default + Live-tester alla märken + EU Data Act ready (pycupra `EUDAConnection` som referens, deadline september 2026) (#13, #59).
+
+### 🚫 Medvetna begränsningar / Conscious limits
+
+- **Image-plattform:** inget officiellt CARIAD render-image API existerar. Image-entiteten kommer i en framtida release att gå över till användar-tillhandahållna URL:er.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — ny E³ 1.2-arkitektur, ännu inte offentligt reverse-engineered (varken i audi_connect_ha eller CarConnectivity). VAG Connect upptäcker dessa fordon och gör **graceful degradation** istället för 404-fel.
+- **Ford / icke-VAG-märken:** utanför scope — se [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) för Ford.
 
 ### 🔧 Integritetskrav
 
-**"Dela min position"** måste vara aktiverat i My-VW / My-Audi / MySkoda / MyCupra — annars backend 403.
+För att GPS-position, fordonsstatus och kupévärmare ska fungera måste **"Dela min position"** vara aktiverat i din My-VW / My-Audi / MySkoda / MyCupra-app — annars svarar backend med 403.
 
-### 📚 Mer info
+### 📚 Mer info / More info
 
-- 🗺️ [`../docs/ROADMAP.md`](../docs/ROADMAP.md) · 📜 [`../docs/CHANGELOG_TECHNICAL.md`](../docs/CHANGELOG_TECHNICAL.md) · 🤝 [`../docs/SESSION_HANDOFF.md`](../docs/SESSION_HANDOFF.md) · 🔬 [`../docs/RESEARCH_NOTES_2026-04-29.md`](../docs/RESEARCH_NOTES_2026-04-29.md)
+- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — komplett P0/P1/P2/P3-prioritering av alla öppna issues
+- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + arkitekturbeslut + externa source-refs
+- 🤝 Session Handoff (för bidragsgivare och AI-verktyg): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
+- 🔒 Integritets- och datahanteringsregler: sektion [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
+- 📋 FAQ Subscription / Service Plus / `missing-capability` diagnos: FAQ-sektion i [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ---
 
@@ -185,41 +220,41 @@ Starta om Home Assistant.
 
 ---
 
-## Vägkarta
+## Vägkarta / Roadmap
 
-### Hittills uppnått
+> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — komplett P0/P1/P2/P3-prioritering med alla ~20 öppna issues kategoriserade.
 
-| Version | Innehåll | Status |
+### Senaste releases / Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+
+| Version | Innehåll | Datum |
 |---|---|---|
-| v1.0–v1.5 | 9 plattformar, 7 märken, bugfixar & entitetsrevision | ✅ Klart |
-| v1.6.0 | SEAT/CUPRA 9 endpoints, Škoda-fix, Audi PPC, lås, nattläge | ✅ Klart |
-| v1.7.0 | Komplett omskrivning Škoda, bilvänliga översättningar alla språk, tillförlitlighet | ✅ Klart |
+| v1.8.6–v1.8.12 | Foundation-Sprint: defensiv stabilitet, Capability-Filter Fas 2, Multi-Brand Connection-State, alla brand-parsers på verifierade live-API-vägar | 2026-04-29 |
+| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
+| v1.9.1 | Audi/VW Lock + Wake hotfix (#92) + Capability-Filter Fas 2 + Scout-vägar #90/#91 | 2026-04-29 |
+| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Fas 2 (#58), CUPRA Born 2026-firmware (#53 Gerhard) | 2026-04-29/30 |
+| v1.11.0–v1.11.1 | Issue #91-closure (Light/Service/Number), Golf GTE Fuel-Range fix (#96), Optimistisk UI (3B-Part-3) | 2026-04-30 |
+| v1.12.0 | 🔋💡⚡🧯🔒 5-i-1 Sprint: 12V (#23) + Per-Light + Skrivbar Number + Smart-Wake (#55) + Read-only Fas 1 (#63) | 2026-04-30 |
+| v1.12.1 | Scout-vägar #105/#106 + Gerhards Born-fixture (#53 med samtycke) + #47 FAQ | 2026-04-30 |
+| v1.12.2 | 🌟 **Första community-Scout-rapporten** (Skoda #107 från tritanium73) | 2026-05-01 |
+| **v1.12.3** | Scout-vägar #111+#113+#114 buntlade med wildcard-strategi (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
 
-### Sessionsplan (P0 → P2)
+### Nästa sessioner / Next sessions
 
-| Session | Version | Omfattning | Issues |
-|---|---|---|---|
-| **1 — Foundation Fix** | v1.8.0 | iot_class, tillgänglighet per VIN, S-PIN fail-fast, falska writables borttagna | **#60** |
-| **1.5 — Integritet & Auth** | v1.8.1 | VIN-maskering i loggar/diagnostik, ConfigEntryAuthFailed vid utgångna credentials, userPosition-dokumentation | — |
-| **2A — Capabilities Foundation** | v1.8.2 | Felklassificering, 3-tillståndsmodell, capabilities-cache (24h TTL) | #68 |
-| **2B — Button gating** | v1.8.3 | Dölj flash/wake på SEAT/CUPRA enligt capabilities | #56 |
-| **2C — Lock debug + userPosition** | v1.8.4 | Analysera lock `internal-error` + verifiera userPosition | #56 |
-| **3 — Command Profile** | v1.8.5 | Märke/region/plattform-routing, RS e-tron GT-fix | #61, #51 |
-| **4 — Diagnostics + Fixtures** | v1.8.6 | Anonymiserade diagnostik, regressionstester | #62, #58 |
-| **5 — Process & Governance** | — | Issue forms, brand captains, CODEOWNERS, integritetsguide | #64 |
-| **6 — Read-only + Locking** | v1.9.0 | Read-only läge, command locking, cloud vs wake | #63, #55 |
-| **7 — Push CUPRA/SEAT** | v1.9.1 | Firebase FCM via mqtt.messagehub.de | #57 |
-| **8 — Push Škoda** | v1.9.2 | MQTT-broker integration | #57 |
-| **9 — Feature batch** | v1.10.0 | Resestatistik, laddhistorik, avgångstimer-UI, larm, laddprofiler | #24, #35, #26, #33, #31 |
-| **10 — HACS Default + v2.0.0** | v2.0.0 | Live-tester alla märken, compatibility matrix, EU Data Act | #13, #59 |
+| Version | Omfattning | Issues |
+|---|---|---|
+| **v1.13.0** ⭐ MINOR | Anonymized Diagnostics-Export + Capability-Filter Fas 3 + Read-only Fas 2/3 | #62, #56 Fas 3, #63 Fas 2/3 |
+| **v1.14.0** MINOR | Trip Statistics från Audi `tripstatistics/v1` | #24, #35 |
+| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26) | various |
+| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
+| **v2.0.0** 🎉 MAJOR | HACS Default + Live-tester alla märken + EU Data Act ready (deadline sept. 2026) | #13, #59 |
 
-> Strikt P0 → P1 → P2-ordning. Sessions 1–4 är icke-förhandlingsbara innan nya funktioner.
+> Ordningen är **strikt P0 → P1 → P2**. Buggfixar har alltid prioritet över funktioner.
 
 ---
 
 ## Licens
 
-Apache License 2.0 — [LICENSE](../LICENSE)
+Apache License 2.0 — [LICENSE](LICENSE)
 
 **VAG Connect™** är ett oregistrerat varumärke (™, inte ®). Använd inte detta namn i forks för att undvika förvirring.
 

--- a/docs/CHANGELOG_TECHNICAL.md
+++ b/docs/CHANGELOG_TECHNICAL.md
@@ -1,4 +1,6 @@
-# Technische Changelog-Details (v1.8.6+)
+# Technische Changelog-Details (v1.8.6+) / Technical changelog details
+
+> 📖 **Bi-lingual title convention (ab v1.12.3 / since v1.12.3):** Section-Titles sind **DE / EN** geteilt durch ` / `. Body-Inhalt bleibt auf Deutsch (Audience ist primär die deutschsprachige VAG-HA-Community + DACH FB-Gruppen).
 
 Dieses Dokument enthält die vollständigen technischen Detail-Notes für
 die Releases v1.8.6 und neuer — gedacht für Contributors, Issue-Reporter,
@@ -12,9 +14,83 @@ weiterhin direkt in `CHANGELOG.md` zu finden.
 
 ---
 
+## [1.12.3] - 2026-05-01
+
+### Scout-Pfade #111 + #113 + #114 mit Wildcard-Strategie / Scout paths bundled with wildcard strategy
+
+PATCH-Release nach v1.12.2. Drei Scout-Reports in einem Release gebundlet:
+- #111 von DnnsJp74 (Audi 23 Felder) — zweiter Community-Scout-Report
+- #113 von Prash (Golf GTE 14 Felder)
+- #114 von Prash (Audi S6 C8 20 Felder)
+
+#### Wildcard-Strategie
+
+Statt jeden neuen Sub-Field einzeln zu registrieren, decken Wildcards ganze Klassen ab. Stoppt das Whack-a-Mole-Pattern aus v1.12.0/1/2 wo wir bei jedem neuen Scout-Report einzeln nachregistriert haben.
+
+Neue Wildcards in `EXPECTED_KEYS["volkswagen"]["selectivestatus"]` (Audi inherits via table alias):
+
+```python
+"fuelStatus.rangeStatus.value.*"
+"fuelStatus.rangeStatus.value.primaryEngine.*"
+"fuelStatus.rangeStatus.value.secondaryEngine.*"
+"vehicleHealthInspection.maintenanceStatus.value.*"
+"departureProfiles.departureProfilesStatus.value.*"
+"userCapabilities.capabilitiesStatus.value.*"
+"automation.climatisationTimer.value.*"
+"automation.chargingProfiles.value.*"
+"charging.chargeMode.value.*"
+"charging.chargingCareSettings.*"
+"vehicleHealthWarnings.warningLights.value.*"
+"batteryChargingCare.value.*"  # proaktiv
+"climatisationTimers.value.*"   # proaktiv
+```
+
+Plus alle 23 #111 paths einzeln (5x Climatisation Zone-Felder, 4x Readiness ConnectionState, 2x Battery Min/Max, etc.) zur expliziten Dokumentation.
+
+#### Tests
+
+`tests/test_v1123_111_audi_scout.py` — 8 Tests:
+- 6 für #111 (verbatim payload silent + Audi inheritance + individual field paths)
+- 2 für #113/#114 (verbatim payloads silent)
+
+#### Hard Rules eingehalten
+
+- ✅ Strict-Semver: PATCH (EXPECTED_KEYS-only update)
+- ✅ Wildcard-Strategie future-proof gegen weitere Firmware-Updates
+- ✅ Audi inheritance via table alias
+
+---
+
+## [1.12.2] - 2026-05-01
+
+### Erstes Community-Scout-Report — Skoda #107 (tritanium73) / First community Scout report
+
+🌟 **Erste Live-Validation der v1.9.0 Reporter Pipeline durch einen Nicht-Maintainer-Community-User.**
+
+User `tritanium73` reichte am 2026-05-01 den ersten Vehicle Data Scout Report eines Community-Users ein. Die volle 1-Klick-Pipeline (Scout → Repair-Notification → pre-filled GitHub Issue → Maintainer-Fix) hat in der Wildbahn funktioniert.
+
+#### Skoda mysmob EXPECTED_KEYS Erweiterungen
+
+14 neue Pfade über 4 Endpoints in `EXPECTED_KEYS["skoda"]`:
+
+| Endpoint | Pfade |
+|---|---|
+| `vehicle-status` | `renders.lightMode` + `renders.darkMode` (2-segment fix für v1.9.1 wildcard-only registry) |
+| `air-conditioning` | `runningRequests`, `steeringWheelPosition`, `windowHeatingState.unspecified`, `timers`, `outsideTemperature`, `errors` |
+| `driving-range` | `carType`, `primaryEngineRange` (Skoda mysmob Variante zu CARIAD-BFFs `fuelStatus.primaryEngine`) |
+| `maintenance` | `maintenanceReport.capturedAt`, `preferredServicePartner`, `predictiveMaintenance`, `customerService` |
+
+Alle Skoda-only — SEAT/CUPRA (OLA) und VW EU/Audi (CARIAD-BFF) tables unaffected.
+
+#### Tests
+
+`tests/test_v1122_107_skoda_scout.py` — 6 Tests inkl. Defensive-Test dass SEAT/CUPRA Inheritance NICHT von Skoda-Updates betroffen ist.
+
+---
+
 ## [1.12.1] - 2026-04-30
 
-### Scout-Pfade #105/#106 + Gerhard's Born Fixture (#53 consent) + #47 FAQ
+### Scout-Pfade #105/#106 + Gerhard's Born Fixture (#53 consent) + #47 FAQ / Scout paths + Born fixture + Subscription FAQ
 
 PATCH-Release nach v1.12.0. Drei orthogonale Tracks die alle aus User-Feedback / Live-Tests heute kamen.
 
@@ -118,7 +194,7 @@ Verlinkt zu v1.9.1 Phase 2 (Auto-Recording-Pipeline) + v1.13.0 Phase 3 Plan (cap
 
 ## [1.12.0] - 2026-04-30
 
-### 5-in-1 Feature-Sprint: 12V (#23) + Per-Light Binary (#91 Welle 3) + Writeable Number (#91 follow-up) + Smart-Wake (#55) + Read-only Mode (#63)
+### 5-in-1 Feature-Sprint: 12V (#23) + Per-Light Binary (#91 Welle 3) + Writeable Number (#91 follow-up) + Smart-Wake (#55) + Read-only Mode (#63) / Five features in one MINOR
 
 **Theme:** "More Control + Diagnostics" — kohärenter MINOR-Sprint vor v2.0.0 mit fünf orthogonalen aber thematisch passenden Features.
 


### PR DESCRIPTION
## Summary

Doc-only PR. About-Section + 8 READMEs waren auf v1.8.12-Stand veraltet (vor allen v1.9.0–v1.12.3 Releases). Heute komplett aktualisiert.

## Was sich ändert

**GitHub About** (already applied via \`gh repo edit\`):
- Beschreibung: war \"68 entities, cloud push\" (factually falsch — iot_class ist \`cloud_polling\`). Jetzt korrekt mit v1.12.3 features
- Topics: +vehicle-data-scout, +phev (20-topic GitHub limit erreicht)

**Alle 8 READMEs (DE master + 7 Sprachen):**
- "Aktueller Stand & ehrliche Limits" Sektion komplett refresht von v1.8.12 → v1.12.3
- 12 LIVE feature blocks dokumentiert (Vehicle Data Scout, 12V, Optimistic UI, PHEV-Range-Triple, Read-only Phase 1, Per-Light, Smart-Wake, etc.)
- "Was noch in Arbeit" auf v1.13.0-v2.0.0 Sessions aktualisiert
- Roadmap-Sektion vereinfacht: \"Single Source of Truth\" Pointer + Tabelle der letzten 9 Releases + nächste 5 Sessions
- Doc links normalized (kein \`../\` prefix nötig)

**Bi-lingual Title Convention:**
- Section titles: \`Deutscher Titel / English Title\` ab v1.12.3
- Body content bleibt deutsch (audience: DACH FB-Gruppen + DE/AT/CH community)
- Documented at top of CHANGELOG.md + CHANGELOG_TECHNICAL.md
- Retroactively applied auf v1.12.0/1/2/3 section titles

**CHANGELOG_TECHNICAL.md:**
- v1.12.2 + v1.12.3 entries nachgereicht (waren in CHANGELOG.md aber nicht im technischen)
- Bi-lingual convention header

## Test plan

- [x] Markdown structure consistent across alle 7 lang files (~265 Zeilen)
- [x] Doc links normalized
- [x] CHANGELOG.md \`[Unreleased]\` Eintrag → \`changelog_check.yml\` läuft
- [x] No code changes — alle Tests + Lint + Hassfest unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)