### PR TITLE
PR #13/19 v2.0.0: heaterSource read-only sensor (issue #163, best-effort)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,17 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   Anti-Diebstahl-Telemetrie erzeugen keine Phantom-Entitäten.
   Übersetzungen alle 8 Sprachen.
 
+- **Heater-Source Sensor [NEW v2.0] — schließt Issue #163 (best-effort)** —
+  neuer `sensor.<vin>_heater_source` Read-Only-Sensor (Diagnostik-
+  Kategorie) für ID.x Heat-Pump-Modelle. Liest aus
+  `climatisation.climatisationSettings.value.heaterSource` (Werte:
+  `electric` / `fuel`). Read-Only-Shape gewählt weil kein bestätigter
+  Tester für Write-Semantik vorhanden ist; falls später ein Tester
+  Write-Support bestätigt wird ein Folge-PR den Sensor zu einem
+  `select.<vin>_heater_source` upgraden. Brand-restricted via
+  `_DATA_PRESENT_REQUIRED` — Fahrzeuge ohne Heat-Pump leaven None →
+  keine Phantom-Entität. Übersetzungen alle 8 Sprachen.
+
 - **Weekly Preheat — `recurring_on` für `set_departure_timer` Service [NEW v2.0]** —
   der bestehende Service `vag_connect.set_departure_timer` akzeptiert
   jetzt eine optionale `recurring_on` Liste mit Wochentagen (z.B.

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1135,6 +1135,16 @@ class VWEUClient(CariadBaseClient):
         if isinstance(wh_enabled, bool):
             d.window_heating_enabled = wh_enabled
 
+        # v2.0.0 (Big-Bang) — heaterSource (issue #163, best-effort).
+        # ID.x heat-pump cars publish ``heaterSource`` ("electric"/"fuel"
+        # in the wild). Read-only sensor exposure since #163 has no
+        # confirmed tester for write semantics yet. Field stays None for
+        # vehicles that don't ship it → _DATA_PRESENT_REQUIRED skips the
+        # sensor for them.
+        heater_src = v(raw, "climatisation", "climatisationSettings", "value", "heaterSource")
+        if isinstance(heater_src, str) and heater_src:
+            d.heater_source = heater_src
+
         # v1.26.0 (#173) — capabilities_count diagnostic. From scout #144
         # (54 items observed). Useful for power-users debugging "why is
         # entity X missing for me?". Read from selectivestatus envelope.

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -529,6 +529,16 @@ class VehicleData:
     siren_active: bool | None = None       # siren == "ACTIVE"
     last_alarm_at: Any | None = None       # ISO timestamp of last alarm
 
+    # v2.0.0 (Big-Bang) — Heat-source mode (issue #163, best-effort).
+    # ID.x heat-pump models surface ``climatisationSettings.value.heaterSource``
+    # ("electric" / "fuel") indicating which heat source the car will use
+    # for pre-conditioning. Issue #163 wanted a tester to confirm whether
+    # the field is read-only (surface as sensor) or writable (surface as
+    # select). Without a confirmed tester we ship the safe READ-ONLY shape;
+    # if a tester later confirms write support a follow-up PR can promote
+    # to a select. Field stays None for non-heat-pump cars.
+    heater_source: str | None = None
+
     # v1.14.0 (#24) — Trip Statistics from CARIAD-BFF
     # ``GET /vehicle/v1/vehicles/{vin}/tripstatistics?type={shortTerm|longTerm}``.
     # Both endpoints return ``{tripDataList: {tripData: [...]}}``; we sort

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -681,6 +681,20 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:shield-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.0.0 (Big-Bang) — heaterSource read-only sensor (issue #163).
+    # ID.x heat-pump cars publish "electric"/"fuel" in
+    # climatisationSettings.value.heaterSource. Brand-restricted via
+    # _DATA_PRESENT_REQUIRED — non-heat-pump cars leave the field None
+    # → no phantom entity is spawned. Diagnostic category since the
+    # value is a niche enum used mostly for power-user automations.
+    VagSensorDescription(
+        key="heater_source",
+        translation_key="heater_source",
+        data_key="heater_source",
+        icon="mdi:radiator",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        condition="electric",
+    ),
 
     # ── v1.9.0 Vehicle Data Scout + Error Reporter ────────────────────────────
     # Two diagnostic sensors that surface drift / runtime errors detected
@@ -901,6 +915,8 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "tire_pressure_rear_right_bar",
     # v2.0.0 (Big-Bang) — Vehicle alarm timestamp (issue #33).
     "last_alarm_at",
+    # v2.0.0 (Big-Bang) — heaterSource (issue #163, ID.x heat-pump only).
+    "heater_source",
 })
 
 # v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -308,6 +308,9 @@
       },
       "last_alarm_at": {
         "name": "Last Alarm"
+      },
+      "heater_source": {
+        "name": "Heater Source"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -302,6 +302,9 @@
       },
       "last_alarm_at": {
         "name": "Poslední Alarm"
+      },
+      "heater_source": {
+        "name": "Zdroj Topení"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -302,6 +302,9 @@
       },
       "last_alarm_at": {
         "name": "Letzter Alarm"
+      },
+      "heater_source": {
+        "name": "Heizquelle"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -302,6 +302,9 @@
       },
       "last_alarm_at": {
         "name": "Last Alarm"
+      },
+      "heater_source": {
+        "name": "Heater Source"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -302,6 +302,9 @@
       },
       "last_alarm_at": {
         "name": "Última Alarma"
+      },
+      "heater_source": {
+        "name": "Fuente de Calefacción"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -302,6 +302,9 @@
       },
       "last_alarm_at": {
         "name": "Dernière Alarme"
+      },
+      "heater_source": {
+        "name": "Source de Chauffage"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -302,6 +302,9 @@
       },
       "last_alarm_at": {
         "name": "Laatste Alarm"
+      },
+      "heater_source": {
+        "name": "Verwarmingsbron"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -302,6 +302,9 @@
       },
       "last_alarm_at": {
         "name": "Ostatni Alarm"
+      },
+      "heater_source": {
+        "name": "Źródło Ogrzewania"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -302,6 +302,9 @@
       },
       "last_alarm_at": {
         "name": "Senaste Larm"
+      },
+      "heater_source": {
+        "name": "Värmekälla"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
## Summary

- **[NEW v2.0] `sensor.<vin>_heater_source`** read-only diagnostic sensor for ID.x heat-pump models. Reads from `climatisation.climatisationSettings.value.heaterSource` (`electric` / `fuel`).
- Closes the long-deferred issue #163 with a safe read-only shape since no tester has confirmed write semantics. If a tester later validates write support, a follow-up PR can promote this to a `select` entity.
- Translations across all 8 locales.

## Why
Field has been silenced in `EXPECTED_KEYS` since v1.17.5 (#132) — exposing it as read-only is the no-regret first step that doesn't break anything if the field turns out to be writable later.

## Phantom-entity protection
`_DATA_PRESENT_REQUIRED` set membership prevents the sensor from spawning on non-heat-pump vehicles whose backend leaves the field as `None`.

## Test plan
- [x] `python -m py_compile` clean
- [x] All 9 modified JSON files parse as valid JSON
- [ ] CI 7/7 green
- [ ] ID.4/ID.7/Born owner reports back what value the sensor takes

🤖 Generated with [Claude Code](https://claude.com/claude-code)