### PR TITLE
v1.26.0: Welle-6 Feature Backlog (#173) — 7 new entities + Cross-Brand Parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,41 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-05-09 🎯 Welle-6 Feature Backlog (#173) — 7 neue Entitäten + Cross-Brand Parity / Welle-6 Feature Backlog (#173) — 7 new entities + Cross-Brand Parity
+
+🎯 **MINOR-Release.** Setzt das Welle-6 Scout-Feature-Backlog (#173) um. **Diese Features waren in den Scout-Reports #129/#130/#132/#133/#143/#144/#145/#146/#147/#165/#167 enthalten aber wurden in v1.19.3 nur EXPECTED_KEYS-silenced statt als Entitäten exposed** — der v1.25.0 Audit hatte das als Pattern-Bruch identifiziert (vergleiche #91 → 5 neue Entitäten in v1.11.0).
+
+### 🆕 Neue Entitäten (7 total)
+
+**Sensoren** (4):
+- **`sensor.<vin>_secondary_engine_range_km`** — Skoda PHEV (Kodiaq iV, Octavia iV, Superb iV) aus `driving-range.secondaryEngineRange.distanceInKm`. Komplementär zu `combustion_range_km` weil Skoda PHEVs beide via separate API-Blöcke seit 2024 firmware reporten. Closes Scout #165 (christianmhz).
+- **`sensor.<vin>_next_charging_timer_id`** — VW EU/Audi aus `automation.chargingProfiles.value.nextChargingTimer.id` (1/2/3). Diagnostic-category. Read-side complement zum v1.16.0 write-side `set_departure_timer` service.
+- **`sensor.<vin>_next_charging_timer_target_soc_reachable`** — VW EU/Audi aus `automation.chargingProfiles.value.nextChargingTimer.targetSOCreachable` ("calculating" oder Prozentwert). User sieht ob das Auto den nächsten Lade-Timer erreichen wird.
+- **`sensor.<vin>_capabilities_count`** — VW EU/Audi aus `userCapabilities.capabilitiesStatus.value[].length` (typisch 54 items). Diagnostic für Power-User die debuggen wollen "warum fehlt Entity X bei mir?".
+
+**Binary Sensors** (3):
+- **`binary_sensor.<vin>_auto_unlock_when_charged`** — Cross-brand (VW EU/Audi via `charging.chargingSettings.value.autoUnlockPlugWhenCharged`; Skoda via `settings.autoUnlockPlugWhenCharged`/`autoUnlockPlugWhenChargedAC`). Diagnostic.
+- **`binary_sensor.<vin>_climate_at_unlock`** — Cross-brand (VW EU/Audi via `climatisation.climatisationSettings.value.climatizationAtUnlock`; Skoda via `airConditioningAtUnlock`). Diagnostic.
+- **`binary_sensor.<vin>_window_heating_enabled`** — Cross-brand (VW EU/Audi via `climatisation.climatisationSettings.value.windowHeatingEnabled`; Skoda via `windowHeatingEnabled`). Distinct from existing `window_heating_front/back` STATE switches — this is the SETTING ("auto-activate during climate?"). Diagnostic.
+
+### 🌍 Cross-Brand Battery-Care Parity
+
+- VW EU/Audi bekommen jetzt `battery_care_enabled` + `battery_care_target_soc_pct` aus Cariad-BFF (`charging.chargingCareSettings.value.batteryCareMode` + `batteryChargingCare.chargingCareSettings.value.batteryCareTargetSoc`). Skoda bekommt zusätzlich Wiring aus `settings.batteryCareModeTargetValueInPercent` + `settings.chargingCareMode`. Existierende Sensor + Binary Sensor (CUPRA/SEAT seit v1.17.5) brauchten kein neues Entity-Description.
+
+### 🌍 Audi/VW EU `charging_rate_kmh` Parität
+
+- Sensor existierte bereits cross-brand seit v1.10.0. Parser für VW EU/Audi war seit dem Anfang da. Closes Scout #167 als bereits-implementiert (Scout-Report kam von Firmware die das Feld zum ersten Mal bei diesem User auslieferte — EXPECTED_KEYS update folgt automatisch über v1.9.0 Pipeline).
+
+### 🛡️ Defensive Coding
+
+- Alle neuen Felder benutzen `safe_int` für Zahlen, explicit `isinstance` für bool/string types
+- `_DATA_PRESENT_REQUIRED` extended um die 4 neuen Sensoren + 3 neuen Binary Sensors → keine Phantom-Entitäten für Brands/Vehicles ohne entsprechende API-Felder
+- Translation-Keys in `strings.json` + DE-Übersetzung + 7 weitere Locales als English-Fallback (proper community translation deferred)
+
+### 📚 Pattern Lessons
+
+Die v1.25.0 Audit-Erkenntnis "silenced ohne Feature-Umsetzung sollte vermieden werden" wird ab jetzt umgesetzt: **Bei jedem Scout-Report VORHER prüfen ob feature-würdig**. Wenn JA: implementieren, dann silencen. Wenn NEIN: silencen + im Close-Comment `category: silence-only` mit Begründung dokumentieren.
+
 ### 📝 Docs / Docs
 
 - **README.md (DE) komplett refactored** auf saubere HACS-Standard-Struktur (472 → 218 Zeilen, 54% schlanker). Klare Sektionen: Was-es-kann / Supported brands matrix / Installation 3-Optionen / Konfiguration Tabelle / Was-du-bekommst / Lovelace examples / FAQ / Privacy / Roadmap / Contributing / License. Historische Session-Notes raus → bleiben in `docs/ROADMAP.md` + `docs/CHANGELOG_TECHNICAL.md`.

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -195,6 +195,28 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:battery-heart-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v1.26.0 Welle-6 Feature Backlog (#173) — new binary sensors.
+    VagBinarySensorDescription(
+        key="auto_unlock_when_charged",
+        translation_key="auto_unlock_when_charged",
+        data_key="auto_unlock_when_charged",
+        icon="mdi:lock-open-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagBinarySensorDescription(
+        key="climate_at_unlock",
+        translation_key="climate_at_unlock",
+        data_key="climate_at_unlock",
+        icon="mdi:car-electric",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagBinarySensorDescription(
+        key="window_heating_enabled",
+        translation_key="window_heating_enabled",
+        data_key="window_heating_enabled",
+        icon="mdi:car-defrost-front",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 BINARY_DESCRIPTIONS = BINARY_DESCRIPTIONS + _NEW_BINARY
 
@@ -210,6 +232,12 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # v1.17.1 — SEAT/CUPRA-only battery care endpoint. Stays None on
     # other brands and on accounts where the feature isn't available.
     "battery_care_enabled",
+    # v1.26.0 Welle-6 Feature Backlog (#173) — phantom protection.
+    # Brand-restricted at parser level (only populated when backend
+    # ships the field). Other vehicles → field stays None → no phantom.
+    "auto_unlock_when_charged",
+    "climate_at_unlock",
+    "window_heating_enabled",
 })
 
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -523,6 +523,27 @@ class SkodaClient(CariadBaseClient):
             settings = charging.get("settings", {})
             d.target_soc = v(settings, "targetStateOfChargeInPercent")
             d.auto_unlock_charge = v(settings, "autoUnlockPlugWhenChargedAC") == "ON"
+            # v1.26.0 Welle-6 (#173, scouts #143/#133) — cross-brand alias.
+            # Skoda's autoUnlockPlugWhenCharged or AC-suffix variant.
+            au_raw = v(settings, "autoUnlockPlugWhenCharged") or v(settings, "autoUnlockPlugWhenChargedAC")
+            if isinstance(au_raw, str):
+                up = au_raw.upper()
+                if up in ("ON", "PERMANENT", "TRUE", "YES"):
+                    d.auto_unlock_when_charged = True
+                elif up in ("OFF", "FALSE", "NO"):
+                    d.auto_unlock_when_charged = False
+            # v1.26.0 — Battery-Care Skoda. From scout #143 batteryCareModeTargetValueInPercent
+            # + chargingCareMode "ACTIVATED"/"DEACTIVATED".
+            care_mode_raw = v(settings, "chargingCareMode")
+            if isinstance(care_mode_raw, str):
+                up = care_mode_raw.upper()
+                if up in ("ACTIVATED", "ACTIVE", "ON", "TRUE"):
+                    d.battery_care_enabled = True
+                elif up in ("DEACTIVATED", "INACTIVE", "OFF", "FALSE"):
+                    d.battery_care_enabled = False
+            care_target_pct = v(settings, "batteryCareModeTargetValueInPercent")
+            if d.battery_care_target_soc_pct is None:  # don't clobber CUPRA/SEAT path
+                d.battery_care_target_soc_pct = safe_int(care_target_pct)
 
         # ── Air conditioning (also has plug state!) ──────────────────────────
         if isinstance(ac, dict):
@@ -537,6 +558,15 @@ class SkodaClient(CariadBaseClient):
             wh = v(ac, "windowHeatingState") or {}
             d.window_heating_front = v(wh, "front") == "ON"
             d.window_heating_back = v(wh, "rear") == "ON"
+            # v1.26.0 Welle-6 (#173, scouts #143) — Skoda climate settings.
+            # airConditioningAtUnlock as climate_at_unlock cross-brand alias.
+            au_clim = v(ac, "airConditioningAtUnlock")
+            if isinstance(au_clim, bool):
+                d.climate_at_unlock = au_clim
+            # windowHeatingEnabled (setting, not state — distinct from front/back ON state).
+            wh_en = v(ac, "windowHeatingEnabled")
+            if isinstance(wh_en, bool):
+                d.window_heating_enabled = wh_en
 
             # v1.17.7 (#129 rocksandclouds + #130 Chr1sDub + #133
             # christianmhz — three converging Skoda Scout-Reports
@@ -611,6 +641,12 @@ class SkodaClient(CariadBaseClient):
                 d.range_km = electric or total
             adblue = v(driving_range, "adBlueRange", "distanceInKm")
             d.adblue_range_km = safe_int(adblue)
+            # v1.26.0 Welle-6 (#173, scout #165 christianmhz) — Skoda PHEV
+            # secondary engine range (Kodiaq iV, Octavia iV, Superb iV).
+            # Distinct from combustion_range_km because Skoda PHEVs report
+            # both via separate API blocks since 2024 firmware.
+            sec_eng = v(driving_range, "secondaryEngineRange", "distanceInKm")
+            d.secondary_engine_range_km = safe_int(sec_eng)
 
         d.is_electric = d.has_battery and not d.has_combustion
         d.is_hybrid = d.has_battery and d.has_combustion

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -774,6 +774,42 @@ class VWEUClient(CariadBaseClient):
         d.charging_power_kw = v(raw, "charging", "chargingStatus", "value", "chargePower_kW")
         d.charging_rate_kmh = v(raw, "charging", "chargingStatus", "value", "chargeRate_kmph")
 
+        # v1.26.0 Welle-6 Feature Backlog (#173) — Battery-Care for VW EU/Audi.
+        # Skoda + CUPRA/SEAT have these via own paths since v1.17.5; VW EU/Audi
+        # finally exposed via Cariad-BFF (paths from scout reports
+        # #144/#145/#146/#147 — were silenced in v1.19.3, now wired as features).
+        care_mode = v(raw, "charging", "chargingCareSettings", "value", "batteryCareMode")
+        if isinstance(care_mode, str):
+            up = care_mode.upper()
+            if up in ("ACTIVATED", "ACTIVE", "ON", "TRUE"):
+                d.battery_care_enabled = True
+            elif up in ("DEACTIVATED", "INACTIVE", "OFF", "FALSE"):
+                d.battery_care_enabled = False
+        care_target = v(raw, "batteryChargingCare", "chargingCareSettings", "value", "batteryCareTargetSoc")
+        if care_target is None:
+            care_target = v(raw, "charging", "chargingCareSettings", "value", "batteryCareTargetSoc")
+        d.battery_care_target_soc_pct = safe_int(care_target)
+
+        # v1.26.0 — Auto-Unlock plug when charged. From scout #144 VW ID.4 Pro.
+        auto_unlock_raw = v(raw, "charging", "chargingSettings", "value", "autoUnlockPlugWhenCharged")
+        if isinstance(auto_unlock_raw, str):
+            up = auto_unlock_raw.upper()
+            if up in ("PERMANENT", "ON", "ACTIVATED", "TRUE", "YES"):
+                d.auto_unlock_when_charged = True
+            elif up in ("OFF", "DEACTIVATED", "FALSE", "NO"):
+                d.auto_unlock_when_charged = False
+
+        # v1.26.0 — Next-Charging-Timer info (read-side complement to v1.16.0
+        # write-side). From scout #144/#145/#146/#147 (3-user convergence).
+        nct_id = v(raw, "automation", "chargingProfiles", "value", "nextChargingTimer", "id")
+        d.next_charging_timer_id = safe_int(nct_id)
+        nct_target = v(
+            raw, "automation", "chargingProfiles", "value",
+            "nextChargingTimer", "targetSOCreachable",
+        )
+        if isinstance(nct_target, str) and nct_target:
+            d.next_charging_timer_target_soc_reachable = nct_target
+
         # v1.10.1 (#58) — safe_int. New CARIAD firmware shipped this as
         # a stringified decimal at least once — see myskoda #503.
         remaining_min = safe_int(
@@ -1038,6 +1074,22 @@ class VWEUClient(CariadBaseClient):
         d.climatisation_state = v(raw, "climatisation", "climatisationStatus", "value", "climatisationState")
         d.climatisation_active = d.climatisation_state not in (None, "OFF", "CLIMATISATION_STATUS_UNAVAILABLE")
         d.target_temperature = v(raw, "climatisation", "climatisationSettings", "value", "targetTemperature_C")
+
+        # v1.26.0 Welle-6 (#173) — climate-at-unlock + window-heating-enabled
+        # SETTINGS (distinct from front/back STATES). Scout #144 VW ID.4 Pro.
+        clim_at_unlock = v(raw, "climatisation", "climatisationSettings", "value", "climatizationAtUnlock")
+        if isinstance(clim_at_unlock, bool):
+            d.climate_at_unlock = clim_at_unlock
+        wh_enabled = v(raw, "climatisation", "climatisationSettings", "value", "windowHeatingEnabled")
+        if isinstance(wh_enabled, bool):
+            d.window_heating_enabled = wh_enabled
+
+        # v1.26.0 (#173) — capabilities_count diagnostic. From scout #144
+        # (54 items observed). Useful for power-users debugging "why is
+        # entity X missing for me?". Read from selectivestatus envelope.
+        caps = v(raw, "userCapabilities", "capabilitiesStatus", "value")
+        if isinstance(caps, list):
+            d.capabilities_count = len(caps)
 
         wh_status = v(raw, "climatisation", "windowHeatingStatus", "value", "windowHeatingStatus") or []
         for wh in wh_status:

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -327,6 +327,66 @@ class VehicleData:
     # into ``image_urls`` in ``_enrich`` so the unified path picks it up.
     composite_render_urls: dict[str, str] | None = None
 
+    # v1.26.0 — Welle 6 Feature Backlog (Issue #173).
+    # All these fields were silently shipped in scout reports
+    # (#129/#130/#132/#133/#143/#144/#145/#146/#147/#165/#167) but
+    # only EXPECTED_KEYS-silenced in v1.19.3. v1.26.0 finally exposes
+    # them as user-visible entities. Each field is brand-restricted
+    # via ``_DATA_PRESENT_REQUIRED`` so non-supporting vehicles don't
+    # see phantom "unknown" entities.
+
+    # Battery-Care wiring for VW EU/Audi: existing fields
+    # ``battery_care_enabled`` + ``battery_care_target_soc_pct`` (defined
+    # below for Skoda/CUPRA/SEAT since v1.17.5) are now ALSO populated by
+    # vw_eu.py from ``charging.chargingCareSettings.value.batteryCareMode``
+    # + ``batteryChargingCare.chargingCareSettings.value.batteryCareTargetSoc``.
+    # No new model fields needed — the binary_sensor + sensor entities
+    # auto-spawn via existing ``_DATA_PRESENT_REQUIRED`` gating once the
+    # Cariad-BFF parser fills the values.
+
+    # Auto-Unlock plug when charged: VW EU/Audi from
+    # ``charging.chargingSettings.value.autoUnlockPlugWhenCharged`` ("permanent"/"OFF").
+    # Skoda from ``settings.autoUnlockPlugWhenCharged`` ("ON"/"OFF").
+    auto_unlock_when_charged: bool | None = None
+
+    # Climatization-at-Unlock: VW EU/Audi from
+    # ``climatisation.climatisationSettings.value.climatizationAtUnlock``.
+    # Skoda from ``airConditioningAtUnlock``. CUPRA/SEAT from
+    # ``mycar.climatisation.airConditioningAtUnlock``.
+    climate_at_unlock: bool | None = None
+
+    # Window-heating-enabled: VW EU/Audi from
+    # ``climatisation.climatisationSettings.value.windowHeatingEnabled``.
+    # Distinct from the existing v1.7.0 ``window_heating_front/back`` switches
+    # (those are STATES "on/off"); this is the SETTING ("auto-activate during
+    # climate?"). Boolean.
+    window_heating_enabled: bool | None = None
+
+    # Next-Charging-Timer info (read-side complement to v1.16.0
+    # write-side service ``set_departure_timer``): VW EU/Audi from
+    # ``automation.chargingProfiles.value.nextChargingTimer.{id, targetSOCreachable}``.
+    # ``id`` = which timer (1/2/3) is queued next.
+    # ``target_soc_reachable`` = "calculating" or a percent value.
+    next_charging_timer_id: int | None = None
+    next_charging_timer_target_soc_reachable: str | None = None
+
+    # Skoda PHEV secondary engine range (Kodiaq iV, Octavia iV, Superb iV).
+    # From ``driving-range.secondaryEngineRange.{distanceInKm, ...}``.
+    # Distinct from ``combustion_range_km`` because Skoda PHEVs report
+    # both via separate API blocks since 2024 firmware.
+    secondary_engine_range_km: int | None = None
+
+    # Audi/VW EU charging rate in km/h (parity with Skoda + CUPRA/SEAT
+    # which have ``charging_rate_kmh`` since v1.10.0). From
+    # ``charging.chargingStatus.value.chargeRate_kmph``. Reused field
+    # ``charging_rate_kmh`` already exists for the other brands — we
+    # don't add a new field, just populate it for VW EU/Audi too.
+
+    # Diagnostic: count of capabilities array (already used internally
+    # for capability gating since v1.13.0, now exposed for power users
+    # who want to see "this VIN reports N capabilities").
+    capabilities_count: int | None = None
+
     # Departure timers
     departure_timer_1_enabled: bool = False
     departure_timer_1_time: str | None = None

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.25.0"
+  "version": "1.26.0"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -654,6 +654,41 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    # v1.26.0 Welle-6 Feature Backlog (#173) — new sensors from scout reports.
+    VagSensorDescription(
+        key="secondary_engine_range_km",
+        translation_key="secondary_engine_range_km",
+        data_key="secondary_engine_range_km",
+        native_unit_of_measurement="km",
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:gas-station-outline",
+        condition="combustion",
+        suggested_display_precision=0,
+    ),
+    VagSensorDescription(
+        key="next_charging_timer_id",
+        translation_key="next_charging_timer_id",
+        data_key="next_charging_timer_id",
+        icon="mdi:numeric",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        condition="electric",
+    ),
+    VagSensorDescription(
+        key="next_charging_timer_target_soc_reachable",
+        translation_key="next_charging_timer_target_soc_reachable",
+        data_key="next_charging_timer_target_soc_reachable",
+        icon="mdi:battery-charging-high",
+        condition="electric",
+    ),
+    VagSensorDescription(
+        key="capabilities_count",
+        translation_key="capabilities_count",
+        data_key="capabilities_count",
+        icon="mdi:format-list-numbered",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 )
 
 # Sensor keys that read from coordinator helpers instead of the per-vehicle
@@ -710,6 +745,15 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # data-present gate keeps the entity from ever being created.
     "license_plate",
     "equipment_count",
+    # v1.26.0 Welle-6 Feature Backlog (#173) — phantom protection for
+    # the new sensors. Brand-restricted at the parser level (Skoda has
+    # secondary_engine_range_km only for PHEV; VW EU/Audi have the
+    # next_charging_timer_* + capabilities_count). Other vehicles leave
+    # the field None → no phantom entity created.
+    "secondary_engine_range_km",
+    "next_charging_timer_id",
+    "next_charging_timer_target_soc_reachable",
+    "capabilities_count",
 })
 
 # v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -260,6 +260,18 @@
       },
       "error_reporter_count": {
         "name": "Error Reporter"
+      },
+      "secondary_engine_range_km": {
+        "name": "Secondary Engine Range"
+      },
+      "next_charging_timer_id": {
+        "name": "Next Charging Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Next Charging Timer Target SoC Reachable"
+      },
+      "capabilities_count": {
+        "name": "Capabilities Count"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "battery_care_enabled": {
         "name": "Battery Care Active"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto Unlock When Charged"
+      },
+      "climate_at_unlock": {
+        "name": "Climate at Unlock"
+      },
+      "window_heating_enabled": {
+        "name": "Window Heating Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -260,6 +260,18 @@
       },
       "equipment_count": {
         "name": "Equipment Count"
+      },
+      "secondary_engine_range_km": {
+        "name": "Secondary Engine Range"
+      },
+      "next_charging_timer_id": {
+        "name": "Next Charging Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Next Charging Timer Target SoC Reachable"
+      },
+      "capabilities_count": {
+        "name": "Capabilities Count"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "battery_care_enabled": {
         "name": "Péče o Baterii Aktivní"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto Unlock When Charged"
+      },
+      "climate_at_unlock": {
+        "name": "Climate at Unlock"
+      },
+      "window_heating_enabled": {
+        "name": "Window Heating Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -260,6 +260,18 @@
       },
       "error_reporter_count": {
         "name": "Fehler-Berichter"
+      },
+      "secondary_engine_range_km": {
+        "name": "Reichweite Verbrenner (sekundär)"
+      },
+      "next_charging_timer_id": {
+        "name": "Nächster Lade-Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Nächster Lade-Timer Ziel-SoC erreichbar"
+      },
+      "capabilities_count": {
+        "name": "Fähigkeiten-Anzahl"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "warning_12v_low": {
         "name": "12V Starterbatterie schwach"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto-Entriegelung wenn vollgeladen"
+      },
+      "climate_at_unlock": {
+        "name": "Klima beim Entsperren"
+      },
+      "window_heating_enabled": {
+        "name": "Scheibenheizung aktiviert"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -260,6 +260,18 @@
       },
       "equipment_count": {
         "name": "Equipment Count"
+      },
+      "secondary_engine_range_km": {
+        "name": "Secondary Engine Range"
+      },
+      "next_charging_timer_id": {
+        "name": "Next Charging Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Next Charging Timer Target SoC Reachable"
+      },
+      "capabilities_count": {
+        "name": "Capabilities Count"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "battery_care_enabled": {
         "name": "Battery Care Active"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto Unlock When Charged"
+      },
+      "climate_at_unlock": {
+        "name": "Climate at Unlock"
+      },
+      "window_heating_enabled": {
+        "name": "Window Heating Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -260,6 +260,18 @@
       },
       "equipment_count": {
         "name": "Equipment Count"
+      },
+      "secondary_engine_range_km": {
+        "name": "Secondary Engine Range"
+      },
+      "next_charging_timer_id": {
+        "name": "Next Charging Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Next Charging Timer Target SoC Reachable"
+      },
+      "capabilities_count": {
+        "name": "Capabilities Count"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "battery_care_enabled": {
         "name": "Cuidado de Batería Activo"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto Unlock When Charged"
+      },
+      "climate_at_unlock": {
+        "name": "Climate at Unlock"
+      },
+      "window_heating_enabled": {
+        "name": "Window Heating Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -260,6 +260,18 @@
       },
       "equipment_count": {
         "name": "Equipment Count"
+      },
+      "secondary_engine_range_km": {
+        "name": "Secondary Engine Range"
+      },
+      "next_charging_timer_id": {
+        "name": "Next Charging Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Next Charging Timer Target SoC Reachable"
+      },
+      "capabilities_count": {
+        "name": "Capabilities Count"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "battery_care_enabled": {
         "name": "Soin Batterie Actif"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto Unlock When Charged"
+      },
+      "climate_at_unlock": {
+        "name": "Climate at Unlock"
+      },
+      "window_heating_enabled": {
+        "name": "Window Heating Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -260,6 +260,18 @@
       },
       "equipment_count": {
         "name": "Equipment Count"
+      },
+      "secondary_engine_range_km": {
+        "name": "Secondary Engine Range"
+      },
+      "next_charging_timer_id": {
+        "name": "Next Charging Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Next Charging Timer Target SoC Reachable"
+      },
+      "capabilities_count": {
+        "name": "Capabilities Count"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "battery_care_enabled": {
         "name": "Batterij-Zorg Actief"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto Unlock When Charged"
+      },
+      "climate_at_unlock": {
+        "name": "Climate at Unlock"
+      },
+      "window_heating_enabled": {
+        "name": "Window Heating Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -260,6 +260,18 @@
       },
       "equipment_count": {
         "name": "Equipment Count"
+      },
+      "secondary_engine_range_km": {
+        "name": "Secondary Engine Range"
+      },
+      "next_charging_timer_id": {
+        "name": "Next Charging Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Next Charging Timer Target SoC Reachable"
+      },
+      "capabilities_count": {
+        "name": "Capabilities Count"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "battery_care_enabled": {
         "name": "Ochrona Baterii Aktywna"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto Unlock When Charged"
+      },
+      "climate_at_unlock": {
+        "name": "Climate at Unlock"
+      },
+      "window_heating_enabled": {
+        "name": "Window Heating Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -260,6 +260,18 @@
       },
       "equipment_count": {
         "name": "Equipment Count"
+      },
+      "secondary_engine_range_km": {
+        "name": "Secondary Engine Range"
+      },
+      "next_charging_timer_id": {
+        "name": "Next Charging Timer ID"
+      },
+      "next_charging_timer_target_soc_reachable": {
+        "name": "Next Charging Timer Target SoC Reachable"
+      },
+      "capabilities_count": {
+        "name": "Capabilities Count"
       }
     },
     "binary_sensor": {
@@ -328,6 +340,15 @@
       },
       "battery_care_enabled": {
         "name": "Batteri-Vård Aktiv"
+      },
+      "auto_unlock_when_charged": {
+        "name": "Auto Unlock When Charged"
+      },
+      "climate_at_unlock": {
+        "name": "Climate at Unlock"
+      },
+      "window_heating_enabled": {
+        "name": "Window Heating Enabled"
       }
     },
     "switch": {


### PR DESCRIPTION
Closes #173. Implements 7 new entities (4 sensors + 3 binary) from scout reports that were silenced in v1.19.3 instead of exposed. Plus cross-brand battery-care parity for VW EU/Audi. See CHANGELOG for full notes. 🤖 [Claude Code](https://claude.com/claude-code)