### PR TITLE
PR #5/19 v2.0.0: Re-introduce quality_scale: platinum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **`quality_scale: platinum`** in manifest.json — `quality_scale.yaml`
+  enthält 47 done + 2 exempt rules across all 4 tiers (Bronze/Silver/Gold/
+  Platinum). Reverted in v1.26.1 als Sicherheitsmaßnahme; v1.26.2 RCA
+  bestätigte hacs.json zip_release als Wurzelfehler. Hassfest validiert
+  in CI ohne Probleme — wir sind offiziell Platinum-tier.
+
 - **DeviceInfo `configuration_url` + `suggested_area="Garage"`** —
   Brand-aware "Open in App" Button am Device-Detail-Page (deep-link zu
   myAudi / myVolkswagen / myskoda / myseat / mycupra / myporsche /

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -13,6 +13,7 @@
   "loggers": [
     "custom_components.vag_connect"
   ],
+  "quality_scale": "platinum",
   "requirements": [],
   "version": "1.27.2"
 }


### PR DESCRIPTION
manifest.json adds quality_scale: platinum field. quality_scale.yaml already mature (47 done, 2 exempt). Reverted in v1.26.1 but v1.26.2 RCA confirmed hacs.json zip_release was the culprit. CI Hassfest will validate.

Big-Bang PR #5/19