### PR TITLE
PR #7/19 v2.0.0: Porsche TPMS sensors (4 corners + aggregate warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,16 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   HA Services + `VagAuxHeatingSwitch` Entity transparent für Skoda PHEV/
   Diesel-Modelle mit Standheizung (Octavia, Superb, Kodiaq iV).
 
+- **Porsche TPMS Sensors [NEW v2.0]** — vier Reifen-Druck-Sensoren
+  (`tire_pressure_front_left_bar` … `tire_pressure_rear_right_bar` in bar
+  mit `device_class=PRESSURE`) plus aggregierter `tire_pressure_warning`
+  binary_sensor (PROBLEM device_class). Datenquelle: PPA
+  `GET /app/connect/v1/vehicles/{vin}/measurements?fields=TIRE_PRESSURE`
+  (Porsche ConnectPlus Subscription erforderlich). kPa↔bar Auto-Convert
+  ist eingebaut. Brand-restricted via `_DATA_PRESENT_REQUIRED` —
+  non-Porsche und pre-TPMS Modelle erzeugen keine Phantom-Entitäten.
+  Übersetzungen alle 8 Sprachen (DE/EN/CS/ES/FR/NL/PL/SV).
+
 ### Fixed
 
 - **#53 CUPRA Born — defensive `command_flash` + OLA parking parser fix.**

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -230,6 +230,18 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:car-defrost-front",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.0.0 (Big-Bang) — Porsche TPMS warning aggregate (any corner
+    # raising ``warning: true`` in the TIRE_PRESSURE measurement).
+    # Brand-restricted via _DATA_PRESENT_REQUIRED below — non-Porsche
+    # vehicles leave the field None → no phantom entity is created.
+    VagBinarySensorDescription(
+        key="tire_pressure_warning",
+        translation_key="tire_pressure_warning",
+        data_key="tire_pressure_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        icon="mdi:car-tire-alert",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 BINARY_DESCRIPTIONS = BINARY_DESCRIPTIONS + _NEW_BINARY
 
@@ -251,6 +263,9 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "auto_unlock_when_charged",
     "climate_at_unlock",
     "window_heating_enabled",
+    # v2.0.0 (Big-Bang) — Porsche-only TPMS warning (PPA TIRE_PRESSURE
+    # measurement). Non-Porsche vehicles leave the field None → no phantom.
+    "tire_pressure_warning",
 })
 
 

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -94,6 +94,9 @@ class PorscheClient:
                     "OPEN_STATE_DOOR_REAR_RIGHT", "OPEN_STATE_LID_FRONT",
                     "OPEN_STATE_LID_REAR", "OPEN_STATE_SUNROOF",
                     "MAIN_SERVICE_RANGE", "OIL_SERVICE_RANGE",
+                    # v2.0.0 (Big-Bang) — TPMS, parsed below into the
+                    # tire_pressure_* fields on VehicleData.
+                    "TIRE_PRESSURE",
                 ])
             }),
             return_exceptions=True,
@@ -155,6 +158,35 @@ class PorscheClient:
             # Service
             d.service_km    = v(m, "MAIN_SERVICE_RANGE", "distance")
             d.oil_service_km = v(m, "OIL_SERVICE_RANGE", "distance")
