### PR TITLE
PR #12/19 v2.0.0: Vehicle alarm sensors (closes #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,17 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   non-Porsche und pre-TPMS Modelle erzeugen keine Phantom-Entitäten.
   Übersetzungen alle 8 Sprachen (DE/EN/CS/ES/FR/NL/PL/SV).
 
+- **Vehicle Alarm / Diebstahl-Sensoren [NEW v2.0] — schließt Issue #33** —
+  drei neue Entitäten exposed direkt aus `access.accessStatus.value` (Cariad-BFF):
+  - `binary_sensor.<vin>_alarm_active` (PROBLEM device_class) — Auto-Alarm
+    aktuell aktiv (`vehicleAlarm == "ALARM"`)
+  - `binary_sensor.<vin>_siren_active` (SOUND device_class) — Sirene
+    schreit gerade (`siren == "ACTIVE"`), Diagnostik-Kategorie
+  - `sensor.<vin>_last_alarm_at` (TIMESTAMP) — letzter Alarm-Zeitstempel
+  Brand-restricted via `_DATA_PRESENT_REQUIRED` — Fahrzeuge ohne
+  Anti-Diebstahl-Telemetrie erzeugen keine Phantom-Entitäten.
+  Übersetzungen alle 8 Sprachen.
+
 - **Weekly Preheat — `recurring_on` für `set_departure_timer` Service [NEW v2.0]** —
   der bestehende Service `vag_connect.set_departure_timer` akzeptiert
   jetzt eine optionale `recurring_on` Liste mit Wochentagen (z.B.

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -242,6 +242,27 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:car-tire-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.0.0 (Big-Bang) — Vehicle alarm (issue #33).
+    # Two PROBLEM-class binary_sensors:
+    # - ``alarm_active``: car-level alarm state (ALARM vs NO_ALARM)
+    # - ``siren_active``: siren currently sounding
+    # Brand-restricted via _DATA_PRESENT_REQUIRED — only populated when
+    # the Cariad-BFF actually publishes the fields.
+    VagBinarySensorDescription(
+        key="alarm_active",
+        translation_key="alarm_active",
+        data_key="alarm_active",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        icon="mdi:shield-alert",
+    ),
+    VagBinarySensorDescription(
+        key="siren_active",
+        translation_key="siren_active",
+        data_key="siren_active",
+        device_class=BinarySensorDeviceClass.SOUND,
+        icon="mdi:bullhorn-variant",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.0.0 (Big-Bang) — read-only ``enabled`` binary_sensors for the
     # 3 departure timers. The existing ``departure_timer_X_switch``
     # entities are write-able and conflate read+write, which makes them
@@ -294,6 +315,11 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # v2.0.0 (Big-Bang) — Porsche-only TPMS warning (PPA TIRE_PRESSURE
     # measurement). Non-Porsche vehicles leave the field None → no phantom.
     "tire_pressure_warning",
+    # v2.0.0 (Big-Bang) — Vehicle alarm (issue #33). Cariad-BFF only
+    # publishes alarm fields on enrolled vehicles with anti-theft
+    # configured. Cars without it leave both fields None → no phantom.
+    "alarm_active",
+    "siren_active",
 })
 
 

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1078,6 +1078,24 @@ class VWEUClient(CariadBaseClient):
         if d.voltage_12v is not None:
             d.warning_12v_low = d.voltage_12v < 11.5
 
+        # ── v2.0.0 (Big-Bang) — Vehicle alarm (issue #33) ─────────────────────
+        # Cariad-BFF surfaces alarm telemetry under access.accessStatus.value.
+        # Defensive: only populate when the field is explicitly present so
+        # _DATA_PRESENT_REQUIRED in binary_sensor.py / sensor.py keeps
+        # phantom entities away from cars that never publish these fields.
+        alarm_raw = v(raw, "access", "accessStatus", "value", "vehicleAlarm")
+        if isinstance(alarm_raw, str):
+            d.alarm_active = alarm_raw.upper() == "ALARM"
+        siren_raw = v(raw, "access", "accessStatus", "value", "siren")
+        if isinstance(siren_raw, str):
+            d.siren_active = siren_raw.upper() == "ACTIVE"
+        last_alarm = (
+            v(raw, "access", "accessStatus", "value", "lastAlarmAt")
+            or v(raw, "access", "accessStatus", "value", "lastAlarmTimestamp")
+        )
+        if last_alarm:
+            d.last_alarm_at = last_alarm
+
         # ── Access / doors / windows ──────────────────────────────────────────
         d.doors_locked = v(raw, "access", "accessStatus", "value", "doorLockStatus") == "LOCKED"
         overall = v(raw, "access", "accessStatus", "value", "overallStatus")

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -518,6 +518,17 @@ class VehicleData:
     tire_pressure_rear_right_bar: float | None = None
     tire_pressure_warning: bool | None = None
 
+    # v2.0.0 (Big-Bang) — Vehicle alarm (issue #33).
+    # Cariad-BFF ``access.accessStatus.value`` may carry vehicleAlarm /
+    # siren fields when the car's anti-theft system has triggered. Surfaced
+    # as two binary_sensors (PROBLEM device class) plus a TIMESTAMP
+    # sensor for the most recent alarm event. Brand-restricted via
+    # _DATA_PRESENT_REQUIRED so cars without this telemetry don't see
+    # phantom entities.
+    alarm_active: bool | None = None       # vehicleAlarm == "ALARM"
+    siren_active: bool | None = None       # siren == "ACTIVE"
+    last_alarm_at: Any | None = None       # ISO timestamp of last alarm
+
     # v1.14.0 (#24) — Trip Statistics from CARIAD-BFF
     # ``GET /vehicle/v1/vehicles/{vin}/tripstatistics?type={shortTerm|longTerm}``.
     # Both endpoints return ``{tripDataList: {tripData: [...]}}``; we sort

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -669,6 +669,18 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:tire",
         suggested_display_precision=2,
     ),
