### PR TITLE
PR v2.1.0 #1: Skoda climate-ready-at sensor (closes scout #186 + #188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased] — v2.1.0 (in progress)
+
+> Sammelt Bullets für die nächste MINOR-Release. Fokus: post-v2.0
+> User-Wins die im Big-Bang Scope-Cut waren oder durch Scout-Reports
+> nachgereicht wurden.
+
+### Added
+
+- **Skoda Climate-Ready-At Sensor** (closes Scout #186 + #188) — neuer
+  `sensor.<vin>_climate_ready_at` (TIMESTAMP device class) für Skoda
+  MY24+ Fahrzeuge mit aktiver Vorklimatisierung. Liest aus
+  `air-conditioning.estimatedDateTimeToReachTargetTemperature`. Sehr
+  nützlich für "Vorklimatisierung 5min vor Abfahrt" Automatisierungen
+  via Template `{{ as_datetime(states('sensor.x')) - 5|minutes }}`.
+  Brand-restricted via `_DATA_PRESENT_REQUIRED` — non-Skoda und
+  inaktive Klimatisierung erzeugen keine Phantom-Entität.
+  Übersetzungen alle 8 Sprachen.
+
+---
+
 ## [2.0.1] - 2026-05-15 🚨🔒 Safety-Fix: `doors_locked` False-Negative Cross-Brand / Safety-Fix: `doors_locked` False-Negative Cross-Brand
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -565,6 +565,19 @@ class SkodaClient(CariadBaseClient):
             wh = v(ac, "windowHeatingState") or {}
             d.window_heating_front = v(wh, "front") == "ON"
             d.window_heating_back = v(wh, "rear") == "ON"
+
+            # v2.1.0 — climate-ready-at (closes scout #186 + #188).
+            # Skoda mysmob air-conditioning endpoint shippt
+            # ``estimatedDateTimeToReachTargetTemperature`` als ISO-8601
+            # Zeitstempel wenn die Klimatisierung aktiv läuft. Sehr
+            # nützlich für "Vorklimatisierung 5min vor Abfahrt"
+            # Automatisierungen — User kann jetzt ``binary_sensor``
+            # triggern wenn ``sensor.<vin>_climate_ready_at`` minus
+            # 5min erreicht. Field ist nur während Climate-Run gesetzt;
+            # bleibt None während OFF.
+            climate_ready = v(ac, "estimatedDateTimeToReachTargetTemperature")
+            if isinstance(climate_ready, str) and climate_ready:
+                d.climate_ready_at = climate_ready
             # v1.26.0 Welle-6 (#173, scouts #143) — Skoda climate settings.
             # airConditioningAtUnlock as climate_at_unlock cross-brand alias.
             au_clim = v(ac, "airConditioningAtUnlock")

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -257,6 +257,13 @@ class VehicleData:
     climatisation_active: bool | None = None
     target_temperature: float | None = None
     outside_temp: float | None = None
+    # v2.1.0 — Skoda climate-ready-at (closes Scout #186 + #188).
+    # ISO-8601 timestamp when the cabin is expected to reach
+    # ``target_temperature``. Only populated during active climate
+    # run; remains None when climatisation is OFF. Skoda-only field
+    # today — other brands' status endpoints don't expose it.
+    # Brand-restricted via _DATA_PRESENT_REQUIRED in sensor.py.
+    climate_ready_at: Any | None = None
 
     # Access
     # v2.0.1 (#131 user-reported follow-up): switched from

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -695,6 +695,21 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         condition="electric",
     ),
+    # v2.1.0 — Skoda climate-ready-at (closes Scout #186 + #188).
+    # ISO-8601 timestamp when the cabin is expected to reach the
+    # target temperature. Only populated during active climate run.
+    # Brand-restricted via _DATA_PRESENT_REQUIRED — Skoda-only today.
+    # Device class TIMESTAMP renders as relative time in HA UI
+    # ("in 8 minutes") and is automation-friendly with template
+    # ``{{ as_datetime(states('sensor.x')) - 5|minutes }}`` for
+    # "5min before climate ready" triggers.
+    VagSensorDescription(
+        key="climate_ready_at",
+        translation_key="climate_ready_at",
+        data_key="climate_ready_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:clock-end",
+    ),
 
     # ── v1.9.0 Vehicle Data Scout + Error Reporter ────────────────────────────
     # Two diagnostic sensors that surface drift / runtime errors detected