+
+            # ── v2.0.0 (Big-Bang) — TPMS ─────────────────────────────────
+            # PPA returns ``TIRE_PRESSURE`` as a dict with per-corner
+            # entries: ``frontLeft``/``frontRight``/``rearLeft``/``rearRight``,
+            # each carrying ``currentPressure`` (kPa or bar depending on
+            # vehicle locale — observed in the wild as kPa float, e.g.
+            # 235.0 → 2.35 bar) and ``warning`` (bool). Defensive: only
+            # populate if the dict actually has corner entries — older
+            # PPA variants ship an empty dict for non-TPMS-equipped cars.
+            tp = m.get("TIRE_PRESSURE", {})
+            if isinstance(tp, dict) and tp:
+                def _bar(corner: str) -> float | None:
+                    raw = v(tp, corner, "currentPressure")
+                    if raw is None:
+                        return None
+                    try:
+                        n = float(raw)
+                    except (TypeError, ValueError):
+                        return None
+                    # kPa heuristic: anything > 10 is kPa, divide by 100
+                    return round(n / 100.0, 2) if n > 10 else round(n, 2)
+                d.tire_pressure_front_left_bar  = _bar("frontLeft")
+                d.tire_pressure_front_right_bar = _bar("frontRight")
+                d.tire_pressure_rear_left_bar   = _bar("rearLeft")
+                d.tire_pressure_rear_right_bar  = _bar("rearRight")
+                d.tire_pressure_warning = any(
+                    bool(v(tp, c, "warning"))
+                    for c in ("frontLeft", "frontRight", "rearLeft", "rearRight")
+                )
 
         return d
 

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -504,6 +504,20 @@ class VehicleData:
     driving_score: int | None = None
     driving_score_class: str | None = None
 
+    # v2.0.0 (Big-Bang) — Porsche TPMS (Tire Pressure Monitoring System).
+    # Populated by PorscheClient from
+    # ``GET /app/connect/v1/vehicles/{vin}/measurements?fields=TIRE_PRESSURE``
+    # (PPA endpoint, requires ConnectPlus subscription on most models).
+    # Per-tire pressure in bar (kPa/100). Warning flag derived from
+    # the per-tire ``warning`` boolean union. Other brands' status
+    # endpoints don't expose per-tire data — fields stay None and
+    # _DATA_PRESENT_REQUIRED prevents phantom entities.
+    tire_pressure_front_left_bar: float | None = None
+    tire_pressure_front_right_bar: float | None = None
+    tire_pressure_rear_left_bar: float | None = None
+    tire_pressure_rear_right_bar: float | None = None
+    tire_pressure_warning: bool | None = None
+
     # v1.14.0 (#24) — Trip Statistics from CARIAD-BFF
     # ``GET /vehicle/v1/vehicles/{vin}/tripstatistics?type={shortTerm|longTerm}``.
     # Both endpoints return ``{tripDataList: {tripData: [...]}}``; we sort

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -625,6 +625,50 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:gauge",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.0.0 (Big-Bang) — Porsche TPMS (4 corners). PPA only — Cariad/OLA/
+    # mysmob status endpoints don't expose per-tire pressure today.
+    # Brand-restricted via _DATA_PRESENT_REQUIRED — non-Porsche vehicles
+    # (and pre-TPMS Porsche models) leave fields None → no phantom entity.
+    VagSensorDescription(
+        key="tire_pressure_front_left_bar",
+        translation_key="tire_pressure_front_left_bar",
+        data_key="tire_pressure_front_left_bar",
+        native_unit_of_measurement="bar",
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:tire",
+        suggested_display_precision=2,
+    ),
+    VagSensorDescription(
+        key="tire_pressure_front_right_bar",
+        translation_key="tire_pressure_front_right_bar",
+        data_key="tire_pressure_front_right_bar",
+        native_unit_of_measurement="bar",
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:tire",
+        suggested_display_precision=2,
+    ),
+    VagSensorDescription(
+        key="tire_pressure_rear_left_bar",
+        translation_key="tire_pressure_rear_left_bar",
+        data_key="tire_pressure_rear_left_bar",
+        native_unit_of_measurement="bar",
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:tire",
+        suggested_display_precision=2,
+    ),
+    VagSensorDescription(
+        key="tire_pressure_rear_right_bar",
+        translation_key="tire_pressure_rear_right_bar",
+        data_key="tire_pressure_rear_right_bar",
+        native_unit_of_measurement="bar",
+        device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:tire",
+        suggested_display_precision=2,
+    ),
 
     # ── v1.9.0 Vehicle Data Scout + Error Reporter ────────────────────────────
     # Two diagnostic sensors that surface drift / runtime errors detected
