### PR TITLE
v1.20.2: Skoda Parser Hardening + Phantom-Entity Fix + Cleanup Bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > Semver-Typen vergeben. Retroaktive Korrektur:
 > `0.9.0→0.8.1`, `0.10.0→0.8.2`, `0.11.0→0.9.0`,
 > `0.12.0→0.10.0`, `0.13.0→0.10.1`, `0.14.0→0.11.0`
+>
+> **v1.19.1 historischer Hinweis (2026-05-07 Audit):** v1.19.1 hat
+> einen neuen Sensor `requests_remaining_today` eingeführt — nach
+> strikter Semver-Regel wäre das MINOR (`v1.20.0`) gewesen, nicht
+> PATCH. Wurde als PATCH released für HACS-Continuity (User-Side
+> kein Breaking Change). Tag bleibt v1.19.1; nachfolgende Releases
+> v1.20.0+ zählen ab v1.19.4 → v1.20.0 als legitime MINOR-Bumps.
+> Lessons-learned dokumentiert für v1.20.2+ Audit-Disziplin.
 
 ---
 
@@ -31,6 +39,54 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > Methodik dahinter.
 
 ## [Unreleased]
+
+## [1.20.2] - 2026-05-07 🧹 Skoda Parser Hardening + Phantom-Entity Fix + Code-Hygiene Bundle / Skoda Parser Hardening + Phantom-Entity Fix + Code-Hygiene Bundle
+
+🧹 **PATCH-Release.** Multi-Item Cleanup-Bundle nach komprehensivem Audit (v1.17.5–v1.20.1 retrospective). Adressiert 7 Findings.
+
+### 🔓 Bug B Proactive Fix — Skoda doors_locked parser hardening (#131)
+
+**Pre-v1.20.2:** `skoda.py:320` hatte buggy fallback `d.doors_locked = v(access, "overallStatus") != "OPEN"` der jeden non-"OPEN" Wert als "locked" interpretierte — auch "CLOSED" (= unlocked aber zu) und "UNAVAILABLE". Plus die echte `lock_raw` Auswertung (line 354) hatte nur einen begrenzten Locked-Value-Set (`YES/LOCKED/TRUE`) und ließ alles andere (inkl. `UNLOCKED`) durchfallen auf den buggy Default.
+
+**v1.20.2 Fix:**
+- Buggy line 320 fallback **entfernt** — `doors_locked` bleibt None wenn kein authoritative Wert vorhanden (besser unknown als wrong)
+- Erweitertes value-set in line 354:
+  - **Locked**: `YES`, `LOCKED`, `TRUE`, `RELIABLE_LOCKED`
+  - **Unlocked**: `NO`, `UNLOCKED`, `FALSE`, `OPEN`, `RELIABLE_UNLOCKED`
+  - **Unknown** → log + leave None (forward-compat shield analog myskoda #503 safe_enum pattern)
+- Per `_LOGGER.info` werden unknown values an die Issue #131 weitergeleitet für proactive value-table-extension
+
+### 🛠️ Phantom-Entity Fix (v1.20.0 follow-up)
+
+v1.20.0 Bundle 2 Phase A führte 2 Skoda-only Sensoren ein (`license_plate` + `equipment_count`) aber vergessen sie in `_DATA_PRESENT_REQUIRED` (`sensor.py:704`) zu adden. **Folge:** alle non-Skoda User (Audi/VW EU/CUPRA/SEAT/Porsche/VW NA) sahen seit v1.20.0 zwei phantom "License Plate: unknown" + "Equipment Count: unknown" Diagnostic-Entities. **Fix:** beide jetzt in `_DATA_PRESENT_REQUIRED` — Entity wird gar nicht erst erstellt für VINs ohne Wert.
+
+### 🌍 `safe_float` Locale-Comma Fallback
+
+v1.10.1 #58 docs versprachen Skoda's gelegentliches `"21,5"` (locale-comma) wäre handled, aber der originale Code akzeptierte nur dot-decimal. v1.20.2 fügt fallback-Replacement `",", "."` als zweiten Versuch hinzu. Backwards-compat: dot-decimal funktioniert weiter unverändert.
+
+### 📋 Code-Hygiene + Doku-Drift Cleanup
+
+- **3 Scaffolding-Module mit `# SCAFFOLDING — NOT WIRED` Header**: `cariad/_home_region.py`, `cariad/push/skoda_mqtt.py`, `cariad/push/cupra_seat_fcm.py` — macht expliziter dass diese Module foundations sind, nicht in production call-paths verdrahtet
+- **ROADMAP "Standalone enhancements" Cleanup**: 2 done-aber-noch-TODO Items markiert (`/v2/widgets/vehicle-status` done v1.20.0, T&C Repair done v1.19.4)
+- **ROADMAP "Last updated" Header**: 11+ run-on "Plus voriges..." durch concise date + bullet-list "Recent shipped (chronological)" ersetzt — drift-prone für future maintainers entlastet
+- **CHANGELOG Semver-Korrektur**: Retrospektive Notiz dass v1.19.1 strikt MINOR hätte sein sollen (neuer Sensor) aber als PATCH released wurde für HACS-Continuity. Tags bleiben, Lessons-learned dokumentiert.
+
+### 🧪 Tests / Tests
+
+- **`test_v1202_skoda_doors_locked_hardening.py`** — 16 Test-Cases: locked-values (6) + unlocked-values (4) + unknown-values + buggy-fallback-removed-regression + priority-chain
+- **Standalone-verified locally**: safe_float locale-comma (6 assertions) + Skoda parser hardening (7 assertions) — 13 total
+
+### 📦 Schließt Issues / Closes
+
+Keine User-Issues direkt — proactive Bug B fix für #131 (wartet weiterhin auf Chr1sDub's spezifische access+overall JSON für targeted fix). Cleanup-Bundle für Audit-Findings.
+
+### 🚫 NICHT in diesem Release / NOT in this release
+
+- **Bug B targeted fix** mit Chr1sDub's exakten JSON-Werten — wartet auf Daten
+- **S-PIN unlock check** (#131 Punkt 2) — Code-Audit zeigt: `coordinator.py:1929-1940` Cascade ist bereits korrekt, brauche User-Diagnose zur Reproduktion
+- **Bundle 2 Phase B Renders** — v1.21.0 (UX-Decision benötigt für 4-8 image entities)
+- **Charging Profile Write-Side** — v1.22.0
+- **Departure-Timer Write-Side** — v1.23.0
 
 ## [1.20.1] - 2026-05-07 🔓📚 BinarySensor LOCK-class fix (#131) + Doc refresh / BinarySensor LOCK-class fix (#131) + Doc refresh
 

--- a/custom_components/vag_connect/cariad/_home_region.py
+++ b/custom_components/vag_connect/cariad/_home_region.py
@@ -1,4 +1,13 @@
 # Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+#
+# ╔════════════════════════════════════════════════════════════════════╗
+# ║ SCAFFOLDING — NOT WIRED INTO PRODUCTION CALL PATHS                ║
+# ║ Built v1.17.6 as foundation for region-routing edge cases.        ║
+# ║ Wire-up plan documented below. Activation pending live-test       ║
+# ║ confirmation on issue #75 (Christian Skoda Kodiaq Mk2 region).    ║
+# ║ See ROADMAP P3 "HomeRegion Wire-In" — sundown candidate v2.0.0    ║
+# ║ if no community user reports a non-EU regional vehicle.           ║
+# ╚════════════════════════════════════════════════════════════════════╝
 """HomeRegion resolution for CARIAD-BFF brands (VW EU + Audi).
 
 Ported from ``evcc-io/evcc`` (``vehicle/vw/api.go``). Some VAG vehicles

--- a/custom_components/vag_connect/cariad/_util.py
+++ b/custom_components/vag_connect/cariad/_util.py
@@ -77,6 +77,17 @@ def safe_float(value: Any, default: float | None = None) -> float | None:
         try:
             return float(stripped)
         except ValueError:
+            # v1.20.2 — locale-comma fallback. Skoda has shipped
+            # ``"21,5"`` (comma decimal, EU locale formatting) on EU
+            # accounts at least once historically. v1.10.1 #58 docs
+            # claimed safe_float handles this but the original code
+            # only accepted dot-decimal — locale-comma silently
+            # returned default. Try once more with comma → dot.
+            if "," in stripped:
+                try:
+                    return float(stripped.replace(",", ".", 1))
+                except ValueError:
+                    return default
             return default
     return default
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -317,7 +317,21 @@ class SkodaClient(CariadBaseClient):
         # ── Access / doors / windows / detail ────────────────────────────────
         if isinstance(status, dict):
             access = v(status, "access") or {}
-            d.doors_locked = v(access, "overallStatus") != "OPEN"
+            # v1.20.2 (#131 Chr1sDub Skoda Octavia iV bug B) — drop the
+            # buggy ``overallStatus != "OPEN"`` fallback. The
+            # ``access.overallStatus`` field describes the access *state*
+            # (e.g. "OPEN", "CLOSED", "UNAVAILABLE", "LOCKED") — it is
+            # NOT a doors-locked indicator. Pre-v1.20.2 we treated any
+            # value other than "OPEN" as locked, which incorrectly
+            # marked closed-but-unlocked vehicles as locked AND
+            # left ``UNAVAILABLE``-state vehicles falsely "locked".
+            #
+            # Newer Skoda firmware (Octavia iV 2024+, Kodiaq Mk2) ships
+            # the proper ``overall.reliableLockStatus`` /
+            # ``overall.doorsLocked`` / ``overall.locked`` flags that
+            # the block below reads authoritatively. Leave
+            # ``doors_locked`` as ``None`` if neither is present —
+            # better "unknown" than "wrong".
             d.doors_open = v(access, "doorsOpenedCount", default=0) > 0
             d.windows_open = v(access, "windowsOpenedCount", default=0) > 0
 
@@ -351,7 +365,33 @@ class SkodaClient(CariadBaseClient):
                 or v(overall, "locked")
             )
             if isinstance(lock_raw, str):
-                d.doors_locked = lock_raw.upper() in ("YES", "LOCKED", "TRUE")
+                # v1.20.2 (#131 Bug B hardening) — explicit unlocked-
+                # value enumeration for safety. Pre-v1.20.2 only matched
+                # locked-values and let everything else fall through to
+                # whatever line 320 set (which was buggy). Now we're
+                # explicit: if value clearly says locked → True, if
+                # clearly says unlocked → False, otherwise log + None.
+                up = lock_raw.upper()
+                _locked_values = {"YES", "LOCKED", "TRUE", "RELIABLE_LOCKED"}
+                _unlocked_values = {
+                    "NO", "UNLOCKED", "FALSE", "OPEN", "RELIABLE_UNLOCKED",
+                }
+                if up in _locked_values:
+                    d.doors_locked = True
+                elif up in _unlocked_values:
+                    d.doors_locked = False
+                else:
+                    # Forward-compat shield (myskoda #503 pattern) —
+                    # log unknown enum value so we can extend the table
+                    # without breaking the parser. Leave field None
+                    # rather than guessing — the binary_sensor / lock
+                    # entity stays "unknown" instead of showing wrong.
+                    _LOGGER.info(
+                        "Skoda lock status: unknown value %r — leaving "
+                        "doors_locked as None. Please report on issue "
+                        "#131 so we can extend the value table.",
+                        lock_raw,
+                    )
 
             def _detail_open(field: str) -> bool | None:
                 """Map detail.{sunroof,trunk,bonnet} string to bool open.

--- a/custom_components/vag_connect/cariad/push/cupra_seat_fcm.py
+++ b/custom_components/vag_connect/cariad/push/cupra_seat_fcm.py
@@ -1,4 +1,13 @@
 # Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+#
+# ╔════════════════════════════════════════════════════════════════════╗
+# ║ SCAFFOLDING — NOT WIRED INTO PRODUCTION CALL PATHS                ║
+# ║ Foundation built v1.19.0; OptionsFlow toggle exists but           ║
+# ║ Coordinator does NOT instantiate CupraSeatPushManager.start().    ║
+# ║ Live activation requires community MyCupra/MySeat tester for      ║
+# ║ FCM project + sender_id + OLA /v2/subscriptions schema.           ║
+# ║ See ROADMAP "Push Bundle Phase 2" + #57 Phase 2.                  ║
+# ╚════════════════════════════════════════════════════════════════════╝
 """CUPRA/SEAT OLA FCM push manager (v1.19.0 foundation).
 
 Subscribes to Firebase Cloud Messaging push notifications for

--- a/custom_components/vag_connect/cariad/push/skoda_mqtt.py
+++ b/custom_components/vag_connect/cariad/push/skoda_mqtt.py
@@ -1,4 +1,13 @@
 # Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+#
+# ╔════════════════════════════════════════════════════════════════════╗
+# ║ SCAFFOLDING — NOT WIRED INTO PRODUCTION CALL PATHS                ║
+# ║ Foundation built v1.18.0; OptionsFlow toggle exists but           ║
+# ║ Coordinator does NOT instantiate SkodaPushManager.start() yet.    ║
+# ║ Live activation requires community Skoda Connect+ tester for      ║
+# ║ FCM-Project-ID + TOTP scheme + broker auth verification.          ║
+# ║ See ROADMAP "Push Bundle Phase 2" + #57 Phase 2.                  ║
+# ╚════════════════════════════════════════════════════════════════════╝
 """Skoda mysmob MQTT push manager (v1.18.0 foundation).
 
 Subscribes to ``mqtt.messagehub.de:8883`` (TLS, MQTTv5) for the user's

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.20.1"
+  "version": "1.20.2"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -701,6 +701,15 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # Field stays None for non-OLA brands and for accounts where
     # battery-care isn't supported / configured.
     "battery_care_target_soc_pct",
+    # v1.20.2 (post-v1.20.0 phantom-entity fix) — Bundle 2 Phase A
+    # introduced two Skoda-only sensors but forgot to gate them.
+    # Without this set membership, all non-Skoda VINs (Audi/VW EU/
+    # CUPRA/SEAT/Porsche/VW NA) showed a phantom "License Plate:
+    # unknown" + "Equipment Count: unknown" diagnostic entity since
+    # v1.20.0 was released. Field stays None for those brands so the
+    # data-present gate keeps the entity from ever being created.
+    "license_plate",
+    "equipment_count",
 })
 
 # v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,23 @@
 > mirrors it for archive/historical purposes and links the active GitHub
 > issues for each session.
 
