### PR TITLE
v2.2.0 PR #10/20: VW EU/Audi subscription parity to PR #8+#9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **VW EU / Audi subscription parity (Phase 2 PR #10/20)** —
+  Cross-brand parity zu PR #8 + #9: VW EU + Audi (CARIAD-BFF) parsen
+  jetzt subscription_expiry_at + subscription_active aus dem
+  `userCapabilities.capabilitiesStatus.value[*].expirationDate`
+  array. **Same earliest-wins aggregation** wie SEAT/CUPRA, drei
+  Key-Schreibweisen abgedeckt, same tri-state Semantik. Defensiv:
+  non-dict cap entries, non-string expiry, malformed ISO 8601 alle
+  silent geskippt — kein false-alarm für perpetuelle Capabilities.
+  Skoda + Porsche + VW NA bleiben weiterhin None (kein scout-konformer
+  capabilities-endpoint mit expiry-leaf). Zero neue API-calls — Daten
+  kommen aus dem existierenden capabilities-fetch. Phantom-Gates aus
+  PR #8/#9 decken automatisch die neuen Brands ab. 12 Tests.
+
 - **SEAT/CUPRA `subscription_active` binary_sensor (Phase 2 PR #9/20)** —
   Companion zu PR #8 `subscription_expiry_at`. Computed tri-state
   boolean True/False/None aus dem earliest expiry across services.

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -340,9 +340,11 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # v2.2.0 (scout #220) — Skoda-only AC-without-external-power.
     # Other brands leave field None → no phantom entity.
     "air_conditioning_without_external_power",
-    # v2.2.0 PR #9/20 — SEAT/CUPRA-only subscription_active companion
-    # to PR #8 subscription_expiry_at. Field stays None on other brands
-    # AND on perpetual entitlements → no false-positive entity.
+    # v2.2.0 PR #9/20 + PR #10/20 — subscription_active companion to
+    # subscription_expiry_at. SEAT/CUPRA from ``mycar.services``;
+    # VW EU + Audi (PR #10) from CARIAD-BFF ``userCapabilities``.
+    # Field stays None on Skoda/Porsche/VW NA AND on perpetual
+    # entitlements → tri-state semantics prevent false-positives.
     "subscription_active",
     # v2.0.0 (Big-Bang) — Porsche-only TPMS warning (PPA TIRE_PRESSURE
     # measurement). Non-Porsche vehicles leave the field None → no phantom.

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1309,6 +1309,52 @@ class VWEUClient(CariadBaseClient):
         if isinstance(caps, list):
             d.capabilities_count = len(caps)
 
+            # v2.2.0 Phase 2 PR #10/20 — VW EU/Audi parity to SEAT/CUPRA
+            # PR #8+#9. The CARIAD-BFF capabilities array carries an
+            # ``expirationDate`` per capability for subscription-gated
+            # services (e.g. ``honkAndFlash``, ``parkingPosition``,
+            # ``access``). We mirror the SEAT/CUPRA earliest-wins
+            # aggregation: scan all capabilities, pick the EARLIEST
+            # expiry, surface as both ``subscription_expiry_at``
+            # (timestamp sensor) and ``subscription_active`` (tri-state
+            # binary_sensor). Tri-state semantics preserved — perpetual
+            # capabilities (no expiry leaf) stay None instead of False.
+            #
+            # Defensive: non-dict cap entries, non-string expiry, and
+            # malformed ISO 8601 are silently skipped. If the whole
+            # capabilities array has no expiry leaves anywhere → field
+            # stays None → phantom-protected sensors never created.
+            cap_earliest: str | None = None
+            for cap in caps:
+                if not isinstance(cap, dict):
+                    continue
+                cap_exp = (
+                    cap.get("expirationDate")
+                    or cap.get("validUntil")
+                    or cap.get("expiresAt")
+                )
+                if not isinstance(cap_exp, str) or not cap_exp:
+                    continue
+                if cap_earliest is None or cap_exp < cap_earliest:
+                    cap_earliest = cap_exp
+            if cap_earliest is not None:
+                d.subscription_expiry_at = cap_earliest
+                try:
+                    # Same Z-suffix normalisation as seat_cupra.py to
+                    # support ``fromisoformat`` on older HA / Python.
+                    parsed = datetime.fromisoformat(
+                        cap_earliest.replace("Z", "+00:00")
+                    )
+                    if parsed.tzinfo is None:
+                        parsed = parsed.replace(tzinfo=timezone.utc)
+                    d.subscription_active = (
+                        parsed > datetime.now(tz=timezone.utc)
+                    )
+                except (ValueError, TypeError):
+                    # Leave subscription_active at None — don't false-
+                    # alarm perpetual users on a parse blip.
+                    pass
+
         wh_status = v(raw, "climatisation", "windowHeatingStatus", "value", "windowHeatingStatus") or []
         for wh in wh_status:
             location = wh.get("windowLocation", "")

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1342,13 +1342,19 @@ class VWEUClient(CariadBaseClient):
                 try:
                     # Same Z-suffix normalisation as seat_cupra.py to
                     # support ``fromisoformat`` on older HA / Python.
-                    parsed = datetime.fromisoformat(
+                    # NB: variable name ``cap_expiry_dt`` (not ``parsed``)
+                    # because ``parsed`` is reused elsewhere in this
+                    # function as ``int | None`` from ``safe_int`` — mypy
+                    # would infer the wider union otherwise.
+                    cap_expiry_dt = datetime.fromisoformat(
                         cap_earliest.replace("Z", "+00:00")
                     )
-                    if parsed.tzinfo is None:
-                        parsed = parsed.replace(tzinfo=timezone.utc)
+                    if cap_expiry_dt.tzinfo is None:
+                        cap_expiry_dt = cap_expiry_dt.replace(
+                            tzinfo=timezone.utc
+                        )
                     d.subscription_active = (
-                        parsed > datetime.now(tz=timezone.utc)
+                        cap_expiry_dt > datetime.now(tz=timezone.utc)
                     )
                 except (ValueError, TypeError):
                     # Leave subscription_active at None — don't false-

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -954,9 +954,11 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # ICE-only and EV-only vehicles → no phantom entity.
     "secondary_engine_type",
     "secondary_engine_fuel_level_pct",
-    # v2.2.0 Phase 2 PR #8/20 — SEAT/CUPRA OLA-only subscription expiry.
-    # Other brands' mycar endpoints don't expose ``services.*.expirationDate``
-    # in the OLA shape, so field stays None → no phantom entity.
+    # v2.2.0 Phase 2 PR #8/20 + PR #10/20 — subscription expiry timestamp.
+    # SEAT/CUPRA parses from ``mycar.services.*.expirationDate``; VW EU
+    # + Audi (PR #10) parse from CARIAD-BFF ``userCapabilities.
+    # capabilitiesStatus.value[*].expirationDate``. Skoda + Porsche +
+    # VW NA leave field None → no phantom entity.
     "subscription_expiry_at",
     "next_charging_timer_id",
     "next_charging_timer_target_soc_reachable",

--- a/tests/test_v220_vw_eu_subscription_parity.py
+++ b/tests/test_v220_vw_eu_subscription_parity.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.0 Phase 2 PR #10/20 — VW EU/Audi subscription parity.
+
+Mirrors the SEAT/CUPRA aggregation from PR #8/#9 but reads from the
+CARIAD-BFF capabilities endpoint where each capability carries its
+own ``expirationDate`` for subscription-gated services
+(``honkAndFlash``, ``parkingPosition``, ``access``, etc.).
+
+Tri-state semantics preserved: perpetual capabilities (no expiry
+leaf) stay None instead of False to avoid false-alarming users with
+lifetime entitlements.
+
+"You'd be amazed how much research you can get done when you have
+no life whatsoever." — Sheldon Cooper, on capability-expiry parsing
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+def _aggregate_caps(caps: list) -> str | None:
+    """Pure mirror of vw_eu.py's earliest-wins loop (lines ~1320-1335).
+
+    Kept in-test so we can exercise the logic without invoking the
+    full async-fetch machinery.
+    """
+    if not isinstance(caps, list):
+        return None
+    earliest: str | None = None
+    for cap in caps:
+        if not isinstance(cap, dict):
+            continue
+        cap_exp = (
+            cap.get("expirationDate")
+            or cap.get("validUntil")
+            or cap.get("expiresAt")
+        )
+        if not isinstance(cap_exp, str) or not cap_exp:
+            continue
+        if earliest is None or cap_exp < earliest:
+            earliest = cap_exp
+    return earliest
+
+
+def _compute_active(earliest: str | None) -> bool | None:
+    if earliest is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(earliest.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed > datetime.now(tz=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+class TestCapabilityAggregation:
+    """Same earliest-wins logic as PR #8, applied to caps array."""
+
+    def test_single_capability_expirationDate(self) -> None:
+        caps = [{"id": "honkAndFlash", "expirationDate": "2027-03-15T00:00:00Z"}]
+        assert _aggregate_caps(caps) == "2027-03-15T00:00:00Z"
+
+    def test_earliest_across_multiple_caps_wins(self) -> None:
+        caps = [
+            {"id": "honkAndFlash", "expirationDate": "2027-03-15T00:00:00Z"},
+            {"id": "parkingPosition", "expirationDate": "2026-08-01T00:00:00Z"},
+            {"id": "access", "expirationDate": "2029-01-01T00:00:00Z"},
+        ]
+        assert _aggregate_caps(caps) == "2026-08-01T00:00:00Z"
+
+    def test_mixed_variants_compose(self) -> None:
+        # CARIAD-BFF has shipped all three spellings in different revs
+        caps = [
+            {"id": "a", "expirationDate": "2027-06-01T00:00:00Z"},
+            {"id": "b", "validUntil": "2026-12-01T00:00:00Z"},
+            {"id": "c", "expiresAt": "2028-01-01T00:00:00Z"},
+        ]
+        assert _aggregate_caps(caps) == "2026-12-01T00:00:00Z"
+
+    def test_perpetual_caps_no_expiry_returns_none(self) -> None:
+        caps = [
+            {"id": "honkAndFlash", "status": []},
+            {"id": "parkingPosition", "status": []},
+        ]
+        assert _aggregate_caps(caps) is None
+
+
+class TestCapabilityDefensive:
+    def test_non_list_returns_none(self) -> None:
+        assert _aggregate_caps(None) is None
+        assert _aggregate_caps({}) is None
+        assert _aggregate_caps("not-a-list") is None
+
+    def test_empty_list_returns_none(self) -> None:
+        assert _aggregate_caps([]) is None
+
+    def test_non_dict_cap_skipped(self) -> None:
+        caps = ["honkAndFlash", {"id": "access", "expirationDate": "2027-01-01T00:00:00Z"}]
+        assert _aggregate_caps(caps) == "2027-01-01T00:00:00Z"
+
+    def test_int_expiry_skipped(self) -> None:
+        caps = [{"id": "access", "expirationDate": 1735689600}]
+        assert _aggregate_caps(caps) is None
+
+    def test_empty_string_expiry_skipped(self) -> None:
+        caps = [{"id": "access", "expirationDate": ""}]
+        assert _aggregate_caps(caps) is None
+
+
+class TestParitySemantics:
+    """The aggregation here must produce the same result-shape as the
+    SEAT/CUPRA aggregation in PR #8 — same tri-state, same earliest-
+    wins, same defensive-skip semantics."""
+
+    def test_future_expiry_yields_active_true(self) -> None:
+        future = (
+            datetime.now(tz=timezone.utc) + timedelta(days=180)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        caps = [{"id": "access", "expirationDate": future}]
+        agg = _aggregate_caps(caps)
+        assert agg == future
+        assert _compute_active(agg) is True
+
+    def test_past_expiry_yields_active_false(self) -> None:
+        past = (
+            datetime.now(tz=timezone.utc) - timedelta(days=1)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        caps = [{"id": "access", "expirationDate": past}]
+        agg = _aggregate_caps(caps)
+        assert agg == past
+        assert _compute_active(agg) is False
+
+    def test_perpetual_yields_active_none(self) -> None:
+        # No expiry leaf anywhere → both fields stay None
+        caps = [{"id": "honkAndFlash"}]
+        assert _aggregate_caps(caps) is None
+        assert _compute_active(None) is None
+
+
+class TestPhantomGateUnchanged:
+    """The gate entries from PR #8/#9 still cover this brand expansion."""
+
+    def test_subscription_expiry_at_still_gated(self) -> None:
+        from custom_components.vag_connect.sensor import _DATA_PRESENT_REQUIRED
+
+        # PR #10 widens populating brands to VW EU + Audi, but the gate
+        # itself stays unchanged — gate just means "skip phantom if
+        # field is None", which still applies to Skoda/Porsche/VW NA.
+        assert "subscription_expiry_at" in _DATA_PRESENT_REQUIRED
+
+    def test_subscription_active_still_gated(self) -> None:
+        from custom_components.vag_connect.binary_sensor import (
+            _DATA_PRESENT_REQUIRED,
+        )
+
+        assert "subscription_active" in _DATA_PRESENT_REQUIRED


### PR DESCRIPTION
## Summary

**Phase 2 PR #10/20** — cross-brand parity. VW EU + Audi (CARIAD-BFF) now populate \`subscription_expiry_at\` + \`subscription_active\` from \`userCapabilities.capabilitiesStatus.value[*].expirationDate\`.

Same earliest-wins aggregation as SEAT/CUPRA (PR #8), same three-variant key spelling support (\`expirationDate\` / \`validUntil\` / \`expiresAt\`), same tri-state semantics (perpetual capabilities → None, not False).

## Brand coverage matrix after this PR

| Brand        | Source |
|--------------|--------|
| SEAT / CUPRA | OLA \`mycar.services.*.expirationDate\` (PR #8) |
| **VW EU / Audi** | **CARIAD-BFF \`userCapabilities.*.expirationDate\` (this PR)** |
| Skoda        | None (mysmob doesn't expose subscription expiry) |
| Porsche      | None (PPA subscription tier handled differently) |
| VW NA        | None (NA backend doesn't expose) |

## Failsafe

- Non-list \`caps\` / empty list → returns None silently
- Non-dict cap entries (legacy string shape) skipped
- Non-string / empty / int expiry skipped (parser never raises)
- Malformed ISO 8601 → leaves \`subscription_active\` at None (don't false-alarm perpetual users on a parse blip)
- **Zero new API calls** — re-uses existing capabilities-endpoint data that's already fetched for \`capabilities_count\` (since v1.26.0)
- **Module-level datetime import used** — lesson from PR #9 fix on the Python lexer scope shadow trap

## Test plan

- [x] 12 test cases in \`tests/test_v220_vw_eu_subscription_parity.py\`:
  - **Aggregation** (4 — single + earliest-wins + mixed-variants + perpetual)
  - **Defensive parsing** (5 — non-list/empty/non-dict-cap/int-expiry/empty-string)
  - **Parity semantics** (3 — future→True, past→False, perpetual→None)
  - **Phantom-gate still applies** (2)
- [x] \`python -m py_compile\` clean on all touched files + test
- [x] All existing tests unaffected (gate keys unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)