### PR TITLE
v2.2.0 PR #13/20: CUPRA/SEAT FCM circuit-breaker wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **CUPRA/SEAT FCM Circuit-Breaker Wiring (Phase 3 PR #13/20)** —
+  Wired die circuit-breaker hooks (PR #12 foundation) in den CUPRA/SEAT
+  FCM push manager an 5 Hook-Sites:
+  (1) `start()` short-circuits wenn state == TRIPPED;
+  (2) `start()` deps-check failure → `_record_failure("missing-dep")`;
+  (3) `_run_loop()` connect-exception → `_record_failure("connect-loop")`;
+  (4) Post-backoff trip check → exit outer loop;
+  (5) `_connect_and_listen()` success → `_record_success()` (resets).
+  **Identische Wiring-Shape wie Skoda MQTT** (PR #12) — parity test
+  vergleicht Hook-Counts zwischen beiden brands. Beide brands haben
+  jetzt die exact gleiche fail-safe behavior. Audi/VW FCM wired in
+  PR #14. 11 Tests inkl. source-level wiring verification +
+  mixin-inheritance + brand-parity regression-shield.
+  *"That, my dear Penny, is what we call defensive programming."
+  — Sheldon Cooper.*
+
 - **Push-Bus 3-strike Circuit-Breaker Foundation (Phase 3 PR #12/20)** —
   Phase 3 opener. Foundational layer für die kommenden MQTT/FCM Live-
   Activations (#13, #14): nach **3 konsekutiven Connect-Failures**

--- a/custom_components/vag_connect/cariad/push/cupra_seat_fcm.py
+++ b/custom_components/vag_connect/cariad/push/cupra_seat_fcm.py
@@ -141,8 +141,25 @@ class CupraSeatPushManager(PushManager):
         self._consecutive_fast_retries: int = 0
 
     async def start(self) -> None:
-        """Spawn the FCM receive loop. Idempotent."""
+        """Spawn the FCM receive loop. Idempotent.
+
+        v2.2.0 PR #13/20: respects the circuit-breaker (PR #12 base).
+        If the breaker is tripped (3 consecutive start failures), this
+        returns immediately without retrying. Caller can poll ``state``
+        for the TRIPPED signal and surface it via Repair-Issue.
+        """
         if self._state in (PushManagerState.CONNECTED, PushManagerState.STARTING):
+            return
+        # v2.2.0 PR #13/20 — short-circuit if breaker tripped.
+        # Reading ``self.state`` (not ``self._state``) honours the
+        # auto-reset transition in the property-getter (1h cooldown).
+        if self.state == PushManagerState.TRIPPED:
+            _LOGGER.warning(
+                "CUPRA/SEAT push (brand=%s): circuit-breaker TRIPPED — "
+                "declining start. Wait for auto-reset (1h) or call "
+                "reset_circuit_breaker().",
+                self._brand,
+            )
             return
         if not self._vins:
             _LOGGER.info(
@@ -161,6 +178,10 @@ class CupraSeatPushManager(PushManager):
                 err,
             )
             self._state = PushManagerState.UNAVAILABLE
+            # v2.2.0 PR #13/20: missing-deps strike. After 3 attempts
+            # the breaker trips so we stop spamming the log every
+            # coordinator-start cycle.
+            self._record_failure(f"missing-dep: {err}")
             return
         self._loop_task = asyncio.create_task(
             self._run_loop(),
@@ -213,6 +234,10 @@ class CupraSeatPushManager(PushManager):
                     self._backoff_seconds,
                 )
                 self._state = PushManagerState.RECONNECTING
+                # v2.2.0 PR #13/20 — record this strike. After 3
+                # consecutive failures the breaker trips and we
+                # exit the outer loop (check below after backoff).
+                self._record_failure(f"connect-loop: {type(err).__name__}")
                 try:
                     await asyncio.wait_for(
                         self._stop_event.wait(),
@@ -222,6 +247,18 @@ class CupraSeatPushManager(PushManager):
                 except asyncio.TimeoutError:
                     pass
                 self._advance_backoff()
+                # v2.2.0 PR #13/20 — exit if breaker tripped during
+                # the strike-counting above. Reading ``self.state``
+                # honours the auto-reset transition.
+                if self.state == PushManagerState.TRIPPED:
+                    _LOGGER.error(
+                        "CUPRA/SEAT push (brand=%s): circuit-breaker "
+                        "tripped — exiting reconnect loop. Next start() "
+                        "call will short-circuit until auto-reset (1h) "
+                        "or manual reset_circuit_breaker().",
+                        self._brand,
+                    )
+                    break
 
     async def _connect_and_listen(self) -> None:
         """One FCM register + OLA subscribe + receive cycle.
@@ -244,6 +281,9 @@ class CupraSeatPushManager(PushManager):
         """
         token = await self._access_token_provider()  # noqa: F841 — used in real impl
         self._state = PushManagerState.CONNECTED
+        # v2.2.0 PR #13/20 — successful connect resets the breaker.
+        # Idempotent: no-op when strike_count is already 0.
+        self._record_success()
         _LOGGER.info(
             "CUPRA/SEAT push: foundation stub — live activation pending. "
             "Brand=%s, would POST subscription for VINs: %s",

--- a/tests/test_v220_cupra_seat_fcm_breaker.py
+++ b/tests/test_v220_cupra_seat_fcm_breaker.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.0 Phase 3 PR #13/20 — CUPRA/SEAT FCM circuit-breaker wiring.
+
+Companion to PR #12 (foundation). Wires the breaker hooks into the
+CUPRA/SEAT FCM push manager at three sites:
+
+  1. ``start()``: short-circuits when state == TRIPPED
+  2. ``start()`` deps-check failure: records strike
+  3. ``_run_loop()`` connect-exception path: records strike
+  4. ``_run_loop()`` post-backoff trip check: breaks outer loop
+  5. ``_connect_and_listen()`` success path: records success (resets)
+
+CUPRA + SEAT share the same OLA FCM backend (different brand
+project_ids) — both go through the same manager class with the
+``brand`` constructor arg discriminating the project.
+
+"That, my dear Penny, is what we call defensive programming."
+— Sheldon Cooper, on why a 3-strike circuit-breaker is the right
+abstraction
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+class TestCupraSeatWiringSites:
+    """Source-level checks that all 5 hook sites are wired.
+
+    We verify via source inspection rather than runtime because the
+    push manager is a stub (real FCM connection still pending tester
+    validation), so triggering live behaviour isn't practical yet.
+    Source inspection is the right level here — confirms the wiring
+    contract without requiring a live broker.
+    """
+
+    def _source(self) -> str:
+        from custom_components.vag_connect.cariad.push import cupra_seat_fcm
+
+        return inspect.getsource(cupra_seat_fcm)
+
+    def test_start_short_circuits_on_tripped(self) -> None:
+        src = self._source()
+        # The start() function must check ``self.state == PushManagerState.TRIPPED``
+        # BEFORE reading self._vins (the existing early-return)
+        assert "if self.state == PushManagerState.TRIPPED" in src
+
+    def test_missing_deps_records_strike(self) -> None:
+        src = self._source()
+        # The except-ImportError branch must call _record_failure
+        # with a reason mentioning missing-dep
+        assert 'self._record_failure(f"missing-dep' in src
+
+    def test_connect_loop_records_strike(self) -> None:
+        src = self._source()
+        # The except-Exception branch in _run_loop must record a
+        # connect-loop strike
+        assert 'self._record_failure(f"connect-loop' in src
+
+    def test_loop_exits_on_trip(self) -> None:
+        src = self._source()
+        # After the backoff sleep + _advance_backoff, the loop must
+        # check is-tripped and break the outer while
+        assert (
+            "if self.state == PushManagerState.TRIPPED" in src
+            and "exiting reconnect loop" in src
+        )
+
+    def test_connect_success_resets_strikes(self) -> None:
+        src = self._source()
+        # The _connect_and_listen path that transitions to CONNECTED
+        # must call _record_success() to clear any prior strike count
+        assert "self._record_success()" in src
+
+
+class TestCupraSeatInheritsBreakerMixin:
+    """The manager class must inherit the breaker mixin from base."""
+
+    def test_class_has_record_failure(self) -> None:
+        from custom_components.vag_connect.cariad.push.cupra_seat_fcm import (
+            CupraSeatPushManager,
+        )
+
+        assert hasattr(CupraSeatPushManager, "_record_failure")
+        assert callable(CupraSeatPushManager._record_failure)
+
+    def test_class_has_record_success(self) -> None:
+        from custom_components.vag_connect.cariad.push.cupra_seat_fcm import (
+            CupraSeatPushManager,
+        )
+
+        assert hasattr(CupraSeatPushManager, "_record_success")
+        assert callable(CupraSeatPushManager._record_success)
+
+    def test_class_has_reset_circuit_breaker(self) -> None:
+        from custom_components.vag_connect.cariad.push.cupra_seat_fcm import (
+            CupraSeatPushManager,
+        )
+
+        assert hasattr(CupraSeatPushManager, "reset_circuit_breaker")
+        assert callable(CupraSeatPushManager.reset_circuit_breaker)
+
+    def test_class_has_is_tripped_property(self) -> None:
+        from custom_components.vag_connect.cariad.push.cupra_seat_fcm import (
+            CupraSeatPushManager,
+        )
+
+        assert hasattr(CupraSeatPushManager, "is_tripped")
+        # Verify it's a property, not a regular method
+        assert isinstance(
+            inspect.getattr_static(CupraSeatPushManager, "is_tripped"), property
+        )
+
+    def test_class_has_strike_count_property(self) -> None:
+        from custom_components.vag_connect.cariad.push.cupra_seat_fcm import (
+            CupraSeatPushManager,
+        )
+
+        assert hasattr(CupraSeatPushManager, "strike_count")
+        assert isinstance(
+            inspect.getattr_static(CupraSeatPushManager, "strike_count"),
+            property,
+        )
+
+
+class TestParityWithSkodaWiring:
+    """The CUPRA/SEAT wiring shape MUST match the Skoda wiring shape
+    so behaviour is identical across brands. Source-level comparison."""
+
+    def test_both_brands_have_same_hook_count(self) -> None:
+        from custom_components.vag_connect.cariad.push import (
+            cupra_seat_fcm,
+            skoda_mqtt,
+        )
+
+        skoda_src = inspect.getsource(skoda_mqtt)
+        cupra_src = inspect.getsource(cupra_seat_fcm)
+
+        # 3 _record_failure call sites (start-deps + connect-loop +
+        # maybe future-third), 1 _record_success call site
+        assert skoda_src.count("self._record_failure(") == cupra_src.count(
+            "self._record_failure("
+        )
+        assert skoda_src.count("self._record_success()") == cupra_src.count(
+            "self._record_success()"
+        )
+
+    def test_both_brands_short_circuit_tripped_state(self) -> None:
+        from custom_components.vag_connect.cariad.push import (
+            cupra_seat_fcm,
+            skoda_mqtt,
+        )
+
+        # Both must have the same TRIPPED short-circuit pattern in start()
+        marker = "if self.state == PushManagerState.TRIPPED"
+        assert marker in inspect.getsource(skoda_mqtt)
+        assert marker in inspect.getsource(cupra_seat_fcm)


### PR DESCRIPTION
## Summary

Wires the circuit-breaker hooks (PR #12 foundation) into the CUPRA/SEAT FCM push manager at 5 sites — **identical wiring shape** to the Skoda MQTT manager (PR #12) so behaviour is uniform across brands.

## Hook sites (mirrors Skoda MQTT)

| # | Site | Action |
|---|------|--------|
| 1 | \`start()\` entry | Short-circuit when \`self.state == TRIPPED\` |
| 2 | \`start()\` deps-check fail | \`_record_failure(\"missing-dep: ...\")\` |
| 3 | \`_run_loop()\` connect-exception | \`_record_failure(\"connect-loop: ...\")\` |
| 4 | Post-backoff trip check | Break outer loop |
| 5 | \`_connect_and_listen()\` CONNECTED transition | \`_record_success()\` |

## Brand parity regression-shield

\`TestParityWithSkodaWiring\` does source-level comparison of \`_record_failure\` + \`_record_success\` call counts between \`skoda_mqtt.py\` and \`cupra_seat_fcm.py\` — both must stay equal. If a future PR adds a hook to one without the other, this test fails.

## Failsafe

- Source-level tests don't require a live broker (good — connection is still stubbed pending tester validation)
- All hooks idempotent (inherited from PR #12 base mixin)
- \`brand\` constructor arg preserved in log messages → CUPRA vs SEAT discrimination retained

## Test plan

- [x] 11 test cases in \`tests/test_v220_cupra_seat_fcm_breaker.py\`:
  - **Source-level wiring** (5)
  - **Mixin inheritance** (5 — \`_record_failure\` / \`_record_success\` / \`reset_circuit_breaker\` / \`is_tripped\` property / \`strike_count\` property)
  - **Brand parity** (2 — equal hook counts + both have TRIPPED check)
- [x] \`python -m py_compile\` clean
- [x] No behaviour change to the PR #12 foundation
- [ ] CI green

Marketing: *\"That, my dear Penny, is what we call defensive programming.\"* — Sheldon Cooper

🤖 Generated with [Claude Code](https://claude.com/claude-code)