### PR TITLE
PR #9/19 v2.0.0: Departure-Timer enabled read-only binary_sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,14 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   bestehendem `_TRIP_STATS_BRANDS` + `_TRIP_STATS_KEYS`. Übersetzungen
   alle 8 Sprachen.
 
+- **Departure-Timer „Enabled" Read-Only Binary-Sensors [NEW v2.0]** —
+  drei neue `binary_sensor.<vin>_departure_timer_X_enabled` Entitäten
+  (X=1/2/3). Bisher war der Aktivierungszustand nur via dem schreib-
+  baren `switch.<vin>_departure_timer_X_switch` lesbar — was Templates
+  und Automatisierungen unangenehm macht weil Switches Side-Effects
+  haben. Die neuen reinen Read-Sensoren entkoppeln Read von Write.
+  Übersetzungen alle 8 Sprachen.
+
 ### Fixed
 
 - **#53 CUPRA Born — defensive `command_flash` + OLA parking parser fix.**

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -242,6 +242,34 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:car-tire-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.0.0 (Big-Bang) — read-only ``enabled`` binary_sensors for the
+    # 3 departure timers. The existing ``departure_timer_X_switch``
+    # entities are write-able and conflate read+write, which makes them
+    # awkward as conditions in template automations. These pure-read
+    # binary_sensors expose the same field with PRESENCE semantics so
+    # automations can ``binary_sensor.<vin>_departure_timer_1_enabled``
+    # without accidentally toggling the timer in a template loop.
+    VagBinarySensorDescription(
+        key="departure_timer_1_enabled",
+        translation_key="departure_timer_1_enabled",
+        data_key="departure_timer_1_enabled",
+        icon="mdi:clock-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagBinarySensorDescription(
+        key="departure_timer_2_enabled",
+        translation_key="departure_timer_2_enabled",
+        data_key="departure_timer_2_enabled",
+        icon="mdi:clock-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagBinarySensorDescription(
+        key="departure_timer_3_enabled",
+        translation_key="departure_timer_3_enabled",
+        data_key="departure_timer_3_enabled",
+        icon="mdi:clock-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 BINARY_DESCRIPTIONS = BINARY_DESCRIPTIONS + _NEW_BINARY
 

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -388,6 +388,15 @@
       },
       "tire_pressure_warning": {
         "name": "Tire Pressure Warning"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Departure Timer 1 Enabled"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Departure Timer 2 Enabled"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Departure Timer 3 Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -379,6 +379,15 @@
       },
       "tire_pressure_warning": {
         "name": "Varování Tlaku Pneumatik"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Časovač Odjezdu 1 Aktivní"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Časovač Odjezdu 2 Aktivní"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Časovač Odjezdu 3 Aktivní"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -379,6 +379,15 @@
       },
       "tire_pressure_warning": {
         "name": "Reifendruck-Warnung"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Abfahrtstimer 1 aktiv"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Abfahrtstimer 2 aktiv"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Abfahrtstimer 3 aktiv"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -379,6 +379,15 @@
       },
       "tire_pressure_warning": {
         "name": "Tire Pressure Warning"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Departure Timer 1 Enabled"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Departure Timer 2 Enabled"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Departure Timer 3 Enabled"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -379,6 +379,15 @@
       },
       "tire_pressure_warning": {
         "name": "Aviso de Presión de Neumáticos"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Temporizador 1 Activo"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Temporizador 2 Activo"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Temporizador 3 Activo"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -379,6 +379,15 @@
       },
       "tire_pressure_warning": {
         "name": "Alerte Pression Pneus"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Minuterie de Départ 1 Activée"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Minuterie de Départ 2 Activée"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Minuterie de Départ 3 Activée"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -379,6 +379,15 @@
       },
       "tire_pressure_warning": {
         "name": "Bandenspanning-Waarschuwing"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Vertrektimer 1 Actief"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Vertrektimer 2 Actief"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Vertrektimer 3 Actief"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -379,6 +379,15 @@
       },
       "tire_pressure_warning": {
         "name": "Ostrzeżenie Ciśnienia Opon"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Timer Odjazdu 1 Aktywny"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Timer Odjazdu 2 Aktywny"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Timer Odjazdu 3 Aktywny"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -379,6 +379,15 @@
       },
       "tire_pressure_warning": {
         "name": "Däcktryck Varning"
+      },
+      "departure_timer_1_enabled": {
+        "name": "Avgångstimer 1 Aktiv"
+      },
+      "departure_timer_2_enabled": {
+        "name": "Avgångstimer 2 Aktiv"
+      },
+      "departure_timer_3_enabled": {
+        "name": "Avgångstimer 3 Aktiv"
       }
     },
     "switch": {


### PR DESCRIPTION
## Summary

- **[NEW v2.0] 3 read-only binary_sensors** for departure-timer enabled state — `binary_sensor.<vin>_departure_timer_1_enabled` / `…_2_enabled` / `…_3_enabled`.
- Decouples read from write so template automations don't risk accidentally toggling the timer through the existing write-able `switch` entity.
- Translations synced across all 8 locales.

## Why
The existing `switch.<vin>_departure_timer_X_switch` entities are write-able. HA templates that read switch state in conditions can occasionally fire the switch's turn_on/turn_off action depending on how they're structured — exactly the kind of subtle bug that costs charging money. A pure-read `binary_sensor` removes the risk entirely.

## Test plan
- [x] `python -m py_compile` clean for `binary_sensor.py`
- [x] All 9 modified JSON files parse as valid JSON
- [ ] CI 7/7 green (Hassfest, HACS, Lint, mypy, Bruno-drift, Tests, .bru-syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)