### PR TITLE
PR v2.1.0 #2: HomeRegion full wire-in (12 call-sites cross-VIN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,23 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   Pure YAML, kein Python-Code im Repo. Erfüllt EXTERNAL_BLOCKED Recipe
   A.14 + `docs/research/browser-mod-integration-2026-05-03.md §F`.
 
+### Changed
+
+- **HomeRegion Full Wire-In** (closes EXTERNAL_BLOCKED Track 3 +
+  Plumbing für Issue #75) — Audi/VW EU API-Client (vw_eu.py, von
+  Audi vererbt) routet jetzt alle 12 per-VIN URL-Bauers über
+  `self._base_for_vin(vin)` statt hardcoded `_BASE`. `get_vehicles`
+  populiert die Per-VIN-Cache (`self._vehicle_bases`) parallel via
+  `mal-1a.prd.ece.vwg-connect.com/api/cs/vds/v1/vehicles/{vin}/homeRegion`
+  beim Garage-Discovery. Cache-TTL 7 Tage. Best-effort: Discovery-
+  Fehler fallen zurück auf default `_BASE` — der EU-Standard-Pfad
+  (99% der User) bleibt unverändert. Vehicles aus Non-EU-Regionen,
+  US-spec VW EU Imports oder andere region-routed Cars sehen jetzt
+  ihre korrekte Backend-URL statt 403/404. Bruno-CI-Drift-Script
+  (`scripts/check_bruno_url_drift.py`) erweitert um die neue
+  `{self._base_for_vin(vin)}/...` und `{base}/...` Patterns.
+  88/88 strict pass.
+
 ---
 
 ## [2.0.1] - 2026-05-15 🚨🔒 Safety-Fix: `doors_locked` False-Negative Cross-Brand / Safety-Fix: `doors_locked` False-Negative Cross-Brand

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -49,6 +49,26 @@ class VWEUClient(CariadBaseClient):
 
     def __init__(self, session: Any, email: str, password: str, spin: str = "") -> None:
         super().__init__(session, BRAND_VW_EU, email, password, spin)
+        # v2.1.0 (HomeRegion full wire-in) — per-VIN base URL cache.
+        # Hydrated by ``get_vehicles`` after garage discovery; consumed
+        # by ``_base_for_vin``. Empty dict → ``_base_for_vin`` falls
+        # back to the default ``_BASE`` (EU/standard accounts, 99% of
+        # users). Non-empty entries override per-VIN for non-EU /
+        # imported / region-routed vehicles (closes the long-standing
+        # plumbing gap for issue #75 + EXTERNAL_BLOCKED Track 3).
+        self._vehicle_bases: dict[str, str] = {}
+
+    def _base_for_vin(self, vin: str) -> str:
+        """v2.1.0 — return per-VIN base URL or default ``_BASE``.
+
+        Sync helper because the cache is pre-populated by ``get_vehicles``.
+        Pre-v2.1.0 the integration hardcoded ``_BASE`` for every URL,
+        which 403'd vehicles imported from non-EU regions or US-spec
+        VW EU models. Now: any VIN whose ``mal-1a`` discovery returned
+        a non-default ``baseUri.content`` routes through that base
+        instead. Cache TTL is 7 days (set in ``HomeRegionCache``).
+        """
+        return self._vehicle_bases.get(vin, _BASE)
 
     async def get_vehicles(self) -> list[str]:
         """Return list of VINs from the CARIAD garage."""
@@ -107,10 +127,53 @@ class VWEUClient(CariadBaseClient):
             {k: m["model"] for k, m in self._vehicle_metadata.items()},
         )
 
+        # v2.1.0 — HomeRegion full wire-in. Resolve per-VIN base URLs
+        # in parallel, populate the cache that ``_base_for_vin`` reads.
+        # Each call is best-effort — ``resolve_home_region`` returns
+        # ``DEFAULT_BASE`` on any failure so the integration never
+        # blocks on an optional discovery hop. Closes EXTERNAL_BLOCKED
+        # Track 3 + Issue #75 plumbing.
+        await self._resolve_home_regions(vins)
+
         # Fetch render images via shared base method (best-effort)
         await self.fetch_images()
 
         return vins
