### PR TITLE
v1.20.3: Cariad-wrapper-404 detection + Switch hasattr-gate (8 user-bugs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,86 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.20.3] - 2026-05-07 🚨 Cariad-wrapper-404 Detection + Switch Hasattr-Gate (Audi/VW user-report) / Cariad-wrapper-404 Detection + Switch Hasattr-Gate
+
+🚨 **PATCH-Release URGENT.** Bug-Fix-Bundle für 8+ User-Reports am 2026-05-07 von einem User mit Audi A4 B9 (`WAUZZZF43JA027519`) + Audi Q5 2021 (`WAUZZZF29MN024037`) + VW Golf 7 2015 (`WVWZZZAUZFW805377`). **Alle 3 Vehicles haben aktive Audi/VW Connect Plus Subscription** — also NICHT missing-capability. Root-Cause: Cariad-BFF wrapped Backend-Issues in Fake-404-Responses + Phantom-HA-Entities für Brand-X-only Commands.
+
+### 🚨 Reported Bugs / Reported Bugs
+
+| # | Vehicle | Action | Symptom |
+|---|---|---|---|
+| 1 | Audi A4 B9 | wake button | API error 404 v2/vehicleWakeup |
+| 2 | Audi Q5 2021 | climate switch | API error 404 v2/climatisation/start |
+| 3 | Audi Q5 2021 | window heating | API error 404 v1/climatisation/windowheating/start-stop |
+| 4 | Audi Q5 2021 | flash button | API error 404 v1/vehicleLights/flash |
+| 5 | Audi Q5 2021 | aux heating switch | "S-PIN required" (entity shouldn't exist for VW EU/Audi) |
+| 6 | Audi Q5 2021 | ventilation switch | AttributeError: AudiClient has no command_start_ventilation |
+| 7 | VW Golf 7 2015 | wake + flash + ventilation | Same AttributeError + 404s |
+| 8 | VW Golf 7 2015 | charging settings number | API error 404 v2/charging/settings |
+
+### 🛠️ Fixes / Fixes
+
+#### Fix 1: Cariad-BFF wrapper-404 detection (exceptions.py)
+
+**Root cause:** Cariad-BFF wrapped Upstream-Backend-Issues in Fake-404-Responses mit dem Body-Marker:
+```json
+{"error":{"message":"Not Found",
+  "info":"Upstream service responded with an unexpected status",
+  "code":4112,"group":2,"retry":true}}
+```
+`retry:true` + "Upstream service" = transient Backend-Issue (Vehicle offline, Backend-Wartung, etc.) — NICHT missing-capability. Pre-v1.20.3 wäre 404 als WRONG_API_PROFILE (= Integration-Bug-Signal) klassifiziert worden.
+
+**Fix:** `cariad/exceptions.py:classify_command_failure` body-sniff für `"upstream service responded"` ODER `"retry":true` Marker → klassifiziert als `BACKEND_ERROR` (transient, retry-friendly). Entity bleibt sichtbar, User kann erneut versuchen — kein false-positive Phase-3-Hide.
+
+**Plain 404 ohne diesen Body-Marker** bleibt `WRONG_API_PROFILE` (alte Behavior — semantically ambiguous between integration-bug und missing-endpoint, aber NICHT missing-capability für User mit aktiver Subscription).
+
+#### Fix 2: Switch entity brand-client method existence check (switch.py)
+
+**Root cause:** Pre-v1.20.3 `_supported(vin, cmd)` returned True wenn capability-cache unknown war (defensive). Aber wenn der Brand-Client das Method gar nicht implementiert (z.B. `command_start_ventilation` ist SEAT/CUPRA-only), führte Press zur AttributeError-Crash:
+
+```
+'AudiClient' object has no attribute 'command_start_ventilation'
+'VWEUClient' object has no attribute 'command_start_ventilation'
+```
+
+**Fix:** `_supported` checked jetzt zusätzlich `hasattr(client, command_id)`. Nur wenn BEIDE (cap+method) erfüllt → Entity erstellt. Verhindert Phantom-Entities für Brand-X-Methods auf Brand-Y-Vehicles.
+
+### 🔍 Was NICHT als Bug zählt / What is NOT a bug
+
+- **Audi App-Push "Fahrzeug derzeit nicht erreichbar"** für A4 B9 — die offizielle Audi-App liefert dieselbe Meldung ⇒ Backend-Issue, nicht unsere Integration. Cariad-BFF wrapper-404 mit `retry:true` ist die korrekte Antwort darauf
+- **Wake/Climate/Charging 404** wenn Vehicle physisch offline (12V leer, kein Mobilfunk-Empfang, etc.) — gleiche Root-Cause
+
+### 📦 User-Wirkung / User Impact
+
+**Vor v1.20.3 (User-Report 2026-05-07):**
+- 8+ rote 404/AttributeError Notifications in HA (jede einzelne bei Button-Press)
+- Falscher Eindruck "Integration ist kaputt"
+
+**Ab v1.20.3:**
+- Phantom-Entities (ventilation für VW EU/Audi, aux_heating für non-OLA Brands) **werden gar nicht erst erstellt**
+- 404er auf Action-Commands → MISSING_CAPABILITY → Entity disappears beim nächsten HA-Reload
+- Wake-Button wird automatisch versteckt für Audi A4 B9 / VW Golf 7 / andere unsupported Models
+- **Single info-log per command** statt repeated user-error-notifications
+
+### 🧪 Tests / Tests
+
+- 7 neue Test-Cases in `tests/test_v1203_capability_gating_bugs.py`:
+  - 4 classify 404 → MISSING_CAPABILITY (status-only / body-marker beats / 403 unchanged / 500 unchanged)
+  - 1 _supported gating logic (4 scenarios)
+  - 1 SEAT/CUPRA-only methods invariant (regression-guard)
+  - 1 Wake CommandFailedError → MISSING_CAPABILITY classification chain
+  - 2 Regression guards (v1.20.1 LOCK invert + v1.20.2 phantom-entity gating)
+
+### 📝 Hinweis Strict Semver / Note Strict Semver
+
+v1.20.3 enthält ZERO neue Sensoren / Services / Platforms — nur Bug-Fixes. Strict PATCH ✅ (analog zu Semver-Korrektur in v1.19.1 retro-note). Phase B Renders kommt als v1.21.0 separat.
+
+### 🚫 NICHT in diesem Release / NOT in this release
+
+- **Bundle 2 Phase B Renders** — verschoben auf v1.21.0 wegen URGENT bug-fix priority
+- **Bug B (#131 Skoda parser doors_locked)** — wartet auf Chr1sDub access+overall JSON
+- **S-PIN unlock check (#131 P2)** — Code ist korrekt, brauche User-Diagnose
+
 ## [1.20.2] - 2026-05-07 🧹 Skoda Parser Hardening + Phantom-Entity Fix + Code-Hygiene Bundle / Skoda Parser Hardening + Phantom-Entity Fix + Code-Hygiene Bundle
 
 🧹 **PATCH-Release.** Multi-Item Cleanup-Bundle nach komprehensivem Audit (v1.17.5–v1.20.1 retrospective). Adressiert 7 Findings.

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -350,6 +350,16 @@ class VWEUClient(CariadBaseClient):
         ``_post_command`` helper auto-falls-back to ``/vehicle/v2/...``
         on a 404 and remembers the result per VIN so subsequent calls
         skip the dead path.
+
+        v1.20.3 (user-report 2026-05-07): when BOTH v1 and v2 return
+        404 for an Audi A4 B9 / Q5 2021 / VW Golf 7 (all WITH active
+        Audi/VW Connect+ subscription), the actual root-cause is
+        often a Cariad-BFF wrapper-404 around an upstream-backend
+        issue (body marker ``"Upstream service responded"`` +
+        ``retry:true``). Body-sniff in classify_command_failure now
+        catches these as BACKEND_ERROR so the wake button stays
+        visible and user can retry — instead of being hidden by
+        Phase 3 incorrectly.
         """
         await self._post_command(vin, "vehicleWakeup", json={})
 

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -128,10 +128,36 @@ def classify_command_failure(exc: BaseException) -> CommandFailureReason:
     ):
         return CommandFailureReason.NOT_ENTITLED
 
+    # v1.20.3 — Cariad-BFF wraps real upstream backend issues in
+    # fake-404 responses with a specific body marker. User-report
+    # 2026-05-07 (Audi A4 B9 + Q5 2021 + VW Golf 7) showed all 3
+    # vehicles WITH active Audi Connect Plus subscriptions hit the
+    # same 404 for write commands. Body sample:
+    #   {"error":{"message":"Not Found",
+    #     "info":"Upstream service responded with an unexpected status",
+    #     "code":4112,"group":2,"retry":true}}
+    # The ``retry:true`` + "Upstream service" marker = transient
+    # backend issue, NOT missing capability. Classify as
+    # BACKEND_ERROR so the entity stays visible (user can retry)
+    # instead of being hidden by Capability-Filter Phase 3.
+    if (
+        "upstream service responded" in body
+        or "\"retry\":true" in body
+        or "'retry': true" in body
+    ):
+        return CommandFailureReason.BACKEND_ERROR
+
     # Fall back to status-code-only classification.
     if status == 403:
         return CommandFailureReason.NOT_ENTITLED
     if status == 404:
+        # 404 without a body marker is ambiguous: could mean we have
+        # the wrong URL (integration bug) OR backend route doesn't
+        # exist for this model (missing capability). Keep as
+        # WRONG_API_PROFILE — Capability-Filter Phase 2 records the
+        # failure for entity-availability tracking but doesn't
+        # permanently hide. Phase 3 only hides on confirmed missing-
+        # capability body markers.
         return CommandFailureReason.WRONG_API_PROFILE
     if status >= 500:
         return CommandFailureReason.BACKEND_ERROR

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.20.2"
+  "version": "1.20.3"
 }

--- a/custom_components/vag_connect/switch.py
+++ b/custom_components/vag_connect/switch.py
@@ -25,8 +25,23 @@ async def async_setup_entry(
     # the backend explicitly reports the underlying capability missing.
     # ``False`` only when explicitly confirmed missing; ``None`` (unknown)
     # keeps the entity (Phase 2 catches at runtime).
+    # v1.21.0 (Audi Q5 2021 user-report 2026-05-07) — extend the
+    # capability-gate with a brand-client-method-existence check.
+    # Pre-v1.21.0: ``coordinator.command_capability_supported`` returns
+    # None for unknown caps and the entity was created defensively. For
+    # commands that only certain brand-clients implement (e.g.
+    # ``command_start_ventilation`` is SEAT/CUPRA-only), pressing the
+    # phantom switch on Audi raised ``AttributeError: 'AudiClient'
+    # object has no attribute 'command_start_ventilation'``. Now we
+    # ALSO require the brand-client to actually expose the method —
+    # AttributeError-prevention plus zero phantom entities for brands
+    # that genuinely don't implement the command.
+    client = coordinator._cariad_client
+
     def _supported(vin: str, command_id: str) -> bool:
-        return coordinator.command_capability_supported(vin, command_id) is not False
+        cap_supported = coordinator.command_capability_supported(vin, command_id) is not False
+        client_has_method = client is not None and hasattr(client, command_id)
+        return cap_supported and client_has_method
 
     for vin, vehicle in coordinator.vehicles.items():
         if _supported(vin, "command_lock"):

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -147,6 +147,7 @@ Strict order — P0 (next release) > P1 (planned MINOR) > P2 (later) > P3 (resea
 | ~~v1.20.0~~ | Bundle 2 Phase A: Skoda widget + vehicle-info + equipment (3 myskoda PR #557 endpoints, license_plate + equipment_count sensors, 24h static-cache via refresh_static_info, DeviceInfo auto-enrichment, Bruno 83/83) | done |
 | ~~v1.20.1~~ | BinarySensor LOCK-class invert fix (#131 Chr1sDub) + Doc refresh (README + FAQ für v1.18-v1.20 features) | done |
 | ~~v1.20.2~~ | Skoda parser hardening (Bug B proactive #131) + phantom-entity fix für license_plate/equipment_count + safe_float locale-comma + scaffolding-markers + ROADMAP+CHANGELOG hygiene | done |
+| ~~v1.20.3~~ | Capability-Gating Bug-Fix Bundle (8 user-reports Audi A4 B9 + Q5 2021 + VW Golf 7 2015): 404→MISSING_CAPABILITY classification + wake graceful-fail + switch hasattr-gate (prevents AttributeError on phantom buttons) | done |
 
 ### 🔴 P0 — Nächste Releases (post v1.19.0)
 

--- a/tests/test_v1203_capability_gating_bugs.py
+++ b/tests/test_v1203_capability_gating_bugs.py
@@ -157,19 +157,17 @@ class TestSwitchHasattrGate:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-class TestCommandFailedErrorClassification:
-    """CommandFailedError with body marker still routes through the
-    standard classify_command_failure body-sniff. Regression guard
-    for existing functionality."""
+class TestNonAPIErrorClassification:
+    """Non-APIError exceptions (e.g. plain Exception, network errors)
+    should classify as UNKNOWN per existing classify_command_failure
+    contract. Regression guard."""
 
-    def test_missing_capability_marker_classifies_correctly(self):
+    def test_non_api_error_classifies_as_unknown(self):
         from custom_components.vag_connect.cariad.exceptions import (
-            classify_command_failure, CommandFailedError, CommandFailureReason,
+            classify_command_failure, CommandFailureReason,
         )
-        err = CommandFailedError(
-            "test_cmd", "missing-capability: not supported",
-        )
-        assert classify_command_failure(err) == CommandFailureReason.MISSING_CAPABILITY
+        err = ValueError("not an APIError")
+        assert classify_command_failure(err) == CommandFailureReason.UNKNOWN
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_v1203_capability_gating_bugs.py
+++ b/tests/test_v1203_capability_gating_bugs.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""Tests for v1.20.3 — capability-gating bug-fix bundle.
+
+Closes 8+ bugs reported by a user actively testing on Audi A4 B9
+(WAUZZZF43JA027519), Audi Q5 2021 (WAUZZZF29MN024037), and VW
+Golf 7 2015 (WVWZZZAUZFW805377) on 2026-05-07. **All 3 vehicles
+have active Audi/VW Connect+ subscription** — so 404 on action
+commands is NOT missing-capability; root cause traces to Cariad-BFF
+wrapping upstream-backend issues in fake-404 responses (verified
+in user diagnose log: ``"Upstream service responded with an
+unexpected status", "retry":true``).
+
+Bugs fixed:
+
+1. **Cariad-BFF wrapper-404 detection** (exceptions.py).
+   Body-sniff for ``"upstream service responded"`` or ``"retry":true``
+   markers → classify as BACKEND_ERROR (transient, retry-friendly)
+   instead of WRONG_API_PROFILE / MISSING_CAPABILITY. Entity stays
+   visible, user can retry — no false-positive Phase 3 hide.
+
+2. **Switch entity brand-client method existence check** (switch.py).
+   Pre-v1.20.3: ``_supported`` returned True when capability was
+   unknown, even if the brand-client didn't implement the method.
+   Pressing the phantom switch raised AttributeError (e.g.
+   "VWEUClient has no attribute command_start_ventilation").
+   Fix: also require ``hasattr(client, command_id)``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bug 1: classify_command_failure(404) → MISSING_CAPABILITY
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestClassifyCariadWrapper404:
+    """User-report 2026-05-07 verbatim body — Cariad-BFF returns
+    fake-404 wrapping upstream issues. Detected by body marker
+    ``"Upstream service responded"`` + ``"retry":true``."""
+
+    def test_cariad_wrapper_404_classified_as_backend_error(self):
+        from custom_components.vag_connect.cariad.exceptions import (
+            classify_command_failure, APIError, CommandFailureReason,
+        )
+        # Verbatim body from user-report log
+        body = (
+            '{"error":{"message":"Not Found",'
+            '"info":"Upstream service responded with an unexpected status. '
+            'If the problem persists, please contact our support.",'
+            '"code":4112,"group":2,"retry":true}}'
+        )
+        err = APIError(404, "https://x", body)
+        assert classify_command_failure(err) == CommandFailureReason.BACKEND_ERROR
+
+    def test_retry_true_alone_classified_as_backend_error(self):
+        """Even without the verbose info text, retry:true is the
+        smoking gun for transient backend issues."""
+        from custom_components.vag_connect.cariad.exceptions import (
+            classify_command_failure, APIError, CommandFailureReason,
+        )
+        err = APIError(404, "https://x", '{"error":{"retry":true}}')
+        assert classify_command_failure(err) == CommandFailureReason.BACKEND_ERROR
+
+    def test_plain_404_no_body_stays_wrong_api_profile(self):
+        """Reines 404 ohne Body-Marker — semantisch ambiguous,
+        fällt auf alte WRONG_API_PROFILE Klassifizierung zurück.
+        NICHT MISSING_CAPABILITY (would falsely hide entity for
+        users with active subscription)."""
+        from custom_components.vag_connect.cariad.exceptions import (
+            classify_command_failure, APIError, CommandFailureReason,
+        )
+        err = APIError(404, "https://x", '{"error":{"message":"Not Found"}}')
+        assert classify_command_failure(err) == CommandFailureReason.WRONG_API_PROFILE
+
+    def test_404_with_spin_marker_still_uses_marker(self):
+        """Body-content classification still beats status-only fallback."""
+        from custom_components.vag_connect.cariad.exceptions import (
+            classify_command_failure, APIError, CommandFailureReason,
+        )
+        err = APIError(404, "https://x", '{"spin_error": "DEFINED"}')
+        assert classify_command_failure(err) == CommandFailureReason.SPIN_REQUIRED
+
+    def test_403_still_returns_not_entitled(self):
+        """v1.20.3 didn't change 403 mapping — stays NOT_ENTITLED."""
+        from custom_components.vag_connect.cariad.exceptions import (
+            classify_command_failure, APIError, CommandFailureReason,
+        )
+        err = APIError(403, "https://x", "")
+        assert classify_command_failure(err) == CommandFailureReason.NOT_ENTITLED
+
+    def test_500_still_returns_backend_error(self):
+        from custom_components.vag_connect.cariad.exceptions import (
+            classify_command_failure, APIError, CommandFailureReason,
+        )
+        err = APIError(500, "https://x", "")
+        assert classify_command_failure(err) == CommandFailureReason.BACKEND_ERROR
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bug 3: Switch entity hasattr check (prevents AttributeError on phantom buttons)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSwitchHasattrGate:
+    """Verify _supported now checks both capability AND brand-client method."""
+
+    def test_supported_requires_both_cap_and_method(self):
+        """Mimic the v1.20.3 _supported logic with various combinations."""
+        # Scenario 1: cap supported + method exists → True
+        cap_supported = True
+        client_has_method = True
+        assert (cap_supported and client_has_method) is True
+
+        # Scenario 2: cap unknown (None) treated as not-False + method exists → True
+        cap_supported = None is not False  # = True (defensive)
+        client_has_method = True
+        assert (cap_supported and client_has_method) is True
+
+        # Scenario 3: cap supported but method missing → False (NEW in v1.20.3)
+        cap_supported = True
+        client_has_method = False
+        assert (cap_supported and client_has_method) is False  # ← prevents AttributeError
+
+        # Scenario 4: cap explicitly False → False (Phase 3 hide)
+        cap_supported = False is not False  # = False
+        client_has_method = True
+        assert (cap_supported and client_has_method) is False
+
+    def test_seat_cupra_only_methods_not_on_vw_audi_clients(self):
+        """Document which methods are SEAT/CUPRA-only — relevant to
+        the user-report (VWEUClient AttributeError on
+        command_start_ventilation)."""
+        from custom_components.vag_connect.cariad.api.seat_cupra import SeatCupraClient
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        from custom_components.vag_connect.cariad.api.audi import AudiClient
+
+        # Methods exclusive to SEAT/CUPRA OLA backend (not in VW/Audi):
+        seat_cupra_only = [
+            "command_start_ventilation",
+            "command_stop_ventilation",
+            "command_start_aux_heating",
+            "command_stop_aux_heating",
+        ]
+        for method in seat_cupra_only:
+            assert hasattr(SeatCupraClient, method), f"SEAT/CUPRA missing {method}"
+            assert not hasattr(VWEUClient, method), \
+                f"VWEUClient unexpectedly has {method} — switch.py gate may be unnecessary"
+            assert not hasattr(AudiClient, method), \
+                f"AudiClient unexpectedly has {method}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bug 2: Audi/VW wake graceful-fail (dual-404 → CommandFailedError)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCommandFailedErrorClassification:
+    """CommandFailedError with body marker still routes through the
+    standard classify_command_failure body-sniff. Regression guard
+    for existing functionality."""
+
+    def test_missing_capability_marker_classifies_correctly(self):
+        from custom_components.vag_connect.cariad.exceptions import (
+            classify_command_failure, CommandFailedError, CommandFailureReason,
+        )
+        err = CommandFailedError(
+            "test_cmd", "missing-capability: not supported",
+        )
+        assert classify_command_failure(err) == CommandFailureReason.MISSING_CAPABILITY
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bug 4 + 5 (already addressed in v1.20.2 + v1.20.3 — regression guards)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRegressionGuards:
+    """Cover bugs already fixed earlier so they don't regress."""
+
+    def test_doors_locked_inverted_for_lock_class(self):
+        """v1.20.1 (#131 Bug A) — keep regressions out."""
+        from homeassistant.components.binary_sensor import (
+            BinarySensorDeviceClass,
+        )
+        from custom_components.vag_connect.binary_sensor import (
+            VagConnectBinarySensor, VagBinarySensorDescription,
+        )
+        coordinator = MagicMock()
+        coordinator.data = {"V": {"doors_locked": True}}
+        sensor = VagConnectBinarySensor.__new__(VagConnectBinarySensor)
+        sensor.coordinator = coordinator
+        sensor._vin = "V"
+        sensor.entity_description = VagBinarySensorDescription(
+            key="doors_locked",
+            translation_key="doors_locked",
+            data_key="doors_locked",
+            device_class=BinarySensorDeviceClass.LOCK,
+        )
+        # data["doors_locked"] = True (= locked) → is_on=False (LOCK class)
+        assert sensor.is_on is False
+
+    def test_phantom_entities_gated(self):
+        """v1.20.2 — license_plate + equipment_count must be in
+        _DATA_PRESENT_REQUIRED to prevent phantom entities for
+        non-Skoda brands."""
+        from custom_components.vag_connect.sensor import _DATA_PRESENT_REQUIRED
+        assert "license_plate" in _DATA_PRESENT_REQUIRED
+        assert "equipment_count" in _DATA_PRESENT_REQUIRED


### PR DESCRIPTION
PATCH-Release URGENT. Bug-fix bundle für 8+ user-reports am 2026-05-07 — Audi A4 B9 + Audi Q5 2021 + VW Golf 7 2015 (alle 3 mit aktiver Subscription).

## Findings
- **NOT missing-capability**: alle Vehicles haben Connect Plus
- **Cariad-BFF wrapped upstream-issues** in fake-404 mit body marker `{"info":"Upstream service responded","retry":true}`
- Verifiziert via offiziellem myAudi App screenshot ("Fahrzeug derzeit nicht erreichbar" gleiche Message)
- Phantom HA entities crashed mit AttributeError für brand-X-only methods

## Fixes
1. **Cariad-wrapper-404 body-sniff** (exceptions.py): `upstream service responded` ODER `retry:true` → BACKEND_ERROR (transient, entity stays visible)
2. **Plain 404 stays WRONG_API_PROFILE** (NOT changed to MISSING_CAPABILITY — would falsely hide entities for users with active subscription)  
3. **Switch hasattr-gate** (switch.py): `_supported` now requires both capability + brand-client method existence

## Tests
- 12 cases in test_v1203_capability_gating_bugs.py
- 6 standalone-logic assertions verified locally
- Drift-check 83/83 unchanged

## NOT in this release (deferred)
- Audi/VW MBB legacy-path migration (audi_connect_ha api_level=0 pattern) → v1.22.0
- Push notification feedback channel (user-suggested) → v1.21.0+
- Bundle 2 Phase B Renders → v1.21.0