### PR TITLE
docs: README cleanup (HACS-Standard) + Golf 7 GTE Tank Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+### 📝 Docs / Docs
+
+- **README.md (DE) komplett refactored** auf saubere HACS-Standard-Struktur (472 → 218 Zeilen, 54% schlanker). Klare Sektionen: Was-es-kann / Supported brands matrix / Installation 3-Optionen / Konfiguration Tabelle / Was-du-bekommst / Lovelace examples / FAQ / Privacy / Roadmap / Contributing / License. Historische Session-Notes raus → bleiben in `docs/ROADMAP.md` + `docs/CHANGELOG_TECHNICAL.md`.
+- **README.en.md** spiegelt gleiche Struktur, English mirror.
+- **`docs/GOLF_7_GTE_TANK_GUIDE.md`** neu (130 Zeilen): Step-by-step User-Anleitung für v1.25.0 PR-G MBB VSR Phase 2 Tank-Level fallback. Voraussetzungs-Tabelle, Logs-Pattern, 3 Diagnose-Szenarien, worst-case Alternative-Wege (OBD-II, EU Data Act, CarConnectivity-connector debug), Reporting-Template für Issue #160 follow-up.
+
 ## [1.25.0] - 2026-05-09 🚀 Sprint C — Cross-Brand Parity + UX/UI + MBB VSR Phase 2 (Golf 7 GTE Tank) / Sprint C — Cross-Brand Parity + UX/UI + MBB VSR Phase 2 (Golf 7 GTE Tank)
 
 🚀 **MINOR-Release.** Größter Sprint seit v1.21.0 (8. Mai 2026). Bündelt 6 PRs (#168, #169, #170, #171 + final mega) mit:

--- a/README.en.md
+++ b/README.en.md
@@ -5,24 +5,23 @@
 <h1 align="center">VAG Connect</h1>
 
 <p align="center">
-  <strong>Home Assistant Integration for Audi · VW · Škoda · SEAT · CUPRA</strong>
+  <strong>Home Assistant Integration for Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
+  <em>One integration for all 7 VAG brands — direct API access, no middleware</em>
 </p>
 
 <p align="center">
-  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
-  <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha" alt="Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
+  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2024.4%2B-blue" alt="Home Assistant"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
 </p>
 
 <p align="center">
-  <a href="../README.md">Deutsch</a> ·
-  <a href="README.en.md">English</a> ·
+  <a href="README.md">Deutsch</a> ·
   <a href="README.fr.md">Français</a> ·
-  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.es.md">Español</a> ·
+  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.pl.md">Polski</a> ·
   <a href="README.cs.md">Čeština</a> ·
   <a href="README.sv.md">Svenska</a>
@@ -30,235 +29,190 @@
 
 ---
 
-**VAG Connect** connects Home Assistant directly to your Audi, VW, Škoda, SEAT, CUPRA, Porsche or VW US/CA — no middleware, no Docker, no extra service. Enter your app credentials, done.
+## 🚗 What it does
 
-80+ entities across 10 platforms, 14 services, cloud-polling architecture. All 7 VAG Group brands in one integration — no separate plugin per brand needed.
+Connects Home Assistant **directly** to your vehicle cloud account (myAudi, We Connect ID, MyŠkoda, MyCupra, MySeat, My Porsche, MyVW). **No middleware, no Docker, no extra service** — log in with your app credentials, done.
 
-Since v0.14.1, VAG Connect speaks **directly** to the CARIAD API via its own async client. No external dependencies, no upstream blockers.
+- **80+ entities** across **10 HA platforms** (sensors, switches, climate, lock, etc.)
+- **14 services** (lock, climate, charging, departure-timer, etc.)
+- **Vehicle render as device picture** + Custom Lovelace card support
+- **GPS position on the HA map** as TrackerEntity
+- **Multi-vehicle support** per account
+- **Read-only mode** for safe use in automations
+- **HACS Quality Scale: Platinum** ⭐
 
-> ✅ **Active multi-brand successor** to [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archived 2025-10-29) and [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). One integration for Audi, VW, Škoda, SEAT, CUPRA, Porsche and VW US/CA — no separate plugin per brand.
+> ✅ **Actively-maintained multi-brand successor** to [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archived 10/2025) and [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 03/2025).
 
-## Current Status & Honest Limits (v1.24.1)
+---
 
-VAG Connect is under active development. So you know what works and what's coming:
+## 📋 Supported brands
 
-### ✅ What works NOW (all 7 brands)
-
-**🛰️ 1-Click Bug Reports & Feature Requests (LIVE since v1.9.0)**
-
-Two diagnostic sensors with a shared reporter pipeline — **first real live-validation by community users** in v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) and v1.12.3 (DnnsJp74 / Audi):
-
-- 🔬 **Vehicle Data Scout** — automatically detects unknown JSON fields in your car's API. Brand-localized in 8 languages (DE: API-Beobachter, FR: Observateur d'API, etc.).
-- 🚨 **Error Reporter** — Ring-buffer of the last 20 integration errors with anonymized context (model, firmware, stack trace).
-- 🔘 **Reporter Pipeline:** both sensors automatically create HA Repair notifications with a pre-filled GitHub issue as a 1-click link. Plus a diagnostics download with everything masked for forum/Facebook.
-- 🔒 **Privacy promise:** Nothing leaves your HA without your explicit click. VINs masked, GPS rounded to 1 decimal, JWTs/UUIDs/emails removed. GDPR-compliant.
-
-**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
-
-`connection_state` sensor (online / standby / offline) for Audi, VW EU, Škoda, SEAT, CUPRA — first VAG integration with centralized connection status. Brand-agnostic helper `compute_connection_state` with recursive `carCapturedTimestamp` walk.
-
-**🔋 12V Battery Monitoring + Smart-Wake (v1.12.0)**
-
-- `voltage_12v` sensor (V) + `warning_12v_low` binary at <11.5V — prevents silent API outages caused by an empty starter battery
-- `wake_count_today` sensor + soft-cap of 3 wakes/day (`_WAKE_BUDGET_PER_DAY`) protects 12V from wake-loops, raises `wake_budget_exhausted` BEFORE the API call
-
-**💨 Optimistic UI for Lock/Climate/Charging (v1.11.1)**
-
-Switches flip immediately on click (myskoda PR #832 pattern), API roundtrip in the background. On failure: revert + ServiceValidationError. 8 actuator methods migrated.
-
-**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up in v1.11.1)**
-
-Three explicit range sensors: `electric_range_km`, `combustion_range_km`, `total_range_km`. VW EU/Audi parser classifies by engine type (4 sources instead of 2). Audi diesel fallback from `measurements.rangeStatus.value.dieselRange`. Verified via evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity logs.
-
-**🔒 Read-only Mode Phase 1 (v1.12.0)**
-
-Options toggle "Read-only Mode" → skip lock/switch/button(non-refresh)/climate/number platforms for privacy/safety-conservative owners. Sensors + binary_sensors + device_tracker remain.
-
-**⚡ Writeable Max-Charge-Current Number (v1.12.0)**
-
-Slider 6–32A instead of just a read-only sensor. New `command_set_max_charge_current` POST chargingSettings.
-
-**💡 Per-Light Binary-Sensors (v1.12.0)**
-
-Dynamically per light type from `lights_individual` dict + aggregate `lights_on` + `lights_count`.
-
-**🛠️ Defensive Stability (v1.8.7 + v1.10.1)**
-
-- 504-retry, transient-network-error retry, 6h stale-cache + 3-failure tolerance
-- Token-refresh-storm protection (max 3/h) — prevents IP bans
-- `safe_int` / `safe_float` / `safe_enum` helpers — tolerate backend quirks
-
-**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhard's #53 first live-validation)**
-
-Field-name fallback chain: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerance for `"connected"` / `"locked"`. Backwards compatibility preserved.
-
-**🔓 Lock + Wake for Audi/VW (v1.9.1, #92 Audi S6 C8)**
-
-`command_lock` now sends S-PIN for Audi/VW (CARIAD BFF answered `403 spin_error`). `command_wake` uses v1→v2 fallback.
-
-**🛡️ Capability-Filter Phase 2 (v1.9.1, #56)**
-
-`classify_command_failure` body-sniffing for `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error` markers. `_cariad_cmd` writes every outcome to FeatureState. Command-bound entities (Lock/Climate/Switch/Buttons) automatically go unavailable on a definitive backend "no".
-
-### ⚠️ Still in progress / What's still planned (planned sessions)
-
-- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Phase 3 (`capability.active && user-enabled` PRE-entity-creation, hides buttons like the MyCupra app) + Read-only Phase 2/3 (Command-Locking + cloud_refresh vs wake_vehicle service separation).
-- **v1.14.0 MINOR** — Trip Statistics from Audi `tripstatistics/v1` (#24, #35).
-- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26).
-- **v1.16.0 MINOR** — Location-specific Charge-Target SoC + Charge profiles (#25, #31).
-- **v1.17.0 MINOR** — Remote Start ICE (#28, audi_connect_ha #717 pattern).
-- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) for real-time updates without polling (#57, #27).
-- **v2.0.0 MAJOR** — HACS Default + Live tests all brands + EU Data Act ready (pycupra `EUDAConnection` as reference, September 2026 deadline) (#13, #59).
-
-### 🚫 Conscious limits
-
-- **Image platform:** no official CARIAD render-image API exists. The image entity will switch to user-supplied URLs in a future release.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — new E³ 1.2 architecture, not yet publicly reverse-engineered (not even in audi_connect_ha or CarConnectivity). VAG Connect detects these vehicles and does **graceful degradation** instead of 404 errors.
-- **Ford / non-VAG brands:** out of scope — see [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) for Ford.
-
-### 🔧 Privacy prerequisite
-
-For GPS position, vehicle status and pre-heating to work, **"Share my position"** must be enabled in your My-VW / My-Audi / MySkoda / MyCupra app — otherwise the backend responds with 403.
-
-### 📚 More info
-
-- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — complete P0/P1/P2/P3 prioritization of all open issues
-- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release field mappings + architecture decisions + external source refs
-- 🤝 Session Handoff (for contributors & AI tools): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔒 Privacy & data handling rules: [`CONTRIBUTING.md`](CONTRIBUTING.md) section (post-#53 third-party review)
-- 📋 FAQ Subscription / Service Plus / `missing-capability` diagnosis: [`CONTRIBUTING.md`](CONTRIBUTING.md) FAQ section
-
-## Supported Brands
-
-| Brand | Auth | API | Status |
+| Brand | Backend | Status | Highlights |
 |---|---|---|---|
-| **Volkswagen EU** | IDK | emea.bff.cariad.digital | ✅ |
-| **Audi** | IDK + AZS/MBB | emea.bff.cariad.digital | ✅ |
-| **Škoda** | IDK | mysmob.api.connect.skoda-auto.cz | ✅ |
-| **SEAT** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| **CUPRA** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
-| VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
-
-> **Porsche & VW NA:** Both brands are available as Beta since v1.0.0. Porsche uses Auth0 (separate from VAG IDK), VW NA uses a separate auth server. Testers wanted — report feedback as an [Issue](https://github.com/its-me-prash/vag-connect-ha/issues)!
+| **Audi** (myAudi) | Cariad-BFF + MBB Legacy | ✅ Stable | PPC/PPE climate, ICE engine start (#28) |
+| **Volkswagen EU** (We Connect ID) | Cariad-BFF + MBB Legacy | ✅ Stable | PHEV range-triple, MBB tank fallback for Golf 7 GTE |
+| **Škoda** (MyŠkoda mysmob) | Skoda mysmob | ✅ Stable | Charging profiles, OTA, workshop attrs, multi-angle renders |
+| **SEAT** (MySEAT OLA) | OLA | ✅ Stable | OLA viewPoint renders (4-7 views) |
+| **CUPRA** (MyCupra OLA) | OLA | ✅ Stable | OLA viewPoint renders, Born MY26 firmware shapes |
+| **Porsche** (My Porsche) | PPA + Auth0 | ✅ Stable | Own HTTP hardening (retry/quota/storm-protection) |
+| **VW US/CA** (myVW NA) | VW NA Cloud | 🟡 Beta | Charge ETA, climate, lock, doors |
 
 ---
 
-## Features
+## 🚀 Installation (HACS)
 
-| Feature | Audi | VW EU | Škoda | SEAT/CUPRA |
-|---|:---:|:---:|:---:|:---:|
-| Fuel / Battery level | ✓ | ✓ | ✓ | ✓ |
-| Range | ✓ | ✓ | ✓ | ✓ |
-| Odometer | ✓ | ✓ | ✓ | ✓ |
-| GPS position | ✓ | ✓ | ✓ | ✓ |
-| Doors (total + per door) | ✓ | ✓ | ✓ | ✓ |
-| Windows | ✓ | ✓ | ✓ | ✓ |
-| Climate start/stop | ✓ | ✓ | ✓ | ✓ |
-| Target temperature | ✓ | ✓ | ✓ | ✓ |
-| Lock / Unlock | ✓ | ✓ | ✓ | ✓ |
-| Flash lights | ✓ | ✓ | ✓ | ✓ |
-| Wake vehicle | ✓ | ✓ | ✓ | ✓ |
-| Service due km/days | ✓ | ✓ | ✓ | ✓ |
-| Online status | ✓ | ✓ | ✓ | ✓ |
-| Battery SoC % | ✓ | ✓ | ✓ | ✓ |
-| Charge state | ✓ | ✓ | ✓ | ✓ |
-| Charge power kW | ✓ | ✓ | ✓ | ✓ |
-| Charge speed km/h | ✓ | ✓ | ✓ | ✓ |
-| Charge ETA | ✓ | ✓ | ✓ | ✓ |
-| Charge target % | ✓ | ✓ | ✓ | ✓ |
-| Trunk / hood / sunroof | ✓ | ✓ | ✓ | ✓ |
-| Window heating | ✓ | ✓ | ✓ | ✓ |
-| Vehicle renders | ✓ | — | — | ✓ |
-| Departure timers 1–3 | ✓ | ✓ | — | — |
-| Battery temperature | ✓ | ✓ | — | — |
-| AdBlue range | ✓ | ✓ | — | ✓ |
+### Option 1: One-click install (recommended)
 
----
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vag-connect-ha&category=integration)
 
-## Installation
+### Option 2: HACS custom repository (manual)
 
-### HACS
+1. **HACS → Integrations → ⋮ → Custom repositories**
+2. URL: `https://github.com/its-me-prash/vag-connect-ha`
+3. Category: **Integration**
+4. Search **VAG Connect** + install
+5. **Restart Home Assistant**
 
-1. HACS → Integrations → ⋮ → Custom Repositories
-2. URL: `https://github.com/its-me-prash/vag-connect-ha` — Category: Integration
-3. Install **VAG Connect** → Restart Home Assistant
-4. Settings → Integrations → **+ Integration** → **VAG Connect**
-
-### Manual
+### Option 3: Manual installation
 
 ```bash
-cp -r custom_components/vag_connect ~/.homeassistant/custom_components/
+cd /config/custom_components
+git clone https://github.com/its-me-prash/vag-connect-ha.git
+mv vag-connect-ha/custom_components/vag_connect .
+rm -rf vag-connect-ha
+# Restart HA
 ```
 
-Restart Home Assistant.
-
 ---
 
-## Configuration
+## ⚙️ Configuration
 
-| Field | Required | Description |
+**Settings → Devices & Services → Add integration → "VAG Connect"**
+
+| Field | Example | Description |
 |---|---|---|
-| Brand | ✓ | Audi / Volkswagen / Škoda / SEAT / CUPRA |
-| Email | ✓ | Login email from the manufacturer app |
-| Password | ✓ | Password from the app |
-| S-PIN | — | Required for locking (under Security in the app) |
-| Poll interval | — | Minutes between updates (default: 5) |
+| Brand | `Audi`, `Volkswagen EU`, etc. | Which brand app do you use? |
+| Email | `you@example.com` | Your VAG account email |
+| Password | `••••••••` | Your account password |
+| S-PIN | `1234` *(optional)* | 4-digit PIN for lock/unlock on some brands |
 
-**Which app?** Audi → myAudi · VW → WeConnect · Škoda → MyŠkoda · SEAT → My SEAT · CUPRA → MyCupra
+**Options** (Settings → Devices & Services → VAG Connect → ⋮ → Configure):
 
----
-
-## Known Limitations
-
-- **S-PIN** required for locking — set in the app under Security
-- **Poll interval** minimum 5 minutes — too short leads to temporary account lock
-- **2FA** — confirm once manually in the app, then automatic
-- **Porsche / VW NA** — functional as Beta, testers wanted
-- **VW China 2026+** — new CEA/XPeng platform, API not public, no ETA
+- **Polling interval** (5-60 min) — default 10 min. Lower = fresher, but eats API quota faster.
+- **Read-only mode** — when on: only status sensors, no switches/buttons that send commands.
+- **Reverse geocoding** (opt-in) — sends GPS to OpenStreetMap for address resolution.
+- **Push toggles** (Skoda MQTT / CUPRA-SEAT FCM / Audi-VW FCM) — foundation in place, live activation pending testers.
 
 ---
 
-## Roadmap
+## 🎨 What you get
 
-> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — complete P0/P1/P2/P3 prioritization with all ~20 open issues categorized.
+### Standard entities per vehicle (all brands)
 
-### Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
+**Sensors**: Battery SoC, range (electric/combustion/total), fuel level, odometer, outside temp, battery temp, 12V voltage, service days, oil service days, charging power/rate/type, last trip stats, charging history, plug state, lights count, equipment count, software version, quota remaining, connection state, last seen.
 
-| Version | Content | Date |
-|---|---|---|
-| v1.8.6–v1.8.12 | Foundation Sprint: defensive stability, Capability-Filter Phase 2, Multi-Brand Connection-State, all brand parsers on verified live API paths | 2026-04-29 |
-| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
-| v1.9.1 | Audi/VW Lock + Wake hotfix (#92) + Capability-Filter Phase 2 + Scout paths #90/#91 | 2026-04-29 |
-| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Phase 2 (#58), CUPRA Born 2026 firmware (#53 Gerhard) | 2026-04-29/30 |
-| v1.11.0–v1.11.1 | Issue #91 closure (Light/Service/Number), Golf GTE fuel-range fix (#96), Optimistic UI (3B-Part-3) | 2026-04-30 |
-| v1.12.0 | 🔋💡⚡🧯🔒 5-in-1 Sprint: 12V (#23) + Per-Light + Writeable Number + Smart-Wake (#55) + Read-only Phase 1 (#63) | 2026-04-30 |
-| v1.12.1 | Scout paths #105/#106 + Gerhard's Born fixture (#53 with consent) + #47 FAQ | 2026-04-30 |
-| v1.12.2 | 🌟 **First community Scout report** (Skoda #107 from tritanium73) | 2026-05-01 |
-| **v1.12.3** | Scout paths #111+#113+#114 bundled with wildcard strategy (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
+**Binary sensors**: Doors locked, doors open (per door), windows open (per window), trunk/hood/sunroof, plug connected, charging, OTA update available, 12V low warning, lights on (per light), vehicle online.
 
-### Next sessions
+**Controls**: Lock/unlock, climate start/stop, charging start/stop, window heating, window heating combined, cabin ventilation (CUPRA/SEAT), aux heating (Webasto, CUPRA/SEAT), departure timer (1-3 via `time` platform), set target SoC, set target temp, set max charge current, set charge mode, honk-and-flash, wake vehicle, refresh.
 
-| Version | Scope | Issues |
-|---|---|---|
-| **v1.13.0** ⭐ MINOR | Anonymized Diagnostics-Export + Capability-Filter Phase 3 + Read-only Phase 2/3 | #62, #56 Phase 3, #63 Phase 2/3 |
-| **v1.14.0** MINOR | Trip Statistics from Audi `tripstatistics/v1` | #24, #35 |
-| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26) | various |
-| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
-| **v2.0.0** 🎉 MAJOR | HACS Default + Live tests all brands + EU Data Act ready (Sept 2026 deadline) | #13, #59 |
+**Image platform**: 1-7 vehicle renders per VIN (Audi/VW: GraphQL MediaService; CUPRA/SEAT: OLA viewPoints; Skoda: widget + multi-angle composites).
 
-> Order is **strictly P0 → P1 → P2**. Bug fixes always take priority over features.
+**Device tracker**: GPS position as TrackerEntity (`source_type: gps`) for the HA Lovelace map.
+
+### Automatic vehicle picture
+
+The car appears as **device picture** in HA, plus as `entity_picture` on every entity. Custom Lovelace cards ([Ultra-Vehicle-Card](https://github.com/WJDDesigns/Ultra-Vehicle-Card), [vehicle-info-card](https://github.com/ngocjohn/vehicle-info-card), [Mushroom](https://github.com/piitaya/lovelace-mushroom) templates) read `extra_state_attributes.image_url` automatically.
 
 ---
 
-## License
+## 🗺️ Lovelace examples
 
-Apache License 2.0 — [LICENSE](LICENSE)
+### Map card
 
-**VAG Connect™** is an unregistered trademark (™, not ®). Please do not use this name in forks to avoid confusion.
+```yaml
+type: map
+title: Fleet
+default_zoom: 12
+hours_to_show: 24
+entities:
+  - device_tracker.audi_a4_b9_position
+  - device_tracker.vw_golf_7_gte_position
+  - zone.home
+```
 
-This integration is an independent community project with no affiliation to Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG or any VAG subsidiary.
+### Picture-entity card with vehicle render
+
+```yaml
+type: picture-entity
+entity: image.audi_a4_b9_render_side_lg
+camera_view: live
+show_state: false
+show_name: false
+```
+
+### Vehicle-info card (custom)
+
+```yaml
+type: custom:vehicle-info-card
+entity: sensor.audi_a4_b9_battery_level
+image: '[[ states.image.audi_a4_b9_render_side_lg.state ]]'
+```
+
+More examples in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md).
 
 ---
 
-*Copyright 2026 [Prash Balan](https://github.com/its-me-prash) · Apache License 2.0*
+## 🔧 FAQ
+
+| Question | Answer |
+|---|---|
+| **When is my car woken?** | Only on service calls (lock/climate/wake), never on status polls. Smart-wake cap: max 3 wakes/day per car (default), 5min cooldown between wakes. |
+| **How much API quota?** | MyCupra/MySeat: ~1500 calls/day. With 10min default polling: ~144 calls/day = 10% of budget. Sensor `requests_remaining_today` shows current state. |
+| **What if tank % is missing on Golf 7 GTE?** | v1.25.0 has MBB VSR Phase 2 read-side fallback. See [Golf 7 GTE tank guide](docs/GOLF_7_GTE_TANK_GUIDE.md). |
+| **Token survives HACS update?** | ✅ Yes since v1.19.2 — token persistence via HA `Store` (no re-login after updates). |
+| **How do I report bugs?** | HA → Integration → 🔧 Repair → Bug report. Diagnostics are anonymized (VINs masked, GPS rounded, tokens stripped). |
+
+Full FAQ in [`docs/FAQ.md`](docs/FAQ.md).
+
+---
+
+## 🛡️ Privacy & security
+
+- **No external services** — everything goes directly between HA and the manufacturer API
+- **Token cache** locally in HA's `.storage/` (per-config-entry, JSON, automatically removed on integration removal)
+- **Diagnostics anonymized**: VINs masked (`***ABC123`), GPS rounded to 1 decimal, tokens/passwords completely stripped
+- **Reverse geocoding opt-in** — disabled by default
+- **VIN masking** consistent across all logs
+
+Details in [`PRIVACY.md`](PRIVACY.md) and [`SECURITY.md`](SECURITY.md).
+
+---
+
+## 🛣️ Roadmap
+
+**Current:** v1.25.0 (Sprint C — cross-brand parity + UX/UI + MBB VSR Phase 2 for Golf 7 GTE tank).
+
+**Pending testers** (see [`docs/EXTERNAL_BLOCKED_ROADMAP.md`](docs/EXTERNAL_BLOCKED_ROADMAP.md)):
+- [#160 MBB Phase 2 write-side](https://github.com/its-me-prash/vag-connect-ha/issues/160) — Audi A4 B9 / Q5 2021 / Golf 7 / Passat B8 owner
+- [#161 Push Phase 2](https://github.com/its-me-prash/vag-connect-ha/issues/161) — Skoda Connect+ / MyCupra/MySeat / Audi+VW Cariad-modern owner
+- [#163 heaterSource](https://github.com/its-me-prash/vag-connect-ha/issues/163) — ID.4/7 / e-tron heat-pump owner
+
+**Planned for v1.26.0**: `device_action` + `device_trigger` (GUI automations for vehicles), `system_health.py`, `logbook.py`, CommandDispatcher Phase 2 refactor, more translation coverage.
+
+Full roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## 🤝 Contributing
+
+PRs welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+**Vehicle Data Scout** (live since v1.9.0): if your integration detects unknown JSON fields, it automatically creates an HA repair notification with a pre-filled GitHub issue link. **1-click bug report without you having to look at code.**
+
+Live testers wanted for the external-blocked tracks above — comment under the relevant issue with `brand + model + year + subscription status`.
+
+---
+
+## 📜 License
+
+[Apache License 2.0](LICENSE) — see also [`NOTICE.md`](NOTICE.md) for attributions to upstream projects ([myskoda](https://github.com/skodaconnect/myskoda), [pycupra](https://github.com/WulfgarW/homeassistant-pycupra), [audi_connect_ha](https://github.com/audiconnect/audi_connect_ha), [volkswagencarnet](https://github.com/Trekky12/volkswagencarnet), [evcc](https://github.com/evcc-io/evcc)).

--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@
 <h1 align="center">VAG Connect</h1>
 
 <p align="center">
-  <strong>Home Assistant Integration für Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong>
+  <strong>Home Assistant Integration für Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
+  <em>Eine Integration für alle 7 VAG-Marken — direkter API-Zugriff, ohne Middleware</em>
 </p>
 
 <p align="center">
-  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge" alt="HACS"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge" alt="Version"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/Lizenz-Apache%202.0-blue.svg?style=for-the-badge" alt="Lizenz"></a>
-  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2024.1%2B-blue?style=for-the-badge" alt="Home Assistant"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha" alt="Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Lizenz"></a>
+  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2024.4%2B-blue" alt="Home Assistant"></a>
+  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
 </p>
 
 <p align="center">
   <a href="README.en.md">English</a> ·
   <a href="README.fr.md">Français</a> ·
-  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.es.md">Español</a> ·
+  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.pl.md">Polski</a> ·
   <a href="README.cs.md">Čeština</a> ·
   <a href="README.sv.md">Svenska</a>
@@ -29,444 +29,190 @@
 
 ---
 
-**VAG Connect** verbindet Home Assistant direkt mit deinem Fahrzeug — ohne Middleware, ohne Docker, ohne extra Dienst. App-Zugangsdaten eingeben, fertig.
+## 🚗 Was es kann
 
-**80+ Entities** über **10 Plattformen**, **14 Services**. Alle 7 VAG-Marken in einer Integration — kein separates Plugin nötig.
+Verbindet Home Assistant **direkt** mit deinem Fahrzeug-Cloud-Account (myAudi, We Connect ID, MyŠkoda, MyCupra, MySeat, My Porsche, MyVW). **Keine Middleware, kein Docker, kein extra Dienst** — Anmeldung mit deinen App-Zugangsdaten, fertig.
 
-> ✅ **Aktiv gepflegter Multi-Brand-Nachfolger** für [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archiviert am 29.10.2025) und [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated am 14.03.2025). Eine Integration für Audi, VW, Škoda, SEAT, CUPRA, Porsche und VW US/CA — kein separates Plugin pro Marke.
+- **80+ Entitäten** über **10 HA Plattformen** (Sensoren, Schalter, Klima, Lock, etc.)
+- **14 Services** (Lock, Climate, Charging, Departure-Timer, etc.)
+- **Vehicle-Bild als Device-Picture** + Custom-Lovelace-Card-Support
+- **GPS-Position auf der HA-Map** als TrackerEntity
+- **Multi-Vehicle-Support** pro Account
+- **Read-only Modus** für sichere Anwendung in Automationen
+- **HACS-Quality-Scale: Platinum** ⭐
 
-## Aktueller Stand & ehrliche Limits / Current Status & Honest Limits (v1.24.1)
-
-VAG Connect entwickelt sich aktiv weiter. Damit du weißt, was funktioniert und was kommt:
-
-### ✅ Was JETZT funktioniert (alle 7 Marken)
-
-**🛰️ 1-Klick Bug-Reports & Feature-Wünsche (LIVE seit v1.9.0)**
-
-Zwei diagnostische Sensoren mit gemeinsamer Reporter-Pipeline — **erste echte Live-Validation durch Community-User** in v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) und v1.12.3 (DnnsJp74 / Audi):
-
-- 🔬 **Vehicle Data Scout** — erkennt automatisch unbekannte JSON-Felder in der API deines Autos. Brand-lokalisiert in 8 Sprachen (DE: API-Beobachter, FR: Observateur d'API, etc.).
-- 🚨 **Error Reporter** — Ring-Buffer der letzten 20 Integration-Fehler mit anonymisiertem Kontext (Modell, Firmware, Stack-Trace).
-- 🔘 **Reporter Pipeline:** beide Sensoren erstellen automatisch HA Repair-Notifications mit pre-filled GitHub-Issue als 1-Klick-Link. Plus Diagnostics-Download mit allem maskiert für Forum/Facebook.
-- 🔒 **Privacy-Versprechen:** Nichts verlässt deine HA ohne deinen expliziten Klick. VINs maskiert, GPS auf 1 Dezimalstelle gerundet, JWTs/UUIDs/Emails entfernt. GDPR-konform.
-
-**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
-
-Sensor `connection_state` (online / standby / offline) für Audi, VW EU, Škoda, SEAT, CUPRA — erste VAG-Integration mit centralisiertem Verbindungsstatus. Brand-agnostic Helper `compute_connection_state` mit recursive `carCapturedTimestamp` Walk.
-
-**🔋 12V-Batterie Monitoring + Smart-Wake (v1.12.0)**
-
-- `voltage_12v` Sensor (V) + `warning_12v_low` Binary bei <11.5V — verhindert silent API-Outages durch leere Starterbatterie
-- `wake_count_today` Sensor + Soft-Cap auf 3 Wakes/Tag (`_WAKE_BUDGET_PER_DAY`) schützt 12V vor Wake-Loops, raised `wake_budget_exhausted` BEVOR API-Call
-
-**💨 Optimistic UI für Lock/Climate/Charging (v1.11.1)**
-
-Switches flippen sofort beim Klick (myskoda PR #832 Pattern), API-Roundtrip im Hintergrund. Bei Failure: revert + ServiceValidationError. 8 Actuator-Methoden umgestellt.
-
-**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up in v1.11.1)**
-
-Drei explizite Range-Sensoren: `electric_range_km`, `combustion_range_km`, `total_range_km`. VW EU/Audi Parser klassifiziert nach Engine-Typ (4 Quellen statt 2). Audi-Diesel-Fallback aus `measurements.rangeStatus.value.dieselRange`. Verifiziert via evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity Logs.
-
-**🔒 Read-only Mode Phase 1 (v1.12.0)**
-
-Options-Toggle "Read-only Mode" → skip lock/switch/button(non-refresh)/climate/number Plattformen für Privacy/Safety-konservative Owner. Sensors + binary_sensors + device_tracker bleiben.
-
-**⚡ Writeable Max-Charge-Current Number (v1.12.0)**
-
-Slider 6-32A statt nur Read-only-Sensor. Neuer `command_set_max_charge_current` POST chargingSettings.
-
-**💡 Per-Light Binary-Sensors (v1.12.0)**
-
-Dynamisch pro Lichttyp aus `lights_individual` dict + Aggregate `lights_on` + `lights_count`.
-
-**🛠️ Defensive Stabilität (v1.8.7 + v1.10.1)**
-
-- 504-Retry, transient-network-error retry, 6h Stale-Cache + 3-Failure-Tolerance
-- Token-Refresh-Storm-Schutz (max 3/h) — verhindert IP-Bans
-- `safe_int` / `safe_float` / `safe_enum` Helper — toleriert Backend-Quirks
-
-**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhard's #53 erste Live-Validation)**
-
-Field-Name-Fallback-Kette: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerance für `"connected"`/`"locked"`. Backwards-compat erhalten.
-
-**🔓 Lock + Wake für Audi/VW (v1.9.1, #92 Audi S6 C8)**
-
-`command_lock` schickt jetzt S-PIN für Audi/VW (CARIAD BFF antwortete `403 spin_error`). `command_wake` nutzt v1→v2 Fallback.
-
-**🛡️ Capability-Filter Phase 2 (v1.9.1, #56)**
-
-`classify_command_failure` body-sniffing für `missing-capability`/`subscription_expired`/`not_entitled`/`spin_error` Marker. `_cariad_cmd` schreibt jedes Outcome in FeatureState. Command-bound Entities (Lock/Climate/Switch/Buttons) gehen automatisch unavailable bei definitivem Backend-No.
-
-### ⚠️ Was noch in Arbeit ist / What's still in progress (geplante Sessions)
-
-**Recent shipped (v1.20.0 → v1.24.1):**
-
-- ~~**v1.20.0**~~ ✅ — **Bundle 2 Phase A**: Skoda widget + vehicle-info + equipment (myskoda PR #557 adoptiert)
-- ~~**v1.20.1–v1.20.3**~~ ✅ — LOCK-class invert (#131) + Skoda parser hardening + Cariad-wrapper-404 detection (8 user reports)
-- ~~**v1.21.0**~~ ✅ — **Audi/VW MBB Legacy-Path Migration Phase 1** — strukturelle Lösung für 8 user-bugs (per-VIN backend cache, HomeRegion aktiviert, command_wake auto-fallback)
-- ~~**v1.22.0**~~ ✅ — **Skoda Widget Render → Image Entity** (Bundle 2 Phase B Pragmatic)
-- ~~**v1.23.0**~~ ✅ — **Audi/VW Push Foundation** (Cariad FCM channel, user-suggested) — alle 3 push-tracks foundation-komplett
-- ~~**v1.24.0**~~ ✅ — **Cross-brand Image-Entity Wiring** — fixes silent CUPRA/SEAT bug + wires Skoda multi-angle composites (myskoda PR #571)
-- ~~**v1.24.1**~~ ✅ — Doc Hygiene + CI-Fix + Quick-Win Hardening (Audit 2026-05-08)
-
-**Geplant / Planned:**
-
-- **v1.24.2 PATCH** — Test Foundation: property-tests via hypothesis (safe_int/safe_float/etc.) + Porsche/VW NA parity tests + bare int()/float() Migration in 4 Brand-Modulen
-- **v1.25.0 MINOR** — Charging-Profile + Departure-Timer Write-Side bundle (slipped 4×, endlich) + `_normalize.py` (DRY für Kelvin/drivetrain) + `BaseAPIClient` extract (Porsche unter HTTP-machinery) + coordinator Phase-1 refactor
-- **post-v1.25 PATCH** — MBB Phase 2: lock/unlock/climate/charger fallbacks, sobald Maintainer-Fleet wake live-test (A4 B9 + Q5 2021 + Golf 7 2015) bestätigt
-- **v1.18.x / v1.19.x / v1.23.x Patches** — Push Phase 2 Live-Activation sobald Community-Tester pro Brand sich melden
-- **v1.17.x Patch** — HomeRegion full wire-in (12 weitere call-sites in vw_eu.py beyond `command_wake`) wenn #75 Christian non-EU vehicle bestätigt
-- **v2.0.0 MAJOR** — HACS Default + Live-Tests alle Marken + EU Data Act ready (pycupra `EUDAConnection` als Reference, September 2026 Deadline) (#13, #59).
-
-### 🚫 Bewusste Limits / Conscious limits
-
-- **Image-Plattform:** Kein offizielles CARIAD Render-Image-API existiert. Image-Entity wird in einer zukünftigen Release auf user-supplied URLs umgestellt.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — neue E³ 1.2 Architektur, öffentlich noch nicht reverse-engineered (auch nicht in audi_connect_ha oder CarConnectivity). VAG Connect erkennt diese Fahrzeuge und macht **graceful degradation** statt 404-Fehler.
-- **Ford / nicht-VAG Marken:** Out of scope — siehe [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) für Ford.
-
-### 🔧 Privacy-Voraussetzung
-
-Damit GPS-Position, Fahrzeugstatus und Standheizung funktionieren, muss in deiner My-VW / My-Audi / MySkoda / MyCupra-App **"Standort teilen"** aktiviert sein — sonst antwortet das Backend mit 403.
-
-### 📚 Mehr Infos / More info
-
-- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — komplette P0/P1/P2/P3 Priorisierung aller offenen Issues
-- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — pro Release Field-Mappings + Architektur-Entscheidungen + externe Source-Refs
-- 🤝 Session Handoff (für Mitwirkende & AI-Tools): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔒 Privacy & data handling Rules: [`CONTRIBUTING.md`](CONTRIBUTING.md) Sektion (post-#53 third-party-review)
-- 📋 FAQ Subscription / Service Plus / `missing-capability` Diagnose: [`CONTRIBUTING.md`](CONTRIBUTING.md) FAQ-Sektion
-
-## Unterstützte Plattformen
-
-```
-sensor  |  binary_sensor  |  device_tracker  |  switch  |  button  |  climate  |  number  |  select  |  image  |  lock
-```
+> ✅ **Aktiv gepflegter Multi-Brand-Nachfolger** für [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archiviert 10/2025) und [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 03/2025).
 
 ---
 
-## Unterstützte Marken
+## 📋 Unterstützte Marken
 
-| Marke | Auth-System | API-Basis | Status |
+| Marke | Backend | Status | Besonderheit |
 |---|---|---|---|
-| **Volkswagen EU** | IDK PKCE | emea.bff.cariad.digital | ✅ Getestet |
-| **Audi** | IDK PKCE + AZS | emea.bff.cariad.digital | ✅ Getestet |
-| **Škoda** | IDK PKCE | mysmob.api.connect.skoda-auto.cz | ✅ Getestet |
-| **SEAT** | IDK PKCE | ola.prod.code.seat.cloud.vwgroup.com | ✅ Getestet |
-| **CUPRA** | IDK PKCE | ola.prod.code.seat.cloud.vwgroup.com | ✅ Getestet |
-| **Volkswagen US/CA** | IDK PKCE (NA) | b-h-s.spr.{cc}00.p.con-veh.net | ⚗️ Beta — Tester gesucht |
-| **Porsche** | Auth0 PKCE | api.ppa.porsche.com | ⚗️ Beta — Tester gesucht |
-
-> **Beta-Marken:** Vollständig implementiert, noch ohne Live-Tester bestätigt. Feedback unter [Issues](https://github.com/its-me-prash/vag-connect-ha/issues) willkommen.
+| **Audi** (myAudi) | Cariad-BFF + MBB Legacy | ✅ Stable | PPC/PPE Klima, ICE Engine Start (#28) |
+| **Volkswagen EU** (We Connect ID) | Cariad-BFF + MBB Legacy | ✅ Stable | PHEV Range-Triple, Tank-Level via MBB für Golf 7 GTE |
+| **Škoda** (MyŠkoda mysmob) | Skoda mysmob | ✅ Stable | Charging-Profiles, OTA, Workshop-Attrs, Multi-Angle Renders |
+| **SEAT** (MySEAT OLA) | OLA | ✅ Stable | OLA viewPoint Renders (4-7 Ansichten) |
+| **CUPRA** (MyCupra OLA) | OLA | ✅ Stable | OLA viewPoint Renders, Born MY26 firmware shapes |
+| **Porsche** (My Porsche) | PPA + Auth0 | ✅ Stable | Eigene HTTP-Hardening (retry/quota/storm-protection) |
+| **VW US/CA** (myVW NA) | VW NA Cloud | 🟡 Beta | Charge ETA, Climate, Lock, Doors |
 
 ---
 
-## Entities & Features
+## 🚀 Installation (HACS)
 
-### Sensoren (27)
+### Option 1: One-Click Install (empfohlen)
 
-| Sensor | Beschreibung | Audi | VW EU | Škoda | SEAT/CUPRA |
-|---|---|:---:|:---:|:---:|:---:|
-| `odometer_km` | Kilometerstand | ✓ | ✓ | ✓ | ✓ |
-| `fuel_level` | Tankstand % | ✓ | ✓ | — | ✓ |
-| `battery_soc` | Akkustand % | ✓ | ✓ | ✓ | ✓ |
-| `range_km` | Reichweite km | ✓ | ✓ | ✓ | — |
-| `vehicle_state` | PARKED / DRIVING / CHARGING / OFFLINE | ✓ | ✓ | ✓ | ✓ |
-| `charging_state` | CHARGING / READY_FOR_CHARGING / OFF | ✓ | ✓ | ✓ | ✓ |
-| `plug_state` | CONNECTED / DISCONNECTED | ✓ | ✓ | ✓ | ✓ |
-| `target_soc` | Ladziel % | ✓ | ✓ | ✓ | ✓ |
-| `charging_power_kw` | Ladeleistung kW | ✓ | ✓ | ✓ | ✓ |
-| `charging_rate_kmh` | Ladegeschwindigkeit km/h | ✓ | ✓ | ✓ | — |
-| `charge_complete_eta` | Ladeende (Uhrzeit) | ✓ | ✓ | ✓ | — |
-| `charging_type` | AC / DC | ✓ | ✓ | — | — |
-| `climatisation_state` | Klimatisierungsstatus | ✓ | ✓ | ✓ | ✓ |
-| `target_temperature` | Zieltemperatur °C | ✓ | ✓ | ✓ | ✓ |
-| `outside_temp` | Außentemperatur °C | ✓ | ✓ | — | — |
-| `service_km` | Nächste Inspektion km | ✓ | ✓ | ✓ | ✓ |
-| `service_due_at` | Nächste Inspektion Tage | ✓ | ✓ | ✓ | — |
-| `oil_service_km` | Ölwechsel km | ✓ | ✓ | ✓ | ✓ |
-| `oil_service_at` | Ölwechsel Tage | ✓ | ✓ | — | — |
-| `battery_temp` | Akkutemperatur °C | ✓ | ✓ | — | — |
-| `adblue_range_km` | AdBlue-Reichweite km | ✓ | ✓ | — | — |
-| `parking_address` | Standort-Adresse (Reverse Geocoding) | ✓ | ✓ | ✓ | ✓ |
-| `parking_city` | Standort-Stadt | ✓ | ✓ | ✓ | ✓ |
-| `last_updated_at` | Letztes API-Update | ✓ | ✓ | ✓ | ✓ |
-| `departure_timer_1_time` | Abfahrtstimer 1 Uhrzeit | ✓ | ✓ | — | — |
-| `departure_timer_2_time` | Abfahrtstimer 2 Uhrzeit | ✓ | ✓ | — | — |
-| `departure_timer_3_time` | Abfahrtstimer 3 Uhrzeit | ✓ | ✓ | — | — |
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vag-connect-ha&category=integration)
 
-### Binary Sensors (16)
+### Option 2: HACS Custom Repository (manuell)
 
-| Binary Sensor | Beschreibung |
-|---|---|
-| `doors_locked` | Alle Türen verriegelt |
-| `doors_open` | Mindestens eine Tür offen |
-| `windows_open` | Mindestens ein Fenster offen |
-| `connector_locked` | Ladekabel verriegelt |
-| `plug_connected` | Ladekabel eingesteckt |
-| `is_charging` | Lädt gerade |
-| `is_driving` | Fährt gerade |
-| `is_online` | Fahrzeug online |
-| `climatisation_active` | Klimatisierung aktiv |
-| `window_heating_front` | Frontscheibenheizung an |
-| `window_heating_back` | Heckscheibenheizung an |
-| `warning_active` | Mindestens eine Warnleuchte aktiv *(diagnostisch)* |
-| `warning_engine` | Motorwarnung *(diagnostisch)* |
-| `warning_oil` | Ölstandwarnung *(diagnostisch)* |
-| `warning_tyre` | Reifendruckwarnung TPMS *(diagnostisch)* |
-| `warning_brakes` | Bremswarnung *(diagnostisch)* |
+1. **HACS → Integrationen → ⋮ → Benutzerdefinierte Repositories**
+2. URL: `https://github.com/its-me-prash/vag-connect-ha`
+3. Kategorie: **Integration**
+4. **VAG Connect** suchen + installieren
+5. **Home Assistant neu starten**
 
-### Schalter, Steuerung & Buttons
-
-| Entity | Typ | Beschreibung |
-|---|---|---|
-| `lock_switch` | Switch | Verriegeln / Entriegeln |
-| `climatisation_switch` | Switch | Klimatisierung an/aus |
-| `charging_switch` | Switch | Laden an/aus |
-| `window_heating_switch` | Switch | Fensterheizung an/aus |
-| `seat_heating_switch` | Switch | Sitzheizung an/aus |
-| `auto_unlock_switch` | Switch | Auto-Entriegelung beim Laden |
-| `departure_timer_{1,2,3}_switch` | Switch | Abfahrtstimer 1–3 aktivieren |
-| `target_soc` | Number | Ladziel 20–100 % |
-| `min_soc` | Number | Mindest-SoC 0–100 % |
-| `max_charge_current` | Number | Max. Ladestrom (A) |
-| `target_temperature` | Number | Klimatisierungs-Zieltemperatur 16–30 °C |
-| `charge_mode` | Select | MANUAL / TIMER / PREFERRED_CHARGING_TIMES |
-| `climate.vorklimatisierung` | Climate | Vorklimatisierung mit Temperatursteuerung |
-| `button.aufwecken` | Button | Fahrzeug aufwecken |
-| `button.daten_aktualisieren` | Button | Sofortaktualisierung |
-| `button.lichtsignal` | Button | Lichter blinken lassen |
-
----
-
-## Fahrzeugbilder (Image-Plattform)
-
-VAG Connect registriert **7 native `image`-Entities** pro Fahrzeug in Home Assistant.
-Die Render-Bilder werden beim ersten Zugriff heruntergeladen und lokal unter `/config/www/vehicles/` gecacht (PNG, transparenter Hintergrund).
-
-> **Aktuell mit Bildern:** Audi ✅ (AZS-Token bestätigt) | Škoda/SEAT/CUPRA experimentell | VW EU: kein bestätigter Endpoint ([Issue #37](https://github.com/its-me-prash/vag-connect-ha/issues/37))
-
-### Verfügbare Image-Entities pro Fahrzeug
-
-| Entity | Dateipfad | Ansicht | Größe | Empfohlen für |
-|---|---|---|---|---|
-| `image.{auto}_icon` | `{VIN}_icon.png` | 3/4-Ansicht | ~76 KB | Badges, Chip-Cards |
-| `image.{auto}_small` | `{VIN}_small.png` | 3/4-Ansicht | ~117 KB | Kleine Karten, Sidebar |
-| `image.{auto}_medium` | `{VIN}_medium.png` | 3/4-Ansicht | ~196 KB | Standard-Karten |
-| `image.{auto}_side_small` | `{VIN}_side_small.png` | Seitenprofil | ~158 KB | Kompakte Seitenansicht |
-| `image.{auto}_side_large` | `{VIN}_side_large.png` | Seitenprofil | ~309 KB | ⭐ **Lovelace-Karten** |
-| `image.{auto}_angle_hd` | `{VIN}_angle_hd.png` | 3/4-Ansicht HD | ~1.7 MB | Hero-Banner, Vollbild |
-| `image.{auto}_angle_large` | `{VIN}_angle_large.png` | 3/4-Ansicht groß | ~879 KB | Dashboard-Hauptkarte |
-
-Alle Bilder auch als lokaler Pfad nutzbar: `/local/vehicles/{VIN}_{tag}.png`
-
-### Lovelace-Beispiele
-
-**Direktanzeige als Picture Entity (empfohlen):**
-```yaml
-type: picture-entity
-entity: image.audi_s6_avant_side_large
-show_name: false
-show_state: false
-```
-
-**Mit Sensor-Daten-Overlay:**
-```yaml
-type: picture-entity
-entity: sensor.audi_s6_avant_akkustand
-image_entity: image.audi_s6_avant_angle_hd
-name: "S6 Avant"
-```
-
-**Custom Button Card mit Hintergrundbild:**
-```yaml
-type: custom:button-card
-entity: sensor.audi_s6_avant_reichweite
-show_icon: false
-styles:
-  card:
-    - background-image: url('/local/vehicles/WVWZZZ1KZAW000000_side_large.png')
-    - background-size: contain
-    - background-repeat: no-repeat
-    - height: 180px
-```
-
-**Garage-View (mehrere Fahrzeuge):**
-```yaml
-type: horizontal-stack
-cards:
-  - type: picture-entity
-    entity: image.audi_s6_avant_side_large
-  - type: picture-entity
-    entity: image.vw_golf_gte_side_large
-```
-
-> Die VIN eines Fahrzeugs findest du als Attribut auf jeder Image-Entity (Developer Tools → Zustände → Attribut `vin`).
-
----
-
-## Empfohlene Lovelace-Cards / Recommended Lovelace Cards
-
-Stand 2026-05-03. Diese Custom-Cards harmonieren gut mit unseren Sensor-/Image-/Switch-Entities. Wir recommendieren sie für deine Dashboards bis unsere eigene "Ultimate VAG Vehicle Card" released ist (geplant — siehe unten).
-
-| Card | Wofür | Status | Repo |
-|---|---|---|---|
-| **flex-table-card** | Multi-Vehicle-Dashboards: Tabelle mit allen Fahrzeugen + Status (range, charge, locked, last_seen) als Spalten | ✅ aktiv (custom-cards Org) | [custom-cards/flex-table-card](https://github.com/custom-cards/flex-table-card) |
-| **vehicle-info-card** | Single-Vehicle-Detailansicht mit Image + Charge + Climate + Doors | ⚠️ wenig Updates (war Mercedes-fokussiert) | [ngocjohn/vehicle-info-card](https://github.com/ngocjohn/vehicle-info-card) |
-| **car-card** | Simple Charge-Status-Card mit visuellem Battery-Indicator (für EV-Schnellansicht) | ✅ aktiv | [flixlix/car-card](https://github.com/flixlix/car-card) |
-| **Ultra-Vehicle-Card** | Polished Premium-Look (großes Render + animierte Details) — gute Inspiration für unser eigenes Card-Projekt | ✅ aktiv | [WJDDesigns/Ultra-Vehicle-Card](https://github.com/WJDDesigns/Ultra-Vehicle-Card) |
-
-### 🚧 Geplant: Ultimate VAG Vehicle Card (eigenes Projekt)
-
-Wir bauen eine **eigene HA Lovelace Card** speziell für VAG Connect. Inspiration aus den oberen drei Cards, aber:
-- Volle Multi-Brand-Unterstützung (Audi/VW/Skoda/SEAT/CUPRA/Porsche/VW NA) mit brand-spezifischen Themes
-- Direkte Integration mit unseren Service-Calls (lock, climate, send_destination, etc.)
-- Battery + Range + Climate + Trip-Stats in einem zusammenhängenden View
-- Optional: `browser_mod` Integration für interaktive Popups (z.B. Adress-Suche → `send_destination` Service)
-
-**Status:** in Planung. Eigenes Repo (`vag-connect-lovelace-card`) wird in einer separaten Session aufgesetzt. Track-link bleibt hier sobald live.
-
-### Browser-Mod Integration (optional)
-
-[`thomasloven/hass-browser_mod`](https://github.com/thomasloven/hass-browser_mod) (1700+ stars, MIT, HACS Default) — bietet starke per-Browser-Steuerung. **Kein hard dependency** für VAG Connect, aber wenn du es nutzt, lassen sich coole Dinge bauen:
-
-- **Vehicle-Alert-Popup** wenn 12V-Battery < 11.5V oder Wake-Budget exhausted
-- **NFC-Tap → Quick-Command-Sheet** mit lock/unlock/climate buttons als Popup
-- **Charging-Session-Screensaver** — Vehicle-Card auto-öffnet bei Lade-Start auf einem bestimmten Dashboard
-- **Confirm-Popup** für `vag_connect.send_destination` ("Soll ich 'Office' an dein Auto senden?") bevor der Service aufgerufen wird
-
-Recipe-Doc folgt in v1.18.0 unter `docs/recipes/browser-mod.md`.
-
----
-
-## Services / Aktionen
-
-| Service | Beschreibung | Parameter |
-|---|---|---|
-| `vag_connect.lock` | Fahrzeug verriegeln | `vin` |
-| `vag_connect.unlock` | Entriegeln (S-PIN erforderlich) | `vin` |
-| `vag_connect.start_climatisation` | Klimatisierung starten | `vin` |
-| `vag_connect.stop_climatisation` | Klimatisierung stoppen | `vin` |
-| `vag_connect.start_charging` | Laden starten | `vin` |
-| `vag_connect.stop_charging` | Laden stoppen | `vin` |
-| `vag_connect.start_window_heating` | Fensterheizung starten | `vin` |
-| `vag_connect.stop_window_heating` | Fensterheizung stoppen | `vin` |
-| `vag_connect.wake_vehicle` | Fahrzeug aufwecken | `vin` |
-| `vag_connect.flash_lights` | Lichter blinken lassen | `vin` |
-| `vag_connect.refresh_vehicle` | Sofortaktualisierung | — |
-| `vag_connect.set_target_soc` | Ladziel setzen (20–100 %) | `vin`, `target_soc` |
-| `vag_connect.set_climatisation_temperature` | Zieltemperatur (16–30 °C) | `vin`, `temperature` |
-| `vag_connect.set_departure_timer` | Abfahrtstimer setzen | `vin`, `timer_id`, `enabled`, `time` |
-
----
-
-## Installation
-
-### HACS (empfohlen)
-
-1. HACS → Integrationen → ⋮ → Benutzerdefinierte Repositories
-2. URL: `https://github.com/its-me-prash/vag-connect-ha` → Kategorie: Integration
-3. **VAG Connect** installieren → Home Assistant neu starten
-4. Einstellungen → Integrationen → **+ Integration** → **VAG Connect**
-
-### Manuell
+### Option 3: Manuelle Installation
 
 ```bash
-cp -r custom_components/vag_connect ~/.homeassistant/custom_components/
+cd /config/custom_components
+git clone https://github.com/its-me-prash/vag-connect-ha.git
+mv vag-connect-ha/custom_components/vag_connect .
+rm -rf vag-connect-ha
+# HA neu starten
 ```
 
-Home Assistant neu starten.
-
 ---
 
-## Konfiguration
+## ⚙️ Konfiguration
 
-| Feld | Pflicht | Beschreibung |
+**Settings → Devices & Services → Integration hinzufügen → "VAG Connect"**
+
+| Feld | Beispiel | Beschreibung |
 |---|---|---|
-| Fahrzeugmarke | ✓ | Audi / VW EU / Škoda / SEAT / CUPRA / VW US/CA / Porsche |
-| E-Mail | ✓ | Anmelde-E-Mail der Hersteller-App |
-| Passwort | ✓ | App-Passwort |
-| S-PIN | — | Nur für Verriegelung (unter Sicherheit in der App) |
-| Abfrageintervall | — | Minuten (Standard: 5, Minimum: 5) |
+| Marke | `Audi`, `Volkswagen EU`, etc. | Welche Brand-App verwendest du? |
+| E-Mail | `du@example.com` | Deine VAG-Account-Email |
+| Passwort | `••••••••` | Dein Account-Passwort |
+| S-PIN | `1234` *(optional)* | 4-stellige PIN für Lock/Unlock auf manchen Brands |
 
-**Welche App?** Audi → myAudi · VW → WeConnect · Škoda → MyŠkoda · SEAT → My SEAT · CUPRA → MyCupra
+**Optionen** (Settings → Devices & Services → VAG Connect → ⋮ → Konfigurieren):
 
----
-
-## Bekannte Einschränkungen
-
-- **S-PIN** für Verriegelung erforderlich — einmalig in der App unter Sicherheit eintragen
-- **Polling** mindestens 5 Minuten — kürzere Intervalle riskieren temporäre Account-Sperren
-- **2FA** — einmalig manuell in der App bestätigen, danach automatisch
-- **VW EU Fahrzeugbilder** — kein bestätigter `vgql`-Endpoint bekannt; Audi-Bilder funktionieren
-- **Alte Fahrzeuge** (kein CARIAD-Support, `GDC_MISSING`) — werden automatisch übersprungen
-- **Warnleuchten** — derzeit nur VW EU / Audi; andere Marken in Arbeit
-- **Nicht verfügbar:** Ladesäulen-Infos, Kennzeichen, WLTP-Reichweite, Akkukapazität, Fahrtrichtung (diese Daten liefert die CARIAD API generell nicht)
+- **Polling-Intervall** (5-60 min) — Default 10 min. Niedriger = aktueller, frisst aber API-Quota schneller.
+- **Read-only Modus** — wenn aktiv: nur Status-Sensoren, keine Schalter/Buttons die Befehle senden würden.
+- **Reverse-Geocoding** (opt-in) — sendet GPS an OpenStreetMap für Adress-Auflösung.
+- **Push-Toggles** (Skoda MQTT / CUPRA-SEAT FCM / Audi-VW FCM) — Foundation gelegt, Live-Activation pending Tester.
 
 ---
 
-## Technischer Hintergrund
+## 🎨 Was du bekommst
 
-### Eigener CARIAD-Client
+### Standard Entitäten pro Vehicle (alle Brands)
 
+**Sensoren**: Battery SoC, Range (electric/combustion/total), Fuel Level, Odometer, Outside Temp, Battery Temp, 12V Voltage, Service Days, Oil Service Days, Charging Power/Rate/Type, Last Trip Stats, Charging History, Plug State, Lights Count, Equipment Count, Software Version, Quota Remaining, Connection State, Last Seen.
+
+**Binary Sensors**: Doors Locked, Doors Open (per door), Windows Open (per window), Trunk/Hood/Sunroof, Plug Connected, Charging, OTA Update Available, 12V Low Warning, Lights On (per light), Vehicle Online.
+
+**Steuerung**: Lock/Unlock, Climate Start/Stop, Charging Start/Stop, Window Heating, Window Heating Combined, Cabin Ventilation (CUPRA/SEAT), Aux Heating (Webasto, CUPRA/SEAT), Departure Timer (1-3 mit `time` platform), Set Target SoC, Set Target Temp, Set Max Charge Current, Set Charge Mode, Honk-and-Flash, Wake Vehicle, Refresh.
+
+**Image Platform**: 1-7 Vehicle-Renders pro VIN (Audi/VW: GraphQL MediaService; CUPRA/SEAT: OLA viewPoints; Skoda: Widget + Multi-Angle Composites).
+
+**Device Tracker**: GPS-Position als TrackerEntity (`source_type: gps`) für die HA Lovelace Map.
+
+### Automatisches Vehicle-Bild
+
+Das Auto erscheint als **Device-Picture** in HA, plus als `entity_picture` auf jedem Entity. Custom Lovelace Cards ([Ultra-Vehicle-Card](https://github.com/WJDDesigns/Ultra-Vehicle-Card), [vehicle-info-card](https://github.com/ngocjohn/vehicle-info-card), [Mushroom](https://github.com/piitaya/lovelace-mushroom) Templates) lesen `extra_state_attributes.image_url` automatisch.
+
+---
+
+## 🗺️ Lovelace-Beispiele
+
+### Map Card
+
+```yaml
+type: map
+title: Fuhrpark
+default_zoom: 12
+hours_to_show: 24
+entities:
+  - device_tracker.audi_a4_b9_position
+  - device_tracker.vw_golf_7_gte_position
+  - zone.home
 ```
-cariad/
-  auth/idk.py        ← IDK PKCE/OIDC (VW, Audi, Škoda, SEAT, CUPRA, VW NA)
-  auth/porsche.py    ← Auth0 PKCE (Porsche)
-  api/vw_eu.py       ← VW EU (CARIAD BFF emea.bff.cariad.digital)
-  api/audi.py        ← Audi: CARIAD BFF + AZS Token für Fahrzeugbilder
-  api/skoda.py       ← Škoda (mysmob API)
-  api/seat_cupra.py  ← SEAT / CUPRA (OLA API)
-  api/porsche.py     ← Porsche (PPA API)
-  api/vw_na.py       ← VW US/CA (NA Auth-Server)
-  api/graphql.py     ← Fahrzeugbilder via vgql (Audi bestätigt)
-  models.py          ← VehicleData, BrandConfig
-  exceptions.py      ← Typisierte Fehlerhierarchie
+
+### Picture-Entity Card mit Vehicle-Render
+
+```yaml
+type: picture-entity
+entity: image.audi_a4_b9_render_side_lg
+camera_view: live
+show_state: false
+show_name: false
 ```
 
-- **Keine externen Abhängigkeiten** — `requirements: []`
-- **Pure aiohttp** — HA-Session wird injiziert
-- **Clean-room** — kein GPL-Code, Endpoints aus MIT/Apache-Projekten
+### Vehicle-Info Card (Custom)
+
+```yaml
+type: custom:vehicle-info-card
+entity: sensor.audi_a4_b9_battery_level
+image: '[[ states.image.audi_a4_b9_render_side_lg.state ]]'
+```
+
+Mehr Beispiele in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md).
 
 ---
 
-## Roadmap
+## 🔧 Häufige Fragen
 
-> 📍 **Single Source of Truth:** [`docs/ROADMAP.md`](docs/ROADMAP.md) — komplette P0/P1/P2/P3 Priorisierung mit allen ~20 offenen Issues kategorisiert.
+| Frage | Antwort |
+|---|---|
+| **Wann wird mein Auto geweckt?** | Nur bei Service-Calls (Lock/Climate/Wake), niemals bei Status-Polls. Smart-Wake-Cap: max 3 Wakes/Tag pro Auto (Default), 5min Cooldown zwischen Wakes. |
+| **Wie viel API-Quota?** | MyCupra/MySeat: ~1500 Calls/Tag. Bei 10min default Polling: ~144 Calls/Tag = 10% Budget. Sensor `requests_remaining_today` zeigt aktuellen Stand. |
+| **Was wenn Tank-% bei Golf 7 GTE fehlt?** | v1.25.0 hat MBB VSR Phase 2 read-side fallback. Siehe [Golf 7 GTE Tank-Guide](docs/GOLF_7_GTE_TANK_GUIDE.md). |
+| **Token bleibt nach HACS-Update?** | ✅ ja, seit v1.19.2 — Token-Persistence via HA `Store` (kein Re-Login mehr nach Updates). |
+| **Wie melde ich Bugs?** | HA → Integration → 🔧 Reparieren → Bug-Report. Diagnostics werden anonymisiert (VINs gemaskt, GPS gerundet, Tokens gestrippt). |
 
-### Letzte Releases / Recent releases (2026-04-29 + 2026-04-30 + 2026-05-01)
-
-| Version | Inhalt | Date |
-|---|---|---|
-| v1.8.6–v1.8.12 | Foundation-Sprint: Defensive Stabilität, Capability-Filter Phase 2, Multi-Brand Connection-State, alle Brand-Parser auf verifizierten Live-API-Pfaden | 2026-04-29 |
-| v1.9.0 | 🛰️ Vehicle Data Scout + Error Reporter + Reporter Pipeline | 2026-04-29 |
-| v1.9.1 | Audi/VW Lock + Wake Hotfix (#92) + Capability-Filter Phase 2 + Scout-Pfade #90/#91 | 2026-04-29 |
-| v1.10.0–v1.10.2 | PHEV-Range-Triple (#94), Defensive Coding Phase 2 (#58), CUPRA Born 2026 Firmware (#53 Gerhard) | 2026-04-29/30 |
-| v1.11.0–v1.11.1 | Issue #91 Closure (Light/Service/Number), Golf GTE Fuel-Range Fix (#96), Optimistic UI (3B-Part-3) | 2026-04-30 |
-| v1.12.0 | 🔋💡⚡🧯🔒 5-in-1 Sprint: 12V (#23) + Per-Light + Writeable Number + Smart-Wake (#55) + Read-only Phase 1 (#63) | 2026-04-30 |
-| v1.12.1 | Scout-Pfade #105/#106 + Gerhard's Born Fixture (#53 mit Consent) + #47 FAQ | 2026-04-30 |
-| v1.12.2 | 🌟 **Erstes Community-Scout-Report** (Skoda #107 von tritanium73) | 2026-05-01 |
-| **v1.12.3** | Scout-Pfade #111+#113+#114 bundled mit Wildcard-Strategie (`fuelStatus.rangeStatus.value.*` etc.) | **2026-05-01** |
-
-### Nächste Sessions / Next sessions
-
-| Version | Scope | Issues |
-|---|---|---|
-| **v1.13.0** ⭐ MINOR | Anonymized Diagnostics-Export + Capability-Filter Phase 3 + Read-only Phase 2/3 | #62, #56 Phase 3, #63 Phase 2/3 |
-| **v1.14.0** MINOR | Trip Statistics aus Audi `tripstatistics/v1` | #24, #35 |
-| **v1.15.0+** MINOR | PPC Climate (#29, #51), Theft/Alarm Binary (#33), Klima-Timer UI (#26) | various |
-| **v1.18.0** MINOR | Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) | #57, #27 |
-| **v2.0.0** 🎉 MAJOR | HACS Default + Live-Tests alle Marken + EU Data Act ready (Sept 2026 Deadline) | #13, #59 |
-
-> Reihenfolge ist **strikt P0 → P1 → P2**. Bug-Fixes haben immer Vorrang vor Features.
+Vollständige FAQ in [`docs/FAQ.md`](docs/FAQ.md).
 
 ---
 
-## Lizenz
+## 🛡️ Privacy & Sicherheit
 
-Apache License 2.0 — [LICENSE](LICENSE)
+- **Keine externen Dienste** — alles geht direkt zwischen HA und Manufacturer-API
+- **Token-Cache** lokal in HA's `.storage/` (per-config-entry, JSON, automatisch entfernt bei Integration-Removal)
+- **Diagnostics anonymisiert**: VINs gemaskt (`***ABC123`), GPS auf 1 Decimal gerundet, Tokens/Passwörter komplett gestrippt
+- **Reverse-Geocoding opt-in** — Default deaktiviert
+- **VIN-Masking** durchgängig in allen Logs
 
-Diese Integration ist ein unabhängiges Community-Projekt ohne Verbindung zu Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG oder anderen VAG-Tochtergesellschaften.
+Details in [`PRIVACY.md`](PRIVACY.md) und [`SECURITY.md`](SECURITY.md).
 
 ---
 
-*Copyright 2026 [Prash Balan](https://github.com/its-me-prash) · Apache License 2.0*
+## 🛣️ Roadmap
+
+**Aktueller Stand:** v1.25.0 (Sprint C — Cross-Brand Parity + UX/UI + MBB VSR Phase 2 für Golf 7 GTE Tank).
+
+**Pending Tester** (siehe [`docs/EXTERNAL_BLOCKED_ROADMAP.md`](docs/EXTERNAL_BLOCKED_ROADMAP.md)):
+- [#160 MBB Phase 2 write-side](https://github.com/its-me-prash/vag-connect-ha/issues/160) — Audi A4 B9 / Q5 2021 / Golf 7 / Passat B8 Owner
+- [#161 Push Phase 2](https://github.com/its-me-prash/vag-connect-ha/issues/161) — Skoda Connect+ / MyCupra/MySeat / Audi+VW Cariad-modern Owner
+- [#163 heaterSource](https://github.com/its-me-prash/vag-connect-ha/issues/163) — ID.4/7 / e-tron Heat-pump Owner
+
+**Geplant für v1.26.0**: `device_action` + `device_trigger` (GUI-Automationen für Vehicles), `system_health.py`, `logbook.py`, CommandDispatcher Phase 2 refactor, weitere Translation-Coverage.
+
+Vollständige Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md).
+
+---
+
+## 🤝 Contributing
+
+PRs willkommen — siehe [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+**Vehicle Data Scout** (live seit v1.9.0): Wenn deine Integration unbekannte JSON-Felder erkennt, erstellt sie automatisch eine HA Repair-Notification mit pre-filled GitHub-Issue-Link. **1-Klick Bug-Report ohne dass du Code anschauen musst.**
+
+Live-Tester gesucht für die external-blocked Tracks oben — Comment unter dem entsprechenden Issue mit `Brand + Modell + Jahr + Subscription-Status`.
+
+---
+
+## 📜 Lizenz
+
+[Apache License 2.0](LICENSE) — siehe auch [`NOTICE.md`](NOTICE.md) für Attributions an Upstream-Projekte ([myskoda](https://github.com/skodaconnect/myskoda), [pycupra](https://github.com/WulfgarW/homeassistant-pycupra), [audi_connect_ha](https://github.com/audiconnect/audi_connect_ha), [volkswagencarnet](https://github.com/Trekky12/volkswagencarnet), [evcc](https://github.com/evcc-io/evcc)).

--- a/docs/GOLF_7_GTE_TANK_GUIDE.md
+++ b/docs/GOLF_7_GTE_TANK_GUIDE.md
@@ -1,0 +1,125 @@
+# Golf 7 GTE Tank-Level Test-Guide (v1.25.0+)
+
+> **Wer das hier liest:** Owner eines VW Golf 7 GTE PHEV (2014–2020) oder eines anderen pre-PPE/MEB Hybriden (Passat GTE B7/B8, A3 e-tron, Q5 hybrid 2014+, etc.) bei dem die WeConnect App **kein Tank-% anzeigt** UND VAG Connect den `fuel_level` Sensor leer lässt.
+
+## Was v1.25.0 geändert hat
+
+VAG Connect v1.25.0 PR-G (Sprint C) bringt einen **MBB VSR Phase 2 read-side Fallback** für genau diese Vehicle-Klasse. Der Hintergrund:
+
+- **Cariad-BFF Gateway** (`emea.bff.cariad.digital`) — die "moderne" API die wir primär nutzen — gibt für Golf 7 GTE bei `fuelStatus.rangeStatus` einen `{error: ...}` Block zurück. Kein Tank-%, keine combustion-range. Das ist das gleiche Problem das die WeConnect App selbst hat.
+- **MBB Legacy Stack** (`fal-3a.prd.eu.dp.vwg-connect.com`, etc.) — die ALTE API die das Auto eigentlich seit Car-Net-Zeiten spricht — publisht das Feld `0x030103000A` (TANK_LEVEL_IN_PERCENTAGE) **immer noch**. Die App hat den Switch zu Cariad gemacht und verloren auf Hybriden.
+- v1.25.0 fügt einen **defensiven Fallback** hinzu: wenn Cariad-BFF leer UND VIN bekanntermaßen MBB-backed → GET die legacy `/fs-car/bs/vsr/v1/.../status` und parse das Field.
+
+## Voraussetzungen
+
+| | |
+|---|---|
+| **Integration-Version** | v1.25.0 oder neuer |
+| **Brand** | Volkswagen EU oder Audi (CARIAD-BFF brands) |
+| **Vehicle-Era** | MIB1 / MIB2 / MIB3 mit Connect+ — typisch 2014–2020 |
+| **Subscription** | aktiver We Connect (Plus) Vertrag — ohne kommt KEIN backend response |
+| **Auth-Token** | gültig (HACS-Update überlebt seit v1.19.2) |
+
+## Schritt-für-Schritt
+
+### 1. Update auf v1.25.0
+
+**HACS:** Settings → HACS → VAG Connect → Update auf v1.25.0 → **HA neu starten**.
+
+Verify in den Settings → Devices & Services → VAG Connect → ⋮ → Über die Integration: **Version 1.25.0** (oder neuer).
+
+### 2. Logs vorbereiten
+
+Settings → System → Logs → ⋮ → Filter:
+
+```
+Logger: custom_components.vag_connect
+Level: DEBUG
+```
+
+Save + scroll-to-end aktiv lassen.
+
+### 3. Wake-Service triggern
+
+Settings → Devices & Services → VAG Connect → DEVICE-Card vom Golf 7 GTE → **Wake Vehicle** Button drücken (oder via `vag_connect.wake_vehicle` Service mit der VIN).
+
+### 4. Was du in den Logs sehen solltest
+
+**Erfolg-Variante A** — VIN war schon vorher als MBB-backed markiert (Fall A4 B9 / Q5 2021 / Golf 7 die schon mal in v1.21.0 wake-fallback gelaufen sind):
+
+```
+INFO MBB VSR Phase 2: filled fuel_level=60% for ***xxxxxx (Cariad-BFF was empty)
+INFO MBB VSR Phase 2: filled combustion_range_km=450 for ***xxxxxx
+```
+
+**Erfolg-Variante B** — VIN wird ERST jetzt als MBB-backed klassifiziert:
+
+```
+INFO VAG wake: Cariad-wrapper-404 for vin ***xxxxxx — marking as MBB-backed and retrying via legacy path
+DEBUG MBB wake POST → https://msg.volkswagen.de/fs-car/bs/vsr/v1/VW/DE/vehicles/***xxxxxx/requests
+```
+
+→ Dann **10 Minuten warten** auf nächsten automatischen Coordinator-Poll, dann sollten die "MBB VSR Phase 2: filled" Lines erscheinen.
+
+### 5. HA-Sensor checken
+
+Settings → Devices & Services → VAG Connect → DEVICE Golf 7 GTE → **Sensoren-Liste**:
+
+- `sensor.<dein_vin_slug>_fuel_level` — sollte jetzt einen Wert haben (z.B. `60` mit Unit `%`)
+- `sensor.<dein_vin_slug>_combustion_range_km` — sollte zugehörige Range haben
+- `sensor.<dein_vin_slug>_total_range_km` (PHEV) — Summe aus electric + combustion
+
+## Wenn nach 24h immer noch `unknown`
+
+### Diagnose 1: Logs lesen
+
+Filter `MBB VSR` in den Logs:
+
+| Log-Line | Bedeutung |
+|---|---|
+| `MBB VSR fetch failed for ***xxxxxx: ...` | HTTP-Request scheiterte. Häufig: 401 (Token), 403 (no Subscription), 404 (vehicle nicht in MBB registry), 500 (Backend down) |
+| `MBB VSR Phase 2: filled fuel_level=...` | ✅ Funktioniert — Sensor sollte Wert haben |
+| Nichts | VIN wurde noch nicht als MBB-backed markiert. Trigger Wake (Schritt 3) noch mal |
+
+### Diagnose 2: Diagnostics Export
+
+Settings → Devices & Services → VAG Connect → Configuration-Card → **Download Diagnostics**.
+
+Im JSON file nach `mbb_backend_cache` suchen — sollte deine Golf-VIN als `"mbb"` markiert sein. Wenn `"cariad"` → Wake hat noch nicht den wrapper-404 erkannt, möglicherweise echtes Cariad-vehicle (selten bei Golf 7).
+
+### Diagnose 3: Worst Case — MBB liefert das Feld nicht
+
+Wenn HTTP success aber field absent → das Auto publisht `0x030103000A` einfach nicht via OCU. Mögliche Gründe:
+- Sehr frühe Golf 7 GTE Firmware (vor 2016) ohne Tank-Telemetrie
+- OCU-Defekt / SIM-Probleme
+- Connect-Subscription ist auf einem reduzierten Tier
+
+**Alternative-Wege wenn MBB tot ist:**
+1. **OBD-II Dongle** (OBDLink MX+ ~80€): HA `obd` Integration → PID `0x2F` (fuel level). 100% zuverlässig weil bypasst die OCU komplett.
+2. **CarConnectivity-connector-volkswagen** ([tillsteinbach](https://github.com/tillsteinbach/CarConnectivity-connector-volkswagen)): debug-log dump dort posten — Till maintains die kanonische "what does this VIN actually publish" reverse-engineering ledger.
+3. **EU Data Act portal** (live seit Sep 2025): Cariad muss dir auf Anfrage CSV-Export deiner raw vehicle data geben. Manuell alle paar Wochen, kein real-time API.
+
+## Dem Maintainer melden (so wird's noch besser)
+
+**Egal welches Ergebnis** (success oder failure) — bitte unter [Issue #160](https://github.com/its-me-prash/vag-connect-ha/issues/160) kommentieren mit:
+
+```
+Vehicle: Golf 7 GTE
+Year: 20XX
+Firmware: <wenn bekannt — siehe sensor.software_version>
+HA: 2026.X.X
+VAG Connect: v1.25.0
+Subscription: We Connect Plus aktiv (ja/nein)
+Result: ✅ tank_pct gefüllt mit 60% nach 12min wait
+        ODER: ❌ blieb unknown — Log-Auszug:
+              MBB VSR fetch failed for ***xxxxxx: APIError 404 ...
+```
+
+→ Mit ~3 erfolgreichen Reports können wir Phase 2 **write-side** (lock/climate/charger MBB fallback) auch shippen, was die anderen Audi-A4-B9 / Q5-2021 user-reports von Mai 2026 strukturell schließt.
+
+## Weiterführend
+
+- v1.21.0 Phase 1 (wake-side MBB fallback): commit `f247d2d`
+- v1.25.0 PR-G (read-side MBB VSR Phase 2): PR [#172](https://github.com/its-me-prash/vag-connect-ha/pull/172), commit `9fd79f2`
+- MBB endpoint-catalog reference: `cariad/_mbb.py` module docstring + `audiconnect/audi_connect_ha audi_models.py` legacy IDS table
+- Golf 7 GTE Range fix (PHEV detection) v1.11.1: closed [#96](https://github.com/its-me-prash/vag-connect-ha/issues/96)


### PR DESCRIPTION
Docs-only PR. README.md + README.en.md auf saubere HACS-Standard-Struktur (54% schlanker, 472→218 Zeilen). Plus neuer docs/GOLF_7_GTE_TANK_GUIDE.md mit step-by-step User-Anleitung für v1.25.0 MBB VSR Phase 2 Tank-Level Fallback. 🤖 [Claude Code](https://claude.com/claude-code)