@@ -801,6 +845,12 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # Other brands leave both fields None; gate prevents phantom entities.
     "driving_score",
     "driving_score_class",
+    # v2.0.0 (Big-Bang) — Porsche-only TPMS (PPA TIRE_PRESSURE measurement).
+    # Non-Porsche vehicles leave the fields None → no phantom entity.
+    "tire_pressure_front_left_bar",
+    "tire_pressure_front_right_bar",
+    "tire_pressure_rear_left_bar",
+    "tire_pressure_rear_right_bar",
 })
 
 # v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -252,6 +252,18 @@
       "driving_score_class": {
         "name": "Driving Score Class"
       },
+      "tire_pressure_front_left_bar": {
+        "name": "Tire Pressure Front Left"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Tire Pressure Front Right"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Tire Pressure Rear Left"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Tire Pressure Rear Right"
+      },
       "departure_timer_1_time": {
         "name": "Departure Timer 1"
       },
@@ -364,6 +376,9 @@
       },
       "window_heating_enabled": {
         "name": "Window Heating Enabled"
+      },
+      "tire_pressure_warning": {
+        "name": "Tire Pressure Warning"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -278,6 +278,18 @@
       },
       "capabilities_count": {
         "name": "Capabilities Count"
+      },
+      "tire_pressure_front_left_bar": {
+        "name": "Tlak Pneumatik Přední Levá"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Tlak Pneumatik Přední Pravá"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Tlak Pneumatik Zadní Levá"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Tlak Pneumatik Zadní Pravá"
       }
     },
     "binary_sensor": {
@@ -355,6 +367,9 @@
       },
       "window_heating_enabled": {
         "name": "Window Heating Enabled"
+      },
+      "tire_pressure_warning": {
+        "name": "Varování Tlaku Pneumatik"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -278,6 +278,18 @@
       },
       "capabilities_count": {
         "name": "Fähigkeiten-Anzahl"
+      },
+      "tire_pressure_front_left_bar": {
+        "name": "Reifendruck Vorne Links"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Reifendruck Vorne Rechts"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Reifendruck Hinten Links"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Reifendruck Hinten Rechts"
       }
     },
     "binary_sensor": {
@@ -355,6 +367,9 @@
       },
       "window_heating_enabled": {
         "name": "Scheibenheizung aktiviert"
+      },
+      "tire_pressure_warning": {
+        "name": "Reifendruck-Warnung"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -278,6 +278,18 @@
       },
       "capabilities_count": {
         "name": "Capabilities Count"
+      },
+      "tire_pressure_front_left_bar": {
+        "name": "Tire Pressure Front Left"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Tire Pressure Front Right"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Tire Pressure Rear Left"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Tire Pressure Rear Right"
       }
     },
     "binary_sensor": {
@@ -355,6 +367,9 @@
       },
       "window_heating_enabled": {
         "name": "Window Heating Enabled"
+      },
+      "tire_pressure_warning": {
+        "name": "Tire Pressure Warning"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -278,6 +278,18 @@
       },
       "capabilities_count": {
         "name": "Capabilities Count"
+      },
+      "tire_pressure_front_left_bar": {
+        "name": "Presión Neumático Delantero Izquierdo"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Presión Neumático Delantero Derecho"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Presión Neumático Trasero Izquierdo"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Presión Neumático Trasero Derecho"
       }
     },
     "binary_sensor": {
@@ -355,6 +367,9 @@
       },
       "window_heating_enabled": {
         "name": "Window Heating Enabled"
+      },
+      "tire_pressure_warning": {
+        "name": "Aviso de Presión de Neumáticos"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -278,6 +278,18 @@
       },
       "capabilities_count": {
         "name": "Capabilities Count"
+      },
+      "tire_pressure_front_left_bar": {
+        "name": "Pression Pneu Avant Gauche"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Pression Pneu Avant Droit"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Pression Pneu Arrière Gauche"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Pression Pneu Arrière Droit"
       }
     },
     "binary_sensor": {
@@ -355,6 +367,9 @@
       },
       "window_heating_enabled": {
         "name": "Window Heating Enabled"
+      },
+      "tire_pressure_warning": {
+        "name": "Alerte Pression Pneus"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -278,6 +278,18 @@
       },
       "capabilities_count": {
         "name": "Capabilities Count"
+      },
+      "tire_pressure_front_left_bar": {
+        "name": "Bandenspanning Voor Links"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Bandenspanning Voor Rechts"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Bandenspanning Achter Links"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Bandenspanning Achter Rechts"
       }
     },
     "binary_sensor": {
@@ -355,6 +367,9 @@
       },
       "window_heating_enabled": {
         "name": "Window Heating Enabled"
+      },
+      "tire_pressure_warning": {
+        "name": "Bandenspanning-Waarschuwing"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -278,6 +278,18 @@
       },
       "capabilities_count": {
         "name": "Capabilities Count"
+      },
+      "tire_pressure_front_left_bar": {
+        "name": "Ciśnienie Opony Przód Lewy"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Ciśnienie Opony Przód Prawy"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Ciśnienie Opony Tył Lewy"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Ciśnienie Opony Tył Prawy"
       }
     },
     "binary_sensor": {
@@ -355,6 +367,9 @@
       },
       "window_heating_enabled": {
         "name": "Window Heating Enabled"
+      },
+      "tire_pressure_warning": {
+        "name": "Ostrzeżenie Ciśnienia Opon"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -278,6 +278,18 @@
       },
       "capabilities_count": {
         "name": "Capabilities Count"
+      },
+      "tire_pressure_front_left_bar": {
+        "name": "Däcktryck Fram Vänster"
+      },
+      "tire_pressure_front_right_bar": {
+        "name": "Däcktryck Fram Höger"
+      },
+      "tire_pressure_rear_left_bar": {
+        "name": "Däcktryck Bak Vänster"
+      },
+      "tire_pressure_rear_right_bar": {
+        "name": "Däcktryck Bak Höger"
       }
     },
     "binary_sensor": {
@@ -355,6 +367,9 @@
       },
       "window_heating_enabled": {
         "name": "Window Heating Enabled"
+      },
+      "tire_pressure_warning": {
+        "name": "Däcktryck Varning"
       }
     },
     "switch": {


### PR DESCRIPTION
## Summary

- **[NEW v2.0] Porsche TPMS** — surfaces the PPA `TIRE_PRESSURE` measurement as four per-corner pressure sensors (`tire_pressure_front_left_bar` / `…front_right_bar` / `…rear_left_bar` / `…rear_right_bar`) in **bar** with `device_class=PRESSURE`, plus an aggregate `tire_pressure_warning` binary_sensor (`PROBLEM` device class).
- kPa↔bar auto-conversion (PPA returns kPa as float in the wild — the parser detects values >10 and divides by 100).
- All 8 translations synced (DE/EN/CS/ES/FR/NL/PL/SV).

## Why
TPMS is one of the highest-value Porsche-specific signals. ConnectPlus subscribers already see it in the My Porsche app — bringing it into HA closes a long-standing gap (the integration previously surfaced battery + GPS + door state but no tire data).

## Phantom-entity protection
All 5 fields gated via `_DATA_PRESENT_REQUIRED` in `sensor.py` + `binary_sensor.py` — non-Porsche vehicles and pre-TPMS Porsche models leave the fields `None`, so no phantom "unknown" entities ever spawn.

## Test plan
- [x] `python -m py_compile` clean for `cariad/api/porsche.py`, `cariad/models.py`, `sensor.py`, `binary_sensor.py`
- [x] All 9 modified JSON files (`strings.json` + 8 translations) parse as valid JSON
- [ ] CI 7/7 green (Hassfest, HACS, Lint, mypy, Bruno-drift, Tests, .bru-syntax) — Porsche is not in Bruno drift coverage today, so this PR adds no .bru files
- [ ] Smoke against a real Porsche Taycan / 911 with ConnectPlus sub once shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)