### PR TITLE
v2.2.0 PR #9/20: subscription_active binary_sensor (companion to PR #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **SEAT/CUPRA `subscription_active` binary_sensor (Phase 2 PR #9/20)** —
+  Companion zu PR #8 `subscription_expiry_at`. Computed tri-state
+  boolean True/False/None aus dem earliest expiry across services.
+  Perfekt für HA-Automatisierungen wie *"if binary_sensor.subscription_active
+  == off → notify"*. **Tri-state semantics preserved**: None ≠ False, so
+  perpetuelle Entitlements (lifetime-subs auf older Born MY24 firmware,
+  dealer-bundled packages) **lösen keine false "expired" alarms aus**.
+  Defensiv: malformed Timestamps fallen zurück auf None statt zu crashen.
+  Computed inline im SEAT/CUPRA parser nach der expiry-aggregation —
+  zero extra API calls. 14 Tests inkl. Tri-state-Logik + Defensive-Parsing
+  + 8-Sprachen-Coverage.
+  *"That subscription? Oh, it's outstanding. Just like Howard's mom's
+  lasagna." — Sheldon Cooper.*
+
 - **SEAT/CUPRA Connect-Subscription Expiry Sensor (Phase 2 PR #8/20)** —
   Long-standing User-Request: zeigt jetzt **wann das Connect-Abonnement
   ausläuft** bevor Lock/Unlock + Climate-Start stop working. Neue

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -242,6 +242,19 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:battery-charging",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.2.0 Phase 2 PR #9/20 — Companion to subscription_expiry_at
+    # (PR #8/20). Simple True/False "is your Connect subscription
+    # currently valid?" — perfect for HA automations like
+    # ``if binary_sensor.subscription_active == off → notify``.
+    # SEAT/CUPRA-only today; tri-state semantics (None preserved for
+    # perpetual entitlements) prevent false-alarms.
+    VagBinarySensorDescription(
+        key="subscription_active",
+        translation_key="subscription_active",
+        data_key="subscription_active",
+        icon="mdi:check-decagram",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.0.0 (Big-Bang) — Porsche TPMS warning aggregate (any corner
     # raising ``warning: true`` in the TIRE_PRESSURE measurement).
     # Brand-restricted via _DATA_PRESENT_REQUIRED below — non-Porsche
@@ -327,6 +340,10 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # v2.2.0 (scout #220) — Skoda-only AC-without-external-power.
     # Other brands leave field None → no phantom entity.
     "air_conditioning_without_external_power",
+    # v2.2.0 PR #9/20 — SEAT/CUPRA-only subscription_active companion
+    # to PR #8 subscription_expiry_at. Field stays None on other brands
+    # AND on perpetual entitlements → no false-positive entity.
+    "subscription_active",
     # v2.0.0 (Big-Bang) — Porsche-only TPMS warning (PPA TIRE_PRESSURE
     # measurement). Non-Porsche vehicles leave the field None → no phantom.
     "tire_pressure_warning",

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -232,6 +232,32 @@ class SeatCupraClient(CariadBaseClient):
                         )
                 if earliest is not None:
                     d.subscription_expiry_at = earliest
+                    # v2.2.0 Phase 2 PR #9/20 — companion boolean.
+                    # Tri-state-preserving: only flip to True/False
+                    # when we successfully parse a timestamp; on parse
+                    # failure leave at None (don't false-alarm a user
+                    # with perpetual entitlements just because our
+                    # datetime parse choked on an unusual format).
+                    try:
+                        from datetime import datetime, timezone  # noqa: PLC0415
+
+                        # Normalise trailing ``Z`` to ``+00:00`` for
+                        # ``fromisoformat`` (Python 3.11+ accepts ``Z``
+                        # natively but we keep this for older HA users).
+                        parsed = datetime.fromisoformat(
+                            earliest.replace("Z", "+00:00")
+                        )
+                        if parsed.tzinfo is None:
+                            parsed = parsed.replace(tzinfo=timezone.utc)
+                        d.subscription_active = (
+                            parsed > datetime.now(tz=timezone.utc)
+                        )
+                    except (ValueError, TypeError) as exc:
+                        _LOGGER.debug(
+                            "subscription_active: could not parse expiry "
+                            "%s — leaving as None (raw_exc=%s)",
+                            earliest, exc,
+                        )
 
         # ── Ranges ───────────────────────────────────────────────────────────
         if isinstance(ranges, dict):

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -238,9 +238,14 @@ class SeatCupraClient(CariadBaseClient):
                     # failure leave at None (don't false-alarm a user
                     # with perpetual entitlements just because our
                     # datetime parse choked on an unusual format).
+                    #
+                    # NB: uses the module-level ``datetime`` / ``timezone``
+                    # imports (line 11). Inline ``from datetime import``
+                    # shadows the module-level name as a function-local
+                    # for the WHOLE ``get_status`` scope (Python lexer
+                    # rule), causing UnboundLocalError on any prior
+                    # reference inside the function.
                     try:
-                        from datetime import datetime, timezone  # noqa: PLC0415
-
                         # Normalise trailing ``Z`` to ``+00:00`` for
                         # ``fromisoformat`` (Python 3.11+ accepts ``Z``
                         # natively but we keep this for older HA users).

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -455,6 +455,18 @@ class VehicleData:
     # request "When does my Connect subscription run out?".
     subscription_expiry_at: str | None = None
 
+    # v2.2.0 Phase 2 PR #9/20 — Companion bool to ``subscription_expiry_at``.
+    # Computed at parse-time from the same SEAT/CUPRA ``mycar.services``
+    # aggregation but normalised to a simple True/False:
+    #   - True  → at least one service has expiry in the future
+    #   - False → earliest expiry is now-or-past (subscription LAPSED)
+    #   - None  → no expiry info at all (perpetual OR brand without block)
+    # Surfaces as ``binary_sensor.subscription_active``. Use case:
+    # ``automation: if binary_sensor.subscription_active == off → notify``.
+    # Tri-state semantics preserved on purpose — None ≠ False so users
+    # with perpetual entitlements don't get false "expired" alarms.
+    subscription_active: bool | None = None
+
     # Audi/VW EU charging rate in km/h (parity with Skoda + CUPRA/SEAT
     # which have ``charging_rate_kmh`` since v1.10.0). From
     # ``charging.chargingStatus.value.chargeRate_kmph``. Reused field

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -408,6 +408,9 @@
       "air_conditioning_without_external_power": {
         "name": "AC Without External Power"
       },
+      "subscription_active": {
+        "name": "Subscription Active"
+      },
       "tire_pressure_warning": {
         "name": "Tire Pressure Warning"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -399,6 +399,9 @@
       "air_conditioning_without_external_power": {
         "name": "AC Without External Power"
       },
+      "subscription_active": {
+        "name": "Předplatné aktivní"
+      },
       "tire_pressure_warning": {
         "name": "Varování Tlaku Pneumatik"
       },

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -399,6 +399,9 @@
       "air_conditioning_without_external_power": {
         "name": "Klima ohne externe Stromversorgung"
       },
+      "subscription_active": {
+        "name": "Abonnement aktiv"
+      },
       "tire_pressure_warning": {
         "name": "Reifendruck-Warnung"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -399,6 +399,9 @@
       "air_conditioning_without_external_power": {
         "name": "AC Without External Power"
       },
+      "subscription_active": {
+        "name": "Subscription Active"
+      },
       "tire_pressure_warning": {
         "name": "Tire Pressure Warning"
       },

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -399,6 +399,9 @@
       "air_conditioning_without_external_power": {
         "name": "AC Without External Power"
       },
+      "subscription_active": {
+        "name": "Suscripción activa"
+      },
       "tire_pressure_warning": {
         "name": "Aviso de Presión de Neumáticos"
       },

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -399,6 +399,9 @@
       "air_conditioning_without_external_power": {
         "name": "AC Without External Power"
       },
+      "subscription_active": {
+        "name": "Abonnement actif"
+      },
       "tire_pressure_warning": {
         "name": "Alerte Pression Pneus"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -399,6 +399,9 @@
       "air_conditioning_without_external_power": {
         "name": "AC Without External Power"
       },
+      "subscription_active": {
+        "name": "Abonnement actief"
+      },
       "tire_pressure_warning": {
         "name": "Bandenspanning-Waarschuwing"
       },

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -399,6 +399,9 @@
       "air_conditioning_without_external_power": {
         "name": "AC Without External Power"
       },
+      "subscription_active": {
+        "name": "Subskrypcja aktywna"
+      },
       "tire_pressure_warning": {
         "name": "Ostrzeżenie Ciśnienia Opon"
       },

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -399,6 +399,9 @@
       "air_conditioning_without_external_power": {
         "name": "AC Without External Power"
       },
+      "subscription_active": {
+        "name": "Prenumeration aktiv"
+      },
       "tire_pressure_warning": {
         "name": "Däcktryck Varning"
       },

--- a/tests/test_v220_subscription_active.py
+++ b/tests/test_v220_subscription_active.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.0 Phase 2 PR #9/20 — subscription_active binary_sensor.
+
+Companion to PR #8/20 ``subscription_expiry_at``. Computes a simple
+True/False/None tri-state from the same earliest-expiry aggregation
+so HA automations can fire on "subscription lapsed" events without
+needing template helpers.
+
+Tri-state semantics:
+- True  → at least one service expires in the future (subscription valid)
+- False → earliest expiry is now-or-past (subscription LAPSED — alarm)
+- None  → no expiry info at all (perpetual OR brand without services block)
+
+The None preservation is intentional: perpetual entitlements (lifetime
+subscriptions on older Born MY24 firmware, dealer-bundled packages)
+should NOT trigger "expired" alarms just because there's no expiry.
+
+"That subscription? Oh, it's outstanding. Just like Howard's mom's lasagna."
+— Sheldon Cooper, the day his Wolowitz-bot's API key finally renewed
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _compute_active(earliest: str | None) -> bool | None:
+    """Pure mirror of the parser logic in seat_cupra.py.
+
+    Kept in-test so we don't depend on importing the full async parser.
+    """
+    if earliest is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(earliest.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed > datetime.now(tz=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+class TestTriStateLogic:
+    """The True / False / None split must be preserved end-to-end."""
+
+    def test_future_expiry_is_active(self) -> None:
+        future = (
+            datetime.now(tz=timezone.utc) + timedelta(days=365)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert _compute_active(future) is True
+
+    def test_past_expiry_is_inactive(self) -> None:
+        past = (
+            datetime.now(tz=timezone.utc) - timedelta(days=1)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert _compute_active(past) is False
+
+    def test_far_past_expiry_is_inactive(self) -> None:
+        # 5 years ago — clearly lapsed
+        assert _compute_active("2020-01-01T00:00:00Z") is False
+
+    def test_far_future_expiry_is_active(self) -> None:
+        assert _compute_active("2099-12-31T23:59:59Z") is True
+
+    def test_none_input_returns_none(self) -> None:
+        # Perpetual entitlement OR brand without services block —
+        # MUST NOT flip to False.
+        assert _compute_active(None) is None
+
+
+class TestDefensiveParsing:
+    """Malformed timestamps fall back to None, never crash."""
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _compute_active("") is None
+
+    def test_garbage_string_returns_none(self) -> None:
+        assert _compute_active("not-a-date") is None
+
+    def test_partial_iso_string_returns_none(self) -> None:
+        # Missing time component AND missing tz
+        assert _compute_active("2026") is None
+
+    def test_iso_with_explicit_offset_works(self) -> None:
+        # +02:00 offset must parse correctly
+        future_str = (
+            datetime.now(tz=timezone.utc) + timedelta(days=10)
+        ).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        assert _compute_active(future_str) is True
+
+    def test_naive_iso_treated_as_utc(self) -> None:
+        # Naive datetime (no tz) — parser tags as UTC. Future date works.
+        # Use far-future to avoid race conditions with test runtime.
+        assert _compute_active("2099-01-01T00:00:00") is True
+
+    def test_iso_with_z_suffix(self) -> None:
+        # Z must be normalised to +00:00 — round-trip test
+        assert _compute_active("2099-06-15T12:00:00Z") is True
+
+
+class TestBinarySensorRegistration:
+    def test_subscription_active_described(self) -> None:
+        from custom_components.vag_connect.binary_sensor import (
+            BINARY_DESCRIPTIONS,
+        )
+
+        keys = {desc.key for desc in BINARY_DESCRIPTIONS}
+        assert "subscription_active" in keys
+
+    def test_subscription_active_phantom_gated(self) -> None:
+        from custom_components.vag_connect.binary_sensor import (
+            _DATA_PRESENT_REQUIRED,
+        )
+
+        assert "subscription_active" in _DATA_PRESENT_REQUIRED
+
+
+class TestTranslationCoverage:
+    @pytest.mark.parametrize(
+        "lang", ["en", "de", "cs", "sv", "fr", "nl", "es", "pl"]
+    )
+    def test_lang_has_subscription_active(self, lang: str) -> None:
+        import json
+        from pathlib import Path
+
+        path = Path(f"custom_components/vag_connect/translations/{lang}.json")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "subscription_active" in data["entity"]["binary_sensor"]
+
+    def test_strings_json_has_subscription_active(self) -> None:
+        import json
+        from pathlib import Path
+
+        data = json.loads(
+            Path("custom_components/vag_connect/strings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert "subscription_active" in data["entity"]["binary_sensor"]


### PR DESCRIPTION
## Summary

**Phase 2 PR #9/20**. Tri-state companion to PR #8 \`subscription_expiry_at\`. Computes a simple True/False/None boolean from the same earliest-expiry aggregation so HA automations can fire on \"subscription lapsed\" events without needing template helpers.

\`\`\`yaml
automation:
  - alias: \"Notify on Connect subscription lapse\"
    trigger:
      - platform: state
        entity_id: binary_sensor.my_cupra_subscription_active
        to: \"off\"
    action:
      - service: notify.mobile_app
        data: { message: \"Connect subscription has lapsed — renew now\" }
\`\`\`

## Tri-state semantics (the important part)

| State | Meaning |
|---|---|
| **True**  | At least one service expires in the future (valid) |
| **False** | Earliest expiry is now-or-past (LAPSED — alarm) |
| **None**  | No expiry info (perpetual entitlement OR brand without services block) |

**None preservation is intentional**: perpetual entitlements (lifetime subscriptions on older Born MY24 firmware, dealer-bundled packages) MUST NOT trigger \"expired\" alarms just because there's no expiry timestamp present.

## What's new

| Layer | Change |
|---|---|
| \`models.py\` | new \`subscription_active: bool \| None\` field |
| \`cariad/api/seat_cupra.py\` | inline computation right after PR #8 earliest-expiry aggregation; \`datetime.fromisoformat\` with Z-suffix normalisation + defensive try/except |
| \`binary_sensor.py\` | entity description + phantom-protection gate |
| 8 lang files + \`strings.json\` | translation keys (DE/CS/SV/FR/NL/ES/PL native; EN canonical) |
| \`tests/test_v220_subscription_active.py\` | 14 test cases |

## Failsafe

- Empty / garbage / partial ISO strings → returns None (parser silent, not False)
- Naive datetime (no tz) → treated as UTC
- \`Z\` suffix normalised to \`+00:00\` for \`fromisoformat\` compat (Python 3.11+ has native Z support; we keep normalisation for older HA)
- **Zero extra API calls** — computed from data already fetched for PR #8

## Test plan

- [x] 14 test cases in \`tests/test_v220_subscription_active.py\`:
  - **Tri-state logic** (5 — future/past/far-past/far-future/None)
  - **Defensive parsing** (6 — empty/garbage/partial/offset/naive-UTC/Z-suffix)
  - **Binary-sensor registration** (description + phantom-gate)
  - **Translation coverage** (parametrised over 8 langs + strings.json)
- [x] \`python -m py_compile\` clean on all 4 touched files + test
- [x] All 9 JSON files parse cleanly
- [ ] CI green

Marketing: *\"That subscription? Oh, it's outstanding. Just like Howard's mom's lasagna.\"* — Sheldon Cooper

🤖 Generated with [Claude Code](https://claude.com/claude-code)