### PR TITLE
PR #19/19 v2.0.0: Release v2.0.0 Big-Bang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,35 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [Unreleased] — v2.0.0 Big-Bang (in progress)
+## [2.0.0] - 2026-05-15 🎯🚀 Big-Bang Release — 19 PRs in einem Schlag / Big-Bang Release — 19 PRs in one shot
 
-> **Note:** Alle [Unreleased] Bullets sammeln sich für die finale v2.0.0
-> Mega-Release. Keine Zwischen-Releases mehr — siehe
-> [Big-Bang Audit & Plan](docs/research/2026-05_big-bang-audit-and-plan.md).
+> **v2.0.0 ist die größte Release in der Geschichte des Projekts.** 19 PRs
+> über 4 Phasen, gebündelt zu **15 [NEW v2.0] Features** quer durch alle
+> 7 Brands. Schließt Issue #33 (Diebstahl-Alarm), Issue #163 (heaterSource),
+> setzt den Architektur-Seam für die Sept-2026 EU Data Act Deadline,
+> und re-introduce't `quality_scale: platinum` nach v1.26.x revert.
+>
+> **TL;DR der 15 NEW v2.0 Features:**
+> 1. Skoda Driving-Score Sensor (MY24+)
+> 2. Cross-brand Aux-Heating Parität (Skoda)
+> 3. Porsche TPMS (4 Reifen + Warning)
+> 4. Long-Term Trip Aggregates (Audi/VW EU)
+> 5. Departure-Timer Read-Only Binary-Sensors
+> 6. Weekly Preheat (`recurring_on` Service-Param)
+> 7. Charging-Station POI Lookup Service
+> 8. Vehicle Alarm Sensors (#33)
+> 9. heaterSource Sensor (#163)
+> 10. Push-Manager Lifecycle-Wiring (3 Brands)
+> 11. EU Data Act Abstraction Shim
+> 12. Auth Resilience One-Click Repair
+> 13. System Health Panel
+> 14. Quality Scale Platinum (re-introduced)
+> 15. DeviceInfo `configuration_url` + `suggested_area`
+>
+> Architektur-Audit: [Big-Bang Audit & Plan](docs/research/2026-05_big-bang-audit-and-plan.md).
+>
+> **Migration**: keine. Alle Änderungen sind additive — bestehende
+> Automationen + Lovelace-Cards funktionieren unverändert weiter.
 
 ### Added
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.27.2"
+  "version": "2.0.0"
 }


### PR DESCRIPTION
## Summary

Final release PR for the v2.0.0 Big-Bang. Bumps `manifest.json` from `1.27.2` to `2.0.0` and converts the `[Unreleased]` CHANGELOG header into the dated `[2.0.0] - 2026-05-15` release entry with a TL;DR of all 15 NEW v2.0 features.

## What v2.0.0 ships

19 PRs across 4 phases bundled into the single largest release in project history:

**Phase 1 — Critical Polish (5 merged PRs)**
- PR #1: CUPRA Born `command_flash` defensive 3-layer fix + OLA parking parser
- PR #2: Auth Resilience One-Click Repair (4 reasons fixable)
- PR #3: System Health Panel
- PR #4: DeviceInfo `configuration_url` + `suggested_area`
- PR #5: `quality_scale: platinum` re-introduced

**Phase 2 — Entity Power Pack (8 merged PRs)**
- PR #6: Skoda Driving-Score Sensor + Cross-brand Aux-Heating Parity
- PR #7: Porsche TPMS (4 corners + warning)
- PR #8: Long-Term Trip Aggregates (Audi + VW EU)
- PR #9: Departure-Timer Enabled Read-Only Binary-Sensors
- PR #10: Weekly Preheat (`recurring_on` service param)
- PR #11: Charging-Station POI Lookup Service
- PR #12: Vehicle Alarm Sensors — closes #33
- PR #13: heaterSource Sensor — closes #163

**Phase 3 — Push Wiring (1 bundled PR for #14-16)**
- PR #14-16: Push-Manager Lifecycle Wiring (Skoda MQTT + CUPRA/SEAT FCM + Audi/VW Cariad FCM, opt-in)

**Phase 4 — Future-Proofing + Docs (3 PRs incl. this one)**
- PR #17: EU Data Act Abstraction Shim
- PR #18: README restructure across 8 languages
- PR #19: this release PR

## Migration
**None.** All v2.0.0 changes are **additive**. Existing automations and Lovelace cards continue to work unchanged.

## Test plan
- [x] `manifest.json` version bumped to 2.0.0
- [x] CHANGELOG `[Unreleased]` → `[2.0.0] - 2026-05-15`
- [ ] CI 7/7 green
- [ ] After merge: `git tag v2.0.0 && git push origin v2.0.0` to trigger HACS release notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)