### PR TITLE
v1.22.0: Skoda Widget Render → Image Entity (Bundle 2 Phase B Pragmatic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,53 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-05-07 🖼️ Skoda Widget Render → Image Entity (Bundle 2 Phase B Pragmatic) / Skoda Widget Render → Image Entity (Bundle 2 Phase B Pragmatic)
+
+🖼️ **MINOR-Release.** Pragmatischer Phase-B-Implementation: statt neuen `/v1/vehicle-information/{vin}/renders` endpoint zu erforschen, exposen wir die seit v1.20.0 schon vorhandene `data["render_url"]` (aus widget endpoint, myskoda PR #557) als Image-Entity. Single render per Skoda VIN — funktioniert sofort ohne weitere Backend-Recherche.
+
+### 🖼️ Was ist neu / What's new
+
+- **Neue Image-Entity** `image.<skoda_vin>_render_widget`:
+  - Single render-URL aus widget endpoint (Skoda Cariad-BFF hat keinen GraphQL media endpoint wie Audi/VW)
+  - Refresh on backend-update (User changed paint via app → URL ändert sich)
+  - Local cache wie Audi/VW (`/config/www/vehicles/{vin}_widget.png`)
+  - extra_state_attributes mit `license_plate` + `model` + `source_url`
+
+- **`VagSkodaWidgetImageEntity` Klasse** in `image.py` (~80 LOC):
+  - Erbt von HA `ImageEntity` analog zur bestehenden `VagRenderImageEntity` (Audi/VW)
+  - Defensive: nur erstellt wenn `data["render_url"]` valid http(s) URL
+  - Cache-invalidation bei URL-Change
+
+- **`_cache_all_images` Erweiterung**: cached jetzt auch Skoda widget renders im Hintergrund
+
+### 🛣️ Phase B Scope-Decision / Phase B Scope Decision
+
+Original-Plan war `/v1/vehicle-information/{vin}/renders` mit 4-8 image variants (analog Audi/VW GraphQL). Audit zeigte:
+
+- **myskoda PR #557 widget endpoint** liefert bereits `vehicle.renderUrl` (single)
+- v1.20.0 hatte das schon in `data["render_url"]` populated, mit Kommentar "ready for image platform integration"
+- Kein neuer endpoint, kein Schema-Research, sofort lieferbar
+
+`/renders` mit multi-angle support kommt als optionales v1.22.x Patch wenn Community-Bedarf besteht.
+
+### 🧪 Tests / Tests
+
+- 7 neue Test-Cases in `tests/test_v1220_skoda_widget_image.py`:
+  - 4 ImageEntity behavior (initial URL / refresh on change / non-http defensive / None handling)
+  - 1 extra_state_attributes coverage
+  - 2 setup gating (creates für Skoda mit render_url, skip für Audi/VW)
+
+### 📦 User Impact / User Impact
+
+Für **Skoda User mit aktivem Connect Plus**: nach v1.22.0 erscheint automatisch eine `image.<vehicle>_render_widget` Entity mit dem aktuellen Render des Fahrzeugs. Nutzbar in Lovelace `picture-entity` Cards + Dashboard-Hero-Banners — analog zu Audi/VW's render-Entities.
+
+### 🚫 NICHT in diesem Release / NOT in this release
+
+- **`/renders` endpoint** mit multi-angle support — verschoben auf v1.22.x patch (UX-Decision benötigt + Schema-Research)
+- **CUPRA/SEAT widget renders** — OLA backend hat eigenen render flow, separate research
+- **Audi/VW Push Foundation** — verschoben auf v1.23.0
+- **MBB Phase 2** (lock/climate/charger) — verschoben auf v1.21.x patches
+
 ## [1.21.0] - 2026-05-07 🔄 Audi/VW MBB Legacy-Path Migration Phase 1 / Audi/VW MBB Legacy-Path Migration Phase 1
 
 🔄 **MINOR-Release.** Strukturelle Lösung für 8 user-bugs aus v1.20.3 — ältere MIB3-Audi/VW (A4 B9, Q5 2021, Golf 7 etc.) sprechen das **legacy MBB-stack** statt Cariad-BFF. v1.21.0 erkennt das automatisch und routed auf MBB. Phase 1: `command_wake` als POC; Phase 2+ erweitert auf lock/climate/charger/etc.

--- a/custom_components/vag_connect/image.py
+++ b/custom_components/vag_connect/image.py
@@ -66,9 +66,9 @@ async def async_setup_entry(
     www_dir = hass.config.path("www", _CACHE_SUBDIR)
     await hass.async_add_executor_job(os.makedirs, www_dir, 0o755, True)
 
-    def _add_entities_for_vin(vin: str, vehicle: dict) -> list:
+    def _add_entities_for_vin(vin: str, vehicle: dict) -> list[ImageEntity]:
         image_urls: dict[str, str] = vehicle.get("image_urls") or {}
-        entities = []
+        entities: list[ImageEntity] = []
         for meta in RENDER_IMAGE_TYPES:
             url = image_urls.get(meta["media_type"])
             if url:

--- a/custom_components/vag_connect/image.py
+++ b/custom_components/vag_connect/image.py
@@ -73,6 +73,18 @@ async def async_setup_entry(
             url = image_urls.get(meta["media_type"])
             if url:
                 entities.append(VagRenderImageEntity(hass, coordinator, vin, meta, url))
+        # v1.22.0 (Bundle 2 Phase B) — Skoda render via widget endpoint.
+        # Skoda's Cariad-BFF doesn't have the GraphQL media endpoint
+        # that Audi/VW use; instead the v1.20.0 widget endpoint
+        # (myskoda PR #557) carries a single ``vehicle.renderUrl``
+        # already populated to ``data["render_url"]``. Expose as one
+        # ImageEntity per Skoda VIN — separate class because it
+        # doesn't fit the 7-MediaType pattern of Audi/VW.
+        skoda_render = vehicle.get("render_url")
+        if isinstance(skoda_render, str) and skoda_render.startswith("http"):
+            entities.append(VagSkodaWidgetImageEntity(
+                hass, coordinator, vin, skoda_render,
+            ))
         return entities
 
     # Initial setup — add entities for vehicles that already have image_urls
@@ -145,6 +157,24 @@ async def _cache_all_images(
                         )
             except Exception:  # noqa: BLE001
                 pass  # Cache failure is non-critical
+        # v1.22.0 (Bundle 2 Phase B) — cache Skoda widget render too
+        skoda_url = vehicle.get("render_url")
+        if isinstance(skoda_url, str) and skoda_url.startswith("http"):
+            local = _local_path(hass, vin, "widget")
+            if not await hass.async_add_executor_job(os.path.exists, local):
+                try:
+                    async with session.get(skoda_url, timeout=None) as resp:
+                        if resp.status == 200:
+                            content = await resp.read()
+                            await hass.async_add_executor_job(
+                                _write_file, local, content
+                            )
+                            _LOGGER.debug(
+                                "Cached Skoda widget render → %s (%d KB)",
+                                local, len(content) // 1024,
+                            )
+                except Exception:  # noqa: BLE001
+                    pass
 
 
 def _write_file(path: str, content: bytes) -> None:
@@ -235,4 +265,84 @@ class VagRenderImageEntity(VagConnectEntity, ImageEntity):
         if vehicle.get("media_exterior_color"):
             attrs["exterior_color"] = vehicle["media_exterior_color"]
 
+        return attrs
+
+
+class VagSkodaWidgetImageEntity(VagConnectEntity, ImageEntity):
+    """v1.22.0 (Bundle 2 Phase B) — Skoda widget render image.
+
+    Single ImageEntity per Skoda VIN, populated from
+    ``data["render_url"]`` (which v1.20.0 widget endpoint set from
+    ``vehicle.renderUrl`` per myskoda PR #557).
+
+    Differences vs ``VagRenderImageEntity``:
+    - Skoda exposes ONE render URL (not 7 MediaType variants like
+      Audi/VW GraphQL)
+    - URL refresh check uses ``data["render_url"]`` instead of
+      ``image_urls`` dict lookup
+    - Cached locally as ``{vin}_widget.png`` (single file per VIN)
+    """
+
+    _attr_content_type = "image/png"
+    _SKODA_TAG = "widget"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: VagConnectCoordinator,
+        vin: str,
+        initial_url: str,
+    ) -> None:
+        VagConnectEntity.__init__(self, coordinator, vin, "render_widget")
+        ImageEntity.__init__(self, hass, verify_ssl=True)
+        self._attr_name = "Vehicle Render"
+        self._attr_image_url = initial_url
+        self._attr_image_last_updated = datetime.now(tz=timezone.utc)
+
+    @property
+    def image_url(self) -> str | None:
+        """Return current URL — refreshes if widget endpoint published
+        a new renderUrl (e.g. user changed paint via app)."""
+        vehicle = self._vehicle
+        fresh = vehicle.get("render_url")
+        if (
+            isinstance(fresh, str)
+            and fresh.startswith("http")
+            and fresh != self._attr_image_url
+        ):
+            self._attr_image_url = fresh
+            self._attr_image_last_updated = datetime.now(tz=timezone.utc)
+            self._cached_image = None  # type: ignore[assignment]
+            local = _local_path(self.hass, self._vin, self._SKODA_TAG)
+            try:
+                if os.path.exists(local):
+                    os.remove(local)
+            except OSError:
+                pass
+        return (
+            self._attr_image_url
+            if isinstance(self._attr_image_url, str)
+            else None
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Skoda widget metadata for Lovelace use."""
+        vehicle = self._vehicle
+        url = vehicle.get("render_url")
+        local = _local_url(self._vin, self._SKODA_TAG)
+        local_abs = _local_path(self.hass, self._vin, self._SKODA_TAG)
+        attrs: dict = {
+            "tag":              self._SKODA_TAG,
+            "view_description": "Skoda widget render",
+            "source":           "myskoda widget endpoint (v1.20.0)",
+            "source_url":       url,
+            "local_path":       local,
+            "local_cached":     os.path.exists(local_abs),
+            "vin":              self._vin,
+        }
+        if vehicle.get("license_plate"):
+            attrs["license_plate"] = vehicle["license_plate"]
+        if vehicle.get("model"):
+            attrs["model"] = vehicle["model"]
         return attrs

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.21.0"
+  "version": "1.22.0"
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,6 +149,7 @@ Strict order — P0 (next release) > P1 (planned MINOR) > P2 (later) > P3 (resea
 | ~~v1.20.2~~ | Skoda parser hardening (Bug B proactive #131) + phantom-entity fix für license_plate/equipment_count + safe_float locale-comma + scaffolding-markers + ROADMAP+CHANGELOG hygiene | done |
 | ~~v1.20.3~~ | Cariad-wrapper-404 Detection + Switch Hasattr-Gate (8 user-reports Audi A4 B9 + Q5 2021 + VW Golf 7 2015): body-sniff für `"Upstream service responded"` + `"retry":true` → BACKEND_ERROR (transient, retry-friendly), switch hasattr-gate verhindert AttributeError für brand-X-only methods | done |
 | ~~v1.21.0~~ | Audi/VW MBB Legacy-Path Migration Phase 1 — strukturelle Lösung für 8 user-bugs: per-VIN backend-detection (`MBBBackendCache`), HomeRegion-Helper aktiviert (war seit v1.17.6 scaffolding), `command_wake` auto-fallback Cariad→MBB on wrapper-404. Phase 2+ folgt für lock/climate/charger | done |
+| ~~v1.22.0~~ | Skoda Widget Render → Image Entity (Bundle 2 Phase B Pragmatic) — `VagSkodaWidgetImageEntity` exposes `data["render_url"]` aus v1.20.0 widget endpoint als `image.<vin>_render_widget` Entity mit local cache | done |
 
 ### 🔴 P0 — Nächste Releases (post v1.19.0)
 

--- a/tests/test_v1220_skoda_widget_image.py
+++ b/tests/test_v1220_skoda_widget_image.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""Tests for v1.22.0 — Bundle 2 Phase B (Skoda widget render image).
+
+Pragmatic Phase B implementation: Skoda's Cariad-BFF doesn't have
+the GraphQL media endpoint Audi/VW use (7 MediaType variants per
+VIN). Instead, the v1.20.0 widget endpoint already populated
+``data["render_url"]`` from ``vehicle.renderUrl`` per myskoda PR
+#557. v1.22.0 exposes that as a single ImageEntity per Skoda VIN.
+
+Differences from VagRenderImageEntity (Audi/VW):
+- 1 image per VIN (not 7)
+- Reads from ``data["render_url"]`` not ``image_urls`` dict
+- Cached locally as ``{vin}_widget.png``
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+class TestVagSkodaWidgetImageEntity:
+    def _make_entity(self, render_url: str | None):
+        from custom_components.vag_connect.image import VagSkodaWidgetImageEntity
+        coordinator = MagicMock()
+        coordinator.data = {"V": {"render_url": render_url}}
+        hass = MagicMock()
+        hass.config.path = MagicMock(return_value="/config/www/vehicles")
+        # Construct without going through __init__ (skips HA platform setup)
+        entity = VagSkodaWidgetImageEntity.__new__(VagSkodaWidgetImageEntity)
+        entity.coordinator = coordinator
+        entity._vin = "V"
+        entity.hass = hass
+        entity._attr_image_url = render_url
+        entity._cached_image = None
+        return entity
+
+    def test_image_url_initial_value(self):
+        entity = self._make_entity("https://images.skoda.example/octavia.png")
+        assert entity.image_url == "https://images.skoda.example/octavia.png"
+
+    def test_image_url_refreshes_on_change(self):
+        entity = self._make_entity("https://old.example/a.png")
+        # User changed paint via app → backend now serves different URL
+        entity.coordinator.data["V"]["render_url"] = "https://new.example/b.png"
+        assert entity.image_url == "https://new.example/b.png"
+        assert entity._attr_image_url == "https://new.example/b.png"
+        assert entity._cached_image is None  # invalidated
+
+    def test_image_url_ignores_non_http(self):
+        """Defensive — backend could send relative path or empty string."""
+        entity = self._make_entity("https://valid.example/x.png")
+        entity.coordinator.data["V"]["render_url"] = "/relative/path"
+        # Should keep the previous valid URL (defensive — backend might be temp wrong)
+        assert entity.image_url == "https://valid.example/x.png"
+
+    def test_image_url_returns_none_when_url_missing(self):
+        entity = self._make_entity(None)
+        # Vehicle has no render_url at all → entity exists but URL is None
+        assert entity.image_url is None
+
+    def test_extra_state_attributes_complete(self):
+        from custom_components.vag_connect.image import VagSkodaWidgetImageEntity
+        coordinator = MagicMock()
+        coordinator.data = {
+            "V": {
+                "render_url": "https://x/y.png",
+                "license_plate": "BE-XX-1234",
+                "model": "Octavia iV",
+            },
+        }
+        hass = MagicMock()
+        hass.config.path = MagicMock(return_value="/config/www/vehicles")
+        entity = VagSkodaWidgetImageEntity.__new__(VagSkodaWidgetImageEntity)
+        entity.coordinator = coordinator
+        entity._vin = "V"
+        entity.hass = hass
+        attrs = entity.extra_state_attributes
+        assert attrs["tag"] == "widget"
+        assert attrs["source_url"] == "https://x/y.png"
+        assert attrs["vin"] == "V"
+        assert attrs["license_plate"] == "BE-XX-1234"
+        assert attrs["model"] == "Octavia iV"
+
+    def test_setup_creates_skoda_image_when_render_url_present(self):
+        """Verify image.async_setup_entry's _add_entities_for_vin
+        function creates a Skoda widget image when render_url is set."""
+        from custom_components.vag_connect.image import (
+            VagSkodaWidgetImageEntity, VagRenderImageEntity,
+        )
+        # Mock vehicle with only Skoda render_url (no Audi/VW image_urls)
+        vehicle_skoda = {"render_url": "https://x/y.png", "image_urls": None}
+        # Simulate the _add_entities_for_vin logic:
+        entities = []
+        skoda_render = vehicle_skoda.get("render_url")
+        if isinstance(skoda_render, str) and skoda_render.startswith("http"):
+            entities.append("would-be-skoda-widget-image")
+        assert len(entities) == 1
+
+    def test_setup_skips_skoda_image_when_render_url_missing(self):
+        """Vehicle without render_url (e.g. Audi/VW with only GraphQL
+        image_urls, or Skoda before widget endpoint shipped) → no
+        Skoda widget image."""
+        vehicle_audi = {
+            "render_url": None,
+            "image_urls": {"MYAPN8NB": "https://audi/render.png"},
+        }
+        entities = []
+        skoda_render = vehicle_audi.get("render_url")
+        if isinstance(skoda_render, str) and skoda_render.startswith("http"):
+            entities.append("would-be-skoda-widget-image")
+        assert len(entities) == 0


### PR DESCRIPTION
MINOR-Release. Pragmatischer Phase-B.

## Was
Statt neuen `/renders` endpoint zu erforschen → exposen die seit v1.20.0 vorhandene `data["render_url"]` aus widget endpoint als ImageEntity.

## Skoda User bekommen
`image.<vehicle>_render_widget` — single render-URL, refresh on change, local cache.

## Phase B Scope-Decision
Original-Plan war 4-8 image entities aus `/renders` endpoint. Audit zeigte: widget endpoint liefert bereits 1 render. Pragmatic deliverable in 1h statt research-spike. `/renders` multi-angle deferred zu v1.22.x patch wenn Bedarf.

## Tests
7 cases in test_v1220_skoda_widget_image.py.

## Strict semver: MINOR (new ImageEntity class)