### PR TITLE
v1.27.1 hotfix: device_tracker GPS data (parking parser data-unwrap fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ carconnectivity.json
 
 # Bruno local environment files (real credentials — never commit)
 tests/bruno/**/environments/*.local.bru
+
+# Claude Code workspace settings (local)
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,52 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
+## [1.27.1] - 2026-05-11 🚨🔧 Hotfix: device_tracker GPS-Daten / Hotfix: device_tracker GPS data
+
+🚨 **PATCH-Release.** v1.27.0 hatte einen Parser-Bug der seit unbestimmter Zeit den device_tracker für Cariad-BFF Brands (VW EU, Audi via Cariad-Pfad) verhindert hat.
+
+### 🐛 Root cause
+
+Cariad-BFF `/vehicle/v1/vehicles/{vin}/parkingposition` returnt:
+```json
+{"data": {"lat": 47.401794, "lon": 8.215701, "carCapturedTimestamp": "..."}}
+```
+
+Der Parser in `cariad/api/vw_eu.py:1195` las direkt `parking.get("lat")` ohne den `data` wrapper auszupacken — Ergebnis war immer `None`. `device_tracker._has_gps()` filtert `None` lat/lon stillschweigend raus → kein Tracker spawned. Bug live entdeckt durch User-Report + verifiziert via `scripts/verify_cariad_for_gte.py` Output.
+
+### 🔧 Fix
+
+`cariad/api/vw_eu.py` parking position parser packt nun `data` wrapper aus:
+```python
+parking_data = parking.get("data") if isinstance(parking, dict) else parking
+d.latitude = parking_data.get("lat")
+d.longitude = parking_data.get("lon")
+```
+
+Mit Fallback auf top-level falls historische/alternative Firmwares ohne `data` wrapper antworten.
+
+Selbe Fix für `parking_data.address` (parking_address + parking_city Sensoren).
+
+### ✅ Was jetzt funktioniert
+
+- `device_tracker.{name}_position` mit live lat/lon (Karte in HA)
+- `sensor.{name}_parking_address` mit `formattedAddress` oder composed street/city/country
+- `sensor.{name}_parking_city`
+- `extra_state_attributes` für Map-Tooltip (parking_address, last_seen, etc.)
+
+### 🧪 Verifikation
+
+Live verifiziert mit Golf 7 GTE (VIN WVWZZZAUZFW...) am 2026-05-11:
+- Cariad parkingposition response: lat 47.401794, lon 8.215701 (Aargau Region)
+- Pre-fix: device_tracker unknown / nicht gespawnt
+- Post-fix: device_tracker.golf_gte_position erscheint mit korrekter Position
+
+### 📋 Affected versions
+
+Parser-Bug existiert wahrscheinlich seit der initialen Cariad-BFF Implementierung. Fix gilt rückwirkend für ALLE Cariad-Brands (VW EU + Audi via Cariad). Skoda mysmob + SEAT/CUPRA OLA + Porsche PPA haben eigene Parser, nicht betroffen.
+
+---
+
 ## [1.27.0] - 2026-05-11 🔬📋 Pre-Cariad PHEV Research + Strategic Roadmap / Pre-Cariad PHEV Research + Strategic Roadmap
 
 🔬 **MINOR-Release.** Diese Version bündelt 6 Stunden tiefgehende Pre-Cariad MBB Forschung, einen kompletten Strategic Roadmap, sowie das Polish-Feature aus Issue #178 (loggers field — `quality_scale` bleibt zurückgehalten bis HA Core stabilisiert).

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1191,9 +1191,21 @@ class VWEUClient(CariadBaseClient):
             setattr(d, f"departure_timer_{i}_time", time_str)
 
         # ── Parking position ──────────────────────────────────────────────────
+        # v1.27.1 hotfix: Cariad-BFF ``/vehicle/v1/vehicles/{vin}/parkingposition``
+        # returns ``{"data": {"lat": ..., "lon": ..., "carCapturedTimestamp": ...}}``.
+        # Pre-v1.27.1 parser read ``parking.get("lat")`` directly (no ``data``
+        # unwrap) → always None → device_tracker never spawned because
+        # ``device_tracker._has_gps()`` filter rejects None values silently.
+        # Verified live response shape via ``scripts/verify_cariad_for_gte.py``
+        # against Golf 7 GTE on 2026-05-11.
         if parking:
-            d.latitude = parking.get("lat")
-            d.longitude = parking.get("lon")
+            parking_data = parking.get("data") if isinstance(parking, dict) else None
+            if not isinstance(parking_data, dict):
+                # Some legacy/historic responses or alternate firmwares may
+                # ship lat/lon at top level — keep that as a fallback.
+                parking_data = parking
+            d.latitude = parking_data.get("lat")
+            d.longitude = parking_data.get("lon")
             # v1.25.0 PR-A — Cross-brand parity: parking_address from
             # Cariad-BFF if present (Skoda mysmob ships
             # ``formattedAddress`` since v1.20.0). Cariad-BFF
@@ -1202,7 +1214,7 @@ class VWEUClient(CariadBaseClient):
             # on most accounts; some firmwares also surface a
             # composed ``formattedAddress``. Saves the HA
             # reverse-geocoding round-trip when supplied.
-            addr_block = parking.get("address") if isinstance(parking, dict) else None
+            addr_block = parking_data.get("address") if isinstance(parking_data, dict) else None
             if isinstance(addr_block, dict):
                 fa = addr_block.get("formattedAddress")
                 if isinstance(fa, str) and fa:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -14,5 +14,5 @@
     "custom_components.vag_connect"
   ],
   "requirements": [],
-  "version": "1.27.0"
+  "version": "1.27.1"
 }

--- a/docs/releases/v1.27.1-release-notes.md
+++ b/docs/releases/v1.27.1-release-notes.md
@@ -1,0 +1,50 @@
+# v1.27.1 — Hotfix: device_tracker GPS data
+
+Patch release that fixes a long-standing parser bug preventing the
+`device_tracker` entity from receiving GPS coordinates for Cariad-BFF
+brands (VW EU, Audi via Cariad path).
+
+## 🐛 Bug
+
+Cariad-BFF `/vehicle/v1/vehicles/{vin}/parkingposition` returns:
+
+```json
+{"data": {"lat": 47.401794, "lon": 8.215701, "carCapturedTimestamp": "..."}}
+```
+
+The parser in `cariad/api/vw_eu.py` was reading `parking.get("lat")` directly
+without unwrapping the `data` envelope → result was always `None`. The
+`device_tracker._has_gps()` filter silently rejects `None` lat/lon → no
+tracker entity ever spawned.
+
+## 🔧 Fix
+
+Parser now unwraps the `data` key with a fallback to top-level for legacy
+firmware variants. Same fix applied to `parking_address` / `parking_city`
+extraction (which read from the same response).
+
+## ✅ Now working
+
+- `device_tracker.{name}_position` with live lat/lon (visible on HA map)
+- `sensor.{name}_parking_address`
+- `sensor.{name}_parking_city`
+- Map tooltip attributes (parking_address, last_seen_at, etc.)
+
+## 📦 Affected versions
+
+The parser bug existed since the initial Cariad-BFF implementation. The fix
+applies retroactively to ALL Cariad-using brands (VW EU + Audi via Cariad).
+Skoda mysmob, SEAT/CUPRA OLA, and Porsche PPA use separate parsers — not
+affected.
+
+## 🧪 Verification
+
+Verified live against a Golf 7 GTE on 2026-05-11:
+- Pre-fix: `device_tracker` unknown / not spawned
+- Post-fix: `device_tracker.golf_gte_position` appears with correct
+  coordinates (47.401794, 8.215701 — Aargau)
+
+## 📦 Upgrade
+
+In-place HACS upgrade. No config changes needed. After upgrade + restart,
+device_tracker entity should appear within one polling cycle (~2-5 minutes).


### PR DESCRIPTION
## Summary

Hotfix for v1.27.0+ device_tracker entity not appearing / not getting GPS coordinates for Cariad-BFF brands (VW EU, Audi via Cariad).

## 🐛 Root cause

Cariad-BFF `/vehicle/v1/vehicles/{vin}/parkingposition` returns:

```json
{"data": {"lat": 47.401794, "lon": 8.215701, "carCapturedTimestamp": "..."}}
```

Parser in `cariad/api/vw_eu.py:1195` read `parking.get("lat")` directly **without unwrapping** the `data` envelope → result was always `None`. The `device_tracker._has_gps()` filter silently rejects `None` lat/lon → tracker entity never spawned.

This bug existed since the initial Cariad-BFF implementation. Discovered today via user report after v1.27.0 install.

## 🔧 Fix

```python
parking_data = parking.get("data") if isinstance(parking, dict) else parking
d.latitude = parking_data.get("lat")
d.longitude = parking_data.get("lon")
```

With fallback to top-level for legacy/alternative firmware variants. Same fix applied to `parking_data.address` (parking_address + parking_city sensors).

## 🧪 Verification

Live verified against Golf 7 GTE (VIN WVWZZZAUZFW...) on 2026-05-11:
- **Pre-fix:** `device_tracker` unknown / not spawned
- **Post-fix:** `device_tracker.golf_gte_position` appears with coordinates 47.401794, 8.215701 (Aargau region, CH)

Cross-verified via `scripts/verify_cariad_for_gte.py` output:
```
✓ 200  parkingposition  {"data":{"lon":8.215701,"lat":47.401794,...}}
```

## 📦 Affected versions

ALL Cariad-using brands (VW EU + Audi via Cariad) since initial Cariad-BFF implementation.

NOT affected: Skoda mysmob, SEAT/CUPRA OLA, Porsche PPA (separate parsers).

## Test plan

- [x] Parser changes compile (`python -m py_compile`)
- [x] Live verified against Golf 7 GTE — coordinates flow through to HA map
- [x] Existing `parking_address` / `parking_city` sensors still work (use same fix path)
- [x] `.claude/settings.local.json` accidentally committed — removed via amend + force-push, added `.claude/` to .gitignore
- [ ] CI green (waiting)

## What this enables

Every Cariad-BFF user (VW EU + Audi via Cariad) will see their car's GPS position appear on HA's map after upgrading + one polling cycle (~2-5 minutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)