### PR TITLE
PR #8/19 v2.0.0: Long-Term Trip Aggregates as first-class entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,16 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   non-Porsche und pre-TPMS Modelle erzeugen keine Phantom-Entitäten.
   Übersetzungen alle 8 Sprachen (DE/EN/CS/ES/FR/NL/PL/SV).
 
+- **Long-Term Trip Aggregates [NEW v2.0]** (Audi + VW EU) — drei neue
+  Lifetime-Sensoren auf Basis der `/tripstatistics?type=longTerm`
+  Antwort, die der Coordinator schon seit v1.14.0 in `lifetime_*`
+  Felder mergt aber bisher NIE als Entitäten exposed wurden:
+  `lifetime_distance_km` (TOTAL_INCREASING), `lifetime_avg_fuel_
+  consumption_l_100km` (combustion-gated), `lifetime_avg_electric_
+  consumption_kwh_100km` (electric-gated). Brand-Gating via
+  bestehendem `_TRIP_STATS_BRANDS` + `_TRIP_STATS_KEYS`. Übersetzungen
+  alle 8 Sprachen.
+
 ### Fixed
 
 - **#53 CUPRA Born — defensive `command_flash` + OLA parking parser fix.**

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -776,6 +776,42 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    # v2.0.0 (Big-Bang) — Long-Term Trip Aggregates [NEW v2.0].
+    # Coordinator already merges ``longTerm`` (since-last-reset) data
+    # into ``lifetime_*`` fields on VehicleData; v2.0.0 finally promotes
+    # them to first-class entities. Brand-restricted via the existing
+    # _TRIP_STATS_BRANDS / _TRIP_STATS_KEYS gating below (Audi + VW EU
+    # only — CARIAD-BFF /tripstatistics endpoint).
+    VagSensorDescription(
+        key="lifetime_distance_km",
+        translation_key="lifetime_distance_km",
+        data_key="lifetime_distance_km",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:counter",
+        suggested_display_precision=0,
+    ),
+    VagSensorDescription(
+        key="lifetime_avg_fuel_consumption_l_100km",
+        translation_key="lifetime_avg_fuel_consumption_l_100km",
+        data_key="lifetime_avg_fuel_consumption_l_100km",
+        native_unit_of_measurement="L/100 km",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:gas-station",
+        suggested_display_precision=1,
+        condition="combustion",
+    ),
+    VagSensorDescription(
+        key="lifetime_avg_electric_consumption_kwh_100km",
+        translation_key="lifetime_avg_electric_consumption_kwh_100km",
+        data_key="lifetime_avg_electric_consumption_kwh_100km",
+        native_unit_of_measurement="kWh/100 km",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:lightning-bolt",
+        suggested_display_precision=1,
+        condition="electric",
+    ),
 )
 
 # Sensor keys that read from coordinator helpers instead of the per-vehicle
@@ -863,6 +899,11 @@ _TRIP_STATS_KEYS: frozenset[str] = frozenset({
     "last_trip_avg_speed_kmh",
     "last_trip_avg_fuel_consumption_l_100km",
     "last_trip_avg_electric_consumption_kwh_100km",
+    # v2.0.0 (Big-Bang) — long-term aggregates from /tripstatistics?type=longTerm
+    # (CARIAD-BFF only). Same brand gate as the per-trip keys above.
+    "lifetime_distance_km",
+    "lifetime_avg_fuel_consumption_l_100km",
+    "lifetime_avg_electric_consumption_kwh_100km",
 })
 _TRIP_STATS_BRANDS: frozenset[str] = frozenset({"audi", "volkswagen"})
 

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -296,6 +296,15 @@
       },
       "capabilities_count": {
         "name": "Capabilities Count"
+      },
+      "lifetime_distance_km": {
+        "name": "Lifetime Distance"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Lifetime Average Fuel Consumption"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Lifetime Average Electric Consumption"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -290,6 +290,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Tlak Pneumatik Zadní Pravá"
+      },
+      "lifetime_distance_km": {
+        "name": "Celková Vzdálenost"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Průměrná Spotřeba Paliva (Celkem)"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Průměrná Spotřeba Energie (Celkem)"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -290,6 +290,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Reifendruck Hinten Rechts"
+      },
+      "lifetime_distance_km": {
+        "name": "Lebensdauer-Distanz"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Durchschnittsverbrauch (Lebensdauer)"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Durchschnitts-Stromverbrauch (Lebensdauer)"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -290,6 +290,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Tire Pressure Rear Right"
+      },
+      "lifetime_distance_km": {
+        "name": "Lifetime Distance"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Lifetime Average Fuel Consumption"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Lifetime Average Electric Consumption"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -290,6 +290,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Presión Neumático Trasero Derecho"
+      },
+      "lifetime_distance_km": {
+        "name": "Distancia Total"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Consumo Medio de Combustible (Total)"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Consumo Eléctrico Medio (Total)"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -290,6 +290,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Pression Pneu Arrière Droit"
+      },
+      "lifetime_distance_km": {
+        "name": "Distance Totale"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Consommation Moyenne de Carburant (Total)"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Consommation Électrique Moyenne (Total)"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -290,6 +290,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Bandenspanning Achter Rechts"
+      },
+      "lifetime_distance_km": {
+        "name": "Totale Afstand"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Gemiddeld Brandstofverbruik (Totaal)"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Gemiddeld Stroomverbruik (Totaal)"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -290,6 +290,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Ciśnienie Opony Tył Prawy"
+      },
+      "lifetime_distance_km": {
+        "name": "Całkowita Odległość"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Średnie Zużycie Paliwa (Całość)"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Średnie Zużycie Energii (Całość)"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -290,6 +290,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Däcktryck Bak Höger"
+      },
+      "lifetime_distance_km": {
+        "name": "Total Distans"
+      },
+      "lifetime_avg_fuel_consumption_l_100km": {
+        "name": "Genomsnittlig Bränsleförbrukning (Totalt)"
+      },
+      "lifetime_avg_electric_consumption_kwh_100km": {
+        "name": "Genomsnittlig Elförbrukning (Totalt)"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
## Summary

- **[NEW v2.0] Lifetime trip aggregates** (Audi + VW EU only) — promotes the three `lifetime_*` fields the coordinator already populates from `/tripstatistics?type=longTerm` to user-visible entities:
  - `lifetime_distance_km` (`TOTAL_INCREASING`)
  - `lifetime_avg_fuel_consumption_l_100km` (combustion-gated)
  - `lifetime_avg_electric_consumption_kwh_100km` (electric-gated)
- All three keys added to the existing `_TRIP_STATS_KEYS` set so the Audi/VW-EU brand gate keeps SEAT / CUPRA / Skoda / Porsche / VW NA users from seeing phantom entities.
- Translations synced across all 8 locales (DE/EN/CS/ES/FR/NL/PL/SV).

## Why
The data has been in the coordinator since v1.14.0 — Lovelace cards and dashboards could only access it via `extra_state_attributes` workarounds until now. First-class entities mean clean automations / energy dashboard tracking for the lifetime distance counter.

## Test plan
- [x] `python -m py_compile` clean for `sensor.py`
- [x] All 9 modified JSON files parse as valid JSON
- [x] `_TRIP_STATS_KEYS` membership covers all three new keys → brand gate works
- [ ] CI 7/7 green (Hassfest, HACS, Lint, mypy, Bruno-drift, Tests, .bru-syntax)
- [ ] Smoke against an Audi / VW EU VIN with active connectPlus subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)