@@ -917,6 +932,10 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "last_alarm_at",
     # v2.0.0 (Big-Bang) — heaterSource (issue #163, ID.x heat-pump only).
     "heater_source",
+    # v2.1.0 — Skoda climate-ready-at (Scout #186/#188). Field is
+    # only populated during active climate run; gating prevents a
+    # phantom "unknown" entity for non-Skoda + idle climates.
+    "climate_ready_at",
 })
 
 # v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -311,6 +311,9 @@
       },
       "heater_source": {
         "name": "Heater Source"
+      },
+      "climate_ready_at": {
+        "name": "Climate Ready At"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -305,6 +305,9 @@
       },
       "heater_source": {
         "name": "Zdroj Topení"
+      },
+      "climate_ready_at": {
+        "name": "Klima Připravená Do"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -305,6 +305,9 @@
       },
       "heater_source": {
         "name": "Heizquelle"
+      },
+      "climate_ready_at": {
+        "name": "Klima fertig um"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -305,6 +305,9 @@
       },
       "heater_source": {
         "name": "Heater Source"
+      },
+      "climate_ready_at": {
+        "name": "Climate Ready At"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -305,6 +305,9 @@
       },
       "heater_source": {
         "name": "Fuente de Calefacción"
+      },
+      "climate_ready_at": {
+        "name": "Clima Listo a Las"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -305,6 +305,9 @@
       },
       "heater_source": {
         "name": "Source de Chauffage"
+      },
+      "climate_ready_at": {
+        "name": "Climat Prêt à"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -305,6 +305,9 @@
       },
       "heater_source": {
         "name": "Verwarmingsbron"
+      },
+      "climate_ready_at": {
+        "name": "Klimaat Klaar Om"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -305,6 +305,9 @@
       },
       "heater_source": {
         "name": "Źródło Ogrzewania"
+      },
+      "climate_ready_at": {
+        "name": "Klimat Gotowy O"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -305,6 +305,9 @@
       },
       "heater_source": {
         "name": "Värmekälla"
+      },
+      "climate_ready_at": {
+        "name": "Klimat Klart kl."
       }
     },
     "binary_sensor": {

--- a/tests/bruno/skoda/15_GET_air_conditioning.bru
+++ b/tests/bruno/skoda/15_GET_air_conditioning.bru
@@ -34,4 +34,9 @@ docs {
   climatisation_active=False. v1.10.1 added safe_float for
   targetTemperature.temperatureValue (some EU firmwares ship
   "21,5" with a comma).
+
+  v2.1.0 — also drives ``sensor.<vin>_climate_ready_at`` (TIMESTAMP)
+  via the new ``estimatedDateTimeToReachTargetTemperature`` field
+  (closes Scout reports #186 + #188). Field is only populated during
+  active climate runs; sensor stays "unknown" when climatisation is OFF.
 }


### PR DESCRIPTION
## Summary

- **[NEW v2.1] `sensor.<vin>_climate_ready_at`** — `TIMESTAMP` device_class — for Skoda MY24+ with active pre-conditioning
- Reads from Skoda mysmob `air-conditioning.estimatedDateTimeToReachTargetTemperature`
- Closes Scout reports #186 + #188
- Translations across all 8 locales

## Use case
Power-user automation: "5 minutes before climate ready, unlock the garage gate":
```yaml
trigger:
  platform: template
  value_template: >
    {{ as_datetime(states('sensor.skoda_x_climate_ready_at')) - now() < timedelta(minutes=5) }}
```

## Phantom-entity protection
`_DATA_PRESENT_REQUIRED` set membership prevents the sensor from spawning on non-Skoda vehicles and on Skoda vehicles with idle climatisation (field is only populated during active runs).

## Test plan
- [x] `python -m py_compile` clean
- [x] All 9 modified JSON files valid
- [x] Bruno doc updated with the new field path
- [ ] CI 7/7 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)