### PR TITLE
v1.23.0: Audi/VW Push Foundation (Cariad FCM channel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,71 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-05-07 🚀 Audi/VW Push Foundation (Cariad FCM channel) / Audi/VW Push Foundation (Cariad FCM channel)
+
+🚀 **MINOR-Release.** Push-Update-Foundation für **Audi + Volkswagen** via Cariad FCM-channel — der gleiche den auch myAudi + WeConnect mobile Apps nutzen für lock-results, charging-state, climate, alarm. Dritte und letzte Push-Foundation der Bundle-Reihe (Skoda v1.18.0 + CUPRA/SEAT v1.19.0 → jetzt Audi/VW v1.23.0). User-suggested 2026-05-07 (myAudi App push notifications → HA-Side feedback channel).
+
+### 🚀 Was ist neu / What's new
+
+- **Neues Modul** `cariad/push/audi_vw_fcm.py`:
+  - `AudiVWPushManager` Klasse, erbt von `PushManager` (v1.18.0 base)
+  - Brand-Constructor-Validation: `audi` ODER `volkswagen` (beide auf Cariad-BFF)
+  - Identische Lifecycle + Reconnect-Backoff wie Skoda + CUPRA/SEAT (5s→600s ±10% jitter, evcc/myskoda Constants)
+  - Lazy-Import nur für `firebase-messaging` (gleiche lib wie v1.18.0/v1.19.0)
+  - Stub-implementation: foundation kann start/stop ohne network — live activation pending
+- **Neuer Config-Flow Toggle** `CONF_ENABLE_PUSH_AUDI_VW` (default False) — coexistiert mit MQTT (Skoda) + FCM (CUPRA/SEAT) toggles. User mit mixed-fleet kann beliebige Kombination opt-in
+- **Bilingual translations** (DE + EN)
+- **`# SCAFFOLDING — NOT WIRED`** Header (analog v1.20.2 Hygiene-Pattern für die anderen 2 push managers)
+
+### 🛣️ User Impact (post-Phase-2 wire-in) / User Impact
+
+Nach Live-Activation (Phase 2 in v1.23.x patches):
+- **Real-time vehicle status updates** ohne 12V-Wake-Cycle
+- **Command-Result Push** in HA als persistent_notification — analog dem myAudi App "Audi S6 Avant wurde verriegelt"
+- Alarm/Theft notifications direkt in HA Repair-Issues statt nur in der App
+- Eliminiert das "musste auf Reload warten um zu sehen ob Lock geklappt hat" UX-Problem
+
+### 🧪 Tests / Tests
+
+- 12 neue Test-Cases in `tests/test_v1230_audi_vw_push_foundation.py`:
+  - 2 brand validation (audi/volkswagen + invalid raises)
+  - 3 lifecycle (no VINs / missing dep / start+stop)
+  - 4 backoff (constants + grow + cap + reset)
+  - 2 const + config_flow (CONF_ENABLE_PUSH_AUDI_VW exposed, all 3 toggles coexist)
+  - 1 inheritance check (AudiVW ⊂ PushManager + all 3 managers share base)
+
+### 🛣️ Phase 2 (live activation) Wire-Up Plan / Phase 2 Wire-Up Plan
+
+```python
+# coordinator.async_setup:
+if (
+    options.get(CONF_ENABLE_PUSH_AUDI_VW, False)
+    and brand in ("audi", "volkswagen")
+):
+    from .cariad.push.audi_vw_fcm import AudiVWPushManager
+    self._push_manager = AudiVWPushManager(
+        on_event=self.async_handle_push_event,
+        user_id=auth.user_id,
+        access_token_provider=auth.get_access_token,
+        vins=list(self.vehicles.keys()),
+        brand=brand,
+    )
+    await self._push_manager.start()
+```
+
+Wartet auf:
+1. Audi/VW Connect+ Tester mit aktivem Abo
+2. Cariad Firebase project_id + sender_id + api_key (TBD via audi_connect_ha cross-reference oder mitmproxy capture)
+3. Notification-subscription endpoint URL Verifikation
+4. Push-event payload schema (welche Events triggern get_status, welche carry full state)
+
+### 🚫 NICHT in diesem Release / NOT in this release
+
+- **Aktive FCM-Verbindung** — Foundation-Stub schlafen lässt sich verbinden für State-Machine-Test
+- **Cariad Firebase credentials** — placeholders, Live-Tester-Verifikation pending
+- **Coordinator wire-in** — analog v1.18.0/v1.19.0 erst wenn Live-Test bestätigt
+- **iot_class change** — wartet bis Push primärer Pfad ist (aktuell 0% User opt-in)
+
 ## [1.22.0] - 2026-05-07 🖼️ Skoda Widget Render → Image Entity (Bundle 2 Phase B Pragmatic) / Skoda Widget Render → Image Entity (Bundle 2 Phase B Pragmatic)
 
 🖼️ **MINOR-Release.** Pragmatischer Phase-B-Implementation: statt neuen `/v1/vehicle-information/{vin}/renders` endpoint zu erforschen, exposen wir die seit v1.20.0 schon vorhandene `data["render_url"]` (aus widget endpoint, myskoda PR #557) als Image-Entity. Single render per Skoda VIN — funktioniert sofort ohne weitere Backend-Recherche.

--- a/custom_components/vag_connect/cariad/push/audi_vw_fcm.py
+++ b/custom_components/vag_connect/cariad/push/audi_vw_fcm.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+#
+# ╔════════════════════════════════════════════════════════════════════╗
+# ║ SCAFFOLDING — NOT WIRED INTO PRODUCTION CALL PATHS                ║
+# ║ Foundation built v1.23.0; OptionsFlow toggle exists but           ║
+# ║ Coordinator does NOT instantiate AudiVWPushManager.start() yet.   ║
+# ║ Live activation requires community Audi/VW user with active       ║
+# ║ Connect+ subscription for FCM-channel + push-event-schema         ║
+# ║ verification.                                                     ║
+# ║ See ROADMAP "Push Bundle Phase 2" + #57 Phase 2 (Audi/VW track).  ║
+# ╚════════════════════════════════════════════════════════════════════╝
+"""Audi/VW Cariad-BFF Firebase Cloud Messaging push manager (v1.23.0 foundation).
+
+User-suggested feature 2026-05-07: "weil ich auf der app push nachrichten
+bekomme, könnte man das doch auch auf der integration als feedback nehmen?"
+
+The myAudi + WeConnect mobile apps subscribe to Cariad's own FCM
+channel for vehicle-event push notifications (lock/unlock results,
+charging-state changes, climate-state changes, alarm/theft alerts).
+We can do the same — registering an FCM token via the cariad-mbb
+infrastructure and forwarding events to the coordinator for
+near-real-time HA updates + command-result-push notifications.
+
+### Architecture
+
+Three pieces (analog to v1.18.0 Skoda MQTT + v1.19.0 CUPRA/SEAT FCM):
+
+1. **FCM client** (``firebase-messaging`` Python lib, lazy-imported)
+   — Same library v1.18.0/v1.19.0 already use. Registers a device
+   with the Cariad Firebase project, persists credentials via HA
+   ``Store`` helper, listens for push notifications.
+
+2. **Cariad notification subscription** — POST FCM token to Cariad's
+   notification-registration endpoint (TBD live-test, expected at
+   ``mal-1a.prd.ece.vwg-connect.com/api/notification/...``). Reference:
+   audi_connect_ha for the endpoint pattern.
+
+3. **Coordinator callback** — each push event decoded into
+   ``PushUpdateEvent`` and forwarded via ``on_event`` callback. The
+   coordinator decides what to refresh (typically a single
+   ``get_status`` for the affected VIN) AND optionally surfaces a
+   ``persistent_notification`` for command-result events ("Audi A4
+   wurde verriegelt") so user gets HA-side confirmation analog to
+   what the official myAudi app shows.
+
+### Brand scope
+
+Both `audi` and `volkswagen` brands. They share the Cariad-BFF
+backend so the FCM channel is unified — single `AudiVWPushManager`
+instance handles both. Per-VIN routing happens via the FCM message
+payload's `vin` field.
+
+### Foundation status (v1.23.0)
+
+This module mirrors ``skoda_mqtt.py`` + ``cupra_seat_fcm.py`` —
+class structure, state machine, lifecycle hooks complete. Live FCM
+connection code is **lazy-imported** + stubbed.
+
+Live activation requires:
+- Audi/VW owner with active Connect+ subscription (live tester)
+- Verified Cariad Firebase project ID + sender_id
+- Confirmed notification-subscription endpoint URL (audi_connect_ha
+  reference, may have changed)
+- Verified push-event payload schema
+
+These can only be validated end-to-end against the live backend.
+v1.23.x patches will activate the path once a community tester
+confirms.
+
+### References
+
+- audiconnect/audi_connect_ha: notification subscription patterns
+- WulfgarW/homeassistant-pycupra: FCM register flow (similar lib)
+- skodaconnect/myskoda PR #566: TOTP auth pattern (for MBB-side FCM)
+- User-report 2026-05-07: myAudi App push screenshots showing
+  "Ver-/Entriegeln: Audi S6 Avant wurde verriegelt" — the kind of
+  event we'd surface as HA persistent_notification
+
+### Privacy
+
+- VINs masked to last 6 chars in logs
+- user_id masked to first 8 chars
+- OAuth + FCM tokens NEVER logged
+- TLS verifies Cariad cert
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from typing import Any
+
+from .base import PushManager, PushManagerState, PushEventCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+# Cariad FCM project — Firebase project ID used by myAudi/WeConnect
+# mobile apps. Public sender_id from Android google-services.json
+# (TBD live-test verification — placeholder pending tester).
+_CARIAD_FCM_PROJECT_ID = "<pending-tester>"
+_CARIAD_FCM_SENDER_ID = "<pending-tester>"
+_CARIAD_FCM_API_KEY = "<pending-tester>"
+
+# Notification-subscription endpoint base. Same MBB setter base
+# we use elsewhere (verified mal-1a.prd.ece.vwg-connect.com pattern).
+_CARIAD_NOTIFICATION_BASE = "https://mal-1a.prd.ece.vwg-connect.com"
+
+# Reconnect backoff bounds — same constants as v1.18.0 Skoda MQTT
+# + v1.19.0 CUPRA/SEAT FCM for consistency.
+_INITIAL_BACKOFF_S = 5.0
+_MAX_BACKOFF_S = 600.0
+_BACKOFF_MULTIPLIER = 2.0
+_FAST_RETRY_THRESHOLD = 10
+
+
+class AudiVWPushManager(PushManager):
+    """Audi/VW Cariad-BFF FCM push manager.
+
+    Lifecycle mirrors ``SkodaPushManager`` + ``CupraSeatPushManager``:
+
+    1. ``start()`` — lazy-imports firebase-messaging, registers (or
+       restores) FCM credentials, POSTs subscription to Cariad
+       notification endpoint for each VIN, spawns receive loop
+    2. Background loop calls ``self.emit()`` on each push
+    3. On disconnect: backoff + reconnect (refreshes OAuth token)
+    4. ``stop()`` — cancels loop, closes FCM client
+
+    Idempotent ``start()`` and ``stop()``.
+
+    Brand-scope: both ``audi`` and ``volkswagen`` share the Cariad-BFF
+    backend → single manager handles both. Per-VIN routing via FCM
+    message payload's ``vin`` field.
+    """
+
+    def __init__(
+        self,
+        on_event: PushEventCallback,
+        *,
+        user_id: str,
+        access_token_provider: Any,
+        vins: list[str],
+        brand: str,  # "audi" or "volkswagen"
+    ) -> None:
+        """Initialise.
+
+        Args:
+            on_event: Coordinator callback receiving each event.
+            user_id: Cariad user-id (UUID format from IDK token).
+            access_token_provider: Async coroutine returning fresh
+                OAuth access token. Called before each subscription
+                POST to ensure auth is valid.
+            vins: List of VINs to subscribe to. The Cariad notification
+                endpoint may take all VINs in one POST (TBD).
+            brand: Either ``"audi"`` or ``"volkswagen"``. Both share
+                Cariad-BFF — kept as parameter for log clarity.
+        """
+        super().__init__(on_event)
+        if brand not in ("audi", "volkswagen"):
+            raise ValueError(
+                f"AudiVWPushManager: brand must be 'audi' or 'volkswagen', "
+                f"got {brand!r}"
+            )
+        self._user_id = user_id
+        self._access_token_provider = access_token_provider
+        self._vins = list(vins)
+        self._brand = brand
+        self._loop_task: asyncio.Task | None = None
+        self._stop_event: asyncio.Event = asyncio.Event()
+        self._backoff_seconds: float = _INITIAL_BACKOFF_S
+        self._consecutive_fast_retries: int = 0
+
+    async def start(self) -> None:
+        """Spawn the FCM receive loop. Idempotent."""
+        if self._state in (PushManagerState.CONNECTED, PushManagerState.STARTING):
+            return
+        if not self._vins:
+            _LOGGER.info(
+                "Audi/VW push: no VINs to subscribe to — staying STOPPED",
+            )
+            return
+        self._state = PushManagerState.STARTING
+        self._stop_event.clear()
+        try:
+            self._lazy_check_dependencies()
+        except ImportError as err:
+            _LOGGER.warning(
+                "Audi/VW push: required dependency missing — %s. "
+                "Run `pip install firebase-messaging` in your HA env "
+                "or disable the push option. Falling back to polling.",
+                err,
+            )
+            self._state = PushManagerState.UNAVAILABLE
+            return
+        self._loop_task = asyncio.create_task(
+            self._run_loop(),
+            name=f"vag_connect-{self._brand}-push-{self._user_id[-6:]}",
+        )
+
+    async def stop(self) -> None:
+        """Cancel the loop + clean up. Idempotent."""
+        if self._state == PushManagerState.STOPPED:
+            return
+        self._stop_event.set()
+        task = self._loop_task
+        if task and not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=10.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+        self._loop_task = None
+        self._state = PushManagerState.STOPPED
+
+    def _lazy_check_dependencies(self) -> None:
+        """Verify firebase-messaging is importable.
+
+        Cariad uses the same FCM library as v1.18.0 (TOTP for MBB) +
+        v1.19.0 (CUPRA/SEAT FCM transport). Single shared dep.
+        """
+        import importlib  # noqa: PLC0415
+        try:
+            importlib.import_module("firebase_messaging")
+        except ImportError as err:
+            raise ImportError(f"firebase_messaging: {err}") from err
+
+    async def _run_loop(self) -> None:
+        """Reconnect-with-backoff outer loop. Mirrors v1.18.0/v1.19.0."""
+        while not self._stop_event.is_set():
+            try:
+                await self._connect_and_listen()
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Audi/VW push: connection lost (vin count=%d, "
+                    "brand=%s): %s — reconnecting in %.1fs",
+                    len(self._vins),
+                    self._brand,
+                    err,
+                    self._backoff_seconds,
+                )
+                self._state = PushManagerState.RECONNECTING
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(),
+                        timeout=self._backoff_seconds,
+                    )
+                    break
+                except asyncio.TimeoutError:
+                    pass
+                self._advance_backoff()
+
+    async def _connect_and_listen(self) -> None:
+        """One FCM register + Cariad subscribe + receive cycle.
+
+        v1.23.0 foundation: this is a STUB. Real implementation will:
+
+        1. Lazy-import ``firebase_messaging.FcmClient``
+        2. Build FcmRegisterConfig with project_id, sender_id, api_key
+           (PENDING live-test verification — currently placeholders)
+        3. ``await client.checkin_or_register()`` → returns FCM token
+        4. POST token + vins to Cariad notification endpoint with
+           bearer auth from ``self._access_token_provider``
+        5. ``await client.start()`` with on_message callback that
+           parses notification → PushUpdateEvent → ``self.emit()``
+
+        For now: refresh OAuth token then sleep until stopped so the
+        lifecycle state machine can be exercised without network I/O.
+        """
+        token = await self._access_token_provider()  # noqa: F841 — used in real impl
+        self._state = PushManagerState.CONNECTED
+        _LOGGER.info(
+            "Audi/VW push: foundation stub — live activation pending. "
+            "Brand=%s, would register FCM for VINs: %s",
+            self._brand,
+            [f"***{vin[-6:]}" for vin in self._vins],
+        )
+        try:
+            await self._stop_event.wait()
+        except asyncio.CancelledError:
+            raise
+        self._state = PushManagerState.STOPPED
+
+    def _advance_backoff(self) -> None:
+        """Bump backoff with jitter, capped. Mirrors v1.18.0/v1.19.0."""
+        self._consecutive_fast_retries += 1
+        if self._consecutive_fast_retries <= _FAST_RETRY_THRESHOLD:
+            self._backoff_seconds = min(
+                self._backoff_seconds * _BACKOFF_MULTIPLIER,
+                _MAX_BACKOFF_S,
+            )
+        else:
+            self._backoff_seconds = _MAX_BACKOFF_S
+        jitter = self._backoff_seconds * 0.1 * (2 * random.random() - 1)
+        self._backoff_seconds = max(
+            _INITIAL_BACKOFF_S,
+            self._backoff_seconds + jitter,
+        )
+
+    def _reset_backoff(self) -> None:
+        """Reset after successful connect."""
+        self._backoff_seconds = _INITIAL_BACKOFF_S
+        self._consecutive_fast_retries = 0

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.selector import (
 from .const import (
     BRANDS,
     CONF_BRAND,
+    CONF_ENABLE_PUSH_AUDI_VW,
     CONF_ENABLE_PUSH_FCM,
     CONF_ENABLE_PUSH_MQTT,
     CONF_ENABLE_REVERSE_GEOCODING,
@@ -458,6 +459,19 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                     default=current_options.get(
                         CONF_ENABLE_PUSH_FCM,
                         current_data.get(CONF_ENABLE_PUSH_FCM, False),
+                    ),
+                ): _BOOL_SELECTOR,
+                # v1.23.0 (#57 Push Bundle, foundation phase, Audi/VW
+                # track) — opt-in toggle for Audi/VW Cariad-BFF FCM
+                # push updates. Default False; same lazy-import +
+                # foundation pattern as v1.18.0 + v1.19.0. Only
+                # meaningful for brand in {audi, volkswagen}.
+                # User-suggested 2026-05-07 (myAudi App push → HA).
+                vol.Optional(
+                    CONF_ENABLE_PUSH_AUDI_VW,
+                    default=current_options.get(
+                        CONF_ENABLE_PUSH_AUDI_VW,
+                        current_data.get(CONF_ENABLE_PUSH_AUDI_VW, False),
                     ),
                 ): _BOOL_SELECTOR,
             }),

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -49,6 +49,20 @@ CONF_ENABLE_PUSH_MQTT         = "enable_push_mqtt"
 # spawns at coordinator setup, registers FCM, POSTs OLA
 # subscription, forwards events to coordinator.
 CONF_ENABLE_PUSH_FCM          = "enable_push_fcm"
+# v1.23.0 (#57 Push Bundle, foundation phase) — opt-in toggle for
+# Audi/VW Cariad-BFF Firebase Cloud Messaging push updates. Default
+# False because:
+# (1) requires firebase-messaging dep (lazy-imported in
+#     cariad/push/audi_vw_fcm.py — same dep as Skoda v1.18.0 +
+#     CUPRA/SEAT v1.19.0)
+# (2) live activation pending community tester (Audi/VW owner with
+#     active Connect+ subscription) for FCM project + sender_id +
+#     notification-subscription endpoint verification
+# (3) only meaningful for brand in {audi, volkswagen} — others ignore
+# When True + brand matches + dep installed: AudiVWPushManager
+# spawns at coordinator setup. User-suggested feature 2026-05-07
+# (myAudi App push notifications → HA-side feedback channel).
+CONF_ENABLE_PUSH_AUDI_VW      = "enable_push_audi_vw"
 
 # Supported brands — must match CariadClientFactory.create() keys
 BRANDS = {

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
   "requirements": [],
-  "version": "1.22.0"
+  "version": "1.23.0"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -78,7 +78,8 @@
           "read_only_mode": "Read-only Mode",
           "force_ppe_climate": "Audi PPE/PPC Climate body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push updates (MQTT, EXPERIMENTAL)",
-          "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)"
+          "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
+          "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -87,7 +88,8 @@
           "read_only_mode": "When enabled, only status sensors are created — no switches, buttons, locks, climate or sliders that send commands. Useful if you want vehicle telemetry without any risk of accidental actuation. Reload the integration after toggling.",
           "force_ppe_climate": "Audi-only. Forces the new PPE/PPC body shape (climatisationMode mandatory, targetTemperature omitted) on climate start. Enable only if you own a Q6 e-tron, A6 e-tron, RS e-tron GT Facelift or A3 2024+ PHEV — climate-start otherwise returns 400. Reload the integration after toggling.",
           "enable_push_mqtt": "EXPERIMENTAL: Skoda-only. Enables real-time MQTT push from Skoda mysmob backend (requires aiomqtt + firebase-messaging Python packages — currently lazy-imported, not pre-installed). Foundation phase in v1.18.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
-          "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling."
+          "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
+          "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling."
         }
       }
     }

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -75,13 +75,15 @@
           "enable_reverse_geocoding": "Adress-Auflösung (Parkposition)",
           "force_ppe_climate": "Audi PPE/PPC Klima-Body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda Push-Updates (MQTT, EXPERIMENTELL)",
-          "enable_push_fcm": "CUPRA/SEAT Push-Updates (FCM, EXPERIMENTELL)"
+          "enable_push_fcm": "CUPRA/SEAT Push-Updates (FCM, EXPERIMENTELL)",
+          "enable_push_audi_vw": "Audi/VW Push-Updates (Cariad FCM, EXPERIMENTELL)"
         },
         "data_description": {
           "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",
           "force_ppe_climate": "Nur für Audi relevant. Erzwingt das neue PPE/PPC Body-Format (climatisationMode mandatory, targetTemperature weggelassen) beim Klima-Start. Nur aktivieren wenn du einen Q6 e-tron, A6 e-tron, RS e-tron GT Facelift oder A3 2024+ PHEV besitzt — sonst antwortet die API mit 400. Integration nach Aktivierung neu laden.",
           "enable_push_mqtt": "EXPERIMENTELL: Nur für Skoda. Aktiviert MQTT-basierte Echtzeit-Updates vom Skoda mysmob Backend (benötigt aiomqtt + firebase-messaging Python-Pakete — derzeit lazy-imported, nicht vorinstalliert). Foundation-Phase in v1.18.0; Live-Aktivierung wartet auf Validierung durch Community-Tester. Wenn Push nicht verfügbar ist, fällt die Integration still auf Polling zurück. Integration nach Aktivierung neu laden.",
-          "enable_push_fcm": "EXPERIMENTELL: Nur für CUPRA/SEAT. Aktiviert Echtzeit-Updates per Firebase Cloud Messaging vom OLA Backend (benötigt firebase-messaging Python-Paket — gleicher Lazy-Import wie v1.18.0 Skoda MQTT). Foundation-Phase in v1.19.0; Live-Aktivierung wartet auf Validierung durch Community-Tester. Wenn Push nicht verfügbar ist, fällt die Integration still auf Polling zurück. Integration nach Aktivierung neu laden."
+          "enable_push_fcm": "EXPERIMENTELL: Nur für CUPRA/SEAT. Aktiviert Echtzeit-Updates per Firebase Cloud Messaging vom OLA Backend (benötigt firebase-messaging Python-Paket — gleicher Lazy-Import wie v1.18.0 Skoda MQTT). Foundation-Phase in v1.19.0; Live-Aktivierung wartet auf Validierung durch Community-Tester. Wenn Push nicht verfügbar ist, fällt die Integration still auf Polling zurück. Integration nach Aktivierung neu laden.",
+          "enable_push_audi_vw": "EXPERIMENTELL: Nur für Audi/VW. Aktiviert Echtzeit-Push vom Cariad FCM-Channel (gleicher den auch die myAudi/WeConnect Apps nutzen — covers Lock-Result, Charging-State, Climate, Alarm). Benötigt firebase-messaging (gleicher Lazy-Import wie v1.18.0 Skoda + v1.19.0 CUPRA/SEAT). Foundation-Phase in v1.23.0; Live-Aktivierung wartet auf Community-Tester. Wenn Push nicht verfügbar ist, fällt die Integration still auf Polling zurück. Integration nach Aktivierung neu laden."
         }
       }
     }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,6 +150,7 @@ Strict order — P0 (next release) > P1 (planned MINOR) > P2 (later) > P3 (resea
 | ~~v1.20.3~~ | Cariad-wrapper-404 Detection + Switch Hasattr-Gate (8 user-reports Audi A4 B9 + Q5 2021 + VW Golf 7 2015): body-sniff für `"Upstream service responded"` + `"retry":true` → BACKEND_ERROR (transient, retry-friendly), switch hasattr-gate verhindert AttributeError für brand-X-only methods | done |
 | ~~v1.21.0~~ | Audi/VW MBB Legacy-Path Migration Phase 1 — strukturelle Lösung für 8 user-bugs: per-VIN backend-detection (`MBBBackendCache`), HomeRegion-Helper aktiviert (war seit v1.17.6 scaffolding), `command_wake` auto-fallback Cariad→MBB on wrapper-404. Phase 2+ folgt für lock/climate/charger | done |
 | ~~v1.22.0~~ | Skoda Widget Render → Image Entity (Bundle 2 Phase B Pragmatic) — `VagSkodaWidgetImageEntity` exposes `data["render_url"]` aus v1.20.0 widget endpoint als `image.<vin>_render_widget` Entity mit local cache | done |
+| ~~v1.23.0~~ | Audi/VW Push Foundation (Cariad FCM channel, user-suggested 2026-05-07) — `cariad/push/audi_vw_fcm.py` mit `AudiVWPushManager` Klasse erbt von PushManager. Brand-validation für audi/volkswagen, identical lifecycle wie v1.18.0/v1.19.0, lazy-import firebase-messaging. Neuer `CONF_ENABLE_PUSH_AUDI_VW` toggle. Foundation komplett für alle 3 push-tracks (Skoda + CUPRA/SEAT + Audi/VW). 12 neue Tests | done |
 
 ### 🔴 P0 — Nächste Releases (post v1.19.0)
 

--- a/tests/test_v1230_audi_vw_push_foundation.py
+++ b/tests/test_v1230_audi_vw_push_foundation.py
@@ -1,0 +1,261 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""Tests for v1.23.0 — Audi/VW Cariad FCM push foundation.
+
+Mirrors v1.18.0 (Skoda MQTT) + v1.19.0 (CUPRA/SEAT FCM) test layout —
+AudiVWPushManager shares the abstract PushManager base + identical
+lifecycle/state-machine semantics.
+
+User-suggested 2026-05-07: "weil ich auf der app push nachrichten
+bekomme, könnte man das doch auch auf der integration als feedback
+nehmen?" — myAudi App push notifications surface as HA-side feedback
+once Phase 2 wires the receive loop.
+
+Foundation phase: class structure, state machine, lifecycle, opt-in
+toggle. Live FCM activation requires a community Audi/VW tester for
+Cariad Firebase project + sender_id + notification-subscription
+endpoint validation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_token_provider():
+    return AsyncMock(return_value="fake-oauth-token-789")
+
+
+@pytest.fixture
+def mock_callback():
+    return AsyncMock()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A) Brand validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBrandValidation:
+    def test_audi_or_volkswagen_only(self, mock_callback, mock_token_provider):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+        for brand in ("audi", "volkswagen"):
+            m = AudiVWPushManager(
+                mock_callback,
+                user_id="u",
+                access_token_provider=mock_token_provider,
+                vins=["V"],
+                brand=brand,
+            )
+            assert m._brand == brand
+        for bad in ("skoda", "cupra", "seat", "porsche", "vw_eu", ""):
+            with pytest.raises(ValueError, match="brand must be"):
+                AudiVWPushManager(
+                    mock_callback,
+                    user_id="u",
+                    access_token_provider=mock_token_provider,
+                    vins=["V"],
+                    brand=bad,
+                )
+
+    def test_initial_state_is_stopped(self, mock_callback, mock_token_provider):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+        from custom_components.vag_connect.cariad.push.base import PushManagerState
+        m = AudiVWPushManager(
+            mock_callback,
+            user_id="u",
+            access_token_provider=mock_token_provider,
+            vins=["V"],
+            brand="audi",
+        )
+        assert m.state == PushManagerState.STOPPED
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B) Lifecycle
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_no_vins_stays_stopped(self, mock_callback, mock_token_provider):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+        from custom_components.vag_connect.cariad.push.base import PushManagerState
+        m = AudiVWPushManager(
+            mock_callback,
+            user_id="u",
+            access_token_provider=mock_token_provider,
+            vins=[],
+            brand="audi",
+        )
+        await m.start()
+        assert m.state == PushManagerState.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_missing_firebase_messaging_yields_unavailable(
+        self, mock_callback, mock_token_provider, monkeypatch,
+    ):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+        from custom_components.vag_connect.cariad.push.base import PushManagerState
+        original = importlib.import_module
+        def fake(name, *a, **k):
+            if name == "firebase_messaging":
+                raise ImportError("not installed")
+            return original(name, *a, **k)
+        monkeypatch.setattr(importlib, "import_module", fake)
+        m = AudiVWPushManager(
+            mock_callback,
+            user_id="u",
+            access_token_provider=mock_token_provider,
+            vins=["V"],
+            brand="volkswagen",
+        )
+        await m.start()
+        assert m.state == PushManagerState.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_start_then_stop_cleanup(
+        self, mock_callback, mock_token_provider, monkeypatch,
+    ):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+        from custom_components.vag_connect.cariad.push.base import PushManagerState
+        m = AudiVWPushManager(
+            mock_callback,
+            user_id="u",
+            access_token_provider=mock_token_provider,
+            vins=["V"],
+            brand="audi",
+        )
+        monkeypatch.setattr(m, "_lazy_check_dependencies", lambda: None)
+        await m.start()
+        await asyncio.sleep(0.05)
+        assert m.state == PushManagerState.CONNECTED
+        await m.stop()
+        assert m.state == PushManagerState.STOPPED
+        assert m._loop_task is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C) Backoff
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBackoff:
+    def _new_manager(self, brand="audi"):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+        return AudiVWPushManager(
+            AsyncMock(),
+            user_id="u",
+            access_token_provider=AsyncMock(return_value="t"),
+            vins=["V"],
+            brand=brand,
+        )
+
+    def test_backoff_constants_match_other_managers(self):
+        """Same backoff bounds as v1.18.0 Skoda + v1.19.0 CUPRA/SEAT
+        for behavioural consistency across all 3 push managers."""
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            _INITIAL_BACKOFF_S, _MAX_BACKOFF_S,
+        )
+        assert _INITIAL_BACKOFF_S == 5.0
+        assert _MAX_BACKOFF_S == 600.0
+
+    def test_advance_grows_backoff(self):
+        m = self._new_manager()
+        initial = m._backoff_seconds
+        m._advance_backoff()
+        assert m._backoff_seconds > initial
+
+    def test_advance_capped(self):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import _MAX_BACKOFF_S
+        m = self._new_manager()
+        for _ in range(50):
+            m._advance_backoff()
+        assert m._backoff_seconds <= _MAX_BACKOFF_S * 1.15
+
+    def test_reset_to_initial(self):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import _INITIAL_BACKOFF_S
+        m = self._new_manager()
+        m._advance_backoff()
+        m._reset_backoff()
+        assert m._backoff_seconds == _INITIAL_BACKOFF_S
+        assert m._consecutive_fast_retries == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D) Const + Config-Flow option exposure
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestConfigFlowOption:
+    def test_const_defines_option_key(self):
+        from custom_components.vag_connect.const import CONF_ENABLE_PUSH_AUDI_VW
+        assert CONF_ENABLE_PUSH_AUDI_VW == "enable_push_audi_vw"
+
+    def test_three_push_toggles_coexist(self):
+        """All 3 brand-tracks have independent toggles — Skoda MQTT
+        (v1.18), CUPRA/SEAT FCM (v1.19), Audi/VW FCM (v1.23). User
+        with mixed fleet can opt-in to any combination."""
+        from custom_components.vag_connect import config_flow
+        for attr in (
+            "CONF_ENABLE_PUSH_MQTT",
+            "CONF_ENABLE_PUSH_FCM",
+            "CONF_ENABLE_PUSH_AUDI_VW",
+        ):
+            assert hasattr(config_flow, attr), f"missing {attr}"
+
+    def test_three_distinct_option_names(self):
+        from custom_components.vag_connect import config_flow
+        keys = {
+            config_flow.CONF_ENABLE_PUSH_MQTT,
+            config_flow.CONF_ENABLE_PUSH_FCM,
+            config_flow.CONF_ENABLE_PUSH_AUDI_VW,
+        }
+        assert len(keys) == 3
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E) Inheritance + module exports
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInheritance:
+    def test_extends_pushmanager_base(self):
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+        from custom_components.vag_connect.cariad.push.base import PushManager
+        assert issubclass(AudiVWPushManager, PushManager)
+
+    def test_all_three_managers_share_base(self):
+        """All 3 brand-track managers inherit from PushManager —
+        coordinator can hold any of them via type hint
+        ``self._push_manager: PushManager | None``."""
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+        from custom_components.vag_connect.cariad.push.cupra_seat_fcm import (
+            CupraSeatPushManager,
+        )
+        from custom_components.vag_connect.cariad.push.skoda_mqtt import (
+            SkodaPushManager,
+        )
+        from custom_components.vag_connect.cariad.push.base import PushManager
+        for cls in (AudiVWPushManager, CupraSeatPushManager, SkodaPushManager):
+            assert issubclass(cls, PushManager)


### PR DESCRIPTION
MINOR-Release. Dritte und letzte Push-Foundation. User-suggested 2026-05-07.

## Was
`AudiVWPushManager` als Foundation für Cariad FCM-channel push (gleicher Channel wie myAudi/WeConnect Apps).

## Architecture
- Inherits from `PushManager` (v1.18.0 base)
- Brand-validation: audi or volkswagen
- Lazy-import firebase-messaging (same lib as v1.18/v1.19)
- Identical lifecycle + backoff
- SCAFFOLDING — not wired to coordinator yet

## Push tracks now (all foundations complete)
| Brand | Module | Toggle | Live |
|---|---|---|---|
| Skoda | skoda_mqtt.py (v1.18) | CONF_ENABLE_PUSH_MQTT | pending |
| CUPRA/SEAT | cupra_seat_fcm.py (v1.19) | CONF_ENABLE_PUSH_FCM | pending |
| Audi/VW | audi_vw_fcm.py (v1.23) | CONF_ENABLE_PUSH_AUDI_VW | pending |

## Tests
12 cases in test_v1230_audi_vw_push_foundation.py.

## Strict semver: MINOR