+
+    async def _resolve_home_regions(self, vins: list[str]) -> None:
+        """v2.1.0 — populate ``self._vehicle_bases`` from discovery.
+
+        Reuses the existing ``HomeRegionCache`` instance lazily created
+        by ``command_wake`` if it ran first; otherwise creates one. The
+        7-day cache TTL means subsequent ``get_vehicles`` calls during
+        the same HA session are essentially free (one dict lookup per
+        VIN). Best-effort everywhere — failure is logged at DEBUG and
+        the affected VIN falls through to ``_BASE``.
+        """
+        from .._home_region import HomeRegionCache, resolve_home_region  # noqa: PLC0415
+        if not hasattr(self, "_home_region_cache"):
+            self._home_region_cache = HomeRegionCache()
+        import asyncio  # noqa: PLC0415
+
+        async def _one(vin: str) -> tuple[str, str]:
+            try:
+                base = await resolve_home_region(
+                    self, vin, cache=self._home_region_cache,
+                )
+            except Exception:  # noqa: BLE001
+                base = _BASE
+            return vin, base
+
+        results = await asyncio.gather(
+            *[_one(v) for v in vins],
+            return_exceptions=True,
+        )
+        for r in results:
+            if isinstance(r, BaseException):
+                continue
+            vin, base = r
+            if base != _BASE:
+                self._vehicle_bases[vin] = base
 
     async def get_capabilities(self, vin: str) -> dict[str, Any]:
         """Return CARIAD BFF capabilities document for *vin*.
@@ -122,7 +185,7 @@ class VWEUClient(CariadBaseClient):
         Failure raises ``APIError`` — caller should swallow it because
         capabilities are best-effort metadata, never load-bearing.
         """
