### PR TITLE
v1.25.0 PR-D: CommandDispatcher foundation (Phase 1A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+### 🏗️ v1.25.0 Sprint C PR-D — CommandDispatcher Foundation (Phase 1A)
+
+- **Neuer `_command_dispatcher.py`** Modul mit `CommandDispatcher` Klasse — owns per-VIN per-command-class lock map + wake cooldown timestamps. Coordinator delegiert via `self._dispatcher` statt der bisherigen `if not hasattr(self, "_command_locks")` lazy-init Code-Smells.
+- Coordinator `__init__` instantiiert dispatcher; `_get_command_lock`, `is_command_in_flight`, wake-cooldown reads/writes delegieren durch.
+- **Phase 1A only**: Lock-state + cooldown-state extracted, **command method bodies (~750 LOC) bleiben in `coordinator.py`**. Phase 2 (full method extraction + `CapabilityCache` + `EnrichmentService` extracts) ist deferred zu v1.26.0 als architektureller Refactor-Sprint — pure Architektur-Änderungen ohne user-visible benefit passen nicht zu "MVP-haft fortschreiten".
+- Removes 4 `if not hasattr(self, ...)` lazy-init smells.
+- Foundation lays groundwork — v1.26.0 Phase 2 extraction wird mechanisch (jede Methode ändert nur `self.X` → `self._coordinator.X`).
+
 ### 🔄 v1.25.0 Sprint C PR-C — Listener Pattern (10 Platforms) + GPS Hardening
 
 - **Adoption von volkswagencarnet PR #943 Pattern**: Neuer `register_dynamic_spawner()` Helper in `entity_base.py` der von 10 Platforms verwendet wird (sensor, binary_sensor, switch, lock, climate, button, number, select, time, device_tracker). Vorher: vehicles asleep at HA startup bekamen ihre Entitäten erst nach HA-Restart wenn Auto wach. Jetzt: dynamischer Listener spawnt Entitäten sobald Coordinator-Daten ankommen — kein Restart mehr nötig.

--- a/custom_components/vag_connect/_command_dispatcher.py
+++ b/custom_components/vag_connect/_command_dispatcher.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""Command dispatcher — per-VIN per-command-class lock + cooldown state.
+
+v1.25.0 PR-D Foundation: extracts the lock-map + wake-cooldown state
+out of `coordinator.py`'s lazy-init `if not hasattr(self, ...)` smell
+into a properly-typed helper class. Coordinator now holds
+``self._dispatcher: CommandDispatcher`` and forwards lock/cooldown
+queries through it.
+
+**This is Phase 1A** — the helper class is established; the 30+
+``async_lock`` / ``async_unlock`` / ``async_start_climate`` / etc.
+command-method bodies stay in ``coordinator.py`` for now (~750 LOC
+that the original Sprint-C-Plan PR-C envisioned moving). Phase 2
+of the coordinator refactor (= moving those methods into the
+dispatcher proper, plus extracting CapabilityCache + EnrichmentService)
+is deferred to **v1.26.0** — see ``docs/SPRINT_C_v1.25.0_PLAN.md``
+"After-v1.25.0 Roadmap" + "Out-of-Scope for v1.25.0".
+
+Pragmatic rationale:
+- v1.25.0 already ships massive user-visible value (cross-brand
+  parity wins, listener pattern, GPS hardening, write-side bundle,
+  UX/UI mega-bundle, MBB Phase 2)
+- A 1-2 day pure-architectural refactor with **zero user benefit**
+  doesn't fit "MVP-haft fortschreiten" (Prash 2026-05-09)
+- The dispatcher class established here makes the v1.26.0 Phase 2
+  extraction mechanical: each method moves intact, just changes
+  ``self.X`` → ``self._coordinator.X``
+
+The Phase 1A work itself: removes a code smell (lazy-init via
+hasattr) + creates the architectural marker. Coordinator size
+delta is small but the new module signals intent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .coordinator import VagConnectCoordinator
+
+
+class CommandDispatcher:
+    """Owns per-VIN per-command-class lock + wake-cooldown state.
+
+    Coordinator delegates lock acquisition + wake-cooldown checks
+    through this helper. Phase 1A: state container only — actual
+    command method bodies still live in ``coordinator.py``.
+    """
+
+    def __init__(self, coordinator: VagConnectCoordinator) -> None:
+        self._coordinator = coordinator
+        # v1.13.0 (#63 Phase 2) — per-VIN per-command-class asyncio.Lock
+        # so a stuck command doesn't permanently freeze the entity.
+        # ``command_class`` is the high-level grouping (e.g. ``"lock"``,
+        # ``"climate"``, ``"charging"``) — finer than command_id (which
+        # distinguishes start/stop) so the user can still do
+        # ``start_climate`` while a previous ``stop_climate`` is in flight.
+        self._command_locks: dict[tuple[str, str], asyncio.Lock] = {}
+        # v1.13.0 (#63 Phase 3) — per-VIN wake cooldown timestamp.
+        # 5-min anti-double-click cooldown catches "user pressed wake
+        # button twice quickly" or automation-bug repeat triggers BEFORE
+        # incrementing the daily budget.
+        self._wake_last_at: dict[str, datetime] = {}
+
+    def get_command_lock(self, vin: str, command_class: str) -> asyncio.Lock:
+        """Lazily create a per-VIN per-command-class lock and return it."""
+        key = (vin, command_class)
+        lock = self._command_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._command_locks[key] = lock
+        return lock
+
+    def is_command_in_flight(self, vin: str, command_class: str) -> bool:
+        """True if a command for this VIN+command-class is currently locked.
+
+        Entity layer can use this to render a ``transitioning`` / ``busy``
+        UI hint without taking the entity unavailable.
+        """
+        lock = self._command_locks.get((vin, command_class))
+        return bool(lock and lock.locked())
+
+    def record_wake(self, vin: str) -> None:
+        """Stamp the last-wake timestamp for cooldown tracking."""
+        self._wake_last_at[vin] = datetime.now(tz=timezone.utc)
+
+    def seconds_since_last_wake(self, vin: str) -> float | None:
+        """Return seconds since last wake for ``vin``, or None if never woken."""
+        last = self._wake_last_at.get(vin)
+        if last is None:
+            return None
+        delta = datetime.now(tz=timezone.utc) - last
+        return delta.total_seconds()

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -394,6 +394,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         self._was_available: bool = True  # tracks availability for log_when_unavailable
         self._cariad_client: Any = None
 
+        # v1.25.0 PR-D Phase 1A: command dispatcher owns lock-map +
+        # wake-cooldown state. Coordinator delegates lock acquisition
+        # + cooldown checks through the dispatcher. See
+        # ``_command_dispatcher.py`` module docstring for refactor plan.
+        from ._command_dispatcher import CommandDispatcher  # noqa: PLC0415
+        self._dispatcher = CommandDispatcher(self)
+
         # Thread-safe dict for vehicle data
         self.vehicles: dict[str, Any] = {}
         self._vehicles_lock = threading.Lock()
@@ -2185,38 +2192,32 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             return str(data.get(CONF_SPIN) or "")
         return ""
 
+    def _ensure_dispatcher(self) -> Any:  # CommandDispatcher (avoid TYPE_CHECKING import)
+        """Return ``self._dispatcher``, lazily creating one if missing.
+
+        v1.25.0 PR-D: tests that bypass __init__ via __new__() may not
+        have a dispatcher set; this fallback ensures coord-level
+        delegations still work. Production __init__ sets it eagerly.
+        """
+        from ._command_dispatcher import CommandDispatcher  # noqa: PLC0415
+        d = getattr(self, "_dispatcher", None)
+        if d is None:
+            d = CommandDispatcher(self)
+            self._dispatcher = d
+        return d
+
     def _get_command_lock(self, vin: str, command_class: str) -> asyncio.Lock:
         """v1.13.0 (#63 Phase 2) — per-VIN per-command-class asyncio.Lock.
 
-        Lazily-created. Stored in ``self._command_locks: dict[(vin, class),
-        Lock]``. Use with ``async with asyncio.timeout(60): async with
-        lock`` so a stuck command doesn't permanently freeze the entity.
-
-        ``command_class`` is the high-level grouping (e.g. ``"lock"``,
-        ``"climate"``, ``"charging"``) — finer than command_id (which
-        distinguishes start/stop) so the user can still do
-        ``start_climate`` while a previous ``stop_climate`` is in flight.
+        v1.25.0 PR-D: state moved to ``self._dispatcher`` (CommandDispatcher).
+        See ``_command_dispatcher.py`` module docstring for refactor plan.
         """
-        if not hasattr(self, "_command_locks"):
-            self._command_locks: dict[tuple[str, str], asyncio.Lock] = {}
-        key = (vin, command_class)
-        lock = self._command_locks.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._command_locks[key] = lock
-        return lock
+        return self._ensure_dispatcher().get_command_lock(vin, command_class)  # type: ignore[no-any-return]
 
     def is_command_in_flight(self, vin: str, command_class: str) -> bool:
-        """v1.13.0 (#63 Phase 2) — True if a command for this
-        VIN+command-class is currently locked (= API call running).
-
-        Entity layer can use this to render a ``transitioning``/``busy``
-        UI hint without taking the entity unavailable.
-        """
-        if not hasattr(self, "_command_locks"):
-            return False
-        lock = self._command_locks.get((vin, command_class))
-        return bool(lock and lock.locked())
+        """v1.13.0 (#63 Phase 2) / v1.25.0 PR-D delegated — True if a
+        command for this VIN+command-class is currently locked."""
+        return self._ensure_dispatcher().is_command_in_flight(vin, command_class)  # type: ignore[no-any-return]
 
     def is_read_only(self) -> bool:
         """v1.12.0 (#63) — return True if user enabled Read-only Mode.
@@ -2490,9 +2491,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # automation-bug repeat triggers BEFORE incrementing the daily
         # budget. In-memory only (restart resets — that's fine, restart
         # is intentional).
-        if not hasattr(self, "_wake_last_at"):
-            self._wake_last_at: dict[str, datetime] = {}
-        last_at = self._wake_last_at.get(vin)
+        # v1.25.0 PR-D: state moved to ``self._dispatcher`` (CommandDispatcher).
+        last_at = self._ensure_dispatcher()._wake_last_at.get(vin)
         if last_at is not None and (now - last_at) < _WAKE_COOLDOWN:
             remaining_s = int((_WAKE_COOLDOWN - (now - last_at)).total_seconds())
             _LOGGER.warning(
@@ -2537,7 +2537,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         count += 1
         self._wake_counts[vin] = (today, count)
         # v1.13.0 (#63 Phase 3) — record cooldown timestamp.
-        self._wake_last_at[vin] = now
+        # v1.25.0 PR-D: state moved to dispatcher.
+        self._ensure_dispatcher()._wake_last_at[vin] = now
         # Push count into vehicle data so the sensor sees it on next read.
         with self._vehicles_lock:
             current = self.vehicles.get(vin)

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -2344,6 +2344,11 @@ class TestCariadCmd:
         coord._was_available = True
         coord.vehicles = {"VIN1": {}}
         coord.async_request_refresh = AsyncMock()
+        # v1.25.0 PR-D: CommandDispatcher state. __new__ bypasses __init__
+        # which normally creates this; tests need to attach a working
+        # dispatcher so _get_command_lock + wake-cooldown delegations work.
+        from custom_components.vag_connect._command_dispatcher import CommandDispatcher
+        coord._dispatcher = CommandDispatcher(coord)
         return coord
 
     def test_cariad_cmd_no_client_logs_error(self):

--- a/tests/test_v1120_features.py
+++ b/tests/test_v1120_features.py
@@ -195,8 +195,10 @@ class TestSmartWakeCounter:
             asyncio.get_event_loop().run_until_complete(coord.async_wake_vehicle("VINX"))
             # v1.13.0 (#63) — clear the 5-min cooldown so the loop can
             # advance the budget counter without hitting wake_cooldown_active.
-            if hasattr(coord, "_wake_last_at"):
-                coord._wake_last_at.clear()
+            # v1.25.0 PR-D: state moved to dispatcher
+            d = getattr(coord, "_dispatcher", None)
+            if d is not None and hasattr(d, "_wake_last_at"):
+                d._wake_last_at.clear()
         assert coord.vehicles["VINX"]["wake_count_today"] == 2
 
     def test_wake_budget_exhausted_raises(self):
@@ -211,8 +213,10 @@ class TestSmartWakeCounter:
             )
             # v1.13.0 (#63) — clear the 5-min cooldown between iterations
             # so the budget-exhaust path is the one being tested.
-            if hasattr(coord, "_wake_last_at"):
-                coord._wake_last_at.clear()
+            # v1.25.0 PR-D: state moved to dispatcher
+            d = getattr(coord, "_dispatcher", None)
+            if d is not None and hasattr(d, "_wake_last_at"):
+                d._wake_last_at.clear()
         # One more should raise (budget exhausted, not cooldown)
         with pytest.raises(ServiceValidationError):
             asyncio.get_event_loop().run_until_complete(


### PR DESCRIPTION
Sub-PR 4/7 of v1.25.0. Pragmatic minimum-viable refactor: state-only extract. Command method bodies (~750 LOC) stay in coordinator. Phase 2 deferred to v1.26.0. 🤖 [Claude Code](https://claude.com/claude-code)