### PR TITLE
v1.26.1 hotfix: integration won't load after v1.25.x — revert manifest quality_scale + DeviceInfo additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,31 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.26.1] - 2026-05-09 🚨 Hotfix: Integration lädt nicht in v1.25.x / Hotfix: integration won't load in v1.25.x
+
+🚨 **PATCH-Release (Hotfix).** User-Report 2026-05-09 22:35: Integration zeigt "Nicht geladen" in HA nach Update auf v1.25.x. Schneller Rollback der wahrscheinlichsten Verdächtigen aus dem v1.25.0 PR-EFG Mega-Bundle:
+
+### 🔄 Reverted
+
+- **`manifest.json`**: Entfernt `quality_scale: "platinum"` und `loggers: ["custom_components.vag_connect"]` (beide neu in v1.25.0). HA's runtime quality-scale validator scheint strenger zu sein als hassfest CI — wenn nicht 100% platinum-compliant verweigert HA möglicherweise den Load. Kommt in v1.27.0+ zurück nachdem wir compliance-Lücken analysiert haben.
+- **`entity_base.py:device_info`**: Entfernt `configuration_url=...` (brand-aware "Open in App" Button) + `suggested_area="Garage"` (Auto-Area beim Setup). Diese DeviceInfo-Felder sind dokumentiert valid aber TypedDict-Validation in neueren HA-Cores könnte zu strict sein. Kommt in v1.27.0 zurück nachdem isoliert.
+
+### 🎯 NICHT reverted (bleiben aktiv)
+
+- v1.26.0 Welle-6 Feature Backlog (7 neue Entitäten + Cross-Brand Battery-Care Parity) — bleibt aktiv, betrifft nur per-vehicle parser logic
+- v1.25.0 _normalize.py Foundation, Cross-Brand Parity Wins, Listener Pattern, GPS hardening, MBB VSR Phase 2, Translation sync — alle bleiben aktiv
+- `entity_base.py:extra_state_attributes` (image_url für Custom Lovelace Cards) — bleibt aktiv, ist additive
+
+### 🩺 Diagnose-Pfad
+
+Wenn dieser Hotfix das Problem nicht löst: bitte HA-Logs unter Settings → System → Logs → Filter `vag_connect` → Trace posten unter neuer Issue. Wahrscheinliche restliche Verdächtigen wären dann Coordinator __init__ (CommandDispatcher) oder Listener Pattern in Platform setup_entry.
+
+### 📋 Verifizierung
+
+- `python -m ruff check custom_components/` → All checks passed
+- `python -m mypy ... (CI flags)` → clean
+- Kein Test-Impact (rein subtractive Änderungen)
+
 ## [1.26.0] - 2026-05-09 🎯 Welle-6 Feature Backlog (#173) — 7 neue Entitäten + Cross-Brand Parity / Welle-6 Feature Backlog (#173) — 7 new entities + Cross-Brand Parity
 
 🎯 **MINOR-Release.** Setzt das Welle-6 Scout-Feature-Backlog (#173) um. **Diese Features waren in den Scout-Reports #129/#130/#132/#133/#143/#144/#145/#146/#147/#165/#167 enthalten aber wurden in v1.19.3 nur EXPECTED_KEYS-silenced statt als Entitäten exposed** — der v1.25.0 Audit hatte das als Pattern-Bruch identifiziert (vergleiche #91 → 5 neue Entitäten in v1.11.0).

--- a/custom_components/vag_connect/entity_base.py
+++ b/custom_components/vag_connect/entity_base.py
@@ -122,6 +122,13 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
         brand = self.coordinator.entry.data.get("brand", "vag")
         name = _device_name(vehicle, brand)
 
+        # v1.26.1 hotfix: revert configuration_url + suggested_area
+        # additions from v1.25.0 PR-EFG. User-report 2026-05-09:
+        # integration "Nicht geladen" after v1.25.x update. Root cause
+        # likely either DeviceInfo TypedDict-strict-validation in newer
+        # HA core OR quality_scale="platinum" runtime check (also
+        # reverted via manifest.json). configuration_url + suggested_area
+        # come back in v1.27.0 once we've isolated the actual culprit.
         return DeviceInfo(
             identifiers={(DOMAIN, self._vin)},
             name=name,
@@ -134,8 +141,6 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
                 else None
             ),
             sw_version=vehicle.get("firmware_version"),
-            configuration_url=self._BRAND_PORTAL.get(brand.lower()),
-            suggested_area="Garage",
         )
 
     @property

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -10,10 +10,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
-  "loggers": [
-    "custom_components.vag_connect"
-  ],
-  "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.26.0"
+  "version": "1.26.1"
 }


### PR DESCRIPTION
🚨 Hotfix per user-report 2026-05-09 22:35. Reverts manifest quality_scale=platinum + loggers field, plus DeviceInfo configuration_url + suggested_area additions. v1.26.0 Welle-6 features stay active. 🤖 [Claude Code](https://claude.com/claude-code)