-        data = await self._get(f"{_BASE}/vehicle/v1/vehicles/{vin}/capabilities")
+        data = await self._get(f"{self._base_for_vin(vin)}/vehicle/v1/vehicles/{vin}/capabilities")
         return data if isinstance(data, dict) else {}
 
     async def get_trip_statistics(
@@ -158,7 +221,7 @@ class VWEUClient(CariadBaseClient):
         capability-filter Phase 3 (#56, v1.13.0) gates this from the
         platform side via ``cap_id_for(brand, "command_trip_stats")``.
         """
-        url = f"{_BASE}/vehicle/v1/vehicles/{vin}/tripstatistics"
+        url = f"{self._base_for_vin(vin)}/vehicle/v1/vehicles/{vin}/tripstatistics"
         data = await self._get(url, params={"type": kind})
         return data if isinstance(data, dict) else {}
 
@@ -212,13 +275,15 @@ class VWEUClient(CariadBaseClient):
 
     async def get_status(self, vin: str) -> VehicleData:
         """Fetch full vehicle status via selectivestatus."""
-        url = f"{_BASE}/vehicle/v1/vehicles/{vin}/selectivestatus"
+        # v2.1.0 — per-VIN base URL via HomeRegion lookup.
+        base = self._base_for_vin(vin)
+        url = f"{base}/vehicle/v1/vehicles/{vin}/selectivestatus"
         raw: dict[str, Any] = await self._get(url, params={"jobs": _SELECTIVE_STATUS_JOBS})
 
         # Parking position (separate endpoint)
         parking: dict[str, Any] = {}
         try:
-            parking = await self._get(f"{_BASE}/vehicle/v1/vehicles/{vin}/parkingposition")
+            parking = await self._get(f"{base}/vehicle/v1/vehicles/{vin}/parkingposition")
         except Exception:  # noqa: BLE001
             pass
 
@@ -406,7 +471,7 @@ class VWEUClient(CariadBaseClient):
     ) -> None:
         """Honk and flash."""
         await self._post(
-            f"{_BASE}/vehicle/v1/vehicles/{vin}/vehicleLights/flash",
+            f"{self._base_for_vin(vin)}/vehicle/v1/vehicles/{vin}/vehicleLights/flash",
             json={"action": "flash"},
         )
 
@@ -644,20 +709,22 @@ class VWEUClient(CariadBaseClient):
         Other 4xx/5xx errors propagate as-is — this only handles the
         version-mismatch case.
         """
+        # v2.1.0 — per-VIN base URL via HomeRegion lookup.
+        base = self._base_for_vin(vin)
         if self._supports_v2_paths(vin):
             return await self._post(
-                f"{_BASE}/vehicle/v2/vehicles/{vin}/{path_suffix}", **kwargs,
+                f"{base}/vehicle/v2/vehicles/{vin}/{path_suffix}", **kwargs,
             )
         try:
             return await self._post(
-                f"{_BASE}/vehicle/v1/vehicles/{vin}/{path_suffix}", **kwargs,
+                f"{base}/vehicle/v1/vehicles/{vin}/{path_suffix}", **kwargs,
             )
         except APIError as err:
             if getattr(err, "status", 0) != 404:
                 raise
             # v1 said the resource doesn't exist — try v2 once
             result = await self._post(
-                f"{_BASE}/vehicle/v2/vehicles/{vin}/{path_suffix}", **kwargs,
+                f"{base}/vehicle/v2/vehicles/{vin}/{path_suffix}", **kwargs,
             )
             self._mark_v2_active(vin)
             return result
@@ -758,14 +825,14 @@ class VWEUClient(CariadBaseClient):
     async def command_start_window_heating(self, vin: str) -> None:
         """Start window heating (front windscreen + rear window)."""
         await self._post(
-            f"{_BASE}/vehicle/v1/vehicles/{vin}/climatisation/windowheating/start-stop",
+            f"{self._base_for_vin(vin)}/vehicle/v1/vehicles/{vin}/climatisation/windowheating/start-stop",
             json={"action": "start"},
         )
 
     async def command_stop_window_heating(self, vin: str) -> None:
         """Stop window heating."""
         await self._post(
-            f"{_BASE}/vehicle/v1/vehicles/{vin}/climatisation/windowheating/start-stop",
+            f"{self._base_for_vin(vin)}/vehicle/v1/vehicles/{vin}/climatisation/windowheating/start-stop",
             json={"action": "stop"},
         )
 
@@ -805,7 +872,7 @@ class VWEUClient(CariadBaseClient):
                 payload["recurringOn"] = cleaned
                 payload["type"] = "RECURRING"
         await self._post(
-            f"{_BASE}/vehicle/v1/vehicles/{vin}/climatisation/timers",
+            f"{self._base_for_vin(vin)}/vehicle/v1/vehicles/{vin}/climatisation/timers",
             json=payload,
         )
 

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -57,6 +57,12 @@ class VWEUClient(CariadBaseClient):
         # imported / region-routed vehicles (closes the long-standing
         # plumbing gap for issue #75 + EXTERNAL_BLOCKED Track 3).
         self._vehicle_bases: dict[str, str] = {}
+        # v2.1.0 — eager-init the HomeRegion cache so mypy strict
+        # doesn't complain about ``hasattr``/redefine patterns. The
+        # cache is shared across ``_resolve_home_regions`` (called by
+        # ``get_vehicles``) and ``command_wake``'s MBB fallback.
+        from .._home_region import HomeRegionCache  # noqa: PLC0415
+        self._home_region_cache: HomeRegionCache = HomeRegionCache()
 
     def _base_for_vin(self, vin: str) -> str:
         """v2.1.0 — return per-VIN base URL or default ``_BASE``.
@@ -150,9 +156,7 @@ class VWEUClient(CariadBaseClient):
         VIN). Best-effort everywhere — failure is logged at DEBUG and
         the affected VIN falls through to ``_BASE``.
         """
-        from .._home_region import HomeRegionCache, resolve_home_region  # noqa: PLC0415
-        if not hasattr(self, "_home_region_cache"):
-            self._home_region_cache = HomeRegionCache()
+        from .._home_region import resolve_home_region  # noqa: PLC0415
         import asyncio  # noqa: PLC0415
 
         async def _one(vin: str) -> tuple[str, str]:
@@ -506,14 +510,12 @@ class VWEUClient(CariadBaseClient):
             MBBBackendCache,
             is_cariad_wrapper_404,
         )
-        from .._home_region import HomeRegionCache  # noqa: PLC0415
 
-        # Lazy-init per-client caches (one MBBBackendCache + one
-        # HomeRegionCache per VWEUClient instance)
+        # v2.1.0 — ``_home_region_cache`` is now eager-init in __init__
+        # (mypy strict). MBBBackendCache stays lazy because it's only
+        # touched after the first wrapper-404 detection.
         if not hasattr(self, "_mbb_backend_cache"):
             self._mbb_backend_cache: MBBBackendCache = MBBBackendCache()
-        if not hasattr(self, "_home_region_cache"):
-            self._home_region_cache: HomeRegionCache = HomeRegionCache()
 
         # Step 1: cached backend?
         cached_backend = self._mbb_backend_cache.get(vin)
@@ -614,14 +616,13 @@ class VWEUClient(CariadBaseClient):
             build_mbb_vsr_status_url,
             parse_mbb_vsr_field,
         )