-**Last updated:** 2026-05-07 — post v1.20.1 (BinarySensor LOCK-class invert fix #131 — bug seit early-release dass `data["doors_locked"]=True` als `is_on=True` durchgereicht wurde, HA's LOCK class hat invertierte Semantik → "Unlocked" UI für tatsächlich verriegelte Vehicles. Plus README + FAQ refresh für v1.18-v1.20 features). Plus voriges v1.20.0 Bundle 2 Phase A (3 neue Skoda mysmob endpoints adoptiert von skodaconnect/myskoda MIT — `/v2/widgets/vehicle-status/{vin}` lightweight per-tick + `/v1/vehicle-information/{vin}` static 24h-cache + `/v1/vehicle-information/{vin}/equipment` static 24h-cache. 4 neue Model-Felder + 2 neue Diagnostic-Sensoren license_plate + equipment_count. Bruno coverage 80/80 → 83/83). Plus voriges v1.19.4 Bundle 1 (T&C brand-deeplinks + Quota Repair-Issue — 2 UX-Erweiterungen der existierenden Repair-Flow-Infrastruktur). Plus voriges v1.19.3 (Scout-Welle 6: 5 Reports von 5 Usern in 48h — #143 Skoda 14 + #144 VW ID.4 Pro 24 + #145/#146/#147 VW convergent 5. Audit zeigte 19 truly new paths von ~58 — Rest von v1.17.5+v1.12.x bereits silenced. Schließt #143/#144/#145/#146/#147). Plus voriges v1.19.2 (Token-Persistence schließt #118 eismarkt — IDK tokens werden jetzt via HA `Store` helper über HACS-Updates + HA-Restarts persistiert; user muss nach v1.19.2-Update einmal Password eingeben, danach nie wieder. Plus voriges v1.19.0 + Backlog-Cleanup vom 2026-05-04. **5 Releases an einem Tag** geshipt (v1.17.5 + v1.17.6 + v1.17.7 + v1.18.0 + v1.19.0). **5 Issues geschlossen** (#129/#130/#132/#133 Scout-Reports done als wired-data; #76 out-of-scope Pre-MQB MBB legacy). **6 GitHub Verification/Diagnostic Pings** für #42/#48/#51/#118/#131/#53. Open Issues von 16→11. Nächste P0 in laufender Sprint-Sequenz: v1.19.1 Pycupra-Hardening (`_safe_path.py` + `PyCupraThrottledException` + RateLimit-Sensor) + v1.19.2 AdBlue Range Skoda. Plus voriges v1.19.0 (CUPRA/SEAT FCM Push Foundation, #57 Phase 1 cont. — `cariad/push/cupra_seat_fcm.py` mit `CupraSeatPushManager` Klasse erbt von `PushManager` base, brand-validation für cupra/seat, identische Lifecycle + Reconnect-Backoff wie v1.18.0 SkodaPushManager. Reuses gleiche `firebase-messaging` Lib via lazy-import. Neuer `CONF_ENABLE_PUSH_FCM` toggle koexistiert mit MQTT toggle. Schließt #57 Phase 1 — Foundation komplett für alle 3 push-fähigen Brands. Phase 2 = Live-Activation in v1.18.x / v1.19.x Patches sobald Tester sich melden). Plus voriges v1.18.0 (Skoda MQTT Push Foundation, #57 Phase 1 — Push-Package mit `base.py` + `skoda_mqtt.py`, Lifecycle + State-Machine + Reconnect-Backoff komplett gebaut, opt-in via OptionsFlow toggle, Lazy-Import für aiomqtt + firebase-messaging deps. Live-Activation wartet auf Community-Tester. v1.19.0 = analoge CUPRA/SEAT FCM Foundation. v1.18.x Patches aktivieren MQTT live sobald Tester sich melden). Plus voriges v1.17.7 (Skoda outside_temp + preferred_workshop attrs als PATCH — beides nutzt EXISTIERENDE sensor + model fields, kein neuer Sensor → echter PATCH. Schließt #129 + #130 + #133. Plus voriges v1.17.6 = HomeRegion-Helper
+**Last updated:** 2026-05-07 — post v1.20.1.
+
+**Recent shipped (chronological):**
+- **v1.20.1** — BinarySensor LOCK-class invert fix #131 + README/FAQ refresh
+- **v1.20.0** MINOR — Bundle 2 Phase A: Skoda widget + vehicle-info + equipment (myskoda PR #557 adopted, 2 new sensors, 24h static-cache)
+- **v1.19.4** — Bundle 1: T&C brand-deeplinks + Quota Repair-Issue
+- **v1.19.3** — Scout-Welle 6: 5 reports, 19 truly new paths silenced (closes #143/#144/#145/#146/#147)
+- **v1.19.2** — Token-Persistence via HA `Store` (closes #118)
+- **v1.19.1** — Pycupra-style API Quota Sensor (note: borderline MINOR, kept as PATCH for HACS continuity — see Semver-Korrektur section)
+- **v1.19.0** MINOR — CUPRA/SEAT FCM Push Foundation (Phase 1)
+- **v1.18.0** MINOR — Skoda MQTT Push Foundation (Phase 1)
+- **v1.17.6 / v1.17.7** — HomeRegion scaffolding + Skoda outside_temp + workshop attrs
+- **v1.17.5** — Scout-Welle 5: 4 community reports, 42 fields silenced
+
+**Pending bundles:** v1.20.2 (Skoda parser hardening + cleanup), v1.21.0 (Bundle 2 Phase B Renders), v1.22.0 (Charging Profile Write-Side), v1.23.0 (Departure-Timer Write-Side).
+
+**External-blocked:** Push Phase 2 wire-in (waits on Skoda + CUPRA/SEAT testers), HomeRegion wire-in (waits on #75 Christian region info), #131 Bug B (waits on Chr1sDub access+overall JSON), S-PIN unlock check (waits on Chr1sDub diagnostic). **5 Releases an einem Tag** geshipt (v1.17.5 + v1.17.6 + v1.17.7 + v1.18.0 + v1.19.0). **5 Issues geschlossen** (#129/#130/#132/#133 Scout-Reports done als wired-data; #76 out-of-scope Pre-MQB MBB legacy). **6 GitHub Verification/Diagnostic Pings** für #42/#48/#51/#118/#131/#53. Open Issues von 16→11. Nächste P0 in laufender Sprint-Sequenz: v1.19.1 Pycupra-Hardening (`_safe_path.py` + `PyCupraThrottledException` + RateLimit-Sensor) + v1.19.2 AdBlue Range Skoda. Plus voriges v1.19.0 (CUPRA/SEAT FCM Push Foundation, #57 Phase 1 cont. — `cariad/push/cupra_seat_fcm.py` mit `CupraSeatPushManager` Klasse erbt von `PushManager` base, brand-validation für cupra/seat, identische Lifecycle + Reconnect-Backoff wie v1.18.0 SkodaPushManager. Reuses gleiche `firebase-messaging` Lib via lazy-import. Neuer `CONF_ENABLE_PUSH_FCM` toggle koexistiert mit MQTT toggle. Schließt #57 Phase 1 — Foundation komplett für alle 3 push-fähigen Brands. Phase 2 = Live-Activation in v1.18.x / v1.19.x Patches sobald Tester sich melden). Plus voriges v1.18.0 (Skoda MQTT Push Foundation, #57 Phase 1 — Push-Package mit `base.py` + `skoda_mqtt.py`, Lifecycle + State-Machine + Reconnect-Backoff komplett gebaut, opt-in via OptionsFlow toggle, Lazy-Import für aiomqtt + firebase-messaging deps. Live-Activation wartet auf Community-Tester. v1.19.0 = analoge CUPRA/SEAT FCM Foundation. v1.18.x Patches aktivieren MQTT live sobald Tester sich melden). Plus voriges v1.17.7 (Skoda outside_temp + preferred_workshop attrs als PATCH — beides nutzt EXISTIERENDE sensor + model fields, kein neuer Sensor → echter PATCH. Schließt #129 + #130 + #133. Plus voriges v1.17.6 = HomeRegion-Helper
 Scaffolding, evcc port — `cariad/_home_region.py` mit per-VIN
 7d-cache + `resolve_home_region()` async helper für
 `mal-1a.prd.ece.vwg-connect.com` Discovery-Endpoint, defensiv
@@ -130,6 +146,7 @@ Strict order — P0 (next release) > P1 (planned MINOR) > P2 (later) > P3 (resea
 | ~~v1.19.4~~ | Bundle 1: T&C brand-deeplinks (raise_issue_auth_required brand=) + Quota Repair-Issue (raise_issue_quota_low + clear_quota_issue, coordinator threshold-trigger, DE+EN translations) | done |
 | ~~v1.20.0~~ | Bundle 2 Phase A: Skoda widget + vehicle-info + equipment (3 myskoda PR #557 endpoints, license_plate + equipment_count sensors, 24h static-cache via refresh_static_info, DeviceInfo auto-enrichment, Bruno 83/83) | done |
 | ~~v1.20.1~~ | BinarySensor LOCK-class invert fix (#131 Chr1sDub) + Doc refresh (README + FAQ für v1.18-v1.20 features) | done |
+| ~~v1.20.2~~ | Skoda parser hardening (Bug B proactive #131) + phantom-entity fix für license_plate/equipment_count + safe_float locale-comma + scaffolding-markers + ROADMAP+CHANGELOG hygiene | done |
 
 ### 🔴 P0 — Nächste Releases (post v1.19.0)
 
@@ -183,14 +200,10 @@ Strict order — P0 (next release) > P1 (planned MINOR) > P2 (later) > P3 (resea
 ### Standalone enhancements (no version pin yet)
 
 - ~~**Diesel AdBlue Range** for Škoda (CC-skoda #24)~~ — already done (code-audit 2026-05-04: `skoda.py:386` + `vw_eu.py:778` + sensor.py:367 + DE/EN translations all wired)
-- **`/v2/widgets/vehicle-status/{vin}`** as lightweight Skoda endpoint
-  (myskoda PR #557): for battery-friendly polling. Pairs well with v1.20.0
-  Skoda Vehicle-Info Bundle.
+- ~~**`/v2/widgets/vehicle-status/{vin}`** as lightweight Skoda endpoint~~ — done v1.20.0 (Bundle 2 Phase A) — myskoda PR #557 adopted, wired into get_status as 9th endpoint, Bruno seq 25
 - ~~**Region-routing** `_get_cariad_url(region)` for US users~~ — Foundation
   built v1.17.6, wire-in pending (waits on #75)
-- **TermsAndConditionsError repair issue** (volkswagencarnet PR #307):
-  HA `ir.async_create_issue` with deeplink to vehicle-account login portal
-  when 401 with `terms_of_use` body is detected. Quick PATCH (~1-2h).
+- ~~**TermsAndConditionsError repair issue** (volkswagencarnet PR #307)~~ — done v1.19.4 (Bundle 1) — brand-aware deeplinks for skoda/vw/audi/seat/cupra/porsche/vw_na all wired in repairs.py
 - ~~**ICE Engine Start S-PIN flow**~~ — done v1.14.0 #28 (Audi engine pack)
 - ~~**PPE Climate Body**~~ — done v1.14.0 #29 (force_ppe_climate option)
 - **MQTT v5 broker testing for Skoda Push** (myskoda PR #566): foundation

--- a/tests/test_v1202_skoda_doors_locked_hardening.py
+++ b/tests/test_v1202_skoda_doors_locked_hardening.py
@@ -1,0 +1,198 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""Tests for v1.20.2 — Skoda doors_locked parser hardening (#131 Bug B).
+
+Proactive defensive fix without waiting for Chr1sDub's specific JSON
+data. Two improvements:
+
+1. Drop the buggy ``access.overallStatus != "OPEN"`` fallback that
+   marked closed-but-unlocked vehicles as locked AND treated
+   UNAVAILABLE-state vehicles as falsely locked. Pre-v1.20.2 line:
+
+       d.doors_locked = v(access, "overallStatus") != "OPEN"
+
+   Removed in v1.20.2 — only authoritative ``overall.reliableLockStatus``
+   / ``overall.doorsLocked`` / ``overall.locked`` are used now.
+
+2. Extended explicit value enumeration with both locked and unlocked
+   sets, plus forward-compat logging for unknown values (myskoda #503
+   safe_enum pattern). Pre-v1.20.2 only matched locked values; any
+   other value silently fell through to line 320's buggy default.
+"""
+
+from __future__ import annotations
+
+
+def _parse_skoda_status_doors_locked(status: dict) -> bool | None:
+    """Standalone reproduction of the v1.20.2 hardened parser block.
+
+    Returns the final value of ``d.doors_locked`` after both blocks
+    have run. ``None`` means the parser couldn't determine state.
+    """
+    def v(d, *keys):
+        cur = d
+        for k in keys:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(k)
+        return cur
+
+    doors_locked: bool | None = None  # default — neither block ran
+    if isinstance(status, dict):
+        # Block 1 (formerly line 320 — REMOVED in v1.20.2)
+        # Pre-v1.20.2: d.doors_locked = v(access, "overallStatus") != "OPEN"
+        # Now: nothing (defer to block 2)
+
+        # Block 2 (line 354 — extended in v1.20.2)
+        overall = v(status, "overall") or {}
+        lock_raw = (
+            v(overall, "reliableLockStatus")
+            or v(overall, "doorsLocked")
+            or v(overall, "locked")
+        )
+        if isinstance(lock_raw, str):
+            up = lock_raw.upper()
+            _locked = {"YES", "LOCKED", "TRUE", "RELIABLE_LOCKED"}
+            _unlocked = {
+                "NO", "UNLOCKED", "FALSE", "OPEN", "RELIABLE_UNLOCKED",
+            }
+            if up in _locked:
+                doors_locked = True
+            elif up in _unlocked:
+                doors_locked = False
+            # else: leave None
+    return doors_locked
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A) Locked values (all variants seen across firmwares)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLockedValues:
+    def test_yes(self):
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"doorsLocked": "YES"}}
+        ) is True
+
+    def test_locked(self):
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"locked": "LOCKED"}}
+        ) is True
+
+    def test_true_string(self):
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"doorsLocked": "TRUE"}}
+        ) is True
+
+    def test_reliable_locked(self):
+        """Kodiaq 2026+ uses ``reliableLockStatus`` field."""
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"reliableLockStatus": "LOCKED"}}
+        ) is True
+
+    def test_reliable_locked_long_value(self):
+        """If backend ever ships ``RELIABLE_LOCKED`` as the value
+        (rare but defensive)."""
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"reliableLockStatus": "RELIABLE_LOCKED"}}
+        ) is True
+
+    def test_lowercase_yes_normalized(self):
+        """uppercase normalization handles arbitrary casing."""
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"doorsLocked": "yes"}}
+        ) is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B) Unlocked values (newly-recognized in v1.20.2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestUnlockedValues:
+    def test_no(self):
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"doorsLocked": "NO"}}
+        ) is False
+
+    def test_unlocked(self):
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"locked": "UNLOCKED"}}
+        ) is False
+
+    def test_false_string(self):
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"doorsLocked": "FALSE"}}
+        ) is False
+
+    def test_open(self):
+        """Some firmwares use ``OPEN`` as the overall lock status
+        (= doors are accessible)."""
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"reliableLockStatus": "OPEN"}}
+        ) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C) Unknown values — leave field None instead of guessing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestUnknownValues:
+    def test_unknown_enum_value_returns_none(self):
+        """v1.20.2 hardening — unknown values must NOT default to a
+        guessed bool. Pre-v1.20.2 fell through to the buggy line 320
+        default. Now: log + leave None."""
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"doorsLocked": "FOOBAR_NEW_VALUE"}}
+        ) is None
+
+    def test_no_overall_block_returns_none(self):
+        """No ``overall`` block in status response → field stays None."""
+        assert _parse_skoda_status_doors_locked(
+            {"access": {"overallStatus": "CLOSED"}}
+        ) is None
+
+    def test_empty_status_returns_none(self):
+        assert _parse_skoda_status_doors_locked({}) is None
+
+    def test_non_string_overall_value_returns_none(self):
+        assert _parse_skoda_status_doors_locked(
+            {"overall": {"doorsLocked": 42}}
+        ) is None
+
+    def test_pre_v1202_buggy_fallback_REMOVED(self):
+        """Critical regression test — pre-v1.20.2 buggy fallback
+        used ``access.overallStatus != "OPEN"`` which incorrectly
+        treated CLOSED-but-unlocked vehicles as locked. v1.20.2
+        removes that line entirely. Verify the bug doesn't return."""
+        # Pre-v1.20.2: this would have set doors_locked=True (buggy)
+        # because "CLOSED" != "OPEN". Now: field stays None.
+        assert _parse_skoda_status_doors_locked(
+            {"access": {"overallStatus": "CLOSED"}}
+        ) is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D) Priority chain (reliableLockStatus > doorsLocked > locked)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPriorityChain:
+    def test_reliable_beats_doors_locked(self):
+        """When both fields are present, reliableLockStatus wins."""
+        assert _parse_skoda_status_doors_locked({
+            "overall": {
+                "reliableLockStatus": "LOCKED",
+                "doorsLocked": "NO",  # would say unlocked, but reliable beats
+            },
+        }) is True
+
+    def test_doors_locked_beats_locked(self):
+        """When only the older two fields are present."""
+        assert _parse_skoda_status_doors_locked({
+            "overall": {
+                "doorsLocked": "YES",
+                "locked": "NO",
+            },
+        }) is True


### PR DESCRIPTION
PATCH-Release. Multi-item cleanup bundle nach Audit (v1.17.5-v1.20.1 retrospective). 7 Findings adressiert.

## Changes
1. **Bug B proactive fix** — Skoda doors_locked parser hardening (#131): drop buggy line 320 fallback + extended explicit unlocked-values + log unknown
2. **Phantom-entity fix** — license_plate + equipment_count added to `_DATA_PRESENT_REQUIRED` (non-Skoda users no longer see phantom 'unknown' since v1.20.0)
3. **safe_float locale-comma** — fallback for Skoda '21,5' (v1.10.1 #58 promised but never delivered)
4. **3 SCAFFOLDING headers** — _home_region.py + skoda_mqtt.py + cupra_seat_fcm.py now explicitly marked
5. **ROADMAP standalone-list** — 2 done-but-still-TODO items marked (T&C v1.19.4, Skoda widget v1.20.0)
6. **ROADMAP 'Last updated'** — 11+ run-on replaced with concise date + chronological bullets
7. **CHANGELOG semver retro** — v1.19.1 historical note (strikt MINOR but kept PATCH for HACS continuity)

## Tests
- 16 cases in test_v1202_skoda_doors_locked_hardening.py
- 13 standalone-logic assertions verified locally
- Drift-check 83/83 unchanged

## NOT in this release
- Bug B targeted fix (waits Chr1sDub data)
- S-PIN unlock check (code is correct, waits diagnostic)
- v1.21.0+ scheduled bundles