### PR TITLE
v2.1.0: Release — Post-Big-Bang Wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,15 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [Unreleased] — v2.1.0 (in progress)
+## [2.1.0] - 2026-05-15 ✨🌍 Post-Big-Bang Wins — Skoda Climate-Ready + HomeRegion + User-Tools / Post-Big-Bang Wins — Skoda Climate-Ready + HomeRegion + User-Tools
 
-> Sammelt Bullets für die nächste MINOR-Release. Fokus: post-v2.0
-> User-Wins die im Big-Bang Scope-Cut waren oder durch Scout-Reports
-> nachgereicht wurden.
+> v2.1.0 sammelt 4 post-v2.0 Wins die im Big-Bang Scope-Cut waren oder
+> durch Scout-Reports nachgereicht wurden. Fokus: ein neuer Skoda-Sensor
+> (#186/#188), ein langjährig pendendes Plumbing-Refactor (HomeRegion +
+> Issue #75), ein User-facing Diagnostik-Script + Browser-Mod-Cookbook.
+>
+> **Migration**: keine. Alle Änderungen additiv — bestehende
+> Automationen + Lovelace-Cards funktionieren unverändert weiter.
 
 ### Added
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.0.1"
+  "version": "2.1.0"
 }


### PR DESCRIPTION
## Summary

v2.1.0 MINOR release bundling the 4 post-v2.0 wins that landed since the Big-Bang:

1. **Skoda Climate-Ready-At sensor** (#212, closes scout #186 + #188) — `TIMESTAMP` sensor for "5min before climate ready" automations
2. **HomeRegion Full Wire-In** (#213, closes EXTERNAL_BLOCKED Track 3 + Issue #75 plumbing) — 12 per-VIN URL builders now route through `_base_for_vin(vin)` so non-EU / imported / region-routed vehicles get their correct backend
3. **`scripts/verify_my_vin.py`** (#214) — user-facing pre-flight diagnostic
4. **`docs/recipes/browser-mod.md`** (#215) — 5 ready-to-paste YAML cookbooks

## Plus the v2.0.1 PATCH (already shipped)
v2.0.1 critical safety fix for `doors_locked` false-negative cross-brand was tagged + released earlier today.

## Migration
**None.** All changes are additive. Existing automations + Lovelace cards continue to work unchanged.

## Test plan
- [x] `manifest.json` version bumped 2.0.1 → 2.1.0
- [x] CHANGELOG `[Unreleased] — v2.1.0` → `[2.1.0]` dated header
- [ ] CI 7/7 green
- [ ] After merge: `git tag v2.1.0 && git push origin v2.1.0` for HACS release notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)