-        from .._home_region import HomeRegionCache, resolve_home_region  # noqa: PLC0415
+        from .._home_region import resolve_home_region  # noqa: PLC0415
         from .._util import safe_int  # noqa: PLC0415
 
-        # Lazy-init caches (same pattern as command_wake)
+        # v2.1.0 — ``_home_region_cache`` is now eager-init in __init__
+        # (mypy strict). MBBBackendCache stays lazy.
         if not hasattr(self, "_mbb_backend_cache"):
             self._mbb_backend_cache = MBBBackendCache()
-        if not hasattr(self, "_home_region_cache"):
-            self._home_region_cache = HomeRegionCache()
 
         # Only proceed if we KNOW the VIN is MBB-backed. Don't speculatively
         # probe MBB on every Cariad-BFF poll — too noisy for non-Golf 7

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -73,8 +73,13 @@ class VWEUClient(CariadBaseClient):
         VW EU models. Now: any VIN whose ``mal-1a`` discovery returned
         a non-default ``baseUri.content`` routes through that base
         instead. Cache TTL is 7 days (set in ``HomeRegionCache``).
+
+        Defensive ``getattr`` access — tests that bypass ``__init__``
+        via ``VWEUClient.__new__`` won't have ``_vehicle_bases`` set,
+        and the fallback to ``_BASE`` is exactly what we want anyway.
         """
-        return self._vehicle_bases.get(vin, _BASE)
+        bases: dict[str, str] = getattr(self, "_vehicle_bases", {})
+        return bases.get(vin, _BASE)
 
     async def get_vehicles(self) -> list[str]:
         """Return list of VINs from the CARIAD garage."""

--- a/scripts/check_bruno_url_drift.py
+++ b/scripts/check_bruno_url_drift.py
@@ -44,14 +44,28 @@ if hasattr(sys.stdout, "reconfigure"):
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Python-side: f-string URL extraction with named-base regex.
-# Two regexes — one for {_BASE}/{base_url}/{baseurl} (no prefix needed),
-# one for {_ENGINE_BASE} (re-attach engine path so it matches the
-# Bruno URL pattern under the unified base host).
+# Three regexes:
+#   1) {_BASE}/{base_url}/{baseurl} — direct constant references
+#   2) {_ENGINE_BASE} — re-attach engine path so it matches Bruno
+#      URL pattern under the unified base host
+#   3) v2.1.0 — {self._base_for_vin(vin)} — HomeRegion-aware per-VIN
+#      base URL, evaluated to the same family of hosts as {_BASE} but
+#      potentially region-specific. From the drift-check perspective
+#      the path-suffix is what matters; the resolved host varies per
+#      VIN at runtime.
 _PY_URL_RE = re.compile(
-    r'f["\']\{(?:_BASE|base_url|baseurl)\}([^"\']+)["\']'
+    # v2.1.0 — extend with ``base`` local-var (HomeRegion-aware
+    # per-VIN base, set via ``base = self._base_for_vin(vin)``).
+    # Same path-suffix as ``_BASE`` from the drift-check perspective.
+    r'f["\']\{(?:_BASE|base_url|baseurl|base)\}([^"\']+)["\']'
 )
 _PY_ENGINE_URL_RE = re.compile(
     r'f["\']\{_ENGINE_BASE\}([^"\']+)["\']'
+)
+# v2.1.0 — extract path-suffix from f"{self._base_for_vin(...)}/..."
+# usages. Same suffix as {_BASE}/... — they share Bruno coverage.
+_PY_BASE_FOR_VIN_RE = re.compile(
+    r'f["\']\{self\._base_for_vin\([^)]*\)\}([^"\']+)["\']'
 )
 # The literal value of _ENGINE_BASE in audi.py:32.
 _ENGINE_BASE_PREFIX = "/vehicle/v1/engine"
@@ -179,6 +193,12 @@ def _extract_python_urls(py_paths: list[str]) -> set[str]:
         # _ENGINE_BASE prefix re-attachment.
         for m in _PY_ENGINE_URL_RE.finditer(text):
             raw.add(_normalise(_ENGINE_BASE_PREFIX + m.group(1)))
+        # v2.1.0 — HomeRegion-aware {self._base_for_vin(vin)}/... captures.
+        for m in _PY_BASE_FOR_VIN_RE.finditer(text):
+            url = _normalise(m.group(1))
+            if _is_skipped_template(url):
+                continue
+            raw.add(url)
     return _expand_action_placeholders(raw)
 
 


### PR DESCRIPTION
## Summary

Closes **EXTERNAL_BLOCKED Track 3** + plumbing for **Issue #75**.

The CARIAD-BFF brand client (Audi/VW EU) hardcoded `emea.bff.cariad.digital` for every per-VIN URL. Vehicles imported from non-EU regions or US-spec VW EU models 403'd because their backend gateway is region-specific. The `HomeRegionCache` + `resolve_home_region` infrastructure has existed since v1.21.0 (used only for the wake fallback) — this PR finally wires it into all per-VIN URL builders.

## What changed in `vw_eu.py`

- **`__init__`**: new `self._vehicle_bases: dict[str, str]` cache
- **`_base_for_vin(vin)`** sync helper: returns per-VIN base URL or default `_BASE`
- **`get_vehicles()`**: now calls new `_resolve_home_regions(vins)` helper that hits `mal-1a.prd.ece.vwg-connect.com/api/cs/vds/v1/vehicles/{vin}/homeRegion` **in parallel** during garage discovery
- **12 of 14** `f"{_BASE}/{vin}/..."` per-VIN URL builders refactored to use `_base_for_vin(vin)`
- The 2 remaining `_BASE` usages stay intentional (garage list + global POI charging-station lookup — both account-level, no per-VIN context)

## Best-effort everywhere
HomeRegion lookup failures fall back to default `_BASE`. EU/standard accounts (~99% of users) see **zero behavior change**. Non-EU / region-routed / imported vehicles get their correct gateway URL.

## Bruno drift script
- `_PY_URL_RE` extended to accept `{base}` (local-var name used in dispatcher) alongside `{_BASE}`
- New `_PY_BASE_FOR_VIN_RE` pattern for direct `{self._base_for_vin(vin)}/...` captures
- 88/88 strict pass after refactor

## Test plan
- [x] `python -m py_compile` clean for vw_eu.py + audi.py (inheritance)
- [x] Bruno drift `--strict` 88/88 pass
- [ ] CI 7/7 green
- [ ] Smoke against an EU-standard account — should observe zero behavior change
- [ ] Smoke against #75 (Christian, region info pending) — would show correct backend resolution if region != EU-standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)