+    # v2.0.0 (Big-Bang) — Vehicle alarm timestamp (issue #33).
+    # Records when the alarm last triggered. Brand-restricted via
+    # _DATA_PRESENT_REQUIRED — only populated when Cariad-BFF actually
+    # publishes the field (cars without alarm telemetry stay None).
+    VagSensorDescription(
+        key="last_alarm_at",
+        translation_key="last_alarm_at",
+        data_key="last_alarm_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:shield-alert",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 
     # ── v1.9.0 Vehicle Data Scout + Error Reporter ────────────────────────────
     # Two diagnostic sensors that surface drift / runtime errors detected
@@ -887,6 +899,8 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "tire_pressure_front_right_bar",
     "tire_pressure_rear_left_bar",
     "tire_pressure_rear_right_bar",
+    # v2.0.0 (Big-Bang) — Vehicle alarm timestamp (issue #33).
+    "last_alarm_at",
 })
 
 # v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -305,6 +305,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Lifetime Average Electric Consumption"
+      },
+      "last_alarm_at": {
+        "name": "Last Alarm"
       }
     },
     "binary_sensor": {
@@ -397,6 +400,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Departure Timer 3 Enabled"
+      },
+      "alarm_active": {
+        "name": "Alarm Active"
+      },
+      "siren_active": {
+        "name": "Siren Active"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -299,6 +299,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Průměrná Spotřeba Energie (Celkem)"
+      },
+      "last_alarm_at": {
+        "name": "Poslední Alarm"
       }
     },
     "binary_sensor": {
@@ -388,6 +391,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Časovač Odjezdu 3 Aktivní"
+      },
+      "alarm_active": {
+        "name": "Alarm Aktivní"
+      },
+      "siren_active": {
+        "name": "Siréna Aktivní"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -299,6 +299,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Durchschnitts-Stromverbrauch (Lebensdauer)"
+      },
+      "last_alarm_at": {
+        "name": "Letzter Alarm"
       }
     },
     "binary_sensor": {
@@ -388,6 +391,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Abfahrtstimer 3 aktiv"
+      },
+      "alarm_active": {
+        "name": "Alarm aktiv"
+      },
+      "siren_active": {
+        "name": "Sirene aktiv"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -299,6 +299,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Lifetime Average Electric Consumption"
+      },
+      "last_alarm_at": {
+        "name": "Last Alarm"
       }
     },
     "binary_sensor": {
@@ -388,6 +391,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Departure Timer 3 Enabled"
+      },
+      "alarm_active": {
+        "name": "Alarm Active"
+      },
+      "siren_active": {
+        "name": "Siren Active"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -299,6 +299,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Consumo Eléctrico Medio (Total)"
+      },
+      "last_alarm_at": {
+        "name": "Última Alarma"
       }
     },
     "binary_sensor": {
@@ -388,6 +391,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Temporizador 3 Activo"
+      },
+      "alarm_active": {
+        "name": "Alarma Activa"
+      },
+      "siren_active": {
+        "name": "Sirena Activa"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -299,6 +299,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Consommation Électrique Moyenne (Total)"
+      },
+      "last_alarm_at": {
+        "name": "Dernière Alarme"
       }
     },
     "binary_sensor": {
@@ -388,6 +391,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Minuterie de Départ 3 Activée"
+      },
+      "alarm_active": {
+        "name": "Alarme Active"
+      },
+      "siren_active": {
+        "name": "Sirène Active"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -299,6 +299,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Gemiddeld Stroomverbruik (Totaal)"
+      },
+      "last_alarm_at": {
+        "name": "Laatste Alarm"
       }
     },
     "binary_sensor": {
@@ -388,6 +391,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Vertrektimer 3 Actief"
+      },
+      "alarm_active": {
+        "name": "Alarm Actief"
+      },
+      "siren_active": {
+        "name": "Sirene Actief"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -299,6 +299,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Średnie Zużycie Energii (Całość)"
+      },
+      "last_alarm_at": {
+        "name": "Ostatni Alarm"
       }
     },
     "binary_sensor": {
@@ -388,6 +391,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Timer Odjazdu 3 Aktywny"
+      },
+      "alarm_active": {
+        "name": "Alarm Aktywny"
+      },
+      "siren_active": {
+        "name": "Syrena Aktywna"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -299,6 +299,9 @@
       },
       "lifetime_avg_electric_consumption_kwh_100km": {
         "name": "Genomsnittlig Elförbrukning (Totalt)"
+      },
+      "last_alarm_at": {
+        "name": "Senaste Larm"
       }
     },
     "binary_sensor": {
@@ -388,6 +391,12 @@
       },
       "departure_timer_3_enabled": {
         "name": "Avgångstimer 3 Aktiv"
+      },
+      "alarm_active": {
+        "name": "Larm Aktivt"
+      },
+      "siren_active": {
+        "name": "Siren Aktiv"
       }
     },
     "switch": {


### PR DESCRIPTION
## Summary

- **[NEW v2.0] Three vehicle-alarm entities** (closes long-standing #33):
  - `binary_sensor.<vin>_alarm_active` (`PROBLEM` device class) — `vehicleAlarm == "ALARM"`
  - `binary_sensor.<vin>_siren_active` (`SOUND` device class, diagnostic) — `siren == "ACTIVE"`
  - `sensor.<vin>_last_alarm_at` (`TIMESTAMP`, diagnostic) — ISO timestamp of last alarm event
- Parser added to `vw_eu.py` reads from `access.accessStatus.value.{vehicleAlarm, siren, lastAlarmAt}`. Audi inherits via `VWEUClient` parent class, so this lands for both Audi + VW EU automatically.
- Translations across all 8 locales.

## Why
Issue #33 is the oldest open feature request. Anti-theft owners want HA to wake the smart-home (e.g. flash all the lights, push notification, start camera recording) when the car alarm triggers. This PR makes that one automation rule away.

## Phantom-entity protection
All three keys gated via `_DATA_PRESENT_REQUIRED`. Non-Cariad brands and Cariad vehicles whose backend doesn't publish the alarm fields leave them `None`, so no phantom "off" entities.

## Test plan
- [x] `python -m py_compile` clean
- [x] All 9 modified JSON files parse as valid JSON
- [ ] CI 7/7 green
- [ ] Smoke against an Audi/VW EU vehicle that has triggered an alarm in the past 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)