### PR TITLE
v2.2.0 PR #7/20: Email-OTP vs TOTP discrimination in IDK auth (Phase 2 opener)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **Email-2FA vs TOTP discrimination in IDK auth (Phase 2 PR #7/20, #183 follow-on)** —
+  Pre-v2.2.0 raised generischer `TwoFactorRequiredError` ob das IDP einen
+  Authenticator-App-TOTP-Code oder einen E-Mail-OTP-Code wollte. Die Repairs-UI
+  zeigte dann in beiden Fällen "open the app and confirm" Copy — was Email-OTP-
+  User vor ihrer Authenticator-App stehen ließ während der Code im Inbox auf
+  sie wartete. Jetzt diskriminiert:
+  - Auth0-Path: `/u/email-challenge` URL-Marker (vs. generic `/u/mfa`)
+  - Legacy-Path: Body-Marker `email-otp` / `email-code` / `send-email-code`
+    (geprüft VOR generischem `two-factor` / `2fa` substring)
+  - Neue `EmailTwoFactorRequiredError` als Subclass von `TwoFactorRequiredError`
+    — bestehende `except` chains laufen unverändert weiter
+  - Eigener Repair-Issue `email_two_factor_required` mit branded copy in allen
+    8 Sprachen + `strings.json` ("Check your inbox" statt "open the app").
+  *"In the future, you should always check your e-mail first. And by 'in the
+  future', I mean **starting now**." — Marshall Eriksen.*
+
 - **`safe_get(data, "a.b[0].c", default=None)` — defensive dot-path nested accessor** —
   neuer Helper in `cariad/_util.py` ersetzt unsichere `resp['a']['b'][0]['c']`
   Patterns die bei MY26 Schema-Rotationen crashen (backend flippt silent

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -65,6 +65,11 @@ _SETUP_ERRORS: dict[str, str] = {
     "two_factor_required": (
         "2FA required. Sign in manually in the app once and confirm the code."
     ),
+    # v2.2.0 PR #7/20 (#183 follow-on) — Email-OTP discriminated copy.
+    "email_two_factor_required": (
+        "Email 2FA required. Check your inbox (and spam) for a 6-digit code "
+        "from VAG IDP, then sign in manually in the brand app once."
+    ),
     "invalid_credentials": (
         "Invalid credentials. Check email and password in the app."
     ),

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -25,6 +25,7 @@ from aiohttp import ClientSession, ClientTimeout, InvalidURL
 
 from ..exceptions import (
     AuthenticationError,
+    EmailTwoFactorRequiredError,
     MarketingConsentError,
     TermsAndConditionsError,
     TwoFactorRequiredError,
@@ -339,9 +340,17 @@ class IDKAuth:
                     _LOGGER.debug("IDK Auth0: captured user_id from redirect: %s", uid[:8])
             if ref.startswith(prefix):
                 break
-            # Detect MFA
-            if "/u/mfa" in ref or "/u/email-challenge" in ref:
-                _LOGGER.debug("IDK Auth0: MFA challenge at %s", ref[:80])
+            # Detect MFA — v2.2.0 (#183 follow-on) discriminates Email-OTP
+            # from authenticator-app TOTP so the Repair-issue surfaces the
+            # right message (check inbox vs. open authenticator).
+            is_email_2fa = "/u/email-challenge" in ref
+            is_mfa = is_email_2fa or "/u/mfa" in ref
+            if is_mfa:
+                _LOGGER.debug(
+                    "IDK Auth0: %s challenge at %s",
+                    "Email-OTP" if is_email_2fa else "TOTP",
+                    ref[:80],
+                )
                 if mfa_code:
                     mfa_state = parse_qs(urlparse(ref).query).get("state", [auth0_state])[0]
                     async with self._session.post(
@@ -355,6 +364,8 @@ class IDKAuth:
                         ref = _make_absolute(_IDK_BASE, raw) if raw else ""
                     continue
                 else:
+                    if is_email_2fa:
+                        raise EmailTwoFactorRequiredError()
                     raise TwoFactorRequiredError()
 
             # v2.2.0 — Detect Marketing-Consent / T&C interstitial.
@@ -614,7 +625,14 @@ class IDKAuth:
         if pw_status == 200:
             if "terms-and-conditions" in pw_body.lower():
                 raise TermsAndConditionsError()
-            if "two-factor" in pw_body.lower() or "2fa" in pw_body.lower():
+            # v2.2.0 (#183 follow-on) — discriminate Email-OTP 2FA from
+            # generic / TOTP 2FA. Body markers observed on legacy signin-
+            # service: "email-otp", "email-code", "send-email-code" all
+            # indicate the IDP wants the user to check inbox for a code.
+            pw_body_lc = pw_body.lower()
+            if any(m in pw_body_lc for m in ("email-otp", "email-code", "send-email-code")):
+                raise EmailTwoFactorRequiredError()
+            if "two-factor" in pw_body_lc or "2fa" in pw_body_lc:
                 raise TwoFactorRequiredError()
             raise AuthenticationError(
                 "Unexpected 200 after password POST — wrong credentials?"
@@ -849,11 +867,18 @@ class IDKAuth:
         ) as resp:
             if resp.status == 200:
                 body = await resp.text()
-                if "terms-and-conditions" in body.lower():
+                body_lc = body.lower()
+                if "terms-and-conditions" in body_lc:
                     raise TermsAndConditionsError()
-                if "marketing" in body.lower() and "consent" in body.lower():
+                if "marketing" in body_lc and "consent" in body_lc:
                     raise MarketingConsentError()
-                if "two-factor" in body.lower() or "2fa" in body.lower():
+                # v2.2.0 (#183 follow-on) — Email-OTP discrimination
+                # (must come BEFORE the generic 2FA check; Email-OTP
+                # bodies also contain "two-factor" boilerplate from the
+                # IDP template).
+                if any(m in body_lc for m in ("email-otp", "email-code", "send-email-code")):
+                    raise EmailTwoFactorRequiredError()
+                if "two-factor" in body_lc or "2fa" in body_lc:
                     raise TwoFactorRequiredError()
                 raise AuthenticationError("Unexpected non-redirect after password submission.")
             if resp.status == 429:

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -206,6 +206,35 @@ class TwoFactorRequiredError(AuthenticationError):
         )
 
 
+class EmailTwoFactorRequiredError(TwoFactorRequiredError):
+    """v2.2.0 (#183 follow-on) — Email-OTP 2FA challenge.
+
+    Discriminated subclass of ``TwoFactorRequiredError`` for the case
+    where the IDP issued an **email OTP** rather than an authenticator-
+    app TOTP code. Detected via the ``/u/email-challenge`` URL fragment
+    (Auth0 path) or ``email-otp`` / ``email-code`` body markers (Legacy
+    path).
+
+    UX matters: Email-2FA users need to check their **inbox** (and
+    potentially spam) for a 6-digit code from VAG IDP, while TOTP users
+    need their authenticator-app rolling code. Different messages →
+    different mental models.
+
+    Both flows ultimately need a one-time human ack in the brand app
+    before headless API access works, so the Repair-issue surfacing is
+    identical except for the actionable text. ``isinstance(err,
+    TwoFactorRequiredError)`` keeps the existing handler chain working.
+    """
+
+    def __init__(self) -> None:
+        # Skip parent's __init__ — we want the more specific message
+        AuthenticationError.__init__(
+            self,
+            "Email 2FA required. Check your inbox (and spam) for a 6-digit "
+            "code from VAG IDP, then sign in manually in the brand app once.",
+        )
+
+
 class RateLimitError(CariadError):
     """Account temporarily blocked by VAG rate limiter."""
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -488,6 +488,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         from .cariad import CariadClientFactory  # noqa: PLC0415
         from .cariad.exceptions import (  # noqa: PLC0415
             AuthenticationError,
+            EmailTwoFactorRequiredError,
             TermsAndConditionsError,
             MarketingConsentError,
             TwoFactorRequiredError,
@@ -595,6 +596,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             raise ValueError("terms_and_conditions") from err
         except MarketingConsentError as err:
             raise ValueError("marketing_consent") from err
+        # v2.2.0 PR #7/20 (#183 follow-on) — Email-OTP subclass MUST be
+        # caught BEFORE the generic TwoFactorRequiredError parent (Python
+        # exception-handler order is first-match).
+        except EmailTwoFactorRequiredError as err:
+            raise ValueError("email_two_factor_required") from err
         except TwoFactorRequiredError as err:
             raise ValueError("two_factor_required") from err
         except RateLimitError as err:

--- a/custom_components/vag_connect/repairs.py
+++ b/custom_components/vag_connect/repairs.py
@@ -39,6 +39,8 @@ _LOGGER = logging.getLogger(__name__)
 _FIXABLE_REASONS: dict[str, str] = {
     "invalid_credentials":   "reauth",
     "two_factor_required":   "reauth",
+    # v2.2.0 PR #7/20 (#183 follow-on) — Email-OTP discriminated reason.
+    "email_two_factor_required": "reauth",
     "terms_and_conditions":  "reauth",
     "marketing_consent":     "reauth",
 }
@@ -90,6 +92,12 @@ def raise_issue_auth_required(
             ir.IssueSeverity.WARNING,
             "two_factor_required",
         ),
+        # v2.2.0 PR #7/20 (#183 follow-on) — distinct copy from generic
+        # 2FA so Email-OTP users know to check inbox (not app).
+        "email_two_factor_required": (
+            ir.IssueSeverity.WARNING,
+            "email_two_factor_required",
+        ),
         "terms_and_conditions": (
             ir.IssueSeverity.ERROR,
             "terms_and_conditions",
@@ -135,7 +143,8 @@ def raise_issue_auth_required(
 
 def clear_auth_issues(hass: HomeAssistant, entry_id: str) -> None:
     """Alle Auth-Issues für diesen Entry löschen (nach erfolgreichem Login)."""
-    for reason in ["two_factor_required", "terms_and_conditions",
+    for reason in ["two_factor_required", "email_two_factor_required",
+                   "terms_and_conditions",
                    "marketing_consent", "too_many_requests",
                    "invalid_credentials", "auth_failed"]:
         ir.async_delete_issue(hass, DOMAIN, f"{entry_id}_{reason}")

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Terms and conditions need to be accepted. Sign in to the app once and confirm.",
       "marketing_consent": "New privacy consent required. Open app: Profile → Consents.",
       "two_factor_required": "Two-factor authentication required. Sign in manually in the app and confirm the email code.",
+      "email_two_factor_required": "Email 2FA required. Check your inbox (and spam) for a 6-digit code from VAG IDP, then sign in manually in the brand app once.",
       "too_many_requests": "Account temporarily suspended (too many login attempts). Please wait 15 minutes.",
       "invalid_credentials": "Email address or password incorrect."
     },
@@ -542,6 +543,10 @@
     "two_factor_required": {
       "title": "Two-factor authentication required — {brand}",
       "description": "Your {brand} account ({username}) requires an email verification code.\n\n**One-time fix:**\n1. Open the **{brand} app** on your phone\n2. Sign in manually\n3. Confirm the code sent by email\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."
+    },
+    "email_two_factor_required": {
+      "title": "Email 2FA — check your inbox ({brand})",
+      "description": "Your {brand} account ({username}) requires an **email verification code**.\n\n**One-time fix:**\n1. **Check your email inbox** (and spam folder) for a 6-digit code from VAG IDP\n2. Open the **{brand} app** on your phone\n3. Sign in manually and enter the code\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."
     },
     "terms_and_conditions": {
       "title": "Accept terms and conditions — {brand}",

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Je nutné přijmout obchodní podmínky. Přihlaste se v aplikaci.",
       "marketing_consent": "Vyžadován nový souhlas. Aplikace → Profil → Souhlasy.",
       "two_factor_required": "Vyžadováno dvoufázové ověření. Přihlaste se ručně v aplikaci.",
+      "email_two_factor_required": "Vyžadováno e-mailové 2FA. Zkontrolujte schránku (i spam), pak se přihlaste ručně v aplikaci.",
       "too_many_requests": "Účet dočasně zablokován. Počkejte 15 minut.",
       "invalid_credentials": "Nesprávná e-mailová adresa nebo heslo."
     },
@@ -533,6 +534,10 @@
     "two_factor_required": {
       "title": "Vyžadováno dvoufázové ověření — {brand}",
       "description": "1. Otevřete aplikaci **{brand}**\n2. Přihlaste se ručně\n3. Potvrďte kód z e-mailu\n4. Restartujte Home Assistant"
+    },
+    "email_two_factor_required": {
+      "title": "E-mailové 2FA — zkontrolujte schránku ({brand})",
+      "description": "Váš účet {brand} ({username}) vyžaduje **e-mailový ověřovací kód**.\n\n**Jednorázová oprava:**\n1. **Zkontrolujte e-mail** (i spam) — 6místný kód od VAG IDP\n2. Otevřete aplikaci **{brand}**\n3. Přihlaste se ručně a zadejte kód\n4. Restartujte Home Assistant"
     },
     "terms_and_conditions": {
       "title": "Přijmout podmínky — {brand}",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Nutzungsbedingungen müssen akzeptiert werden. Einmal in der App anmelden und bestätigen.",
       "marketing_consent": "Neue Datenschutzzustimmung erforderlich. App öffnen: Profil → Einwilligungen.",
       "two_factor_required": "Zwei-Faktor-Bestätigung nötig. Einmal manuell in der App anmelden und den Code per E-Mail bestätigen.",
+      "email_two_factor_required": "E-Mail-2FA nötig. Postfach (und Spam) auf 6-stelligen Code von VAG IDP prüfen, dann einmal manuell in der Marken-App anmelden.",
       "too_many_requests": "Account vorübergehend gesperrt (zu viele Anmeldeversuche). Bitte 15 Minuten warten.",
       "invalid_credentials": "E-Mail-Adresse oder Passwort falsch."
     },
@@ -533,6 +534,10 @@
     "two_factor_required": {
       "title": "Zwei-Faktor-Anmeldung erforderlich — {brand}",
       "description": "Dein {brand}-Konto ({username}) verlangt eine Bestätigung per E-Mail-Code.\n\n**Einmalige Lösung:**\n1. Öffne die **{brand}-App** auf deinem Handy\n2. Melde dich dort manuell an\n3. Bestätige den Code, der per E-Mail kommt\n4. Starte Home Assistant neu\n\nNach diesem einmaligen Schritt speichert die Integration das Login-Token — du musst das nicht wiederholen."
+    },
+    "email_two_factor_required": {
+      "title": "E-Mail-2FA — Postfach prüfen ({brand})",
+      "description": "Dein {brand}-Konto ({username}) erfordert einen **E-Mail-Bestätigungscode**.\n\n**Einmalige Behebung:**\n1. **Postfach prüfen** (und Spam-Ordner) — 6-stelliger Code von VAG IDP\n2. **{brand}-App** auf dem Smartphone öffnen\n3. Manuell anmelden und Code eingeben\n4. Home Assistant neu starten\n\nNach diesem einmaligen Schritt speichert die Integration den Login-Token — du musst es nicht wiederholen."
     },
     "terms_and_conditions": {
       "title": "Nutzungsbedingungen akzeptieren — {brand}",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Terms and conditions need to be accepted. Sign in to the app once and confirm.",
       "marketing_consent": "New privacy consent required. Open app: Profile → Consents.",
       "two_factor_required": "Two-factor authentication required. Sign in manually in the app and confirm the email code.",
+      "email_two_factor_required": "Email 2FA required. Check your inbox (and spam) for a 6-digit code from VAG IDP, then sign in manually in the brand app once.",
       "too_many_requests": "Account temporarily suspended (too many login attempts). Please wait 15 minutes.",
       "invalid_credentials": "Email address or password incorrect."
     },
@@ -533,6 +534,10 @@
     "two_factor_required": {
       "title": "Two-factor authentication required — {brand}",
       "description": "Your {brand} account ({username}) requires an email verification code.\n\n**One-time fix:**\n1. Open the **{brand} app** on your phone\n2. Sign in manually\n3. Confirm the code sent by email\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."
+    },
+    "email_two_factor_required": {
+      "title": "Email 2FA — check your inbox ({brand})",
+      "description": "Your {brand} account ({username}) requires an **email verification code**.\n\n**One-time fix:**\n1. **Check your email inbox** (and spam folder) for a 6-digit code from VAG IDP\n2. Open the **{brand} app** on your phone\n3. Sign in manually and enter the code\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."
     },
     "terms_and_conditions": {
       "title": "Accept terms and conditions — {brand}",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Hay que aceptar los términos. Inicia sesión en la aplicación.",
       "marketing_consent": "Nuevo consentimiento requerido. App → Perfil → Consentimientos.",
       "two_factor_required": "Se requiere autenticación de dos factores. Inicia sesión manualmente.",
+      "email_two_factor_required": "Se requiere 2FA por email. Revisa tu bandeja de entrada (y spam) para un código de 6 dígitos, luego inicia sesión manualmente en la app.",
       "too_many_requests": "Cuenta suspendida temporalmente. Espera 15 minutos.",
       "invalid_credentials": "Correo electrónico o contraseña incorrectos."
     },
@@ -533,6 +534,10 @@
     "two_factor_required": {
       "title": "Autenticación de dos factores — {brand}",
       "description": "1. Abre la app **{brand}**\n2. Inicia sesión manualmente\n3. Confirma el código de correo\n4. Reinicia Home Assistant"
+    },
+    "email_two_factor_required": {
+      "title": "2FA por email — revisa tu bandeja ({brand})",
+      "description": "Tu cuenta de {brand} ({username}) requiere un **código de verificación por email**.\n\n**Solución única:**\n1. **Revisa tu email** (y spam) — código de 6 dígitos de VAG IDP\n2. Abre la app de **{brand}**\n3. Inicia sesión manualmente e ingresa el código\n4. Reinicia Home Assistant"
     },
     "terms_and_conditions": {
       "title": "Aceptar términos — {brand}",

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Conditions d'utilisation à accepter. Connectez-vous dans l'application.",
       "marketing_consent": "Nouveau consentement RGPD requis. Application → Profil → Consentements.",
       "two_factor_required": "Double authentification requise. Connectez-vous manuellement dans l'application.",
+      "email_two_factor_required": "Authentification 2FA par e-mail requise. Vérifiez votre boîte de réception (et spam) pour un code à 6 chiffres, puis connectez-vous manuellement dans l'application.",
       "too_many_requests": "Compte suspendu temporairement. Attendez 15 minutes.",
       "invalid_credentials": "Adresse e-mail ou mot de passe incorrect."
     },
@@ -533,6 +534,10 @@
     "two_factor_required": {
       "title": "Double authentification requise — {brand}",
       "description": "Votre compte {brand} ({username}) nécessite un code de vérification par e-mail.\n\n1. Ouvrez l'application **{brand}**\n2. Connectez-vous manuellement\n3. Confirmez le code reçu par e-mail\n4. Redémarrez Home Assistant"
+    },
+    "email_two_factor_required": {
+      "title": "2FA par e-mail — vérifiez votre boîte ({brand})",
+      "description": "Votre compte {brand} ({username}) nécessite un **code de vérification par e-mail**.\n\n**Solution unique :**\n1. **Vérifiez votre e-mail** (et spam) — code à 6 chiffres de VAG IDP\n2. Ouvrez l'application **{brand}**\n3. Connectez-vous manuellement et entrez le code\n4. Redémarrez Home Assistant"
     },
     "terms_and_conditions": {
       "title": "Accepter les conditions — {brand}",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Gebruiksvoorwaarden moeten worden geaccepteerd. Log eenmaal in via de app.",
       "marketing_consent": "Nieuwe privacytoestemming vereist. App → Profiel → Toestemmingen.",
       "two_factor_required": "Tweestapsverificatie vereist. Log handmatig in via de app.",
+      "email_two_factor_required": "E-mail 2FA vereist. Controleer je inbox (en spam) op een 6-cijferige code, log dan handmatig in via de app.",
       "too_many_requests": "Account tijdelijk geblokkeerd. Wacht 15 minuten.",
       "invalid_credentials": "E-mailadres of wachtwoord onjuist."
     },
@@ -533,6 +534,10 @@
     "two_factor_required": {
       "title": "Tweestapsverificatie vereist — {brand}",
       "description": "1. Open de **{brand}-app**\n2. Meld u handmatig aan\n3. Bevestig de e-mailcode\n4. Start Home Assistant opnieuw"
+    },
+    "email_two_factor_required": {
+      "title": "E-mail 2FA — controleer je inbox ({brand})",
+      "description": "Je {brand}-account ({username}) vereist een **e-mailverificatiecode**.\n\n**Eenmalige oplossing:**\n1. **Controleer je e-mail** (en spam) — 6-cijferige code van VAG IDP\n2. Open de **{brand}-app**\n3. Log handmatig in en voer de code in\n4. Herstart Home Assistant"
     },
     "terms_and_conditions": {
       "title": "Gebruiksvoorwaarden accepteren — {brand}",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Warunki użytkowania muszą być zaakceptowane. Zaloguj się w aplikacji.",
       "marketing_consent": "Wymagana nowa zgoda. Aplikacja → Profil → Zgody.",
       "two_factor_required": "Wymagane uwierzytelnianie dwuskładnikowe. Zaloguj się ręcznie w aplikacji.",
+      "email_two_factor_required": "Wymagane 2FA przez e-mail. Sprawdź skrzynkę (i spam) w poszukiwaniu 6-cyfrowego kodu, następnie zaloguj się ręcznie w aplikacji.",
       "too_many_requests": "Konto tymczasowo zablokowane. Poczekaj 15 minut.",
       "invalid_credentials": "Nieprawidłowy e-mail lub hasło."
     },
@@ -533,6 +534,10 @@
     "two_factor_required": {
       "title": "Wymagane uwierzytelnianie dwuskładnikowe — {brand}",
       "description": "1. Otwórz aplikację **{brand}**\n2. Zaloguj się ręcznie\n3. Potwierdź kod e-mail\n4. Uruchom ponownie Home Assistant"
+    },
+    "email_two_factor_required": {
+      "title": "2FA przez e-mail — sprawdź skrzynkę ({brand})",
+      "description": "Twoje konto {brand} ({username}) wymaga **kodu weryfikacyjnego e-mail**.\n\n**Jednorazowa naprawa:**\n1. **Sprawdź e-mail** (i spam) — 6-cyfrowy kod od VAG IDP\n2. Otwórz aplikację **{brand}**\n3. Zaloguj się ręcznie i wprowadź kod\n4. Uruchom ponownie Home Assistant"
     },
     "terms_and_conditions": {
       "title": "Akceptacja warunków — {brand}",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -58,6 +58,7 @@
       "terms_and_conditions": "Användarvillkor måste accepteras. Logga in i appen.",
       "marketing_consent": "Nytt dataskyddssamtycke krävs. App → Profil → Samtycken.",
       "two_factor_required": "Tvåfaktorsautentisering krävs. Logga in manuellt i appen.",
+      "email_two_factor_required": "E-post 2FA krävs. Kolla inkorgen (och skräp) efter en 6-siffrig kod, logga sedan in manuellt i appen.",
       "too_many_requests": "Kontot är tillfälligt spärrat. Vänta 15 minuter.",
       "invalid_credentials": "Felaktig e-postadress eller lösenord."
     },
@@ -533,6 +534,10 @@
     "two_factor_required": {
       "title": "Tvåfaktorsautentisering krävs — {brand}",
       "description": "1. Öppna **{brand}-appen**\n2. Logga in manuellt\n3. Bekräfta e-postkoden\n4. Starta om Home Assistant"
+    },
+    "email_two_factor_required": {
+      "title": "E-post 2FA — kolla din inkorg ({brand})",
+      "description": "Ditt {brand}-konto ({username}) kräver en **e-postbekräftelsekod**.\n\n**Engångsfix:**\n1. **Kolla din e-post** (och skräppost) — 6-siffrig kod från VAG IDP\n2. Öppna **{brand}-appen**\n3. Logga in manuellt och ange koden\n4. Starta om Home Assistant"
     },
     "terms_and_conditions": {
       "title": "Acceptera villkor — {brand}",

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -572,7 +572,9 @@ class TestRepairs:
         hass = MagicMock()
         with patch("homeassistant.helpers.issue_registry.async_delete_issue") as mock_del:
             clear_auth_issues(hass, "entry_123")
-        assert mock_del.call_count == 6  # 6 issue types
+        # v2.2.0 PR #7/20 — added ``email_two_factor_required`` →
+        # 7 issue types total (was 6 pre-Phase-2).
+        assert mock_del.call_count == 7
 
     def test_unknown_reason_uses_auth_failed(self):
         from custom_components.vag_connect.repairs import raise_issue_auth_required

--- a/tests/test_v220_email_2fa_detection.py
+++ b/tests/test_v220_email_2fa_detection.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.0 PR #7/20 — Email-OTP vs TOTP discrimination in IDK auth.
+
+Follow-on to PR #1 (consent-screen detection) and #183 (Auth Resilience
+für 2026). Pre-v2.2.0 the IDK auth flow raised a generic
+``TwoFactorRequiredError`` whether the IDP demanded an authenticator-
+app TOTP code or an email OTP. The Repairs UI then showed the same
+"open the app and confirm the code" copy in both cases, which left
+Email-OTP users staring at their authenticator-app trying to find a
+code that was actually sitting in their inbox.
+
+This PR adds:
+
+1. ``EmailTwoFactorRequiredError`` (subclass of ``TwoFactorRequiredError``)
+   — keeps the existing ``isinstance`` handler chain working while
+   carrying the discriminated copy.
+
+2. Auth0-path detection via ``/u/email-challenge`` URL fragment
+   (distinct from generic ``/u/mfa``).
+
+3. Legacy-path detection via body markers ``email-otp`` / ``email-code``
+   / ``send-email-code`` (checked BEFORE the generic ``two-factor`` /
+   ``2fa`` substring so Email-OTP doesn't get swallowed by the parent).
+
+4. End-to-end surfacing: coordinator → ``email_two_factor_required``
+   ValueError → Repairs flow → branded translation copy that tells the
+   user to **check their inbox** rather than open the authenticator.
+
+"In the future, you should always check your e-mail first. And by
+'in the future', I mean **starting now**."
+— Marshall Eriksen, on the importance of OTP-channel discrimination
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestEmailTwoFactorExceptionShape:
+    """The subclass must inherit ``TwoFactorRequiredError`` so the
+    existing ``except`` chain in coordinator.py still catches it."""
+
+    def test_is_subclass_of_two_factor(self) -> None:
+        from custom_components.vag_connect.cariad.exceptions import (
+            EmailTwoFactorRequiredError,
+            TwoFactorRequiredError,
+        )
+
+        assert issubclass(EmailTwoFactorRequiredError, TwoFactorRequiredError)
+
+    def test_isinstance_chain_works(self) -> None:
+        from custom_components.vag_connect.cariad.exceptions import (
+            AuthenticationError,
+            EmailTwoFactorRequiredError,
+            TwoFactorRequiredError,
+        )
+
+        err = EmailTwoFactorRequiredError()
+        assert isinstance(err, TwoFactorRequiredError)
+        assert isinstance(err, AuthenticationError)
+
+    def test_email_specific_message(self) -> None:
+        from custom_components.vag_connect.cariad.exceptions import (
+            EmailTwoFactorRequiredError,
+            TwoFactorRequiredError,
+        )
+
+        # Distinct copy — must mention "inbox" / "email" / "VAG IDP"
+        msg = str(EmailTwoFactorRequiredError())
+        msg_lc = msg.lower()
+        assert "email" in msg_lc or "inbox" in msg_lc
+        # Generic TOTP message must NOT mention inbox (regression-shield)
+        assert "inbox" not in str(TwoFactorRequiredError()).lower()
+
+
+class TestLegacyBodyMarkers:
+    """The Legacy-path detection runs three substring checks before
+    falling through to the generic 2FA pattern."""
+
+    def test_email_otp_marker_caught(self) -> None:
+        body = "<html>Please enter the email-otp sent to your inbox</html>"
+        body_lc = body.lower()
+        is_email = any(
+            m in body_lc for m in ("email-otp", "email-code", "send-email-code")
+        )
+        assert is_email is True
+
+    def test_email_code_marker_caught(self) -> None:
+        body_lc = "we sent an email-code to your address".lower()
+        is_email = any(
+            m in body_lc for m in ("email-otp", "email-code", "send-email-code")
+        )
+        assert is_email is True
+
+    def test_send_email_code_marker_caught(self) -> None:
+        body_lc = "<form action=/send-email-code>...".lower()
+        is_email = any(
+            m in body_lc for m in ("email-otp", "email-code", "send-email-code")
+        )
+        assert is_email is True
+
+    def test_generic_2fa_body_not_caught_by_email_pattern(self) -> None:
+        # Pure TOTP body has no email markers
+        body_lc = "<html>Two-factor authentication required</html>".lower()
+        is_email = any(
+            m in body_lc for m in ("email-otp", "email-code", "send-email-code")
+        )
+        assert is_email is False
+        # But the generic 2FA fallback would catch it
+        is_generic = "two-factor" in body_lc or "2fa" in body_lc
+        assert is_generic is True
+
+
+class TestAuth0URLMarker:
+    """Auth0-path discriminates via the ``/u/email-challenge`` fragment."""
+
+    def test_email_challenge_url_detected(self) -> None:
+        ref = "https://identity.vwgroup.io/u/email-challenge?state=xyz"
+        is_email_2fa = "/u/email-challenge" in ref
+        assert is_email_2fa is True
+
+    def test_mfa_url_not_email(self) -> None:
+        ref = "https://identity.vwgroup.io/u/mfa?state=xyz"
+        is_email_2fa = "/u/email-challenge" in ref
+        is_mfa = is_email_2fa or "/u/mfa" in ref
+        assert is_email_2fa is False
+        assert is_mfa is True
+
+    def test_callback_url_neither(self) -> None:
+        ref = "carnet://callback?code=abc"
+        is_email_2fa = "/u/email-challenge" in ref
+        is_mfa = is_email_2fa or "/u/mfa" in ref
+        assert is_email_2fa is False
+        assert is_mfa is False
+
+
+class TestRepairsRegistration:
+    """``email_two_factor_required`` must be in the fixable-reasons +
+    issue-map + clear-list, mirroring the generic two_factor_required."""
+
+    def test_email_2fa_in_fixable_reasons(self) -> None:
+        from custom_components.vag_connect.repairs import _FIXABLE_REASONS
+
+        assert "email_two_factor_required" in _FIXABLE_REASONS
+        assert _FIXABLE_REASONS["email_two_factor_required"] == "reauth"
+
+    def test_email_2fa_setup_error_message(self) -> None:
+        from custom_components.vag_connect import _SETUP_ERRORS
+
+        assert "email_two_factor_required" in _SETUP_ERRORS
+        msg_lc = _SETUP_ERRORS["email_two_factor_required"].lower()
+        # Distinct copy — must reference inbox
+        assert "inbox" in msg_lc or "email" in msg_lc
+
+
+class TestTranslationCoverage:
+    """All 8 lang files + strings.json must define the new key in BOTH
+    ``config.error`` and ``issues`` sections."""
+
+    @pytest.mark.parametrize(
+        "lang", ["en", "de", "cs", "sv", "fr", "nl", "es", "pl"]
+    )
+    def test_lang_has_email_2fa_error(self, lang: str) -> None:
+        import json
+        from pathlib import Path
+
+        path = Path(
+            f"custom_components/vag_connect/translations/{lang}.json"
+        )
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "email_two_factor_required" in data["config"]["error"], (
+            f"{lang}: missing config.error.email_two_factor_required"
+        )
+
+    @pytest.mark.parametrize(
+        "lang", ["en", "de", "cs", "sv", "fr", "nl", "es", "pl"]
+    )
+    def test_lang_has_email_2fa_issue(self, lang: str) -> None:
+        import json
+        from pathlib import Path
+
+        path = Path(
+            f"custom_components/vag_connect/translations/{lang}.json"
+        )
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "email_two_factor_required" in data["issues"], (
+            f"{lang}: missing issues.email_two_factor_required"
+        )
+        issue = data["issues"]["email_two_factor_required"]
+        assert "title" in issue
+        assert "description" in issue
+        # {brand} placeholder required for Repair-flow templating
+        assert "{brand}" in issue["title"]
+
+    def test_strings_json_has_both(self) -> None:
+        import json
+        from pathlib import Path
+
+        data = json.loads(
+            Path("custom_components/vag_connect/strings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert "email_two_factor_required" in data["config"]["error"]
+        assert "email_two_factor_required" in data["issues"]
+
+
+class TestExceptionHandlerOrder:
+    """The coordinator's exception-handler chain must catch
+    ``EmailTwoFactorRequiredError`` with the email-specific reason
+    BEFORE the parent ``TwoFactorRequiredError`` catches it as generic.
+    This test reads the source to verify ordering."""
+
+    def test_email_handler_before_generic_2fa_in_coordinator(self) -> None:
+        from pathlib import Path
+
+        src = Path("custom_components/vag_connect/coordinator.py").read_text(
+            encoding="utf-8"
+        )
+        email_pos = src.find("except EmailTwoFactorRequiredError")
+        generic_pos = src.find("except TwoFactorRequiredError")
+        assert email_pos > 0, "EmailTwoFactorRequiredError handler missing"
+        assert generic_pos > 0, "TwoFactorRequiredError handler missing"
+        assert email_pos < generic_pos, (
+            "EmailTwoFactorRequiredError handler must come BEFORE the parent "
+            "TwoFactorRequiredError handler (Python exception-handler order)"
+        )


### PR DESCRIPTION
## Summary

**Phase 2 PR #7/20** opener. Follow-on to PR #1 (consent-screen detection, merged) and ticket #183 (Auth Resilience für 2026).

Pre-v2.2.0 the IDK auth flow raised a generic \`TwoFactorRequiredError\` whether the IDP demanded an authenticator-app TOTP code or an email OTP. The Repairs UI then showed the same \"open the app and confirm the code\" copy in both cases, which left Email-OTP users staring at their authenticator-app trying to find a code that was actually sitting in their inbox.

## What's new

| Layer | Change |
|---|---|
| **`cariad/exceptions.py`** | New \`EmailTwoFactorRequiredError\` subclass of \`TwoFactorRequiredError\` — existing \`isinstance\` / \`except\` chains keep working |
| **`cariad/auth/idk.py` Auth0-path** | Detects \`/u/email-challenge\` URL fragment distinct from generic \`/u/mfa\` |
| **`cariad/auth/idk.py` Legacy-path** | Body markers \`email-otp\` / \`email-code\` / \`send-email-code\` checked BEFORE generic \`two-factor\` / \`2fa\` substring (both legacy POST sites updated) |
| **`coordinator.py`** | Catches email subclass FIRST (first-match handler order) → \`ValueError(\"email_two_factor_required\")\` |
| **`__init__.py`** | New \`_SETUP_ERRORS\` entry with \"Check your inbox\" copy |
| **`repairs.py`** | New \`_FIXABLE_REASONS\` + \`issue_map\` + \`clear_auth_issues\` entry |
| **8 lang files + strings.json** | New key in \`config.error\` (inline) AND \`issues\` (Repair card). DE/FR/ES/CS/NL/PL/SV native translations; EN canonical |

## Failsafe

- **Subclass relationship**: every existing \`except TwoFactorRequiredError\` handler throughout the codebase continues to catch this — no behavioural regression for unknown callers
- **Detection is purely additive**: if a body doesn't match the new email markers, fall-through to generic 2FA is unchanged
- **Translation fallback**: HA falls back to \`auth_failed\` template if a Repair card arrives with a key the current HA version doesn't recognise

## Test plan

- [x] 18 test cases in \`tests/test_v220_email_2fa_detection.py\`:
  - Exception-shape (subclass + isinstance chain + distinct message)
  - Legacy body-marker detection (3 markers + regression-shield for pure TOTP body)
  - Auth0 URL-marker detection (positive + 2 negatives)
  - Repairs registration (\`_FIXABLE_REASONS\` + \`_SETUP_ERRORS\` coverage)
  - **Translation coverage** parametrised over 8 langs × 2 sections + strings.json
  - **Exception-handler ORDER** source-level check that EmailTwoFactor handler precedes generic TwoFactor handler in coordinator.py
- [x] \`python -m py_compile\` clean on all 5 touched python files + test
- [x] All 9 JSON files parse cleanly
- [ ] CI green (7/7 checks)

## Restructure note

Plan re-baselined: 6 PRs done in Phase 1, 14 PRs remaining → total 20 PRs in v2.2.0. Numbering going forward is \`PR #N/20\`.

Marketing: *\"In the future, you should always check your e-mail first. And by 'in the future', I mean **starting now**.\"* — Marshall Eriksen

🤖 Generated with [Claude Code](https://claude.com/claude-code)