### PR TITLE
v2.2.0 PR #11/20: subscription_days_remaining (Phase 2 closer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **`subscription_days_remaining` derived sensor (Phase 2 PR #11/20 — Phase 2 closer)** —
+  Schließt das Subscription-Feature-Dreieck: timestamp (PR #8) + bool
+  (PR #9) + **int days remaining (this PR)**. **Automation-friendly**:
+  Threshold-Trigger wie `if state(...) < 30 → notify` sind trivial
+  gegen einen int-Sensor, viel einfacher als gegen ein TIMESTAMP zu
+  templaten. Negative Werte wenn expired (`-3` = "expired 3 days ago"),
+  so doubles der gleiche Sensor als "wie lange ist's her" Alarm.
+  Berechnet inline neben PR #9 active-bool (zero overhead, single
+  datetime parse). Brand coverage identisch zu PR #8+#10: SEAT, CUPRA,
+  VW EU, Audi populiert; Skoda, Porsche, VW NA bleiben None.
+  Floor-division via `timedelta.days` — Partial-days inflaten nicht.
+  13 Tests inkl. Arithmetik (far-future, near-future, past, far-past,
+  partial-day-floored) + defensives Parsing + Sensor-Registration.
+  Phase 2 = ✅ COMPLETE (5 PRs: #7 Email-2FA + #8-#11 Subscription-Triangle).
+  *"Bazinga! Now THAT'S what I call a renewable resource." — Sheldon Cooper.*
+
 - **VW EU / Audi subscription parity (Phase 2 PR #10/20)** —
   Cross-brand parity zu PR #8 + #9: VW EU + Audi (CARIAD-BFF) parsen
   jetzt subscription_expiry_at + subscription_active aus dem

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -249,14 +249,20 @@ class SeatCupraClient(CariadBaseClient):
                         # Normalise trailing ``Z`` to ``+00:00`` for
                         # ``fromisoformat`` (Python 3.11+ accepts ``Z``
                         # natively but we keep this for older HA users).
-                        parsed = datetime.fromisoformat(
+                        exp_dt = datetime.fromisoformat(
                             earliest.replace("Z", "+00:00")
                         )
-                        if parsed.tzinfo is None:
-                            parsed = parsed.replace(tzinfo=timezone.utc)
-                        d.subscription_active = (
-                            parsed > datetime.now(tz=timezone.utc)
-                        )
+                        if exp_dt.tzinfo is None:
+                            exp_dt = exp_dt.replace(tzinfo=timezone.utc)
+                        now_utc = datetime.now(tz=timezone.utc)
+                        d.subscription_active = exp_dt > now_utc
+                        # v2.2.0 Phase 2 PR #11/20 — derived integer days
+                        # remaining. Negative when expired (e.g. -3 means
+                        # "expired 3 days ago"). Floor-divide so partial
+                        # days don't inflate the count.
+                        d.subscription_days_remaining = (
+                            exp_dt - now_utc
+                        ).days
                     except (ValueError, TypeError) as exc:
                         _LOGGER.debug(
                             "subscription_active: could not parse expiry "

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1353,9 +1353,15 @@ class VWEUClient(CariadBaseClient):
                         cap_expiry_dt = cap_expiry_dt.replace(
                             tzinfo=timezone.utc
                         )
-                    d.subscription_active = (
-                        cap_expiry_dt > datetime.now(tz=timezone.utc)
-                    )
+                    now_utc = datetime.now(tz=timezone.utc)
+                    d.subscription_active = cap_expiry_dt > now_utc
+                    # v2.2.0 Phase 2 PR #11/20 — derived integer days
+                    # remaining. Negative when expired (e.g. -3 means
+                    # "expired 3 days ago"). Floor-divide via
+                    # ``timedelta.days`` so partial days don't inflate.
+                    d.subscription_days_remaining = (
+                        cap_expiry_dt - now_utc
+                    ).days
                 except (ValueError, TypeError):
                     # Leave subscription_active at None — don't false-
                     # alarm perpetual users on a parse blip.

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -467,6 +467,18 @@ class VehicleData:
     # with perpetual entitlements don't get false "expired" alarms.
     subscription_active: bool | None = None
 
+    # v2.2.0 Phase 2 PR #11/20 — Derived integer days until expiry.
+    # Closes the subscription-feature triangle (expiry timestamp +
+    # active bool + days-remaining int). Computed from
+    # ``subscription_expiry_at`` minus current UTC, rounded DOWN to
+    # whole days. Negative values when expired (e.g. -3 means "expired
+    # 3 days ago"). Stays None when ``subscription_expiry_at`` is None
+    # (perpetual entitlement or brand without subscription block).
+    # Use case: threshold-based renewal reminders like
+    # ``automation: if sensor.subscription_days_remaining < 30 → notify``.
+    # Much easier to template against than parsing the timestamp.
+    subscription_days_remaining: int | None = None
+
     # Audi/VW EU charging rate in km/h (parity with Skoda + CUPRA/SEAT
     # which have ``charging_rate_kmh`` since v1.10.0). From
     # ``charging.chargingStatus.value.chargeRate_kmph``. Reused field

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -836,6 +836,20 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:calendar-clock",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.2.0 Phase 2 PR #11/20 — derived integer days until expiry.
+    # Closes the subscription-feature triangle (timestamp + active +
+    # days). Negative when expired. Automation-friendly: threshold
+    # triggers like ``if state(...) < 30 → notify`` are trivial against
+    # an int sensor (much easier than templating against a TIMESTAMP).
+    VagSensorDescription(
+        key="subscription_days_remaining",
+        translation_key="subscription_days_remaining",
+        data_key="subscription_days_remaining",
+        native_unit_of_measurement="d",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:calendar-end",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     VagSensorDescription(
         key="next_charging_timer_target_soc_reachable",
         translation_key="next_charging_timer_target_soc_reachable",
@@ -960,6 +974,10 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # capabilitiesStatus.value[*].expirationDate``. Skoda + Porsche +
     # VW NA leave field None → no phantom entity.
     "subscription_expiry_at",
+    # v2.2.0 Phase 2 PR #11/20 — derived days-remaining int sensor.
+    # Computed from the same expiry-aggregation as PR #8/#10, so same
+    # brand-coverage matrix (None on Skoda/Porsche/VW NA).
+    "subscription_days_remaining",
     "next_charging_timer_id",
     "next_charging_timer_target_soc_reachable",
     "capabilities_count",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -298,6 +298,9 @@
       "subscription_expiry_at": {
         "name": "Subscription Expires"
       },
+      "subscription_days_remaining": {
+        "name": "Subscription Days Remaining"
+      },
       "next_charging_timer_id": {
         "name": "Next Charging Timer ID"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -280,6 +280,9 @@
       "subscription_expiry_at": {
         "name": "Předplatné vyprší"
       },
+      "subscription_days_remaining": {
+        "name": "Předplatné zbývá dní"
+      },
       "next_charging_timer_id": {
         "name": "Next Charging Timer ID"
       },

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -280,6 +280,9 @@
       "subscription_expiry_at": {
         "name": "Abonnement läuft ab"
       },
+      "subscription_days_remaining": {
+        "name": "Abonnement Restlaufzeit"
+      },
       "next_charging_timer_id": {
         "name": "Nächster Lade-Timer ID"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -280,6 +280,9 @@
       "subscription_expiry_at": {
         "name": "Subscription Expires"
       },
+      "subscription_days_remaining": {
+        "name": "Subscription Days Remaining"
+      },
       "next_charging_timer_id": {
         "name": "Next Charging Timer ID"
       },

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -280,6 +280,9 @@
       "subscription_expiry_at": {
         "name": "Suscripción expira"
       },
+      "subscription_days_remaining": {
+        "name": "Días restantes de suscripción"
+      },
       "next_charging_timer_id": {
         "name": "Next Charging Timer ID"
       },

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -280,6 +280,9 @@
       "subscription_expiry_at": {
         "name": "Abonnement expire"
       },
+      "subscription_days_remaining": {
+        "name": "Jours d'abonnement restants"
+      },
       "next_charging_timer_id": {
         "name": "Next Charging Timer ID"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -280,6 +280,9 @@
       "subscription_expiry_at": {
         "name": "Abonnement verloopt"
       },
+      "subscription_days_remaining": {
+        "name": "Abonnement resterende dagen"
+      },
       "next_charging_timer_id": {
         "name": "Next Charging Timer ID"
       },

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -280,6 +280,9 @@
       "subscription_expiry_at": {
         "name": "Subskrypcja wygasa"
       },
+      "subscription_days_remaining": {
+        "name": "Pozostałe dni subskrypcji"
+      },
       "next_charging_timer_id": {
         "name": "Next Charging Timer ID"
       },

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -280,6 +280,9 @@
       "subscription_expiry_at": {
         "name": "Prenumeration löper ut"
       },
+      "subscription_days_remaining": {
+        "name": "Prenumeration dagar kvar"
+      },
       "next_charging_timer_id": {
         "name": "Next Charging Timer ID"
       },

--- a/tests/test_v220_subscription_days_remaining.py
+++ b/tests/test_v220_subscription_days_remaining.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.0 Phase 2 PR #11/20 — subscription_days_remaining derived sensor.
+
+Closes the subscription-feature triangle:
+  - PR #8:  ``subscription_expiry_at``  (TIMESTAMP — when does it expire?)
+  - PR #9:  ``subscription_active``     (BOOL — is it currently valid?)
+  - PR #11: ``subscription_days_remaining`` (INT — how many days left?)
+
+The int sensor is **automation-friendly**: threshold triggers like
+``if state(...) < 30 → notify`` are trivial against an integer
+sensor, much easier than templating against a TIMESTAMP.
+
+Negative values when expired (e.g. -3 means "expired 3 days ago"),
+so the same sensor doubles as a "how long ago did it lapse" alarm.
+
+"Bazinga! Now THAT'S what I call a renewable resource."
+— Sheldon Cooper, on the day his Wolowitz-bot's Connect sub auto-renewed
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+def _compute_days(earliest: str | None) -> int | None:
+    """Pure mirror of the inline computation in seat_cupra.py + vw_eu.py."""
+    if earliest is None:
+        return None
+    try:
+        exp_dt = datetime.fromisoformat(earliest.replace("Z", "+00:00"))
+        if exp_dt.tzinfo is None:
+            exp_dt = exp_dt.replace(tzinfo=timezone.utc)
+        return (exp_dt - datetime.now(tz=timezone.utc)).days
+    except (ValueError, TypeError):
+        return None
+
+
+class TestDaysRemainingArithmetic:
+    """``timedelta.days`` floor-divides, so partial days don't inflate."""
+
+    def test_far_future_positive_days(self) -> None:
+        future = (
+            datetime.now(tz=timezone.utc) + timedelta(days=365)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = _compute_days(future)
+        # Allow ±1 day tolerance for test-runtime drift
+        assert result is not None
+        assert 363 <= result <= 365
+
+    def test_near_future_small_positive(self) -> None:
+        future = (
+            datetime.now(tz=timezone.utc) + timedelta(days=10)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = _compute_days(future)
+        assert result is not None
+        assert 8 <= result <= 10
+
+    def test_past_expiry_negative_days(self) -> None:
+        # Expired 5 days ago — should be -5 or -6 depending on hours
+        past = (
+            datetime.now(tz=timezone.utc) - timedelta(days=5)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = _compute_days(past)
+        assert result is not None
+        assert -6 <= result <= -4
+
+    def test_far_past_large_negative(self) -> None:
+        # 2 years ago — should be ~-730
+        past = (
+            datetime.now(tz=timezone.utc) - timedelta(days=730)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = _compute_days(past)
+        assert result is not None
+        assert -732 <= result <= -728
+
+    def test_partial_day_floored_down(self) -> None:
+        # 12 hours from now → 0 days (floor-divide)
+        future = (
+            datetime.now(tz=timezone.utc) + timedelta(hours=12)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = _compute_days(future)
+        assert result == 0
+
+
+class TestDaysRemainingDefensive:
+    def test_none_input_returns_none(self) -> None:
+        # Perpetual entitlement → MUST stay None (not 0)
+        assert _compute_days(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _compute_days("") is None
+
+    def test_garbage_string_returns_none(self) -> None:
+        assert _compute_days("not-a-date") is None
+
+    def test_partial_iso_returns_none(self) -> None:
+        assert _compute_days("2026") is None
+
+    def test_iso_with_z_suffix(self) -> None:
+        # Z must normalise to +00:00
+        future = (
+            datetime.now(tz=timezone.utc) + timedelta(days=30)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = _compute_days(future)
+        assert result is not None
+        assert 28 <= result <= 30
+
+    def test_naive_iso_treated_as_utc(self) -> None:
+        # Naive datetime → tagged as UTC. Use far-future to avoid race.
+        assert _compute_days("2099-01-01T00:00:00") is not None
+
+
+class TestSensorRegistration:
+    def test_described(self) -> None:
+        from custom_components.vag_connect.sensor import SENSOR_DESCRIPTIONS
+
+        keys = {desc.key for desc in SENSOR_DESCRIPTIONS}
+        assert "subscription_days_remaining" in keys
+
+    def test_uses_measurement_state_class(self) -> None:
+        from homeassistant.components.sensor import SensorStateClass
+
+        from custom_components.vag_connect.sensor import SENSOR_DESCRIPTIONS
+
+        desc = next(
+            d
+            for d in SENSOR_DESCRIPTIONS
+            if d.key == "subscription_days_remaining"
+        )
+        assert desc.state_class == SensorStateClass.MEASUREMENT
+
+    def test_phantom_gated(self) -> None:
+        from custom_components.vag_connect.sensor import _DATA_PRESENT_REQUIRED
+
+        assert "subscription_days_remaining" in _DATA_PRESENT_REQUIRED


### PR DESCRIPTION
## Summary

**Phase 2 closer.** Closes the subscription-feature triangle:

| PR | Field | Type | Use case |
|----|-------|------|----------|
| #8/20 | \`subscription_expiry_at\` | TIMESTAMP | When does it expire? |
| #9/20 | \`subscription_active\` | BOOL (tri-state) | Is it valid right now? |
| **#11/20** | **\`subscription_days_remaining\`** | **INT** | **How many days left?** ← THIS |

The int sensor is **automation-friendly**: threshold triggers like \`if state(...) < 30 → notify\` are trivial against an integer, MUCH easier than templating against a TIMESTAMP.

Negative values when expired (e.g. \`-3\` means \"expired 3 days ago\"), so the same sensor doubles as a \"how long ago did it lapse\" alarm — one sensor powers both renewal-reminder AND lapse-alarm automations.

## Brand coverage matrix (Phase 2 final state)

| Brand        | expiry_at | active | days_remaining |
|--------------|-----------|--------|----------------|
| SEAT / CUPRA | ✓ PR #8   | ✓ PR #9 | ✓ this PR     |
| VW EU / Audi | ✓ PR #10  | ✓ PR #10 | ✓ this PR    |
| Skoda        | — (no field) | — (no field) | — (no field) |
| Porsche      | — (PPA handled differently) | — | — |
| VW NA        | — (NA backend doesn't expose) | — | — |

## Failsafe

- **Negative-value handling**: \`timedelta.days\` floor-divides, so partial days don't inflate (12h from now → 0, not 1)
- **Perpetual entitlement** → field stays None (NOT 0 — perpetual ≠ expired-today; users with lifetime subs MUST NOT see a \"0 days left\" alarm)
- **Malformed timestamp** → leaves field None (parser silent)
- **Zero overhead** — reuses the same \`datetime.fromisoformat\` + \`now_utc\` binding that PR #9 already computes for \`subscription_active\`

## Test plan

- [x] 13 test cases in \`tests/test_v220_subscription_days_remaining.py\`:
  - **Arithmetic** (5 — far-future/near-future/past/far-past/partial-day-floored)
  - **Defensive parsing** (6 — None/empty/garbage/partial/Z-suffix/naive-UTC)
  - **Sensor registration** (3 — description + state_class + phantom-gate)
- [x] \`python -m py_compile\` clean on all 5 touched files + test
- [x] All 9 JSON files parse cleanly
- [ ] CI green

## Phase 2 = COMPLETE ✅

5 PRs merged:
- #7 Email-OTP vs TOTP discrimination
- #8 \`subscription_expiry_at\` (SEAT/CUPRA)
- #9 \`subscription_active\` binary_sensor (tri-state)
- #10 VW EU/Audi subscription parity
- #11 \`subscription_days_remaining\` (this PR)

**Next:** Phase 3 (MQTT/FCM Live Activation, 3 PRs with 3-strike circuit-breaker).

Marketing: *\"Bazinga! Now THAT'S what I call a renewable resource.\"* — Sheldon Cooper

🤖 Generated with [Claude Code](https://claude.com/claude-code)