### PR TITLE
v1.14.0: Audi Feature Pack Bundle (#24 + #28 + #29 + #116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,81 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-05-02 🚗 Audi Feature Pack Bundle / Audi Feature Pack (Trip Stats + Engine Start ICE + PPC Climate Body) + Skoda Scout-Pfade #116
+
+🚗 **Drei Audi-spezifische Features in einem MINOR-Release** + Skoda Scout-Pfade aus #116 (MavericklCS) als Add-On. Bundle 2 aus dem v1.13.0 Pre-Research-Plan (`docs/RESEARCH_NOTES_2026-05-02.md`).
+
+### ✨ Neu / Added
+
+- 🛣️ **#24 Trip Statistics für VW EU + Audi** — neuer CARIAD-BFF Endpoint `GET /vehicle/v1/vehicles/{vin}/tripstatistics?type={shortTerm|longTerm}` (verifiziert in audi_connect_ha + audiconnectpy + ioBroker/vw-connect). Vier neue Sensor-Entitäten pro Audi/VW EU Vehicle:
+  - `last_trip_distance_km` (DISTANCE) — letzte Fahrt-Strecke aus shortTerm `mileage`
+  - `last_trip_avg_speed_kmh` (SPEED) — Ø-Geschwindigkeit
+  - `last_trip_avg_fuel_consumption_l_100km` (combustion-only) — Ø-Verbrauch in l/100km (Backend liefert ×10, Parser teilt)
+  - `last_trip_avg_electric_consumption_kwh_100km` (electric-only) — Ø-Stromverbrauch in kWh/100km
+  - Plus `recent_trips` (letzte 5) als `extra_state_attributes` auf `last_trip_distance_km` (audi #113 "aggregate-in-state" convention — vermeidet 255-char state limit)
+  - 1h-Cache-Cycle in `coordinator.refresh_trip_statistics` — Brand-restriction audi/volkswagen (andere Brands skippen ohne Error), Phase 3 Capability-Gate (`command_trip_stats` → cap-id `tripStatistics`), 1h Cache-TTL via `_trip_stats_fetched_at`
+  - **Subscription-required** (Audi connect Plus / WeConnect Plus) — Phase 3 versteckt die Entities wenn das Abo fehlt
+- 🔥 **#28 Audi ICE Remote Engine Start/Stop** — zwei-Schritt S-PIN-Flow nach audi_connect_ha PR #717:
+  - `service: vag_connect.engine_start` — `PUT /vehicle/v1/engine/{VIN}/userpromptproof` (S-PIN) → extract `userPromptProof` → `POST /vehicle/v1/engine/{VIN}/start` mit `securedActivationData`
+  - `service: vag_connect.engine_stop` — single `POST /vehicle/v1/engine/{VIN}/stop` (kein S-PIN nötig)
+  - **Audi-only** — andere Brands haben keinen `/engine/`-Subtree. Path-Pattern ist `/vehicle/v1/engine/{VIN}/...` (NICHT `/vehicle/v1/vehicles/{VIN}/engine/...`). VIN wird automatisch uppercased.
+  - **S-PIN aus gespeicherter Konfiguration** — landet NIE im Service-Call-Log
+  - **Capability-gated** über `CAPABILITY_MAP["audi"]["command_engine_start"] = "engineRemoteStart"` (⚠️ [Inference] cap-id, noch kein Live-Capabilities-Response gesehen)
+  - Per-VIN `engine` lock-class via `_COMMAND_CLASS` — start/stop serialisieren nicht parallel
+- 🌡️ **#29 PPE/PPC Klima-Body conditional** — Audi Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV brauchen das neue PPE-Body-Format (audi_connect_ha PR #644 + #677):
+  - `climatisationMode: "comfort"` mandatory
+  - `targetTemperature` + `targetTemperatureUnit` MÜSSEN omitted werden
+  - Neue Option `force_ppe_climate` (default False, Audi-only Effekt) in der Options-Flow. User-overridable da Auto-Detection unzuverlässig ist (kein verifiziertes Modell-Mapping public).
+  - `command_start_climate(vin, ppe_mode=True)` schaltet das Body-Format um
+- 🛰️ **#116 Skoda Scout-Pfade** — vierter Community-Scout-Report von **MavericklCS** (2026-05-01). 5 neue Pfade in `EXPECTED_KEYS["skoda"]`:
+  - `driving-range`: 4× `primaryEngineRange.{engineType,currentSoCInPercent,currentFuelLevelInPercent,remainingRangeInKm}`
+  - `maintenance`: `predictiveMaintenance.setting` + `predictiveMaintenance.setting.*` Wildcard
+
+### 🔄 Geändert / Changed
+
+- 🔧 `cariad/_capabilities.py` — Audi-Inheritance-Trick erweitert: `CAPABILITY_MAP["audi"]` ist jetzt eine **Kopie** von VW EU's Map (statt Alias) plus Audi-only Patch-Eintrag für `command_engine_start`. Verhindert Pollution der VW EU Map.
+- 🔧 `coordinator.py` — `_COMMAND_CLASS` registry erweitert um `command_engine_start`/`command_engine_stop` → "engine" class. Trip-Stats refresh als best-effort gather() im Poll-Loop nach `_async_push_update`.
+- 🔧 `sensor.py` — neuer `_TRIP_STATS_BRANDS` frozenset für Brand-Gating der 4 Trip-Stats Sensoren. Neuer `extra_state_attributes` Override in `VagConnectSensor` für `recent_trips` auf `last_trip_distance_km`.
+- 🔧 `vw_eu.py` — `command_start_climate(vin, ppe_mode: bool = False)` mit conditional fallback-payload. Default = legacy body (backwards-compat).
+
+### 🌐 Übersetzungen / Translations
+
+8 Sprachen (de/en/fr/es/nl/pl/cs/sv) — neue keys:
+- `entity.sensor.{last_trip_distance_km, last_trip_avg_speed_kmh, last_trip_avg_fuel_consumption_l_100km, last_trip_avg_electric_consumption_kwh_100km}`
+- `options.step.init.data.force_ppe_climate` + `data_description.force_ppe_climate`
+
+### 🧪 Tests / Tests
+
+- `tests/test_v1140_audi_pack.py` — 19 neue Tests:
+  - `TestParseTripStatistics` (6) — pure parser tests + ×10 division + sort + cap at 5 + garbage handling
+  - `TestGetTripStatisticsURL` (1) — URL + type query param
+  - `TestRefreshTripStatisticsBrandRestriction` (4) — Brand-restriction + capability gate + 1h cache
+  - `TestAudiEngineStart` (5) — two-step flow + uppercase VIN + no-spin raises + missing-proof raises + stop endpoint
+  - `TestPpcClimateBody` (3) — legacy body / PPE body / default-legacy
+  - `TestCapabilityMapEngineStart` (4) — Audi-only inheritance copy + trip_stats brand-presence
+  - `TestScoutPathsSkoda` (2) — primaryEngineRange.* + predictiveMaintenance.setting wildcard
+  - `TestEngineCommandClass` (1) — engine class shared start/stop
+
+### 🔬 Pre-Research / Pre-Research
+
+- Bundle 2 aus `docs/RESEARCH_NOTES_2026-05-02.md` (verfasst 2026-05-02 vor v1.13.0). Alle drei Issues lieferten ✅ verified Recherche-Ergebnisse:
+  - #24 (Trip Stats): CARIAD-BFF Endpoint + per-trip Field-Liste verifiziert
+  - #28 (Engine Start): audi_connect_ha PR #717 source-read komplett — Endpoint + Body + Response-Shape
+  - #29 (PPE Climate): Body-Pattern aus audi #644 + #677 verifiziert; Detection via User-Option (Auto-Heuristik defer)
+
+### 📦 Schließt Issues / Closes
+
+- Closes #24 (Verbrauchsdaten / Trip Stats Audi)
+- Closes #28 (Remote Start ICE Audi 2024+)
+- Closes #29 (PPC Climate für 2025 A3/Q5 / Q6/A6 e-tron)
+- Closes #116 (Skoda Scout-Report von MavericklCS)
+
+### ❌ Deferred / Not in this release
+
+- **#35 Ladehistorie LTS** — `chargedEnergy_kWh` Feld nicht in CARIAD-BFF verifiziert (Research v1.13.0). Wartet auf API-Hinweis aus Live-Tests.
+- **#51 RS e-tron GT Facelift** — graceful degradation only (volle PPE Lock/Charging-Endpoint-Map noch nicht reverse-engineered, Hard Rule #15 verbietet endpoint-guessing).
+- **PPE Auto-Detection** — User opt-in only (keine zuverlässige VIN/Model/Year-Heuristik public verfügbar).
+
 ## [1.13.0] - 2026-05-02 🛡️ Production Hardening Bundle / Production Hardening (Capability Phase 3 + Read-only Phase 2 + Diagnostics-Polish + Process)
 
 🛡️ **Drei P0-Themen aus dem Roadmap-Backlog in einem MINOR-Release.** Alle drei waren bereits angefangene Arbeit (Phase 1 ausgeliefert) — jetzt Closure mit Phase 2/3, plus die Diagnostics-Hardening die wir für Issue-Reporting brauchen, plus Process-Docs (#64) für Brand Captains.

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -199,6 +199,20 @@ def _register_services(hass: HomeAssistant) -> None:
             call.data.get("departure_time"),
         )
 
+    async def _handle_engine_start(call: ServiceCall) -> None:
+        """v1.14.0 (#28) — Audi ICE Remote Engine Start.
+
+        S-PIN is taken from the saved config entry, NOT from the service
+        call (so it never lands in HA service-call logs). Returns
+        ``ServiceValidationError`` if the brand isn't audi or no S-PIN
+        is configured.
+        """
+        await _coord_writeable(call.data["vin"]).async_engine_start(call.data["vin"])
+
+    async def _handle_engine_stop(call: ServiceCall) -> None:
+        """v1.14.0 (#28) — Audi ICE Remote Engine Stop. No S-PIN required."""
+        await _coord_writeable(call.data["vin"]).async_engine_stop(call.data["vin"])
+
     async def _handle_refresh(_call: ServiceCall) -> None:
         """Pull latest cloud-cached state — does NOT wake the vehicle.
 
@@ -252,6 +266,9 @@ def _register_services(hass: HomeAssistant) -> None:
                 vol.Required("enabled"):        cv.boolean,
                 vol.Optional("departure_time"): cv.string,
             })),
+        # v1.14.0 (#28) — Audi-only ICE Remote Engine Start/Stop.
+        ("engine_start",                   _handle_engine_start,        SERVICE_VIN_SCHEMA),
+        ("engine_stop",                    _handle_engine_stop,         SERVICE_VIN_SCHEMA),
     ]:
         hass.services.async_register(DOMAIN, name, handler, schema)
 
@@ -269,8 +286,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: VagConnectConfigEntry) 
             "lock", "unlock", "start_climatisation", "stop_climatisation",
             "start_charging", "stop_charging", "start_window_heating",
             "stop_window_heating", "wake_vehicle", "flash_lights",
-            "refresh_vehicle", "set_target_soc", "set_climatisation_temperature",
-            "set_departure_timer",
+            "refresh_vehicle", "refresh_cloud_cache", "set_target_soc",
+            "set_climatisation_temperature", "set_departure_timer",
+            "engine_start", "engine_stop",
         ]:
             if hass.services.has_service(DOMAIN, svc):
                 hass.services.async_remove(DOMAIN, svc)

--- a/custom_components/vag_connect/cariad/_capabilities.py
+++ b/custom_components/vag_connect/cariad/_capabilities.py
@@ -69,11 +69,23 @@ CAPABILITY_MAP: Final[dict[str, dict[str, str]]] = {
         "command_stop_window_heating": "windowHeating",
         "command_set_climate_temperature": "climatisation",
         "command_set_departure_timer": "departureTimers",
+        # v1.14.0 (#24) — Trip Statistics (subscription-required: Audi
+        # connect Plus / WeConnect Plus). ⚠️ [Inference] cap-id matches
+        # CARIAD camelCase pattern; not yet seen in a Scout-confirmed
+        # capabilities response. Phase 3 returns ``None`` → don't filter
+        # if the cap row is absent, so vehicles without a published
+        # capability still get the entities.
+        "command_trip_stats": "tripStatistics",
     },
     # ─────────────────────────────────────────────────────────────────
     # Audi inherits VW EU's CARIAD-BFF capabilities (AudiClient(VWEUClient)).
     # Identical endpoint, identical schema, mostly identical cap-ids.
     # See cariad/api/audi.py for the inheritance.
+    #
+    # v1.14.0 (#28) — Audi-only ICE Remote Engine Start has no
+    # corresponding entry in CAPABILITY_MAP["volkswagen"] — VW EU's
+    # CARIAD-BFF doesn't expose the /engine/ subtree. The Audi-only
+    # cap-id is patched in below the inheritance assignment.
     # ─────────────────────────────────────────────────────────────────
     "audi": {},  # populated at module load below from "volkswagen"
     # ─────────────────────────────────────────────────────────────────
@@ -146,6 +158,17 @@ CAPABILITY_MAP: Final[dict[str, dict[str, str]]] = {
 # Same alias-trick used for EXPECTED_KEYS in cariad/_unexpected_keys.py.
 CAPABILITY_MAP["audi"] = CAPABILITY_MAP["volkswagen"]
 CAPABILITY_MAP["seat"] = CAPABILITY_MAP["cupra"]
+
+# v1.14.0 (#28) — Audi-only ICE Engine Start. Replace the alias with a
+# COPY so we can add Audi-specific entries without polluting VW EU's
+# table (the alias trick above shares the same dict by reference).
+# ⚠️ [Inference] cap-id ``engineRemoteStart`` is the camelCase guess
+# that matches CARIAD vocabulary patterns (``honkAndFlash``,
+# ``vehicleWakeUpTrigger``). NOT confirmed in a live capabilities
+# response yet — when a Scout report surfaces the real id we update.
+CAPABILITY_MAP["audi"] = dict(CAPABILITY_MAP["audi"])
+CAPABILITY_MAP["audi"]["command_engine_start"] = "engineRemoteStart"
+CAPABILITY_MAP["audi"]["command_engine_stop"] = "engineRemoteStart"
 
 
 def cap_id_for(brand: str, command_id: str) -> str | None:

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -145,6 +145,17 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             # feature once we have a verified live response.
             "carType",
             "primaryEngineRange",
+            # v1.14.0 (#116, MavericklCS Scout-Report 2026-05-01) — four
+            # ``primaryEngineRange.*`` children on a Skoda gasoline-engine
+            # vehicle. Confirms the structure inferred in v1.12.2 from
+            # tritanium73's #107 report. ``currentSoCInPercent`` on a
+            # gasoline car is unusual — likely the 12V SoC; will be
+            # cross-checked with future Scout-Reports before wiring as a
+            # sensor.
+            "primaryEngineRange.engineType",
+            "primaryEngineRange.currentSoCInPercent",
+            "primaryEngineRange.currentFuelLevelInPercent",
+            "primaryEngineRange.remainingRangeInKm",
         },
         "maintenance": {
             "maintenanceReport", "maintenanceReport.mileageInKm",
@@ -159,6 +170,12 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "preferredServicePartner",
             "predictiveMaintenance",
             "customerService",
+            # v1.14.0 (#116, MavericklCS) — ``predictiveMaintenance``
+            # has a ``setting`` sub-block (4 keys observed). Wildcard
+            # registration covers all current + future setting children
+            # without per-field whack-a-mole.
+            "predictiveMaintenance.setting",
+            "predictiveMaintenance.setting.*",
         },
         "readiness": {
             "unreachable", "inMotion", "carCapturedTimestamp",

--- a/custom_components/vag_connect/cariad/api/audi.py
+++ b/custom_components/vag_connect/cariad/api/audi.py
@@ -17,9 +17,11 @@ Source: arjenvrh/audi_connect_ha (MIT) — token exchange pattern
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from aiohttp import ClientSession, ClientTimeout
 
+from ..exceptions import SpinError
 from ..models import BRAND_AUDI
 from .graphql import VehicleImageData, VehicleImageFetcher
 from .vw_eu import VWEUClient
@@ -30,6 +32,12 @@ _AZS_TOKEN_URL  = "https://emea.bff.cariad.digital/login/v1/audi/token"
 _GRAPHQL_URL    = "https://app-api.live-my.audi.com/vgql/v1/graphql"
 _APP_VERSION    = "4.31.0"
 _USER_AGENT     = "Android/4.31.0 (Build 800341641.root project 'myaudi_android'.ext.buildTime) Android/13"
+
+# v1.14.0 (#28) — Audi ICE Remote Engine Start (CARIAD BFF, two-step S-PIN flow).
+# Source: arjenvrh/audi_connect_ha PR #717 (`audi_services.py`). The path is
+# ``/vehicle/v1/engine/{VIN}/...`` — note: NOT under ``/vehicles/{VIN}/engine``.
+# VIN must be uppercased in the URL — confirmed in upstream PR.
+_ENGINE_BASE = "https://emea.bff.cariad.digital/vehicle/v1/engine"
 
 
 class AudiClient(VWEUClient):
@@ -87,6 +95,57 @@ class AudiClient(VWEUClient):
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("AZS token exchange error: %s", err)
             return None
+
+    # ── v1.14.0 (#28) — ICE Remote Engine Start ─────────────────────────
+    async def command_engine_start(self, vin: str, spin: str = "") -> None:
+        """v1.14.0 (#28) — Audi ICE Remote Engine Start (two-step S-PIN flow).
+
+        Step 1: ``PUT /vehicle/v1/engine/{VIN}/userpromptproof`` with
+        ``{"spin": ...}`` returns a top-level ``userPromptProof`` token.
+        Step 2: ``POST /vehicle/v1/engine/{VIN}/start`` with
+        ``{"securedActivationData": <token>, "spin": ...}``.
+
+        Raises ``SpinError`` if no S-PIN is configured. Wrong S-PIN /
+        missing capability surface as ``APIError`` and are routed to
+        ``classify_command_failure`` by the coordinator wrapper.
+
+        Audi-only — VW EU does not expose this endpoint. Capability gating
+        is recommended (see ``_capabilities.py:command_engine_start``).
+
+        Source: arjenvrh/audi_connect_ha PR #717 (audi_services.py).
+        """
+        pin = spin or self._spin
+        if not pin:
+            raise SpinError("S-PIN required for Audi engine start")
+        vin_u = vin.upper()
+        # Step 1 — proof. Response is read at the top level: {"userPromptProof": "..."}.
+        proof_resp: Any = await self._request(
+            "PUT",
+            f"{_ENGINE_BASE}/{vin_u}/userpromptproof",
+            json={"spin": pin},
+        )
+        secured = (
+            proof_resp.get("userPromptProof") if isinstance(proof_resp, dict) else None
+        )
+        if not isinstance(secured, str) or not secured:
+            raise SpinError(
+                "Audi engine start: missing userPromptProof in response — "
+                "S-PIN may be wrong or vehicle does not support engine start"
+            )
+        # Step 2 — start. Body uses the proof token from step 1.
+        await self._post(
+            f"{_ENGINE_BASE}/{vin_u}/start",
+            json={"securedActivationData": secured, "spin": pin},
+        )
+
+    async def command_engine_stop(self, vin: str) -> None:
+        """v1.14.0 (#28) — Audi ICE Remote Engine Stop.
+
+        Single ``POST /vehicle/v1/engine/{VIN}/stop`` with no body. No S-PIN
+        required (mirrors upstream PR #717).
+        """
+        vin_u = vin.upper()
+        await self._post(f"{_ENGINE_BASE}/{vin_u}/stop")
 
     async def fetch_images(self) -> None:
         """Override: exchange IDK→AZS token, call app-api.live-my.audi.com."""

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -125,6 +125,43 @@ class VWEUClient(CariadBaseClient):
         data = await self._get(f"{_BASE}/vehicle/v1/vehicles/{vin}/capabilities")
         return data if isinstance(data, dict) else {}
 
+    async def get_trip_statistics(
+        self, vin: str, kind: str = "shortTerm"
+    ) -> dict[str, Any]:
+        """v1.14.0 (#24) — Trip Stats from CARIAD-BFF.
+
+        ``kind`` is ``"shortTerm"`` (per-ignition-cycle trips, "Seit Start")
+        or ``"longTerm"`` (since-last-reset aggregates, "Seit Tanken /
+        Gesamt"). Both return a list under ``tripDataList.tripData[]`` —
+        callers sort by ``overallMileage`` descending and take ``[0]`` as
+        the most recent trip (the audi #113 "aggregate-in-state"
+        convention).
+
+        Per-trip fields (verified across audi_connect_ha, audiconnectpy,
+        davidgiga1993/AudiAPI, ioBroker/vw-connect):
+        - ``timestamp`` (ISO 8601 UTC) — trip end time
+        - ``mileage`` (km) — distance of this trip
+        - ``startMileage`` / ``overallMileage`` (km) — odometer at start/end
+        - ``traveltime`` (minutes)
+        - ``averageSpeed`` (km/h)
+        - ``averageFuelConsumption`` (l/100 km × 10 — divide by 10)
+        - ``averageElectricEngineConsumption`` (kWh/100 km × 10)
+        - ``averageAuxConsumerConsumption`` (kWh/100 km × 10, often missing)
+
+        Returns the raw response dict so the coordinator can parse + cache.
+        Returns an empty dict if the response is not a JSON object (defensive
+        against backend edge-cases — best-effort, never raises into the
+        polling loop).
+
+        Subscription-required (Audi connect Plus / WeConnect Plus) — if
+        the user lacks the entitlement the backend returns 403; the
+        capability-filter Phase 3 (#56, v1.13.0) gates this from the
+        platform side via ``cap_id_for(brand, "command_trip_stats")``.
+        """
+        url = f"{_BASE}/vehicle/v1/vehicles/{vin}/tripstatistics"
+        data = await self._get(url, params={"type": kind})
+        return data if isinstance(data, dict) else {}
+
     async def get_status(self, vin: str) -> VehicleData:
         """Fetch full vehicle status via selectivestatus."""
         url = f"{_BASE}/vehicle/v1/vehicles/{vin}/selectivestatus"
@@ -218,25 +255,48 @@ class VWEUClient(CariadBaseClient):
             fallback_payload=fallback_payload,
         )
 
-    async def command_start_climate(self, vin: str) -> None:
+    async def command_start_climate(
+        self, vin: str, ppe_mode: bool = False
+    ) -> None:
         """Start pre-conditioning — combined endpoint with separate fallback,
         each on v1/v2.
 
         Default target temperature 21°C and window heating enabled match
         the previous separate-endpoint payload — kept so behaviour does
         not regress when the combined endpoint isn't available.
+
+        v1.14.0 (#29, audi #644 + #677) — when ``ppe_mode=True`` the
+        fallback body uses the PPE/PPC shape:
+        - ``climatisationMode: "comfort"`` (mandatory, NOT null)
+        - ``targetTemperature`` + ``targetTemperatureUnit`` OMITTED
+        Required for Q6 e-tron, A6 e-tron, RS e-tron GT Facelift, A3 2024+
+        PHEV — all of which return ``400 Bad Request`` for the legacy
+        body shape. Coordinator gates this via ``CONF_FORCE_PPE_CLIMATE``
+        option (Audi-only, user-overridable since auto-detection is
+        unreliable). ⚠️ [Inference] — body shape verified from upstream
+        PRs but Audi never published a definitive PPE compatibility list.
         """
+        if ppe_mode:
+            fallback_payload = {
+                "climatisationMode": "comfort",
+                "climatisationWithoutExternalPower": True,
+                "windowHeatingEnabled": True,
+                # NOTE: targetTemperature* OMITTED for PPE — body validator
+                # rejects it on Q6/A6 e-tron / PPC vehicles.
+            }
+        else:
+            fallback_payload = {
+                "targetTemperature": 21.0,
+                "targetTemperatureUnit": "celsius",
+                "climatisationWithoutExternalPower": True,
+                "windowHeatingEnabled": True,
+            }
         await self._post_command_with_fallback_paths(
             vin,
             primary_suffix="climatisation/start-stop",
             primary_payload={"action": "start"},
             fallback_suffix="climatisation/start",
-            fallback_payload={
-                "targetTemperature": 21.0,
-                "targetTemperatureUnit": "celsius",
-                "climatisationWithoutExternalPower": True,
-                "windowHeatingEnabled": True,
-            },
+            fallback_payload=fallback_payload,
         )
 
     async def command_stop_climate(self, vin: str) -> None:

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -330,6 +330,29 @@ class VehicleData:
     trunk_locked: bool | None = None
     sunroof_open: bool | None = None
 
+    # v1.14.0 (#24) — Trip Statistics from CARIAD-BFF
+    # ``GET /vehicle/v1/vehicles/{vin}/tripstatistics?type={shortTerm|longTerm}``.
+    # Both endpoints return ``{tripDataList: {tripData: [...]}}``; we sort
+    # by ``overallMileage`` desc and take ``[0]`` as the most recent
+    # trip (the audi #113 "aggregate-in-state" convention — keeps each
+    # field a separate sensor state rather than building a list entity).
+    # Consumption fields come back from the API as integers ×10
+    # (averageFuelConsumption: 68 ⇒ 6.8 l/100 km); the parser divides
+    # by 10 so the value stored here is already the human number.
+    # ``recent_trips`` holds the last 5 short-term trips for the
+    # ``last_trip_distance_km`` sensor's ``extra_state_attributes`` —
+    # avoids state-string-too-long (255 char limit).
+    last_trip_distance_km: float | None = None
+    last_trip_duration_min: int | None = None
+    last_trip_avg_speed_kmh: float | None = None
+    last_trip_avg_fuel_consumption_l_100km: float | None = None
+    last_trip_avg_electric_consumption_kwh_100km: float | None = None
+    last_trip_timestamp: str | None = None
+    lifetime_distance_km: float | None = None
+    lifetime_avg_fuel_consumption_l_100km: float | None = None
+    lifetime_avg_electric_consumption_kwh_100km: float | None = None
+    recent_trips: list[dict[str, Any]] = field(default_factory=list)
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to plain dict for coordinator.vehicles storage."""
         from dataclasses import asdict  # noqa: PLC0415

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_BRAND,
     CONF_ENABLE_REVERSE_GEOCODING,
     CONF_FORCE_ACCESS,
+    CONF_FORCE_PPE_CLIMATE,
     CONF_READ_ONLY,
     CONF_SCAN_INTERVAL,
     CONF_SPIN,
@@ -416,6 +417,19 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                     default=current_options.get(
                         CONF_READ_ONLY,
                         current_data.get(CONF_READ_ONLY, False),
+                    ),
+                ): _BOOL_SELECTOR,
+                # v1.14.0 (#29 + #51 Facelift) — PPE/PPC Climate body.
+                # Audi-only effect; harmless toggle on other brands.
+                # Forces ``climatisationMode: comfort`` body shape and
+                # omits ``targetTemperature*`` for Audi Q6/A6 e-tron,
+                # RS e-tron GT Facelift, A3 2024+ PHEV. Auto-detection
+                # is too unreliable to default-on; user opts in.
+                vol.Optional(
+                    CONF_FORCE_PPE_CLIMATE,
+                    default=current_options.get(
+                        CONF_FORCE_PPE_CLIMATE,
+                        current_data.get(CONF_FORCE_PPE_CLIMATE, False),
                     ),
                 ): _BOOL_SELECTOR,
             }),

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -17,6 +17,13 @@ CONF_ENABLE_REVERSE_GEOCODING = "enable_reverse_geocoding"
 # want vehicle telemetry but no risk of accidental actuation or
 # subscription-counting commands.
 CONF_READ_ONLY                = "read_only_mode"
+# v1.14.0 (#29 + #51 Facelift) — PPE/PPC Climate body conditional.
+# Audi-only option (default False). When True, ``command_start_climate``
+# uses the PPE body shape — ``climatisationMode: "comfort"`` mandatory,
+# ``targetTemperature*`` MUST BE OMITTED (audi_connect_ha PR #644 + #677).
+# Auto-detection from VIN/model/year is unreliable (no public PPE list);
+# user-overridable until we have a proper detection mechanism.
+CONF_FORCE_PPE_CLIMATE        = "force_ppe_climate"
 
 # Supported brands — must match CariadClientFactory.create() keys
 BRANDS = {

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -997,7 +997,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Fetch shortTerm (per-ignition trips, "Seit Start") and longTerm
         # (since-last-reset aggregates, "Seit Tanken / Gesamt") in parallel.
         try:
-            short_resp, long_resp = await asyncio.gather(
+            results = await asyncio.gather(
                 client.get_trip_statistics(vin, "shortTerm"),
                 client.get_trip_statistics(vin, "longTerm"),
                 return_exceptions=True,
@@ -1007,6 +1007,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 "Trip stats fetch failed for %s: %s", mask_vin(vin), err
             )
             return
+        # ``return_exceptions=True`` — drop exceptions to None so the parser
+        # treats them as empty responses (keeps stale cache).
+        short_resp: Any = (
+            results[0] if not isinstance(results[0], BaseException) else None
+        )
+        long_resp: Any = (
+            results[1] if not isinstance(results[1], BaseException) else None
+        )
         parsed = _parse_trip_statistics(short_resp, long_resp)
         if not parsed:
             return  # empty response — keep stale cache

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     CONF_BRAND,
     CONF_ENABLE_REVERSE_GEOCODING,
+    CONF_FORCE_PPE_CLIMATE,
     CONF_PASSWORD,
     CONF_READ_ONLY,
     CONF_SCAN_INTERVAL,
@@ -89,6 +90,112 @@ _WAKE_COOLDOWN = timedelta(minutes=5)
 # (typical CARIAD command roundtrip is 10-30s; 60s is a safe upper bound
 # even for slow weekend backend windows).
 _COMMAND_LOCK_TIMEOUT = 60.0
+
+
+def _parse_trip_statistics(
+    short_resp: Any, long_resp: Any
+) -> dict[str, Any]:
+    """v1.14.0 (#24) — Pure parser for CARIAD-BFF tripstatistics responses.
+
+    Returns a dict of ``last_trip_*`` + ``lifetime_*`` + ``recent_trips``
+    fields ready to merge into ``coordinator.vehicles[vin]``. Empty dict
+    on no usable data (preserves stale cache).
+
+    Both endpoints share the same ``{tripDataList: {tripData: [...]}}``
+    shape — sorted by ``overallMileage`` desc, ``[0]`` is the most
+    recent. Consumption fields come back as integers ×10 (sources:
+    audi_connect_ha audi_services.py + audiconnectpy + ioBroker/vw-connect)
+    so we divide by 10 to get human numbers (l/100km, kWh/100km).
+
+    Pure function — safe to test in isolation, no I/O, no logging.
+    """
+    out: dict[str, Any] = {}
+
+    def _extract_trips(resp: Any) -> list[dict[str, Any]]:
+        if not isinstance(resp, dict):
+            return []
+        wrapper = resp.get("tripDataList")
+        if not isinstance(wrapper, dict):
+            return []
+        trips = wrapper.get("tripData")
+        if not isinstance(trips, list):
+            return []
+        # defensive: drop non-dict entries
+        good = [t for t in trips if isinstance(t, dict)]
+        # sort by overallMileage descending — newest at [0]
+        good.sort(
+            key=lambda t: t.get("overallMileage", 0)
+            if isinstance(t.get("overallMileage"), (int, float))
+            else 0,
+            reverse=True,
+        )
+        return good
+
+    def _div10(val: Any) -> float | None:
+        if isinstance(val, (int, float)) and val > 0:
+            return round(val / 10.0, 1)
+        return None
+
+    short_trips = _extract_trips(short_resp)
+    long_trips = _extract_trips(long_resp)
+    out["_shortterm_count"] = len(short_trips)
+    out["_longterm_count"] = len(long_trips)
+
+    # Last trip — from shortTerm (per-ignition cycle)
+    if short_trips:
+        last = short_trips[0]
+        out["last_trip_distance_km"] = (
+            float(last["mileage"]) if isinstance(last.get("mileage"), (int, float)) else None
+        )
+        out["last_trip_duration_min"] = (
+            int(last["traveltime"]) if isinstance(last.get("traveltime"), (int, float)) else None
+        )
+        out["last_trip_avg_speed_kmh"] = (
+            float(last["averageSpeed"])
+            if isinstance(last.get("averageSpeed"), (int, float))
+            else None
+        )
+        out["last_trip_avg_fuel_consumption_l_100km"] = _div10(
+            last.get("averageFuelConsumption")
+        )
+        out["last_trip_avg_electric_consumption_kwh_100km"] = _div10(
+            last.get("averageElectricEngineConsumption")
+        )
+        ts = last.get("timestamp")
+        out["last_trip_timestamp"] = ts if isinstance(ts, str) else None
+
+        # Keep only the 5 most-recent in extra_state_attributes (255-char
+        # state limit avoidance, plus recorder bloat protection).
+        out["recent_trips"] = [
+            {
+                "timestamp": t.get("timestamp"),
+                "distance_km": t.get("mileage"),
+                "duration_min": t.get("traveltime"),
+                "avg_speed_kmh": t.get("averageSpeed"),
+                "avg_fuel_l_100km": _div10(t.get("averageFuelConsumption")),
+                "avg_electric_kwh_100km": _div10(
+                    t.get("averageElectricEngineConsumption")
+                ),
+            }
+            for t in short_trips[:5]
+        ]
+
+    # Lifetime — from longTerm (since-last-reset aggregate, take [0])
+    if long_trips:
+        agg = long_trips[0]
+        out["lifetime_distance_km"] = (
+            float(agg["overallMileage"])
+            if isinstance(agg.get("overallMileage"), (int, float))
+            else None
+        )
+        out["lifetime_avg_fuel_consumption_l_100km"] = _div10(
+            agg.get("averageFuelConsumption")
+        )
+        out["lifetime_avg_electric_consumption_kwh_100km"] = _div10(
+            agg.get("averageElectricEngineConsumption")
+        )
+
+    return out
 
 
 @dataclass
@@ -419,6 +526,20 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 # call: ``ensure_*_issue`` deletes when empty and updates
                 # in-place when the IDs already exist.
                 self._refresh_reporter_issues()
+                # v1.14.0 (#24) — Trip Stats refresh, best-effort + cached
+                # 1h. Brand-restricted to audi/volkswagen inside helper.
+                # Runs after vehicle update so newest VINs are present
+                # in self.vehicles when the parser merges back.
+                try:
+                    await asyncio.gather(
+                        *[
+                            self.refresh_trip_statistics(vin)
+                            for vin in self.vehicles
+                        ],
+                        return_exceptions=True,
+                    )
+                except Exception:  # noqa: BLE001
+                    pass  # never let trip-stats break the poll
                 await self._async_push_update(fresh, success=any_success)
             except Exception as err:  # noqa: BLE001
                 # Auth failure that survived the client's refresh-then-relogin
@@ -828,6 +949,79 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             len(data),
         )
 
+    # ── v1.14.0 (#24) — Trip Statistics 1h cache + parser ────────────────
+    _TRIP_STATS_REFRESH_INTERVAL = timedelta(hours=1)
+    _TRIP_STATS_BRANDS = ("audi", "volkswagen")  # CARIAD-BFF only
+    _RECENT_TRIPS_LIMIT = 5  # how many trips to keep in extra_state_attributes
+
+    async def refresh_trip_statistics(
+        self, vin: str, force: bool = False
+    ) -> None:
+        """v1.14.0 (#24) — Best-effort fetch + parse of CARIAD-BFF trip
+        statistics. Failure is logged at debug and never blocks polling.
+
+        Brand-restricted to ``audi`` and ``volkswagen`` (the only brands
+        whose backends we've verified to expose ``GET /vehicle/v1/vehicles/
+        {vin}/tripstatistics``). Other brands return silently.
+
+        Cache: ``self._trip_stats_fetched_at[vin]`` — refresh only if
+        more than 1h has passed since last successful fetch (or
+        ``force=True``). Trip data changes rarely (per-ignition-cycle for
+        shortTerm, even rarer for longTerm) so polling at the standard
+        coordinator interval would waste API calls + subscription quota.
+
+        Capability gate: if Phase 3 (#56) reports
+        ``command_trip_stats: False`` for this VIN we skip — saves a
+        guaranteed 403 against subscription-less accounts.
+        """
+        brand = ""
+        try:
+            brand = str(self.entry.data.get(CONF_BRAND, "")).lower()
+        except Exception:  # noqa: BLE001
+            return
+        if brand not in self._TRIP_STATS_BRANDS:
+            return
+        if not hasattr(self, "_trip_stats_fetched_at"):
+            self._trip_stats_fetched_at: dict[str, datetime] = {}
+        if not force:
+            last = self._trip_stats_fetched_at.get(vin)
+            if last is not None:
+                if datetime.now(tz=timezone.utc) - last < self._TRIP_STATS_REFRESH_INTERVAL:
+                    return
+        # Phase 3 (#56) capability gate — saves a guaranteed 403.
+        if self.command_capability_supported(vin, "command_trip_stats") is False:
+            return
+        client = self._cariad_client
+        if client is None or not hasattr(client, "get_trip_statistics"):
+            return
+        # Fetch shortTerm (per-ignition trips, "Seit Start") and longTerm
+        # (since-last-reset aggregates, "Seit Tanken / Gesamt") in parallel.
+        try:
+            short_resp, long_resp = await asyncio.gather(
+                client.get_trip_statistics(vin, "shortTerm"),
+                client.get_trip_statistics(vin, "longTerm"),
+                return_exceptions=True,
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Trip stats fetch failed for %s: %s", mask_vin(vin), err
+            )
+            return
+        parsed = _parse_trip_statistics(short_resp, long_resp)
+        if not parsed:
+            return  # empty response — keep stale cache
+        with self._vehicles_lock:
+            v = self.vehicles.get(vin)
+            if isinstance(v, dict):
+                v.update(parsed)
+        self._trip_stats_fetched_at[vin] = datetime.now(tz=timezone.utc)
+        _LOGGER.debug(
+            "Trip stats updated for %s: %d short / %d long term",
+            mask_vin(vin),
+            parsed.get("_shortterm_count", 0),
+            parsed.get("_longterm_count", 0),
+        )
+
     async def _async_push_update(self, data: dict, success: bool = True) -> None:
         """Push vehicle data to HA.
 
@@ -1102,12 +1296,31 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # v1.11.1 (3B-Part-3) — optimistic UI: climate flips to active
         # immediately. Backend value will overwrite on next poll if it
         # disagrees (which is rare — start succeeds for entitled VINs).
+        # v1.14.0 (#29) — PPE/PPC body shape conditional. User option
+        # ``force_ppe_climate`` forces the new body shape (no
+        # targetTemperature*, climatisationMode mandatory) for Audi
+        # vehicles on PPC platforms (Q6 e-tron, A6 e-tron, RS e-tron GT
+        # Facelift, A3 2024+ PHEV). VW EU and other brands ignore the
+        # option — only Audi's CARIAD backend differentiates.
+        cmd_kwargs: dict[str, Any] = {}
+        brand = str(self.entry.data.get(CONF_BRAND, "")).lower()
+        if brand in ("audi", "volkswagen"):
+            options = getattr(self.entry, "options", None) or {}
+            data = getattr(self.entry, "data", None) or {}
+            ppe_mode = False
+            if isinstance(options, dict):
+                ppe_mode = bool(options.get(CONF_FORCE_PPE_CLIMATE, False))
+            if not ppe_mode and isinstance(data, dict):
+                ppe_mode = bool(data.get(CONF_FORCE_PPE_CLIMATE, False))
+            if ppe_mode:
+                cmd_kwargs["ppe_mode"] = True
         await self._cariad_cmd_optimistic(
             vin, "command_start_climate",
             optimistic={
                 "climatisation_state": "VENTILATION",
                 "climatisation_active": True,
             },
+            **cmd_kwargs,
         )
 
     async def async_stop_climatisation(self, vin: str) -> None:
@@ -1178,6 +1391,25 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             enabled=enabled,
             departure_time=departure_time,
         )
+
+    async def async_engine_start(self, vin: str) -> None:
+        """v1.14.0 (#28) — Audi ICE Remote Engine Start.
+
+        Audi-only — the underlying client method is implemented on
+        ``AudiClient`` (CARIAD-BFF ``/vehicle/v1/engine/{VIN}/...``).
+        Other brands' clients don't expose ``command_engine_start`` so
+        the dispatch will raise ``AttributeError``, which Phase 2's
+        ``record_command_failure`` then classifies as
+        ``MISSING_CAPABILITY``.
+
+        Capability gating (Phase 3, v1.13.0) is recommended on the
+        platform side — see ``cariad/_capabilities.py``.
+        """
+        await self._cariad_cmd(vin, "command_engine_start")
+
+    async def async_engine_stop(self, vin: str) -> None:
+        """v1.14.0 (#28) — Audi ICE Remote Engine Stop. No S-PIN required."""
+        await self._cariad_cmd(vin, "command_engine_stop")
 
     def _get_command_lock(self, vin: str, command_class: str) -> asyncio.Lock:
         """v1.13.0 (#63 Phase 2) — per-VIN per-command-class asyncio.Lock.
@@ -1326,6 +1558,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         "command_flash": "flash",
         "command_wake": "wake",
         "command_set_departure_timer": "departure_timer",
+        # v1.14.0 (#28) — Audi ICE Remote Engine Start/Stop. Both share
+        # the "engine" class so a stop request waits for an in-flight
+        # start (and vice versa) instead of overlapping.
+        "command_engine_start": "engine",
+        "command_engine_stop": "engine",
     }
 
     async def _cariad_cmd(self, vin: str, method: str, **kwargs: Any) -> None:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.13.0"
+  "version": "1.14.0"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -447,6 +447,56 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
     # by the integration so users can 1-click report them via the HA Repair
     # dashboard. data_key="" — value comes from coordinator helpers, not
     # the vehicle dict — see ``ReporterSensor.native_value``.
+    # ── v1.14.0 (#24) — Trip Statistics (Audi + VW EU) ────────────────
+    # Subscription-required (Audi connect Plus / WeConnect Plus).
+    # Phase 3 capability gate (#56) hides these entities for accounts
+    # without the subscription. Data populated by 1h cache cycle in
+    # ``coordinator.refresh_trip_statistics`` from the CARIAD-BFF
+    # ``GET /vehicle/v1/vehicles/{vin}/tripstatistics`` endpoint.
+    # ``recent_trips`` (list of last 5) lives in
+    # ``last_trip_distance_km.extra_state_attributes`` to avoid the
+    # 255-char state limit for list-shaped data.
+    VagSensorDescription(
+        key="last_trip_distance_km",
+        translation_key="last_trip_distance_km",
+        data_key="last_trip_distance_km",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:road-variant",
+        suggested_display_precision=1,
+    ),
+    VagSensorDescription(
+        key="last_trip_avg_speed_kmh",
+        translation_key="last_trip_avg_speed_kmh",
+        data_key="last_trip_avg_speed_kmh",
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        device_class=SensorDeviceClass.SPEED,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:speedometer",
+        suggested_display_precision=0,
+    ),
+    VagSensorDescription(
+        key="last_trip_avg_fuel_consumption_l_100km",
+        translation_key="last_trip_avg_fuel_consumption_l_100km",
+        data_key="last_trip_avg_fuel_consumption_l_100km",
+        native_unit_of_measurement="L/100 km",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:gas-station",
+        suggested_display_precision=1,
+        condition="combustion",
+    ),
+    VagSensorDescription(
+        key="last_trip_avg_electric_consumption_kwh_100km",
+        translation_key="last_trip_avg_electric_consumption_kwh_100km",
+        data_key="last_trip_avg_electric_consumption_kwh_100km",
+        native_unit_of_measurement="kWh/100 km",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:lightning-bolt",
+        suggested_display_precision=1,
+        condition="electric",
+    ),
+
     VagSensorDescription(
         key="api_observer_findings",
         translation_key="api_observer_findings",
@@ -492,6 +542,19 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "voltage_12v",
 })
 
+# v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level
+# (CARIAD-BFF only — Audi + VW EU). Other brands' clients don't expose
+# ``get_trip_statistics``. Gate at setup so SEAT/CUPRA/Skoda/Porsche/VW NA
+# users don't get four "unknown" sensors per VIN. Capability gating
+# (Phase 3, #56) further hides them when the subscription is absent.
+_TRIP_STATS_KEYS: frozenset[str] = frozenset({
+    "last_trip_distance_km",
+    "last_trip_avg_speed_kmh",
+    "last_trip_avg_fuel_consumption_l_100km",
+    "last_trip_avg_electric_consumption_kwh_100km",
+})
+_TRIP_STATS_BRANDS: frozenset[str] = frozenset({"audi", "volkswagen"})
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -500,6 +563,9 @@ async def async_setup_entry(
 ) -> None:
     """Sensor-Entities einrichten."""
     coordinator: VagConnectCoordinator = entry.runtime_data
+    # v1.14.0 (#24) — read brand once for trip-stats brand-restriction.
+    brand = str(entry.data.get("brand", "")).lower()
+    trip_stats_supported = brand in _TRIP_STATS_BRANDS
     entities: list[VagConnectSensor] = []
 
     for vin, vehicle in coordinator.vehicles.items():
@@ -523,6 +589,19 @@ async def async_setup_entry(
                 and vehicle.get(desc.data_key) is None
             ):
                 continue
+            # v1.14.0 (#24) — Trip Stats brand-gate. Skip the four
+            # tripstatistics sensors entirely for non-CARIAD brands so
+            # SEAT/CUPRA/Skoda/Porsche/VW NA users don't see "unknown"
+            # entities forever. Phase 3 capability filter additionally
+            # hides them when the audi/vw subscription is missing.
+            if desc.key in _TRIP_STATS_KEYS:
+                if not trip_stats_supported:
+                    continue
+                if (
+                    coordinator.command_capability_supported(vin, "command_trip_stats")
+                    is False
+                ):
+                    continue
             if desc.key in _REPORTER_KEYS:
                 # v1.9.0 — reporter sensors read from coordinator helpers
                 # rather than per-vehicle data fields.
@@ -554,6 +633,22 @@ class VagConnectSensor(VagConnectEntity, SensorEntity):
         self.entity_description = description
         if description.suggested_display_precision is not None:
             self._attr_suggested_display_precision = description.suggested_display_precision
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """v1.14.0 (#24) — Surface ``recent_trips`` (last 5 short-term
+        trips) on the ``last_trip_distance_km`` sensor.
+
+        Pattern from audi #113 — list-shaped data goes into attributes
+        because HA caps state strings at 255 chars and per-trip metadata
+        easily exceeds that. Other sensors return ``None`` so we don't
+        accidentally inflate recorder rows.
+        """
+        if self.entity_description.key == "last_trip_distance_km":
+            recent = self._vehicle.get("recent_trips")
+            if isinstance(recent, list) and recent:
+                return {"recent_trips": recent[: 5]}
+        return None
 
     @property
     def native_value(self) -> Any:

--- a/custom_components/vag_connect/services.yaml
+++ b/custom_components/vag_connect/services.yaml
@@ -191,3 +191,29 @@ set_departure_timer:
       required: false
       selector:
         text:
+
+# v1.14.0 (#28) — Audi-only ICE Remote Engine Start/Stop.
+engine_start:
+  name: Motor starten (Audi ICE)
+  description: >-
+    Startet den Verbrennungsmotor remote (Audi-only, S-PIN erforderlich).
+    Zwei-Schritt-Flow: PUT /vehicle/v1/engine/{VIN}/userpromptproof + POST /vehicle/v1/engine/{VIN}/start.
+    Nur für Audi-Modelle mit ICE/Hybrid + aktivem Audi connect Plus Abo.
+    Der S-PIN wird aus der gespeicherten Konfiguration genommen — landet NIE im Service-Call-Log.
+  fields:
+    vin:
+      name: VIN
+      required: true
+      selector:
+        text:
+engine_stop:
+  name: Motor stoppen (Audi ICE)
+  description: >-
+    Stoppt den Verbrennungsmotor remote (Audi-only, kein S-PIN nötig).
+    Single POST /vehicle/v1/engine/{VIN}/stop.
+  fields:
+    vin:
+      name: VIN
+      required: true
+      selector:
+        text:

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -75,13 +75,15 @@
           "scan_interval": "Update Interval",
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Reverse Geocoding (parking address)",
-          "read_only_mode": "Read-only Mode"
+          "read_only_mode": "Read-only Mode",
+          "force_ppe_climate": "Audi PPE/PPC Climate body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
           "spin": "S-PIN for door locking. App → Security → S-PIN.",
           "enable_reverse_geocoding": "Sends parking GPS to OpenStreetMap Nominatim to resolve street/city. Off by default for privacy.",
-          "read_only_mode": "When enabled, only status sensors are created — no switches, buttons, locks, climate or sliders that send commands. Useful if you want vehicle telemetry without any risk of accidental actuation. Reload the integration after toggling."
+          "read_only_mode": "When enabled, only status sensors are created — no switches, buttons, locks, climate or sliders that send commands. Useful if you want vehicle telemetry without any risk of accidental actuation. Reload the integration after toggling.",
+          "force_ppe_climate": "Audi-only. Forces the new PPE/PPC body shape (climatisationMode mandatory, targetTemperature omitted) on climate start. Enable only if you own a Q6 e-tron, A6 e-tron, RS e-tron GT Facelift or A3 2024+ PHEV — climate-start otherwise returns 400. Reload the integration after toggling."
         }
       }
     }
@@ -183,6 +185,18 @@
       },
       "wake_count_today": {
         "name": "Wake-ups Today"
+      },
+      "last_trip_distance_km": {
+        "name": "Last Trip Distance"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Last Trip Average Speed"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Last Trip Average Fuel Consumption"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Last Trip Average Electric Consumption"
       },
       "departure_timer_1_time": {
         "name": "Departure Timer 1"

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -75,13 +75,15 @@
           "scan_interval": "Interval aktualizace",
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Reverzní geokódování (adresa parkování)",
-          "read_only_mode": "Režim jen pro čtení"
+          "read_only_mode": "Režim jen pro čtení",
+          "force_ppe_climate": "Audi PPE/PPC klima-tělo (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",
           "spin": "S-PIN pro zamykání dveří.",
           "enable_reverse_geocoding": "Odesílá GPS parkování do OpenStreetMap Nominatim pro získání ulice/města. Výchozí: vypnuto (soukromí).",
-          "read_only_mode": "Když je povoleno, vytváří se pouze stavové senzory — žádné spínače, tlačítka, zámky, klima ani posuvníky odesílající příkazy. Užitečné, pokud chcete telemetrii vozidla bez rizika náhodného spuštění. Po přepnutí znovu načtěte integraci."
+          "read_only_mode": "Když je povoleno, vytváří se pouze stavové senzory — žádné spínače, tlačítka, zámky, klima ani posuvníky odesílající příkazy. Užitečné, pokud chcete telemetrii vozidla bez rizika náhodného spuštění. Po přepnutí znovu načtěte integraci.",
+          "force_ppe_climate": "Pouze Audi. Vynucuje nový PPE/PPC formát těla (climatisationMode povinný, targetTemperature vynechaný) při startu klimatizace. Zapnout pouze pokud vlastníš Q6 e-tron, A6 e-tron, RS e-tron GT Facelift nebo A3 2024+ PHEV — jinak API vrátí 400. Po zapnutí znovu načti integraci."
         }
       }
     }
@@ -183,6 +185,18 @@
       },
       "wake_count_today": {
         "name": "Probuzení dnes"
+      },
+      "last_trip_distance_km": {
+        "name": "Poslední Jízda — Vzdálenost"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Poslední Jízda — Prům. Rychlost"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Poslední Jízda — Prům. Spotřeba Paliva"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Poslední Jízda — Prům. Spotřeba Elektřiny"
       },
       "departure_timer_1_time": {
         "name": "Časovač odjezdu 1"

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -72,10 +72,12 @@
         "data": {
           "scan_interval": "Aktualisierungsintervall (Minuten)",
           "spin": "S-PIN",
-          "enable_reverse_geocoding": "Adress-Auflösung (Parkposition)"
+          "enable_reverse_geocoding": "Adress-Auflösung (Parkposition)",
+          "force_ppe_climate": "Audi PPE/PPC Klima-Body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
-          "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz)."
+          "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",
+          "force_ppe_climate": "Nur für Audi relevant. Erzwingt das neue PPE/PPC Body-Format (climatisationMode mandatory, targetTemperature weggelassen) beim Klima-Start. Nur aktivieren wenn du einen Q6 e-tron, A6 e-tron, RS e-tron GT Facelift oder A3 2024+ PHEV besitzt — sonst antwortet die API mit 400. Integration nach Aktivierung neu laden."
         }
       }
     }
@@ -177,6 +179,18 @@
       },
       "wake_count_today": {
         "name": "Wake-Ups heute"
+      },
+      "last_trip_distance_km": {
+        "name": "Letzte Fahrt — Strecke"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Letzte Fahrt — Ø Geschwindigkeit"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Letzte Fahrt — Ø Kraftstoffverbrauch"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Letzte Fahrt — Ø Stromverbrauch"
       },
       "departure_timer_1_time": {
         "name": "Abfahrtstimer 1"

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -75,13 +75,15 @@
           "scan_interval": "Update Interval",
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Reverse Geocoding (parking address)",
-          "read_only_mode": "Read-only Mode"
+          "read_only_mode": "Read-only Mode",
+          "force_ppe_climate": "Audi PPE/PPC Climate body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
           "spin": "S-PIN for door locking. App → Security → S-PIN.",
           "enable_reverse_geocoding": "Sends parking GPS to OpenStreetMap Nominatim to resolve street/city. Off by default for privacy.",
-          "read_only_mode": "When enabled, only status sensors are created — no switches, buttons, locks, climate or sliders that send commands. Useful if you want vehicle telemetry without any risk of accidental actuation. Reload the integration after toggling."
+          "read_only_mode": "When enabled, only status sensors are created — no switches, buttons, locks, climate or sliders that send commands. Useful if you want vehicle telemetry without any risk of accidental actuation. Reload the integration after toggling.",
+          "force_ppe_climate": "Audi-only. Forces the new PPE/PPC body shape (climatisationMode mandatory, targetTemperature omitted) on climate start. Enable only if you own a Q6 e-tron, A6 e-tron, RS e-tron GT Facelift or A3 2024+ PHEV — climate-start otherwise returns 400. Reload the integration after toggling."
         }
       }
     }
@@ -183,6 +185,18 @@
       },
       "wake_count_today": {
         "name": "Wake-ups Today"
+      },
+      "last_trip_distance_km": {
+        "name": "Last Trip Distance"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Last Trip Average Speed"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Last Trip Average Fuel Consumption"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Last Trip Average Electric Consumption"
       },
       "departure_timer_1_time": {
         "name": "Departure Timer 1"

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -75,13 +75,15 @@
           "scan_interval": "Intervalo de actualización",
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Geocodificación inversa (dirección de aparcamiento)",
-          "read_only_mode": "Modo solo lectura"
+          "read_only_mode": "Modo solo lectura",
+          "force_ppe_climate": "Climatización PPE/PPC Audi (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",
           "spin": "S-PIN para bloqueo de puertas.",
           "enable_reverse_geocoding": "Envía GPS de aparcamiento a OpenStreetMap Nominatim para resolver calle/ciudad. Desactivado por defecto (privacidad).",
-          "read_only_mode": "Cuando está activado, solo se crean sensores de estado — sin interruptores, botones, cerraduras, clima o deslizadores que envíen comandos. Útil si quieres telemetría del vehículo sin riesgo de actuación accidental. Recarga la integración tras activar."
+          "read_only_mode": "Cuando está activado, solo se crean sensores de estado — sin interruptores, botones, cerraduras, clima o deslizadores que envíen comandos. Útil si quieres telemetría del vehículo sin riesgo de actuación accidental. Recarga la integración tras activar.",
+          "force_ppe_climate": "Solo para Audi. Fuerza el nuevo formato PPE/PPC (climatisationMode obligatorio, targetTemperature omitido) al iniciar la climatización. Activar solo si posees Q6 e-tron, A6 e-tron, RS e-tron GT Facelift o A3 2024+ PHEV — de lo contrario la API responde 400. Recarga la integración tras activar."
         }
       }
     }
@@ -183,6 +185,18 @@
       },
       "wake_count_today": {
         "name": "Despertares hoy"
+      },
+      "last_trip_distance_km": {
+        "name": "Último Viaje — Distancia"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Último Viaje — Velocidad Media"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Último Viaje — Consumo Medio Combustible"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Último Viaje — Consumo Medio Eléctrico"
       },
       "departure_timer_1_time": {
         "name": "Temporizador de salida 1"

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -75,13 +75,15 @@
           "scan_interval": "Intervalle de mise à jour",
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Géocodage inverse (adresse de stationnement)",
-          "read_only_mode": "Mode lecture seule"
+          "read_only_mode": "Mode lecture seule",
+          "force_ppe_climate": "Climate Audi PPE/PPC (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",
           "spin": "S-PIN pour le verrouillage des portes.",
           "enable_reverse_geocoding": "Envoie le GPS de stationnement à OpenStreetMap Nominatim pour obtenir rue/ville. Désactivé par défaut (confidentialité).",
-          "read_only_mode": "Lorsqu'activé, seuls les capteurs d'état sont créés — pas d'interrupteurs, boutons, verrous, climat ou curseurs qui envoient des commandes. Utile si vous voulez la télémétrie véhicule sans risque d'actionnement accidentel. Rechargez l'intégration après activation."
+          "read_only_mode": "Lorsqu'activé, seuls les capteurs d'état sont créés — pas d'interrupteurs, boutons, verrous, climat ou curseurs qui envoient des commandes. Utile si vous voulez la télémétrie véhicule sans risque d'actionnement accidentel. Rechargez l'intégration après activation.",
+          "force_ppe_climate": "Audi uniquement. Force le nouveau format de payload PPE/PPC (climatisationMode obligatoire, targetTemperature omis) au démarrage du climat. À activer uniquement si vous possédez une Q6 e-tron, A6 e-tron, RS e-tron GT Facelift ou A3 2024+ PHEV — sinon l'API renvoie 400. Rechargez l'intégration après activation."
         }
       }
     }
@@ -183,6 +185,18 @@
       },
       "wake_count_today": {
         "name": "Réveils aujourd'hui"
+      },
+      "last_trip_distance_km": {
+        "name": "Dernier Trajet — Distance"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Dernier Trajet — Vitesse Moyenne"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Dernier Trajet — Conso. Carburant Moyenne"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Dernier Trajet — Conso. Électrique Moyenne"
       },
       "departure_timer_1_time": {
         "name": "Minuterie de départ 1"

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -75,13 +75,15 @@
           "scan_interval": "Update-interval",
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Reverse geocoding (parkeeradres)",
-          "read_only_mode": "Alleen-lezen modus"
+          "read_only_mode": "Alleen-lezen modus",
+          "force_ppe_climate": "Audi PPE/PPC klimaat-body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",
           "spin": "S-PIN voor deurvergrendeling.",
           "enable_reverse_geocoding": "Verzendt parkeer-GPS naar OpenStreetMap Nominatim om straat/stad te vinden. Standaard uit (privacy).",
-          "read_only_mode": "Indien ingeschakeld worden alleen statussensoren aangemaakt — geen schakelaars, knoppen, sloten, klimaat of schuifregelaars die commando's verzenden. Handig als je voertuigtelemetrie wilt zonder risico op onbedoelde bediening. Herlaad de integratie na inschakelen."
+          "read_only_mode": "Indien ingeschakeld worden alleen statussensoren aangemaakt — geen schakelaars, knoppen, sloten, klimaat of schuifregelaars die commando's verzenden. Handig als je voertuigtelemetrie wilt zonder risico op onbedoelde bediening. Herlaad de integratie na inschakelen.",
+          "force_ppe_climate": "Alleen voor Audi. Forceert het nieuwe PPE/PPC body-formaat (climatisationMode verplicht, targetTemperature weggelaten) bij klimaat-start. Alleen inschakelen als je een Q6 e-tron, A6 e-tron, RS e-tron GT Facelift of A3 2024+ PHEV bezit — anders geeft de API 400 terug. Integratie herladen na inschakelen."
         }
       }
     }
@@ -183,6 +185,18 @@
       },
       "wake_count_today": {
         "name": "Wake-ups vandaag"
+      },
+      "last_trip_distance_km": {
+        "name": "Laatste Rit — Afstand"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Laatste Rit — Gem. Snelheid"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Laatste Rit — Gem. Brandstofverbruik"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Laatste Rit — Gem. Elektrisch Verbruik"
       },
       "departure_timer_1_time": {
         "name": "Vertrektimer 1"

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -75,13 +75,15 @@
           "scan_interval": "Interwał aktualizacji",
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Geokodowanie odwrotne (adres parkowania)",
-          "read_only_mode": "Tryb tylko do odczytu"
+          "read_only_mode": "Tryb tylko do odczytu",
+          "force_ppe_climate": "Audi PPE/PPC klimat-body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",
           "spin": "S-PIN do blokowania drzwi.",
           "enable_reverse_geocoding": "Wysyła GPS parkowania do OpenStreetMap Nominatim, aby uzyskać ulicę/miasto. Domyślnie wyłączone (prywatność).",
-          "read_only_mode": "Po włączeniu tworzone są tylko czujniki statusu — bez przełączników, przycisków, blokad, klimatu czy suwaków wysyłających polecenia. Przydatne gdy chcesz telemetrię pojazdu bez ryzyka przypadkowego uruchomienia. Przeładuj integrację po włączeniu."
+          "read_only_mode": "Po włączeniu tworzone są tylko czujniki statusu — bez przełączników, przycisków, blokad, klimatu czy suwaków wysyłających polecenia. Przydatne gdy chcesz telemetrię pojazdu bez ryzyka przypadkowego uruchomienia. Przeładuj integrację po włączeniu.",
+          "force_ppe_climate": "Tylko Audi. Wymusza nowy format PPE/PPC (climatisationMode obowiązkowy, targetTemperature pominięty) przy starcie klimatyzacji. Włącz tylko jeśli masz Q6 e-tron, A6 e-tron, RS e-tron GT Facelift lub A3 2024+ PHEV — w przeciwnym razie API zwraca 400. Po włączeniu przeładuj integrację."
         }
       }
     }
@@ -183,6 +185,18 @@
       },
       "wake_count_today": {
         "name": "Wybudzenia dziś"
+      },
+      "last_trip_distance_km": {
+        "name": "Ostatnia Trasa — Dystans"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Ostatnia Trasa — Średnia Prędkość"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Ostatnia Trasa — Średnie Zużycie Paliwa"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Ostatnia Trasa — Średnie Zużycie Energii"
       },
       "departure_timer_1_time": {
         "name": "Timer odjazdu 1"

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -75,13 +75,15 @@
           "scan_interval": "Uppdateringsintervall",
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Omvänd geokodning (parkeringsadress)",
-          "read_only_mode": "Skrivskyddat läge"
+          "read_only_mode": "Skrivskyddat läge",
+          "force_ppe_climate": "Audi PPE/PPC klimat-body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",
           "spin": "S-PIN för dörrlåsning.",
           "enable_reverse_geocoding": "Skickar parkerings-GPS till OpenStreetMap Nominatim för att hämta gata/stad. Av som standard (integritet).",
-          "read_only_mode": "När aktiverat skapas endast statussensorer — inga brytare, knappar, lås, klimat eller reglage som skickar kommandon. Användbart om du vill ha fordonstelemetri utan risk för oavsiktlig aktivering. Ladda om integrationen efter ändring."
+          "read_only_mode": "När aktiverat skapas endast statussensorer — inga brytare, knappar, lås, klimat eller reglage som skickar kommandon. Användbart om du vill ha fordonstelemetri utan risk för oavsiktlig aktivering. Ladda om integrationen efter ändring.",
+          "force_ppe_climate": "Endast Audi. Tvingar det nya PPE/PPC body-formatet (climatisationMode obligatoriskt, targetTemperature utelämnat) vid klimatstart. Aktivera bara om du äger en Q6 e-tron, A6 e-tron, RS e-tron GT Facelift eller A3 2024+ PHEV — annars svarar API:t med 400. Ladda om integrationen efter aktivering."
         }
       }
     }
@@ -183,6 +185,18 @@
       },
       "wake_count_today": {
         "name": "Väckningar idag"
+      },
+      "last_trip_distance_km": {
+        "name": "Senaste Resa — Avstånd"
+      },
+      "last_trip_avg_speed_kmh": {
+        "name": "Senaste Resa — Medel-Hastighet"
+      },
+      "last_trip_avg_fuel_consumption_l_100km": {
+        "name": "Senaste Resa — Medel-Bränsleförbrukning"
+      },
+      "last_trip_avg_electric_consumption_kwh_100km": {
+        "name": "Senaste Resa — Medel-Elförbrukning"
       },
       "departure_timer_1_time": {
         "name": "Avgångstimer 1"

--- a/docs/CHANGELOG_TECHNICAL.md
+++ b/docs/CHANGELOG_TECHNICAL.md
@@ -14,6 +14,181 @@ weiterhin direkt in `CHANGELOG.md` zu finden.
 
 ---
 
+## [1.14.0] - 2026-05-02
+
+### Audi Feature Pack Bundle / Audi Feature Pack Bundle
+
+MINOR-Release. Bundle 2 aus `docs/RESEARCH_NOTES_2026-05-02.md`. Drei Audi-spezifische Features in einem Release plus Skoda Scout-Pfade #116 als Add-On.
+
+#### #24 Trip Statistics für VW EU + Audi
+
+**Endpoint:** `GET https://emea.bff.cariad.digital/vehicle/v1/vehicles/{vin}/tripstatistics?type={shortTerm|longTerm}` (verified in audi_connect_ha + audiconnectpy + ioBroker/vw-connect, see RESEARCH_NOTES_2026-05-02 §Bundle 2 #24).
+
+**Response shape:**
+```json
+{"tripDataList": {"tripData": [
+  {"tripID": ..., "tripType": "shortTermReset",
+   "timestamp": "2026-04-28T17:42:11Z",
+   "mileage": 23, "startMileage": 41205, "overallMileage": 41228,
+   "traveltime": 31, "averageSpeed": 44,
+   "averageFuelConsumption": 68,           // ×10 — divide
+   "averageElectricEngineConsumption": 0}, // ×10 — divide
+  ...
+]}}
+```
+
+**Files:**
+- `cariad/api/vw_eu.py` — new `get_trip_statistics(vin, kind="shortTerm")` method (Audi inherits via `AudiClient(VWEUClient)`)
+- `cariad/models.py` — extended `VehicleData` with 9 new fields:
+  - `last_trip_distance_km`, `last_trip_duration_min`, `last_trip_avg_speed_kmh`
+  - `last_trip_avg_fuel_consumption_l_100km`, `last_trip_avg_electric_consumption_kwh_100km`
+  - `last_trip_timestamp`
+  - `lifetime_distance_km`, `lifetime_avg_fuel_consumption_l_100km`, `lifetime_avg_electric_consumption_kwh_100km`
+  - `recent_trips: list[dict]` (last 5)
+- `coordinator.py`:
+  - New module-level pure function `_parse_trip_statistics(short_resp, long_resp)` — sort by `overallMileage` desc, take `[0]`, divide consumption fields by 10, build `recent_trips` list capped at 5.
+  - New method `refresh_trip_statistics(vin, force=False)` — brand-restricted to `audi`/`volkswagen`, 1h cache via `_trip_stats_fetched_at[vin]`, capability-gated via `command_capability_supported(vin, "command_trip_stats") is False` early-return, parallel `gather()` for shortTerm + longTerm.
+  - Hooked into `_poll_loop` after `_async_push_update` as best-effort gather (never blocks polling).
+- `cariad/_capabilities.py` — added `"command_trip_stats": "tripStatistics"` to `volkswagen` map (audi inherits via copy in line below).
+- `sensor.py`:
+  - 4 new `VagSensorDescription` entries with `state_class=MEASUREMENT`, conditional gating (`combustion`/`electric`)
+  - New `_TRIP_STATS_KEYS` + `_TRIP_STATS_BRANDS` frozenset for setup-time gating (skip 4 sensors entirely on non-CARIAD brands so SEAT/CUPRA/Skoda/Porsche/VW NA don't get phantom "unknown" entities)
+  - New `extra_state_attributes` override on `VagConnectSensor` to surface `recent_trips` on the `last_trip_distance_km` sensor (audi #113 "aggregate-in-state" + 255-char state limit avoidance).
+
+#### #28 Audi ICE Remote Engine Start/Stop
+
+**Source:** arjenvrh/audi_connect_ha PR #717 — confirmed via `gh pr diff 717` (Research Notes §Bundle 2 #28).
+
+**Endpoints:**
+- `PUT /vehicle/v1/engine/{VIN}/userpromptproof` (S-PIN) → `{"userPromptProof": "..."}` at top-level
+- `POST /vehicle/v1/engine/{VIN}/start` with `{"securedActivationData": <token>, "spin": <pin>}`
+- `POST /vehicle/v1/engine/{VIN}/stop` with no body, no S-PIN
+
+Note: path is `/vehicle/v1/engine/{vin}/...` — NOT `/vehicle/v1/vehicles/{vin}/engine/...`. VIN must be uppercased in URL (upstream PR explicitly does `vin.upper()`).
+
+**Files:**
+- `cariad/api/audi.py`:
+  - New constant `_ENGINE_BASE = "https://emea.bff.cariad.digital/vehicle/v1/engine"`
+  - New method `command_engine_start(vin, spin="")` — raises `SpinError` if no PIN, two-step flow with proof extraction
+  - New method `command_engine_stop(vin)` — single POST, no body
+  - Uses `self._request("PUT", ...)` for step 1 (base.py only exposes `_get`/`_post` helpers; PUT goes via `_request`)
+- `cariad/_capabilities.py`:
+  - **Audi inheritance changed from alias to copy** — `CAPABILITY_MAP["audi"] = dict(CAPABILITY_MAP["audi"])` so audi-only patches don't pollute VW EU's table
+  - Added `"command_engine_start": "engineRemoteStart"` + `"command_engine_stop": "engineRemoteStart"` to audi (NOT to volkswagen). ⚠️ [Inference] cap-id, no Live-Capabilities-Response yet.
+- `coordinator.py`:
+  - `_COMMAND_CLASS` registry extended with `command_engine_start`/`command_engine_stop` → `"engine"` class (start/stop serialize via shared lock)
+  - New methods `async_engine_start(vin)` + `async_engine_stop(vin)` wrapping `_cariad_cmd`
+- `__init__.py`:
+  - New service handlers `_handle_engine_start` + `_handle_engine_stop` (both go through `_coord_writeable` for Read-only Mode v1.13.0 protection)
+  - Service registry: `engine_start` + `engine_stop` with `SERVICE_VIN_SCHEMA`
+  - `async_unload_entry` removes the new services on unload
+- `services.yaml` — descriptions for `engine_start`/`engine_stop` documenting two-step flow + S-PIN-from-config
+
+#### #29 PPE/PPC Climate Body conditional
+
+**Body shape difference (verified from audi_connect_ha PR #644 + #677):**
+
+Legacy MQB:
+```json
+{"targetTemperature": 21.0, "targetTemperatureUnit": "celsius",
+ "climatisationWithoutExternalPower": true, "windowHeatingEnabled": true}
+```
+
+PPE/PPC (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV):
+```json
+{"climatisationMode": "comfort",            // MANDATORY, not null
+ "climatisationWithoutExternalPower": true,
+ "windowHeatingEnabled": true
+ // targetTemperature* OMITTED — body validator rejects PPE otherwise
+}
+```
+
+**Files:**
+- `const.py` — new `CONF_FORCE_PPE_CLIMATE = "force_ppe_climate"`
+- `cariad/api/vw_eu.py` — `command_start_climate(vin, ppe_mode: bool = False)` with conditional fallback-payload. Default `False` = legacy body (backwards-compat for all existing callers).
+- `coordinator.py` — `async_start_climatisation(vin)` reads `CONF_FORCE_PPE_CLIMATE` from options/data (Audi-only), passes `ppe_mode=True` as kwarg when set.
+- `config_flow.py` — extended OptionsFlow with `force_ppe_climate` boolean toggle.
+- `strings.json` + 8 translations — option label + helper text describing PPE eligibility.
+
+**Why user-overridable instead of auto-detected:**
+- audi_connect_ha has `api_level` user-toggle (issues #677, #706 show even that is fragile across vehicles)
+- No public PPE compatibility list — guessing from VIN/model/year would mis-fire
+- Hard Rule #15: "do not endpoint-guess for PPC/PPE — risks Audi account suspension"
+- Body-shape-changes on a known endpoint are safer than endpoint-guessing — server-validated
+
+#### #116 Skoda Scout-Pfade (MavericklCS, fourth community Scout-Report)
+
+`cariad/_unexpected_keys.py` — extensions to `EXPECTED_KEYS["skoda"]`:
+
+```python
+"driving-range": {
+  ...
+  # v1.14.0 (#116, MavericklCS Scout-Report 2026-05-01)
+  "primaryEngineRange.engineType",
+  "primaryEngineRange.currentSoCInPercent",
+  "primaryEngineRange.currentFuelLevelInPercent",
+  "primaryEngineRange.remainingRangeInKm",
+},
+"maintenance": {
+  ...
+  # v1.14.0 (#116, MavericklCS) — predictiveMaintenance.setting (4 keys observed)
+  "predictiveMaintenance.setting",
+  "predictiveMaintenance.setting.*",
+}
+```
+
+`primaryEngineRange.currentSoCInPercent` on a `engineType: "gasoline"` vehicle is unusual — likely the 12V starter battery SoC (paralleling our v1.12.0 #23 `voltage_12v` work). Wait for next Scout-Report with vehicle-model context before wiring as a sensor.
+
+#### Translations
+
+8 Sprachen — neue keys:
+- `entity.sensor.{last_trip_distance_km, last_trip_avg_speed_kmh, last_trip_avg_fuel_consumption_l_100km, last_trip_avg_electric_consumption_kwh_100km}` — sensor display names
+- `options.step.init.data.force_ppe_climate` (label) + `data_description.force_ppe_climate` (helper text)
+
+Service descriptions for `engine_start` + `engine_stop` live in `services.yaml` (German, no per-language file expansion yet).
+
+#### Tests
+
+`tests/test_v1140_audi_pack.py` — 19 new tests, six classes:
+- `TestParseTripStatistics` (6) — pure parser exercises sort, ×10 division, recent_trips cap, garbage tolerance
+- `TestGetTripStatisticsURL` (1) — URL + `type` query param
+- `TestRefreshTripStatisticsBrandRestriction` (4) — non-CARIAD brand skip, audi makes 2 calls, capability-False skips, 1h cache window
+- `TestAudiEngineStart` (5) — two-step flow body shapes, VIN uppercase, no-S-PIN raises, missing-proof raises, stop endpoint
+- `TestPpcClimateBody` (3) — legacy body / PPE body / default-legacy backwards-compat
+- `TestCapabilityMapEngineStart` (4) — Audi has, VW does not, copy-not-alias verification, trip_stats cap
+- `TestScoutPathsSkoda` (2) — `primaryEngineRange.*` + `predictiveMaintenance.setting.*` registered
+- `TestEngineCommandClass` (1) — engine class shared between start/stop
+
+#### Files modified
+
+```
+custom_components/vag_connect/
+  __init__.py                     (+ engine_start/engine_stop services)
+  cariad/_capabilities.py         (audi inheritance copy + engine + trip_stats cap-ids)
+  cariad/_unexpected_keys.py      (+ #116 Skoda scout paths)
+  cariad/api/audi.py              (+ command_engine_start/stop + _ENGINE_BASE constant)
+  cariad/api/vw_eu.py             (+ get_trip_statistics + ppe_mode kwarg on command_start_climate)
+  cariad/models.py                (+ 9 trip-stats fields + recent_trips list)
+  config_flow.py                  (+ CONF_FORCE_PPE_CLIMATE option in OptionsFlow)
+  const.py                        (+ CONF_FORCE_PPE_CLIMATE)
+  coordinator.py                  (+ _parse_trip_statistics module fn + refresh_trip_statistics
+                                   + _COMMAND_CLASS engine entries
+                                   + async_engine_start/_stop helpers
+                                   + ppe_mode wiring in async_start_climatisation
+                                   + trip stats refresh in poll loop)
+  manifest.json                   (1.13.0 → 1.14.0)
+  sensor.py                       (+ 4 trip-stats sensors + _TRIP_STATS_BRANDS
+                                   + extra_state_attributes for recent_trips)
+  services.yaml                   (+ engine_start/engine_stop blocks)
+  strings.json                    (+ 4 sensor names + force_ppe_climate option)
+  translations/{de,en,fr,es,cs,nl,pl,sv}.json
+                                  (+ same as strings.json mirrored)
+
+tests/test_v1140_audi_pack.py     (NEW, 19 tests)
+```
+
+---
+
 ## [1.13.0] - 2026-05-02
 
 ### Production Hardening Bundle / Production Hardening Bundle

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,12 +5,10 @@
 > mirrors it for archive/historical purposes and links the active GitHub
 > issues for each session.
 
-**Last updated:** 2026-05-02 — post v1.13.0 (Production Hardening Bundle:
-Capability-Filter Phase 3 #56 + Read-only Phase 2/3 #63 +
-Anonymized Diagnostics-Export #62 + Process & Governance Doc-PR #64).
-Nächste P0: Bundle 2 (v1.14.0 Audi Feature Pack — #24 Trip Stats +
-#29 PPC Climate + #28 ICE Remote Start, alle in `RESEARCH_NOTES_2026-05-02.md`
-vorrecherchiert).
+**Last updated:** 2026-05-02 — post v1.14.0 (Audi Feature Pack:
+Trip Stats #24 + Engine Start ICE #28 + PPC Climate Body #29 +
+Skoda Scout-Pfade #116). Nächste P0: Bundle 3 (v1.15.0 Cross-Brand
+UX — #26 Klima-Timer UI + #25/#31 read-only Sensoren).
 
 ---
 
@@ -56,6 +54,7 @@ vorrecherchiert).
 | **v1.12.2** | 🌟🛰️ **Erstes Community-Scout-Report (Skoda #107 von tritanium73)** — User `tritanium73` reichte am 2026-05-01 den ersten Vehicle Data Scout Report von einem Nicht-Maintainer ein. 14 neue Skoda mysmob Pfade über 4 Endpoints (`renders.{lightMode,darkMode}` 2-segment fix, 6× `air-conditioning`, 2× `driving-range` mit `carType`+`primaryEngineRange`, 4× `maintenance` meta-blocks). Volle v1.9.0 Pipeline funktioniert in der Wildbahn. (6 neue Tests) | **2026-05-01** |
 | **v1.12.3** | 🛰️ **Scout-Pfade #111 (DnnsJp74) + #113 (Golf GTE) + #114 (Audi S6 C8)** — drei Scout-Reports zusammen. #111: 23 Audi-Pfade von Community-User DnnsJp74 (zweiter community Scout report nach #107). #113+#114: 14+20 Felder von Prash auf eigenen Vehicles (Golf GTE + Audi S6) — alle drei zeigen `.value` Container Children. Wildcards `fuelStatus.rangeStatus.value.*`, `vehicleHealthInspection.maintenanceStatus.value.*`, `departureProfiles.departureProfilesStatus.value.*`, `userCapabilities.capabilitiesStatus.value.*` decken alle Klassen future-proof ab. (8 neue Tests) | **2026-05-01** |
 | **v1.13.0** | 🛡️ **Production Hardening Bundle** — drei P0-Themen aus dem Backlog (#56/#63/#62) plus Process-Docs (#64) in einem MINOR. Capability-Filter Phase 3 mit `cariad/_capabilities.py` Single-Source-of-Truth (`CAPABILITY_MAP[brand][command_id]→cap_id`, Audi/SEAT erben via Table-Alias) — gates PRE-Entity-Creation (Phase 1+2 waren post-failure). Read-only Phase 2 service-side: `_coord_writeable(vin)` raised `read_only_mode_active` ServiceValidationError. Read-only Phase 3 cloud_refresh vs wake distinction (`refresh_cloud_cache` neu, `refresh_vehicle` bleibt als Alias) + 5-min wake cooldown pro VIN + per-VIN-per-command-class asyncio.Lock mit timeout. Diagnostics: token-redaction expanded (access/refresh/id_token snake+camel + client_secret), Email partial-mask `u***@***.com`, GPS opt-in 1-decimal rounding wenn reverse-geocoding aus. Process: `.github/ISSUE_TEMPLATE/{scout_report,error_report}.yml` + `BRAND_CAPTAINS.md`. Pre-Research: `docs/RESEARCH_NOTES_2026-05-02.md` (423 Zeilen, 13 Issues über 3 Bundles). (31 neue Tests) | **2026-05-02** |
+| **v1.14.0** | 🚗 **Audi Feature Pack Bundle** — Bundle 2 aus dem Pre-Research-Plan. (1) #24 Trip Statistics für VW EU + Audi via CARIAD-BFF `/vehicle/v1/vehicles/{vin}/tripstatistics?type={shortTerm\|longTerm}` — 4 neue Sensoren (`last_trip_distance_km`, `_avg_speed_kmh`, `_avg_fuel_consumption_l_100km`, `_avg_electric_consumption_kwh_100km`) + `recent_trips` als attributes. 1h-Cache-Cycle, brand-restriction, capability-gate (`tripStatistics`). Backend liefert consumption ×10 — Parser teilt. (2) #28 Audi ICE Remote Engine Start/Stop — zwei-Schritt S-PIN-Flow nach audi_connect_ha PR #717 (`PUT /vehicle/v1/engine/{VIN}/userpromptproof` → extract `userPromptProof` → `POST /engine/{VIN}/start` mit `securedActivationData`). Stop ohne S-PIN. Audi-only via `CAPABILITY_MAP["audi"]` Copy-and-Patch (verhindert Pollution VW EU Map). Service `vag_connect.engine_start`/`engine_stop`. (3) #29 PPE/PPC Klima-Body conditional — `force_ppe_climate` Option (User-overridable, Audi-only Effekt). `command_start_climate(ppe_mode=True)` schaltet auf neues Body-Format (climatisationMode mandatory, targetTemperature omitted). Plus #116 Skoda Scout-Pfade (MavericklCS) — 4× `primaryEngineRange.*` + `predictiveMaintenance.setting.*` Wildcard. (19 neue Tests) | **2026-05-02** |
 
 **Sprint summary 2026-04-29:** 7 releases, ~50 new tests, branch
 protection activated, CHANGELOG split into human + technical, 4 parallel
@@ -84,20 +83,15 @@ Strict order — P0 (next release) > P1 (planned MINOR) > P2 (later) > P3 (resea
 | ~~v1.12.2~~ | Erstes Community-Scout-Report (Skoda #107 von tritanium73) | done |
 | ~~v1.12.3~~ | Scout-Pfade #111/#113/#114 + Wildcard-Strategie für `.value.*` Container | done |
 | ~~v1.13.0~~ | Production Hardening Bundle: Capability-Filter Phase 3 (#56) + Read-only Phase 2/3 (#63) + Anonymized Diagnostics-Export (#62) + Process & Governance Doc-PR (#64) | done |
+| ~~v1.14.0~~ | Audi Feature Pack: Trip Stats #24 + Engine Start ICE #28 + PPE/PPC Klima-Body #29 + Skoda Scout-Pfade #116 | done |
 
-### 🔴 P0 — Nächste Release (v1.14.0, MINOR — Audi Feature Pack)
+### 🔴 P0 — Nächste Release (v1.15.0, MINOR — Cross-Brand UX)
 
-Bundle 2 aus `docs/RESEARCH_NOTES_2026-05-02.md`. Drei Audi-spezifische Features die in mehreren Issues angefragt sind. #35 (Ladehistorie LTS) wurde DEFERRED — verifizierter Backend-Endpoint hat kein `chargedEnergy_kWh` Feld, braucht eigene Research-Session.
-
-| Session | Version | Scope | Issues |
-|---|---|---|---|
-| **Audi Feature Pack** | **v1.14.0** ⭐ | MINOR: (1) Trip Stats — Audi `tripstatistics/v1` (verified `audi_services.py:337`), per-trip data model (numeric aggregate in state, JSON in attrs per audi #113). (2) PPC Climate Body conditional shape (audi #644 + #677 — `climatisationMode: "comfort"` mandatory, `targetTemperature*` muss omitted für Q6/A6 e-tron). (3) ICE Engine Start S-PIN flow (audi_connect_ha #717 — zwei-Schritt PUT `/engine/{VIN}/userpromptproof` + POST `/engine/{VIN}/start`). Capability-gated. | #24, #29, #28 |
-
-### 🟡 P1 — Cross-Brand UX (v1.15.0)
+Bundle 3 aus `docs/RESEARCH_NOTES_2026-05-02.md`.
 
 | Session | Version | Scope | Issues |
 |---|---|---|---|
-| **Cross-Brand UX** | **v1.15.0** | MINOR: dedizierte Number-Entities pro Departure-Timer + Klima-Schedule UI (#26). Read-only Sensoren für Standort-spez. Ladeziel (#25) und Ladeprofile (#31). Write-Side für #25/#31 deferred (braucht eigene Research-Session — multiple-charging-profile API ist brand-spezifisch). | #26, #25 (read-only), #31 (read-only) |
+| **Cross-Brand UX** | **v1.15.0** ⭐ | MINOR: dedizierte Number-Entities pro Departure-Timer + Klima-Schedule UI (#26). Read-only Sensoren für Standort-spez. Ladeziel (#25) und Ladeprofile (#31). Write-Side für #25/#31 deferred (braucht eigene Research-Session — multiple-charging-profile API ist brand-spezifisch). | #26, #25 (read-only), #31 (read-only) |
 | **Old-Bug Verify-Pings** | community | User-Comments auf #42 (CUPRA Formentor) + #48 (all-actions-fail) + #51 (Audi RS e-tron GT 404) — höchstwahrscheinlich gefixt durch v1.8.4 SecToken / v1.8.5 v1/v2 fallback / v1.9.1 Wake-Fix / v1.10.2 Born firmware fixes. Status-Bestätigung gefragt. | #42, #48, #51 |
 
 ### 🟠 P2 — Future MINOR Sprints (v1.16.0+)

--- a/tests/test_v1130_production_hardening.py
+++ b/tests/test_v1130_production_hardening.py
@@ -40,12 +40,22 @@ class TestCapabilityMap:
         assert cap_id_for("volkswagen", "command_lock") == "access"
 
     def test_audi_inherits_volkswagen(self):
+        """v1.13.0 (#56): audi inherits VW EU CARIAD-BFF cap-ids.
+
+        v1.14.0 (#28) — the inheritance moved from alias (``is``) to a
+        defensive copy so audi-only patches like ``command_engine_start``
+        don't pollute the VW EU table. We still assert the VW cap-ids
+        are present in the audi table by content, plus a representative
+        spot-check via ``cap_id_for``.
+        """
         from custom_components.vag_connect.cariad._capabilities import (
             CAPABILITY_MAP,
             cap_id_for,
         )
 
-        assert CAPABILITY_MAP["audi"] is CAPABILITY_MAP["volkswagen"]
+        # Every VW EU command-id must still resolve in audi (content equivalence)
+        for command_id, cap_id in CAPABILITY_MAP["volkswagen"].items():
+            assert CAPABILITY_MAP["audi"].get(command_id) == cap_id, command_id
         assert cap_id_for("audi", "command_flash") == "honkAndFlash"
 
     def test_seat_inherits_cupra(self):

--- a/tests/test_v1140_audi_pack.py
+++ b/tests/test_v1140_audi_pack.py
@@ -1,0 +1,375 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""Tests for v1.14.0 — Audi Feature Pack Bundle.
+
+Four feature groups:
+
+A) #24 Trip Statistics — `_parse_trip_statistics` pure function +
+   `VWEUClient.get_trip_statistics` URL/params + coordinator
+   `refresh_trip_statistics` brand-restriction + 1h cache.
+B) #28 Audi ICE Engine Start — two-step S-PIN flow + endpoint URLs +
+   request body shapes + S-PIN-required guard + engine stop endpoint.
+C) #29 PPC Climate Body conditional — `command_start_climate(ppe_mode=True)`
+   uses the PPE body shape (no targetTemperature, climatisationMode mandatory).
+D) Capability-Map Audi-only Engine Start — Audi has command_engine_start,
+   VW EU does not.
+
+Plus E) #116 Scout-Pfade — registered EXPECTED_KEYS for skoda
+``primaryEngineRange.*`` + ``predictiveMaintenance.setting.*`` wildcard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A) #24 — Trip Statistics
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestParseTripStatistics:
+    """Pure function: shape-tolerant parser + sort + ×10 division."""
+
+    def _short(self, *trips):
+        return {"tripDataList": {"tripData": list(trips)}}
+
+    def test_parse_empty_response_returns_empty_dict(self):
+        from custom_components.vag_connect.coordinator import _parse_trip_statistics
+        out = _parse_trip_statistics({}, {})
+        assert out == {"_shortterm_count": 0, "_longterm_count": 0}
+
+    def test_parse_short_term_picks_highest_overall_mileage(self):
+        from custom_components.vag_connect.coordinator import _parse_trip_statistics
+        short = self._short(
+            {"overallMileage": 100, "mileage": 5, "averageFuelConsumption": 80,
+             "averageElectricEngineConsumption": 0, "traveltime": 12,
+             "averageSpeed": 30, "timestamp": "2026-04-29T08:00:00Z"},
+            {"overallMileage": 200, "mileage": 12, "averageFuelConsumption": 65,
+             "averageElectricEngineConsumption": 0, "traveltime": 25,
+             "averageSpeed": 50, "timestamp": "2026-04-30T17:00:00Z"},
+        )
+        out = _parse_trip_statistics(short, {})
+        # Newest = overallMileage 200 trip
+        assert out["last_trip_distance_km"] == 12.0
+        assert out["last_trip_avg_fuel_consumption_l_100km"] == 6.5
+        assert out["last_trip_avg_electric_consumption_kwh_100km"] is None
+        assert out["last_trip_duration_min"] == 25
+        assert out["last_trip_avg_speed_kmh"] == 50.0
+        assert out["last_trip_timestamp"] == "2026-04-30T17:00:00Z"
+        # recent_trips sorted same way
+        assert out["recent_trips"][0]["distance_km"] == 12
+
+    def test_consumption_division_by_ten(self):
+        """Backend returns averageFuelConsumption × 10 — divider must apply."""
+        from custom_components.vag_connect.coordinator import _parse_trip_statistics
+        short = self._short(
+            {"overallMileage": 1, "mileage": 10,
+             "averageFuelConsumption": 78,
+             "averageElectricEngineConsumption": 145,
+             "traveltime": 15, "averageSpeed": 40},
+        )
+        out = _parse_trip_statistics(short, {})
+        assert out["last_trip_avg_fuel_consumption_l_100km"] == 7.8
+        assert out["last_trip_avg_electric_consumption_kwh_100km"] == 14.5
+
+    def test_long_term_aggregates_into_lifetime_fields(self):
+        from custom_components.vag_connect.coordinator import _parse_trip_statistics
+        long = self._short({
+            "overallMileage": 12345, "averageFuelConsumption": 70,
+            "averageElectricEngineConsumption": 0,
+        })
+        out = _parse_trip_statistics({}, long)
+        assert out["lifetime_distance_km"] == 12345.0
+        assert out["lifetime_avg_fuel_consumption_l_100km"] == 7.0
+
+    def test_recent_trips_capped_at_five(self):
+        from custom_components.vag_connect.coordinator import _parse_trip_statistics
+        trips = [
+            {"overallMileage": i, "mileage": 1, "averageFuelConsumption": 50}
+            for i in range(20)
+        ]
+        out = _parse_trip_statistics(self._short(*trips), {})
+        assert len(out["recent_trips"]) == 5
+
+    def test_garbage_response_is_safe(self):
+        from custom_components.vag_connect.coordinator import _parse_trip_statistics
+        # not a dict
+        assert _parse_trip_statistics("oops", None) == {
+            "_shortterm_count": 0, "_longterm_count": 0
+        }
+        # missing nested wrapper
+        assert _parse_trip_statistics({"unrelated": True}, {}) == {
+            "_shortterm_count": 0, "_longterm_count": 0
+        }
+        # tripData not a list
+        assert _parse_trip_statistics(
+            {"tripDataList": {"tripData": "broken"}}, {}
+        ) == {"_shortterm_count": 0, "_longterm_count": 0}
+
+
+class TestGetTripStatisticsURL:
+    """VWEUClient.get_trip_statistics hits the right URL with type param."""
+
+    def test_url_and_query_param(self):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+
+        client = VWEUClient.__new__(VWEUClient)
+        client._get = AsyncMock(return_value={"tripDataList": {"tripData": []}})
+        result = asyncio.get_event_loop().run_until_complete(
+            client.get_trip_statistics("VINX", "longTerm")
+        )
+        client._get.assert_awaited_once_with(
+            "https://emea.bff.cariad.digital/vehicle/v1/vehicles/VINX/tripstatistics",
+            params={"type": "longTerm"},
+        )
+        assert result == {"tripDataList": {"tripData": []}}
+
+
+class TestRefreshTripStatisticsBrandRestriction:
+    """Coordinator.refresh_trip_statistics is no-op for non-CARIAD brands."""
+
+    def _coord(self, brand="audi"):
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        coord.entry = MagicMock()
+        coord.entry.data = {"brand": brand}
+        coord._vehicles_lock = threading.Lock()
+        coord.vehicles = {"VINX": {"_dummy": True}}
+        coord._cariad_client = MagicMock()
+        coord._cariad_client.get_trip_statistics = AsyncMock(
+            return_value={"tripDataList": {"tripData": []}}
+        )
+        coord.command_capability_supported = MagicMock(return_value=None)
+        return coord
+
+    def test_skoda_brand_skips_fetch(self):
+        coord = self._coord(brand="skoda")
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_trip_statistics("VINX")
+        )
+        coord._cariad_client.get_trip_statistics.assert_not_called()
+
+    def test_audi_brand_calls_both_endpoints(self):
+        coord = self._coord(brand="audi")
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_trip_statistics("VINX")
+        )
+        # Two calls: shortTerm + longTerm
+        assert coord._cariad_client.get_trip_statistics.await_count == 2
+
+    def test_capability_false_skips(self):
+        coord = self._coord(brand="audi")
+        coord.command_capability_supported = MagicMock(return_value=False)
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_trip_statistics("VINX")
+        )
+        coord._cariad_client.get_trip_statistics.assert_not_called()
+
+    def test_one_hour_cache_skips_within_window(self):
+        coord = self._coord(brand="audi")
+        coord._trip_stats_fetched_at = {
+            "VINX": datetime.now(tz=timezone.utc) - timedelta(minutes=30)
+        }
+        asyncio.get_event_loop().run_until_complete(
+            coord.refresh_trip_statistics("VINX")
+        )
+        coord._cariad_client.get_trip_statistics.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B) #28 — Audi ICE Engine Start
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAudiEngineStart:
+    """AudiClient.command_engine_start two-step S-PIN flow."""
+
+    def _client(self, spin="9999"):
+        from custom_components.vag_connect.cariad.api.audi import AudiClient
+        client = AudiClient.__new__(AudiClient)
+        client._spin = spin
+        client._request = AsyncMock(return_value={"userPromptProof": "TOKEN_ABC"})
+        client._post = AsyncMock(return_value={"data": {"requestID": "r1"}})
+        return client
+
+    def test_engine_start_two_step_flow(self):
+        client = self._client()
+        asyncio.get_event_loop().run_until_complete(
+            client.command_engine_start("vinx")
+        )
+        # Step 1: PUT userpromptproof with S-PIN
+        client._request.assert_awaited_once_with(
+            "PUT",
+            "https://emea.bff.cariad.digital/vehicle/v1/engine/VINX/userpromptproof",
+            json={"spin": "9999"},
+        )
+        # Step 2: POST start with proof token
+        client._post.assert_awaited_once_with(
+            "https://emea.bff.cariad.digital/vehicle/v1/engine/VINX/start",
+            json={"securedActivationData": "TOKEN_ABC", "spin": "9999"},
+        )
+
+    def test_engine_start_uppercases_vin(self):
+        client = self._client()
+        asyncio.get_event_loop().run_until_complete(
+            client.command_engine_start("wvwzzz1jzcw000123")
+        )
+        url = client._request.await_args.args[1]
+        assert "WVWZZZ1JZCW000123" in url
+
+    def test_engine_start_no_spin_raises(self):
+        from custom_components.vag_connect.cariad.exceptions import SpinError
+
+        client = self._client(spin="")
+        with pytest.raises(SpinError):
+            asyncio.get_event_loop().run_until_complete(
+                client.command_engine_start("vinx")
+            )
+
+    def test_engine_start_missing_proof_in_response_raises(self):
+        from custom_components.vag_connect.cariad.exceptions import SpinError
+
+        client = self._client()
+        client._request = AsyncMock(return_value={})  # no userPromptProof
+        with pytest.raises(SpinError):
+            asyncio.get_event_loop().run_until_complete(
+                client.command_engine_start("vinx")
+            )
+
+    def test_engine_stop_no_body_no_spin(self):
+        client = self._client(spin="")  # stop ignores S-PIN
+        client._post = AsyncMock(return_value=None)
+        asyncio.get_event_loop().run_until_complete(client.command_engine_stop("vinx"))
+        client._post.assert_awaited_once_with(
+            "https://emea.bff.cariad.digital/vehicle/v1/engine/VINX/stop"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C) #29 — PPC Climate Body conditional
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPpcClimateBody:
+    """command_start_climate uses different body shape based on ppe_mode."""
+
+    def _client(self):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        client = VWEUClient.__new__(VWEUClient)
+        client._post_command_with_fallback_paths = AsyncMock(return_value=None)
+        return client
+
+    def test_legacy_body_includes_target_temperature(self):
+        client = self._client()
+        asyncio.get_event_loop().run_until_complete(
+            client.command_start_climate("VINX", ppe_mode=False)
+        )
+        kwargs = client._post_command_with_fallback_paths.await_args.kwargs
+        fallback = kwargs["fallback_payload"]
+        assert "targetTemperature" in fallback
+        assert "targetTemperatureUnit" in fallback
+        assert "climatisationMode" not in fallback
+
+    def test_ppe_body_omits_target_temperature_and_sets_mode(self):
+        client = self._client()
+        asyncio.get_event_loop().run_until_complete(
+            client.command_start_climate("VINX", ppe_mode=True)
+        )
+        kwargs = client._post_command_with_fallback_paths.await_args.kwargs
+        fallback = kwargs["fallback_payload"]
+        # PPE: targetTemperature MUST be omitted
+        assert "targetTemperature" not in fallback
+        assert "targetTemperatureUnit" not in fallback
+        # PPE: climatisationMode MANDATORY
+        assert fallback["climatisationMode"] == "comfort"
+        # Other fields preserved
+        assert fallback["windowHeatingEnabled"] is True
+
+    def test_default_is_legacy_body(self):
+        """Backwards-compat: existing callers without ppe_mode get legacy."""
+        client = self._client()
+        asyncio.get_event_loop().run_until_complete(
+            client.command_start_climate("VINX")
+        )
+        fallback = client._post_command_with_fallback_paths.await_args.kwargs[
+            "fallback_payload"
+        ]
+        assert "targetTemperature" in fallback
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D) Capability-Map — Audi-only Engine Start
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCapabilityMapEngineStart:
+    """v1.14.0 (#28): audi gets engine_start cap-id; VW EU does NOT
+    (the inheritance dict was COPIED before the audi-only patch)."""
+
+    def test_audi_has_engine_start(self):
+        from custom_components.vag_connect.cariad._capabilities import cap_id_for
+        assert cap_id_for("audi", "command_engine_start") == "engineRemoteStart"
+        assert cap_id_for("audi", "command_engine_stop") == "engineRemoteStart"
+
+    def test_volkswagen_does_not_have_engine_start(self):
+        from custom_components.vag_connect.cariad._capabilities import cap_id_for
+        assert cap_id_for("volkswagen", "command_engine_start") is None
+        assert cap_id_for("volkswagen", "command_engine_stop") is None
+
+    def test_audi_inheritance_was_copied_not_aliased(self):
+        """Adding an audi-only cap-id must NOT leak into VW EU's table."""
+        from custom_components.vag_connect.cariad._capabilities import CAPABILITY_MAP
+        assert "command_engine_start" not in CAPABILITY_MAP["volkswagen"]
+        assert "command_engine_start" in CAPABILITY_MAP["audi"]
+
+    def test_trip_stats_cap_id_present_on_vw_and_audi(self):
+        from custom_components.vag_connect.cariad._capabilities import cap_id_for
+        assert cap_id_for("volkswagen", "command_trip_stats") == "tripStatistics"
+        assert cap_id_for("audi", "command_trip_stats") == "tripStatistics"
+        # Other brands don't have trip stats
+        assert cap_id_for("skoda", "command_trip_stats") is None
+        assert cap_id_for("cupra", "command_trip_stats") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E) #116 Scout-Pfade — Skoda EXPECTED_KEYS extensions
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestScoutPathsSkoda:
+    """v1.14.0 (#116, MavericklCS): four primaryEngineRange.* fields +
+    predictiveMaintenance.setting wildcard registered for skoda."""
+
+    def test_primary_engine_range_children_registered(self):
+        from custom_components.vag_connect.cariad._unexpected_keys import EXPECTED_KEYS
+        skoda_dr = EXPECTED_KEYS["skoda"]["driving-range"]
+        assert "primaryEngineRange.engineType" in skoda_dr
+        assert "primaryEngineRange.currentSoCInPercent" in skoda_dr
+        assert "primaryEngineRange.currentFuelLevelInPercent" in skoda_dr
+        assert "primaryEngineRange.remainingRangeInKm" in skoda_dr
+
+    def test_predictive_maintenance_setting_wildcard_registered(self):
+        from custom_components.vag_connect.cariad._unexpected_keys import EXPECTED_KEYS
+        skoda_m = EXPECTED_KEYS["skoda"]["maintenance"]
+        assert "predictiveMaintenance.setting" in skoda_m
+        assert "predictiveMaintenance.setting.*" in skoda_m
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F) Coordinator command-class registry — engine grouping
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestEngineCommandClass:
+    """Engine start/stop share the same lock class so they serialize."""
+
+    def test_engine_start_and_stop_share_class(self):
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        cmd_class = VagConnectCoordinator._COMMAND_CLASS
+        assert cmd_class["command_engine_start"] == "engine"
+        assert cmd_class["command_engine_stop"] == "engine"


### PR DESCRIPTION
## Summary

Bundle 2 aus dem v1.13.0 Pre-Research-Plan (`docs/RESEARCH_NOTES_2026-05-02.md`). Drei Audi-spezifische Features in einem MINOR-Release plus Skoda Scout-Pfade #116 als Add-On.

- 🛣️ **#24 Trip Statistics** — CARIAD-BFF `tripstatistics` Endpoint, 4 neue Sensoren für VW EU + Audi, 1h-Cache + capability-gate, ×10 division für consumption fields
- 🔥 **#28 Audi ICE Engine Start/Stop** — zwei-Schritt S-PIN-Flow nach audi_connect_ha PR #717, Audi-only via `CAPABILITY_MAP` copy-and-patch
- 🌡️ **#29 PPE/PPC Klima-Body** — `force_ppe_climate` Option, conditional `command_start_climate(ppe_mode=True)` für Q6/A6 e-tron + RS e-tron GT Facelift + A3 2024+ PHEV
- 🛰️ **#116 Skoda Scout-Pfade** (MavericklCS) — 4× `primaryEngineRange.*` + `predictiveMaintenance.setting.*` Wildcard

Pre-Research für #28 + #24 wurde von 2 parallel laufenden Research-Agents geliefert (audi_connect_ha PR #717 source-read + CARIAD-BFF tripstatistics field shapes über audi_connect_ha + audiconnectpy + ioBroker/vw-connect).

## Closes

- #24 Verbrauchsdaten / Trip Stats
- #28 Remote Start ICE
- #29 PPC Klimatisierungs-Entity 2025+ Modelle
- #116 Skoda Scout-Report (MavericklCS)

## Test plan

- [x] 19 neue Tests in `tests/test_v1140_audi_pack.py` (6 Klassen)
- [x] Alle 10 JSON-Dateien validiert
- [x] CAPABILITY_MAP smoke-test (audi has engine_start, vw does not, copy-not-alias)
- [x] _COMMAND_CLASS hat engine entries
- [x] _parse_trip_statistics ist module-level pure function
- [x] CHANGELOG + ROADMAP + CHANGELOG_TECHNICAL bilingual
- [x] manifest 1.13.0 → 1.14.0
- [ ] CI: Lint, Tests, Hassfest, HACS, CHANGELOG (5 required checks)
- [ ] Live-Test post-merge auf Maintainer Audi (S6 C8) für Trip-Stats sichtbarkeit + PPE-Option-Toggle
- [ ] Engine Start ICE: warten auf ICE-User-Tester (nicht blocker für Release, capability-gated)

## Files

- 25 files changed, +1367 / -43
- New: `tests/test_v1140_audi_pack.py`
- 9 fields added to `VehicleData`, 4 sensor entities, 2 new services, 1 new option

## Deferred

- #35 Ladehistorie LTS — `chargedEnergy_kWh` Feld nicht in CARIAD verifiziert
- #51 RS e-tron GT Facelift — graceful degradation only (PPE Lock/Charging endpoints noch nicht reverse-engineered)
- PPE Auto-Detection — User opt-in only

🤖 Generated with [Claude Code](https://claude.com/claude-code)