### PR TITLE
PR #14-16/19 v2.0.0: Push-manager lifecycle wiring (Skoda MQTT + CUPRA/SEAT FCM + Audi/VW Cariad FCM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,20 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   non-Porsche und pre-TPMS Modelle erzeugen keine Phantom-Entitäten.
   Übersetzungen alle 8 Sprachen (DE/EN/CS/ES/FR/NL/PL/SV).
 
+- **Push-Manager Lifecycle-Wiring (Skoda MQTT, CUPRA/SEAT FCM, Audi/VW Cariad FCM) [NEW v2.0]** —
+  schließt PR #14-16 in einem gemeinsamen Architektur-PR. Coordinator
+  hat jetzt 3 neue Slots (`_skoda_push`, `_cupra_seat_push`,
+  `_audi_vw_push`) plus `async_start_push_managers()` /
+  `async_stop_push_managers()` Helpers. Aktivierung pro Brand via die
+  bereits vorhandenen OptionsFlow-Toggles (`enable_push_mqtt`,
+  `enable_push_fcm`, `enable_push_audi_vw`). System-Health-Panel zeigt
+  pro Push-Channel den `state` (stopped / starting / connected /
+  reconnecting / disabled / unavailable). Die unterliegenden
+  `_connect_and_listen` sind weiterhin Scaffolding (lazy-imported
+  aiomqtt + firebase-messaging) — sobald ein Tester die FCM-Keys /
+  MQTT-Broker-Auth bestätigt geht das ohne Coordinator-Refactor live.
+  Schließt #14-#16 aus der v2.0.0 Big-Bang Audit.
+
 - **Vehicle Alarm / Diebstahl-Sensoren [NEW v2.0] — schließt Issue #33** —
   drei neue Entitäten exposed direkt aus `access.accessStatus.value` (Cariad-BFF):
   - `binary_sensor.<vin>_alarm_active` (PROBLEM device_class) — Auto-Alarm

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -119,6 +119,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: VagConnectConfigEntry) -
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
+    # v2.0.0 (Big-Bang) — wire brand-specific push managers (opt-in
+    # via OptionsFlow toggles). Idempotent: managers are scaffolding
+    # today, so this stands up the lifecycle without making real
+    # broker / FCM connections. Activation flips on at the moment a
+    # tester confirms FCM keys / MQTT broker auth — coordinator
+    # changes already in place, so it's a single inner-method swap.
+    try:
+        await coordinator.async_start_push_managers()
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception(
+            "VAG Connect: push manager startup failed — falling back to polling"
+        )
+
     if not hass.services.has_service(DOMAIN, "lock"):
         _register_services(hass)
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -23,6 +23,9 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_BRAND,
+    CONF_ENABLE_PUSH_AUDI_VW,
+    CONF_ENABLE_PUSH_FCM,
+    CONF_ENABLE_PUSH_MQTT,
     CONF_ENABLE_REVERSE_GEOCODING,
     CONF_FORCE_PPE_CLIMATE,
     CONF_PASSWORD,
@@ -393,6 +396,17 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         self._started = False
         self._was_available: bool = True  # tracks availability for log_when_unavailable
         self._cariad_client: Any = None
+
+        # v2.0.0 (Big-Bang) — Push manager lifecycle slots.
+        # Wired by ``async_start_push_manager`` after the first
+        # successful poll once the OAuth user_id + VIN list are known.
+        # Each is None when the brand doesn't match, the OptionsFlow
+        # toggle is OFF, or the lifecycle has been torn down.
+        # ``state`` attribute on each manager is consumed by
+        # system_health.py for at-a-glance push-channel diagnostics.
+        self._skoda_push: Any = None
+        self._cupra_seat_push: Any = None
+        self._audi_vw_push: Any = None
 
         # v1.25.0 PR-D Phase 1A: command dispatcher owns lock-map +
         # wake-cooldown state. Coordinator delegates lock acquisition
@@ -833,8 +847,112 @@ class VagConnectCoordinator(DataUpdateCoordinator):
     async def async_shutdown(self) -> None:
         """Stop polling loop and release resources."""
         self._started = False
+        # v2.0.0 (Big-Bang) — stop push managers before dropping client.
+        await self.async_stop_push_managers()
         self._cariad_client = None
         _LOGGER.debug("VAG Connect: shutdown complete")
