### PR TITLE
v2.0.1 PATCH: Critical safety fix — doors_locked false-negative cross-brand (#131 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,34 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.0.1] - 2026-05-15 🚨🔒 Safety-Fix: `doors_locked` False-Negative Cross-Brand / Safety-Fix: `doors_locked` False-Negative Cross-Brand
+
+### Fixed
+
+- **Critical Safety-Fix: `doors_locked` zeigte fälschlich "Unlocked" für tatsächlich verriegelte Autos** (User-Bericht via #131 Follow-up).
+
+  **Root cause** war ein **Doppel-Bug**:
+  1. **Dataclass-Default** `doors_locked: bool = False` in `cariad/models.py` — bei jedem Parser-Miss (Backend-Hiccup, `.error` Envelope, fehlendes Feld, unbekannter Firmware-Wert) blieb das Feld auf `False` statt korrekt `None`.
+  2. **4 von 5 Brand-Parser** verwendeten `field = X == "LOCKED"` Pattern — wenn `X` `None` war, wurde `doors_locked` AKTIV auf `False` gesetzt (statt unverändert zu lassen). Skoda war seit v1.20.2 bereits defensiv.
+
+  **Fix:**
+  - 14 sicherheitsrelevante Booleans in `models.py` umgestellt von `bool = False` auf `bool | None = None`: `doors_locked`, `doors_open`, `windows_open`, `connector_locked`, `is_charging`, `plug_connected`, `auto_unlock_charge`, `climatisation_active`, `is_driving`, `is_online`, `warning_active`, `warning_oil`, `warning_engine`, `warning_tyre`, `warning_brakes`.
+  - 4 Brand-Parser auf defensive `isinstance(str)` + `.upper()` umgestellt: **`vw_eu.py`** (auch Audi via Vererbung), **`porsche.py`**, **`seat_cupra.py`**, **`vw_na.py`**.
+  - **VW EU/Audi**: `overallStatus == "SAFE"` jetzt explizit detected → setzt `doors_open=False, windows_open=False`. Vorher fielen "SAFE" Cars auf Default-False (zufällig richtig); jetzt explizit + nachvollziehbar.
+  - **Skoda**: bereits korrekt am Parser-Level — profitiert automatisch vom Default-Fix.
+  - Existing LOCK-Class Invert in `binary_sensor.py:390-394` und `lock.py:53` funktionieren transparent mit `None` (zeigen "Unknown" statt falsch "Unlocked").
+
+  **User-Impact:**
+  - Vor v2.0.1: Backend-Hiccup → HA zeigt "Unlocked" obwohl Auto verriegelt → User glaubt sicher, Auto ist offen
+  - Ab v2.0.1: Backend-Hiccup → HA zeigt "Unknown" → User sieht klar dass aktuell keine Daten verfügbar
+  - Auch betroffen waren `windows_open`, `connector_locked`, `warning_*` — alle false-negatives die echte Gefahren maskieren konnten
+
+### Added
+
+- **CUPRA Born MY26 `charging.rateInKmph` Parser-Fallback (closes Scout #192)** — neuer dritter Fallback in `seat_cupra.py:464` für die Lade-Rate (`chargeRateInKmPerHour` → `chargeRate_kmph` → `rateInKmph`). Born MY26 Firmware shippt das Feld auf `charging.rateInKmph` direkt am OLA Endpoint.
+
+---
+
 ## [2.0.0] - 2026-05-15 🎯🚀 Big-Bang Release — 19 PRs in einem Schlag / Big-Bang Release — 19 PRs in one shot
 
 > **v2.0.0 ist die größte Release in der Geschichte des Projekts.** 19 PRs

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -126,21 +126,38 @@ class PorscheClient:
             # Charging
             ch = m.get("CHARGING_SUMMARY", {})
             d.charging_state    = v(ch, "status")
-            d.is_charging       = d.charging_state in ("CHARGING", "CHARGING_AC", "CHARGING_DC")
+            # v2.0.1 (#131 follow-up) — defensive parsing.
+            if isinstance(d.charging_state, str):
+                d.is_charging = d.charging_state.upper() in (
+                    "CHARGING", "CHARGING_AC", "CHARGING_DC"
+                )
             d.charging_power_kw = v(ch, "chargingPower")
-            d.plug_connected    = v(ch, "plugState") == "CONNECTED"
-            d.plug_state        = v(ch, "plugState")
+            plug_state = v(ch, "plugState")
+            if isinstance(plug_state, str):
+                d.plug_connected = plug_state.upper() == "CONNECTED"
+                d.plug_state = plug_state
             d.target_soc        = v(ch, "targetSoc")
 
-            # Lock
+            # Lock — v2.0.1 (#131 follow-up): defensive parsing.
+            # Only assign when the source is an actual string; otherwise
+            # leave the dataclass default ``None`` so the entity stays
+            # "unknown" instead of falsely reporting "Unlocked".
             lock = v(m, "LOCK_STATE_VEHICLE", "lockState")
-            d.doors_locked = lock == "LOCKED"
+            if isinstance(lock, str):
+                d.doors_locked = lock.upper() == "LOCKED"
 
-            # Doors
-            d.doors_open = any(
-                v(m, f"OPEN_STATE_DOOR_{pos}", "openState") == "OPEN"
+            # Doors — v2.0.1: only assign when at least one door
+            # actually publishes its openState. PPA sometimes returns
+            # the LOCK_STATE_VEHICLE block but skips the per-door blocks
+            # for a few minutes after wake (observed against Taycan).
+            door_states = [
+                v(m, f"OPEN_STATE_DOOR_{pos}", "openState")
                 for pos in ("FRONT_LEFT", "FRONT_RIGHT", "REAR_LEFT", "REAR_RIGHT")
-            )
+            ]
+            if any(isinstance(s, str) for s in door_states):
+                d.doors_open = any(
+                    isinstance(s, str) and s.upper() == "OPEN" for s in door_states
+                )
             d.hood_open   = v(m, "OPEN_STATE_LID_FRONT",  "openState") == "OPEN"
             d.trunk_open  = v(m, "OPEN_STATE_LID_REAR",   "openState") == "OPEN"
             d.sunroof_open = v(m, "OPEN_STATE_SUNROOF",   "openState") == "OPEN"

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -186,7 +186,12 @@ class SeatCupraClient(CariadBaseClient):
             d.has_battery = d.battery_soc is not None
 
             access = v(mycar, "access") or {}
-            d.doors_locked = v(access, "accessStatus", "value", "doorLockStatus") == "LOCKED"
+            # v2.0.1 (#131 follow-up) — defensive parsing, see vw_eu.py
+            # for the full rationale. Per-door + top-level fallbacks
+            # below (lines ~265 + ~331) further refine the value.
+            access_lock = v(access, "accessStatus", "value", "doorLockStatus")
+            if isinstance(access_lock, str):
+                d.doors_locked = access_lock.upper() == "LOCKED"
 
         # ── Ranges ───────────────────────────────────────────────────────────
         if isinstance(ranges, dict):
@@ -327,7 +332,14 @@ class SeatCupraClient(CariadBaseClient):
             #   status.lights        : "off" / "on" (vehicle lights state)
             #   status.hood.locked   : "false"/"true" string
             top_locked = v(status, "locked")
-            if isinstance(top_locked, bool) and not d.doors_locked:
+            if isinstance(top_locked, bool):
+                # v2.0.1 (#131 follow-up): always honour an explicit
+                # top-level boolean. Pre-v2.0.1 used ``and not
+                # d.doors_locked`` which shadowed the top-level signal
+                # whenever the access-block already set False — but
+                # access-block-False during a parser miss meant we'd
+                # incorrectly skip the more authoritative top-level
+                # signal. Now: explicit bool always wins.
                 d.doors_locked = top_locked
             top_hood_locked = v(status, "hood", "locked")
             if isinstance(top_hood_locked, str) and d.hood_open is None:
@@ -449,7 +461,11 @@ class SeatCupraClient(CariadBaseClient):
                 or v(chg, "chargePowerInKw")  # Legacy
                 or v(chg, "chargePower_kW")   # Legacy
             )
-            d.charging_rate_kmh = v(chg, "chargeRateInKmPerHour") or v(chg, "chargeRate_kmph")
+            d.charging_rate_kmh = (
+                v(chg, "chargeRateInKmPerHour")  # Rainer #109 shape A
+                or v(chg, "chargeRate_kmph")     # Legacy CARIAD path
+                or v(chg, "rateInKmph")          # v2.0.1 Scout #192 — Cupra Born MY26 ships this on the OLA charging endpoint
+            )
             remaining = (
                 v(chg, "remainingTimeInMinutes")  # Rainer #109 shape B — verified
                 or v(chg, "remainingTime")        # Rainer #109 shape A — verified
@@ -492,10 +508,18 @@ class SeatCupraClient(CariadBaseClient):
                 or v(plug, "lockState")           # Rainer #109 shape
                 or v(plug, "plugLockState")        # Legacy CARIAD
             )
-            d.connector_locked = (
-                isinstance(plug_lock_raw, str)
-                and plug_lock_raw.lower() == "locked"
-            ) or v(plug, "externalPower") == "READY"
+            ext_power = v(plug, "externalPower")
+            # v2.0.1 (#131 follow-up) — only assign when at least one of
+            # the two source fields is present. Pre-v2.0.1 always
+            # assigned False when both were missing, masking a real
+            # "still locked, can't unplug yet" state during parser miss.
+            if isinstance(plug_lock_raw, str) or isinstance(ext_power, str):
+                d.connector_locked = (
+                    isinstance(plug_lock_raw, str)
+                    and plug_lock_raw.lower() == "locked"
+                ) or (
+                    isinstance(ext_power, str) and ext_power.upper() == "READY"
+                )
 
         # ── Charging info (settings) ─────────────────────────────────────────
         # OLA `/v2/vehicles/{vin}/charging/settings` field variance.

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -504,7 +504,9 @@ class SkodaClient(CariadBaseClient):
             c = charging.get("status", {})
             d.battery_soc = v(c, "battery", "stateOfChargeInPercent")
             d.charging_state = v(c, "state")
-            d.is_charging = d.charging_state == "CHARGING"
+            # v2.0.1 (#131 follow-up) — defensive parsing.
+            if isinstance(d.charging_state, str):
+                d.is_charging = d.charging_state.upper() == "CHARGING"
             d.charging_power_kw = v(c, "chargePowerInKw")
             d.charging_rate_kmh = v(c, "chargingRateInKilometersPerHour")
             d.charging_type = v(c, "chargeType")
@@ -594,10 +596,13 @@ class SkodaClient(CariadBaseClient):
                     d.outside_temp = ot_val
 
             plug_conn = v(ac, "chargerConnectionState")
-            if plug_conn:
-                d.plug_connected = plug_conn == "CONNECTED"
+            if isinstance(plug_conn, str):
+                d.plug_connected = plug_conn.upper() == "CONNECTED"
                 d.plug_state = plug_conn
-            d.connector_locked = v(ac, "chargerLockState") == "LOCKED"
+            # v2.0.1 (#131 follow-up) — defensive parsing.
+            charger_lock = v(ac, "chargerLockState")
+            if isinstance(charger_lock, str):
+                d.connector_locked = charger_lock.upper() == "LOCKED"
 
         # ── Parking position (v3 with formatted address) ─────────────────────
         if isinstance(parking, dict):

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -835,7 +835,10 @@ class VWEUClient(CariadBaseClient):
 
         # ── Charging ──────────────────────────────────────────────────────────
         d.charging_state = v(raw, "charging", "chargingStatus", "value", "chargingState")
-        d.is_charging = d.charging_state == "CHARGING"
+        # v2.0.1 (#131 follow-up) — defensive: keep is_charging None
+        # when charging_state is missing (preserves "unknown" semantics).
+        if isinstance(d.charging_state, str):
+            d.is_charging = d.charging_state.upper() == "CHARGING"
         d.charging_power_kw = v(raw, "charging", "chargingStatus", "value", "chargePower_kW")
         d.charging_rate_kmh = v(raw, "charging", "chargingStatus", "value", "chargeRate_kmph")
 
@@ -907,8 +910,13 @@ class VWEUClient(CariadBaseClient):
 
         plug_state = v(raw, "charging", "plugStatus", "value", "plugConnectionState")
         d.plug_state = plug_state
-        d.plug_connected = plug_state == "CONNECTED"
-        d.connector_locked = v(raw, "charging", "plugStatus", "value", "plugLockState") == "LOCKED"
+        # v2.0.1 (#131 follow-up) — defensive parsing.
+        if isinstance(plug_state, str):
+            d.plug_connected = plug_state.upper() == "CONNECTED"
+        # v2.0.1 (#131 follow-up) — defensive parsing.
+        plug_lock = v(raw, "charging", "plugStatus", "value", "plugLockState")
+        if isinstance(plug_lock, str):
+            d.connector_locked = plug_lock.upper() == "LOCKED"
 
         d.target_soc = v(raw, "charging", "chargingSettings", "value", "targetSOC_pct")
         d.charge_mode = v(raw, "charging", "chargingStatus", "value", "chargeMode")
@@ -1145,10 +1153,21 @@ class VWEUClient(CariadBaseClient):
             d.last_alarm_at = last_alarm
 
         # ── Access / doors / windows ──────────────────────────────────────────
-        d.doors_locked = v(raw, "access", "accessStatus", "value", "doorLockStatus") == "LOCKED"
+        # v2.0.1 (#131 user-reported follow-up) — defensive parsing.
+        # Previously: ``d.doors_locked = X == "LOCKED"`` always assigned
+        # True or False, even when X was None (missing field, .error
+        # envelope, backend hiccup). Combined with the old
+        # ``doors_locked: bool = False`` dataclass default that made HA
+        # falsely show "Unlocked" for actually-locked cars during any
+        # parser-miss scenario. New shape: only assign when the source
+        # field is an actual string; otherwise leave the dataclass
+        # default ``None`` so the entity stays "unknown" instead of
+        # showing wrong state. Same fix applied to ``doors_open`` and
+        # ``windows_open`` below.
+        lock_raw = v(raw, "access", "accessStatus", "value", "doorLockStatus")
+        if isinstance(lock_raw, str):
+            d.doors_locked = lock_raw.upper() == "LOCKED"
         overall = v(raw, "access", "accessStatus", "value", "overallStatus")
-        d.doors_open = False
-        d.windows_open = False
         if overall == "UNSAFE":
             doors: list[dict[str, Any]] = v(raw, "access", "accessStatus", "value", "doors") or []
             d.doors_open = any(
@@ -1168,6 +1187,15 @@ class VWEUClient(CariadBaseClient):
                 for door in doors
                 if door.get("name") and door.get("status")
             }
+        elif overall == "SAFE":
+            # v2.0.1 (#131 follow-up) — explicit SAFE detection. Backend
+            # publishes "SAFE" when the car is locked + all openings shut.
+            # Pre-v2.0.1 the parser only handled "UNSAFE" and left both
+            # fields at the (now removed) ``False`` dataclass default.
+            # Now we explicitly set False when SAFE, leave None otherwise
+            # (truly unknown state — backend hiccup, error envelope).
+            d.doors_open = False
+            d.windows_open = False
 
         # ── Climatisation ─────────────────────────────────────────────────────
         d.climatisation_state = v(raw, "climatisation", "climatisationStatus", "value", "climatisationState")

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -120,30 +120,49 @@ class VWNAClient:
             d.battery_soc = v(bat, "stateOfChargePercent")
             d.has_battery = d.battery_soc is not None
 
-            # Doors
+            # Doors — v2.0.1 (#131 follow-up): defensive parsing.
+            # Only assign safety-critical booleans when the source is
+            # an actual string; otherwise leave the dataclass default
+            # ``None`` so the entity stays "unknown" instead of falsely
+            # reporting "Unlocked"/"Closed" for an actually-locked car.
             door_status = v(vehicle_raw, "doorStatus") or {}
-            d.doors_locked = v(door_status, "overallStatus") == "LOCKED"
-            d.doors_open   = any(
-                v(door_status, k) == "OPEN"
-                for k in ("frontLeftDoor", "frontRightDoor", "rearLeftDoor", "rearRightDoor")
-            )
-            d.trunk_open = v(door_status, "trunk") == "OPEN"
-            d.hood_open  = v(door_status, "hood") == "OPEN"
+            overall_lock = v(door_status, "overallStatus")
+            if isinstance(overall_lock, str):
+                d.doors_locked = overall_lock.upper() == "LOCKED"
+            door_keys = ("frontLeftDoor", "frontRightDoor", "rearLeftDoor", "rearRightDoor")
+            door_states = [v(door_status, k) for k in door_keys]
+            if any(isinstance(s, str) for s in door_states):
+                d.doors_open = any(
+                    isinstance(s, str) and s.upper() == "OPEN" for s in door_states
+                )
+            trunk = v(door_status, "trunk")
+            if isinstance(trunk, str):
+                d.trunk_open = trunk.upper() == "OPEN"
+            hood = v(door_status, "hood")
+            if isinstance(hood, str):
+                d.hood_open = hood.upper() == "OPEN"
 
-            # Windows
+            # Windows — v2.0.1 (#131 follow-up): same defensive shape.
             win = v(vehicle_raw, "windowStatus") or {}
-            d.windows_open = any(
-                v(win, k) == "OPEN"
-                for k in ("frontLeftWindow", "frontRightWindow", "rearLeftWindow", "rearRightWindow")
+            window_keys = (
+                "frontLeftWindow", "frontRightWindow",
+                "rearLeftWindow", "rearRightWindow",
             )
+            window_states = [v(win, k) for k in window_keys]
+            if any(isinstance(s, str) for s in window_states):
+                d.windows_open = any(
+                    isinstance(s, str) and s.upper() == "OPEN" for s in window_states
+                )
 
             # GPS
             pos = v(vehicle_raw, "vehicleLocation") or {}
             d.latitude  = v(pos, "latitude")
             d.longitude = v(pos, "longitude")
 
-            # Connection
-            d.is_online = v(vehicle_raw, "connectionStatus", "connectionState") == "CONNECTED"
+            # Connection — v2.0.1 (#131 follow-up): defensive parsing.
+            conn_state = v(vehicle_raw, "connectionStatus", "connectionState")
+            if isinstance(conn_state, str):
+                d.is_online = conn_state.upper() == "CONNECTED"
 
             # Drivetrain type
             engine = v(vehicle_raw, "vehicleType", "engine") or ""
@@ -157,11 +176,14 @@ class VWNAClient:
         # ── Charging ──────────────────────────────────────────────────────────
         if isinstance(charge, dict):
             d.charging_state    = v(charge, "chargingStatus", "chargingState")
-            d.is_charging       = d.charging_state == "CHARGING"
+            # v2.0.1 (#131 follow-up) — defensive parsing.
+            if isinstance(d.charging_state, str):
+                d.is_charging = d.charging_state.upper() == "CHARGING"
             d.charging_power_kw = v(charge, "chargingStatus", "chargePower_kW")
             plug = v(charge, "plugStatus", "plugConnectionState")
-            d.plug_connected    = plug == "CONNECTED"
-            d.plug_state        = plug
+            if isinstance(plug, str):
+                d.plug_connected = plug.upper() == "CONNECTED"
+                d.plug_state = plug
             d.target_soc        = v(charge, "chargingSettings", "targetSOC_pct")
             # v1.24.2 (audit): safe_int + safe_float defensive coerce
             remaining_min = safe_int(v(charge, "chargingStatus", "remainingChargingTimeToComplete_min"))

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -159,13 +159,19 @@ class VehicleData:
     # e.g. {"MYAPN8NB": "https://mediaservice.audi.com/media/fast/v3_...", ...}
     image_urls: dict = None  # type: ignore[assignment]
     # Vehicle media names from GraphQL (vehicle.media.shortName/longName)
-    # Warning lights
-    warning_active: bool = False
+    # Warning lights — v2.0.1 (#131 follow-up): switched from
+    # ``bool = False`` to ``bool | None = None`` so that a parser miss
+    # (Backend-Hiccup, .error envelope, missing field, unknown firmware
+    # value) leaves the entity ``unknown`` rather than falsely "no
+    # warning". The previous default-False masked real warnings during
+    # the Cariad-BFF nightly maintenance windows (see #190 for an
+    # example backend-hiccup that flipped 17 fields to .error envelope).
+    warning_active: bool | None = None
     warning_count: int = 0
-    warning_oil: bool = False
-    warning_engine: bool = False
-    warning_tyre: bool = False
-    warning_brakes: bool = False
+    warning_oil: bool | None = None
+    warning_engine: bool | None = None
+    warning_tyre: bool | None = None
+    warning_brakes: bool | None = None
 
     media_short_name: str | None = None  # e.g. "Q4 e-tron"
     media_long_name: str | None = None   # e.g. "Audi Q4 50 e-tron quattro"
@@ -211,9 +217,18 @@ class VehicleData:
 
     # Charging
     charging_state: str | None = None
-    is_charging: bool = False
+    # v2.0.1 (#131 follow-up) — switched ``is_charging`` /
+    # ``plug_connected`` / ``auto_unlock_charge`` / ``connector_locked``
+    # from ``bool = False`` to ``bool | None = None``. Same false-
+    # negative reasoning as ``doors_locked`` above: parser-miss on a
+    # backend-hiccup must NOT default to "not charging" / "plug
+    # disconnected" / "connector unlocked" — that hides real state.
+    # ``connector_locked`` is the most safety-relevant of these (LOCK
+    # device class) — user can't pull a still-locked plug, so a
+    # wrong-False masks a real "you can't unplug yet" state.
+    is_charging: bool | None = None
     plug_state: str | None = None
-    plug_connected: bool = False
+    plug_connected: bool | None = None
     charging_power_kw: float | None = None
     charging_rate_kmh: float | None = None
     charge_complete_eta: Any | None = None
@@ -221,8 +236,8 @@ class VehicleData:
     target_soc: int | None = None
     max_charge_current: float | None = None
     min_soc: int | None = None  # Minimum SoC for departure timer (PHEV)
-    auto_unlock_charge: bool = False
-    connector_locked: bool = False
+    auto_unlock_charge: bool | None = None
+    connector_locked: bool | None = None
     charging_station_name: str | None = None
     charging_station_address: str | None = None
     charging_station_kw: float | None = None
@@ -237,14 +252,26 @@ class VehicleData:
 
     # Climate
     climatisation_state: str | None = None
-    climatisation_active: bool = False
+    # v2.0.1 (#131 follow-up) — same false-negative reasoning as the
+    # Access block: parser-miss must NOT default to "climate off".
+    climatisation_active: bool | None = None
     target_temperature: float | None = None
     outside_temp: float | None = None
 
     # Access
-    doors_locked: bool = False
-    doors_open: bool = False
-    windows_open: bool = False
+    # v2.0.1 (#131 user-reported follow-up): switched from
+    # ``bool = False`` to ``bool | None = None`` to fix a critical
+    # safety false-negative: when the parser couldn't extract the lock
+    # state from the response (Backend-Hiccup .error envelope, missing
+    # field, unknown firmware value) the dataclass default was False,
+    # so the binary_sensor + lock entity displayed "Unlocked" for an
+    # actually-locked car. Cars now correctly show "Unknown" instead.
+    # The lock entity (lock.py:is_locked) and the binary_sensor (with
+    # LOCK device_class invert) both already handle ``None`` as
+    # "unknown" — no entity-side change needed.
+    doors_locked: bool | None = None
+    doors_open: bool | None = None
+    windows_open: bool | None = None
     doors_individual: dict[str, bool] = field(default_factory=dict)
     # v1.8.9 (Session 3C) — per-window state, mirrors ``doors_individual``.
     # Keys: frontLeft / frontRight / rearLeft / rearRight. Value True ==
@@ -262,8 +289,12 @@ class VehicleData:
     # Status
     vehicle_state: str | None = None
     connection_state: str | None = None
-    is_driving: bool = False
-    is_online: bool = False
+    # v2.0.1 (#131 follow-up) — same false-negative reasoning. Parser
+    # miss must NOT default to "vehicle parked + offline". Conditional
+    # automations like "wake car when leaving driveway" relied on
+    # ``is_online`` being honest about its uncertainty.
+    is_driving: bool | None = None
+    is_online: bool | None = None
     last_updated_at: Any | None = None
     # v1.8.11 (Session 3S) — when the *vehicle* last reported data to the
     # backend, derived from ``carCapturedTimestamp`` on the status response

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.0.0"
+  "version": "2.0.1"
 }


### PR DESCRIPTION
## Summary

**Critical safety bug fix** reported via #131 user follow-up: `doors_locked` showed "Unlocked" for actually-locked cars whenever the parser couldn't extract the lock state.

**Root cause double-bug:**
1. **Dataclass default** `doors_locked: bool = False` — parser-miss left field on False instead of None.
2. **4 of 5 brand parsers** used `field = X == "LOCKED"` pattern — when `X` was `None` the comparison evaluated to `False` (active assignment) rather than leaving the field unchanged.

## Fix
- **14 safety-critical bools** in `cariad/models.py` switched from `bool = False` → `bool | None = None`
- **4 brand parsers** (`vw_eu`, `porsche`, `seat_cupra`, `vw_na`) refactored to defensive `isinstance(str) + .upper()` pattern
- `vw_eu` also adds explicit `overallStatus == "SAFE"` detection so "SAFE" cars correctly set `doors_open=False`
- **Skoda already correct** at parser level since v1.20.2 — benefits automatically from the dataclass default change

## Plus closes scout #192
- `seat_cupra` adds third fallback `charging.rateInKmph` for Cupra Born MY26 firmware

## User-Impact
- Before v2.0.1: Backend-Hiccup → HA shows "Unlocked" but car is locked → user trusts wrong state
- After v2.0.1: Backend-Hiccup → HA shows "Unknown" → user sees clearly that data is unavailable
- Same fix protects `windows_open`, `connector_locked`, `warning_*` from false-negatives that could mask real hazards

## Test plan
- [x] All 5 brand parsers compile clean
- [x] LOCK device_class invert in `binary_sensor.py:390` and `lock.py:53` already handle `None` → "Unknown"
- [ ] CI 7/7 green
- [ ] Smoke against real vehicle: lock → wait for backend-hiccup window → confirm sensor shows "Unknown" not "Unlocked"

## Manifest
`2.0.0` → `2.0.1` (PATCH per Semver — pure bugfix + 1 scout-driven addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)