+
+    # ── v2.0.0 (Big-Bang) — Push-manager lifecycle ────────────────────────
+    # Wired in __init__ to None; instantiated lazily after the first
+    # successful poll once we know the user_id + VIN list. Three brand-
+    # specific classes share the same ``PushManager`` interface so the
+    # lifecycle hooks below stay brand-agnostic. Each manager carries the
+    # ``state`` attribute consumed by system_health.py.
+
+    async def async_start_push_managers(self) -> None:
+        """Spawn the brand-appropriate push manager(s) if opted in.
+
+        Called from the platform's ``async_setup_entry`` after the first
+        coordinator refresh. Idempotent — subsequent calls return
+        immediately if a manager is already running.
+
+        Opt-in is per-brand via OptionsFlow toggles:
+        - Skoda → ``CONF_ENABLE_PUSH_MQTT``
+        - CUPRA/SEAT → ``CONF_ENABLE_PUSH_FCM``
+        - Audi/VW EU → ``CONF_ENABLE_PUSH_AUDI_VW``
+
+        All three push manager implementations are currently SCAFFOLDING
+        (stub ``_connect_and_listen``) — wiring the lifecycle now means
+        the moment a tester confirms FCM keys / MQTT broker auth the
+        live activation lands behind a single inner-method change with
+        zero coordinator-side refactor.
+        """
+        options = dict(getattr(self.entry, "options", {}) or {})
+        brand = self.entry.data.get(CONF_BRAND, "")
+        client = self._cariad_client
+        if client is None:
+            return
+        # User-id is captured by the brand client after the first auth
+        # cycle; bail quietly if not yet available (next refresh re-tries).
+        user_id = getattr(client, "user_id", None) or getattr(client, "_user_id", None)
+        vins = list(getattr(self, "vehicles", {}).keys())
+        if not user_id or not vins:
+            return
+
+        async def _on_push_event(event: Any) -> None:
+            """Coordinator-side push callback — refresh the affected VIN."""
+            _LOGGER.debug(
+                "VAG push: event vin=***%s type=%s — requesting refresh",
+                (event.vin or "??????")[-6:],
+                event.event_type,
+            )
+            try:
+                await self.async_request_refresh()
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("VAG push: refresh after event failed")
+
+        token_provider = getattr(client, "async_get_access_token", None)
+        if token_provider is None:
+            async def token_provider() -> str:  # type: ignore[no-redef]
+                tokens = getattr(client, "_tokens", None)
+                return getattr(tokens, "access_token", "") or ""
+
+        if brand == "skoda" and options.get(CONF_ENABLE_PUSH_MQTT) and self._skoda_push is None:
+            from .cariad.push.skoda_mqtt import SkodaPushManager  # noqa: PLC0415
+            self._skoda_push = SkodaPushManager(
+                _on_push_event,
+                user_id=user_id,
+                access_token_provider=token_provider,
+                vins=vins,
+            )
+            await self._skoda_push.start()
+
+        if brand in ("cupra", "seat") and options.get(CONF_ENABLE_PUSH_FCM) and self._cupra_seat_push is None:
+            from .cariad.push.cupra_seat_fcm import CupraSeatPushManager  # noqa: PLC0415
+            self._cupra_seat_push = CupraSeatPushManager(
+                _on_push_event,
+                user_id=user_id,
+                access_token_provider=token_provider,
+                vins=vins,
+                brand=brand,
+            )
+            await self._cupra_seat_push.start()
+
+        if brand in ("audi", "volkswagen") and options.get(CONF_ENABLE_PUSH_AUDI_VW) and self._audi_vw_push is None:
+            from .cariad.push.audi_vw_fcm import AudiVWPushManager  # noqa: PLC0415
+            self._audi_vw_push = AudiVWPushManager(
+                _on_push_event,
+                user_id=user_id,
+                access_token_provider=token_provider,
+                vins=vins,
+                brand=brand,
+            )
+            await self._audi_vw_push.start()
+
+    async def async_stop_push_managers(self) -> None:
+        """Stop any running push managers. Idempotent.
+
+        Called from ``async_shutdown`` so unload-or-reload is clean.
+        """
+        for attr in ("_skoda_push", "_cupra_seat_push", "_audi_vw_push"):
+            mgr = getattr(self, attr, None)
+            if mgr is None:
+                continue
+            try:
+                await mgr.stop()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("VAG push: stop %s raised — ignoring", attr)
+            setattr(self, attr, None)
 
     # ── Vehicle Data Scout + Error Reporter (v1.9.0) ───────────────────────
 


### PR DESCRIPTION
## Summary

Bundles the three push-wiring PRs from the v2.0.0 Big-Bang audit (#14, #15, #16) into one architectural change.

- Coordinator gains three slots: `_skoda_push`, `_cupra_seat_push`, `_audi_vw_push` (consumed by `system_health.py` for per-channel state display).
- New helpers `async_start_push_managers()` / `async_stop_push_managers()` — idempotent, brand-routed via the existing OptionsFlow toggles (`enable_push_mqtt`, `enable_push_fcm`, `enable_push_audi_vw`).
- Hook in `__init__.async_setup_entry` after the first refresh so the user_id + VIN list are available; wrapped in try/except so push startup never blocks the integration.

## What this is NOT
The underlying `_connect_and_listen` methods on all three managers are **still scaffolding stubs** that wait for `stop_event` without making real network connections. Wiring the lifecycle now means **the moment a tester confirms FCM keys / MQTT broker auth, live activation is a single inner-method swap with zero coordinator refactor**.

## Why bundle into one PR
All three changes touch the same code paths (`coordinator.__init__`, `async_shutdown`, `__init__.async_setup_entry`) with the same shape. Splitting them into 3 PRs would mean 3× rebase cost for the same architectural pattern.

## Test plan
- [x] `python -m py_compile` clean for `coordinator.py`, `__init__.py`
- [x] OptionsFlow toggles already exist (since v1.18.0 scaffolding) — no new config schema
- [x] All three push manager init signatures match my call sites
- [ ] CI 7/7 green
- [ ] system_health panel shows the new push-channel state once a Skoda / CUPRA / SEAT / Audi / VW user opts into the toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)