### PR TITLE
v2.2.0 PR #14/20: Audi/VW FCM circuit-breaker wiring (Phase 3 closer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,25 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **Audi/VW FCM Circuit-Breaker Wiring (Phase 3 PR #14/20 — Phase 3 closer)** —
+  Schließt die cross-brand circuit-breaker coverage. Skoda MQTT (#12) +
+  CUPRA/SEAT FCM (#13) + Audi/VW FCM (this PR) haben jetzt alle die
+  **identical 5-hook wiring**:
+  (1) `start()` short-circuits bei TRIPPED;
+  (2) deps-check failure → strike;
+  (3) connect-exception → strike;
+  (4) post-backoff trip check → exit loop;
+  (5) success → reset.
+  **3-way parity test** als regression-shield: alle 3 Brands müssen
+  identical `_record_failure` + `_record_success` counts haben, alle
+  müssen den TRIPPED short-circuit und den recovery-hint im log-message
+  haben. Jede zukünftige drift (extra hook, missing hook, divergierende
+  reason-strings) bricht den test. Phase 3 = ✅ COMPLETE — alle Push-
+  Manager haben jetzt identische fail-safe Semantik bevor wir in Phase 4
+  Live-Activation versuchen. 14 Tests.
+  *"Live activation can wait. The safety net must come first."
+  — paraphrased Sheldon Cooper.*
+
 - **CUPRA/SEAT FCM Circuit-Breaker Wiring (Phase 3 PR #13/20)** —
   Wired die circuit-breaker hooks (PR #12 foundation) in den CUPRA/SEAT
   FCM push manager an 5 Hook-Sites:

--- a/custom_components/vag_connect/cariad/push/audi_vw_fcm.py
+++ b/custom_components/vag_connect/cariad/push/audi_vw_fcm.py
@@ -171,8 +171,25 @@ class AudiVWPushManager(PushManager):
         self._consecutive_fast_retries: int = 0
 
     async def start(self) -> None:
-        """Spawn the FCM receive loop. Idempotent."""
+        """Spawn the FCM receive loop. Idempotent.
+
+        v2.2.0 PR #14/20: respects the circuit-breaker (PR #12 base).
+        If the breaker is tripped (3 consecutive start failures), this
+        returns immediately without retrying. Caller can poll ``state``
+        for the TRIPPED signal and surface it via Repair-Issue.
+        """
         if self._state in (PushManagerState.CONNECTED, PushManagerState.STARTING):
+            return
+        # v2.2.0 PR #14/20 — short-circuit if breaker tripped.
+        # Reading ``self.state`` (not ``self._state``) honours the
+        # auto-reset transition in the property-getter (1h cooldown).
+        if self.state == PushManagerState.TRIPPED:
+            _LOGGER.warning(
+                "Audi/VW push (brand=%s): circuit-breaker TRIPPED — "
+                "declining start. Wait for auto-reset (1h) or call "
+                "reset_circuit_breaker().",
+                self._brand,
+            )
             return
         if not self._vins:
             _LOGGER.info(
@@ -191,6 +208,10 @@ class AudiVWPushManager(PushManager):
                 err,
             )
             self._state = PushManagerState.UNAVAILABLE
+            # v2.2.0 PR #14/20: missing-deps strike. After 3 attempts
+            # the breaker trips so we stop spamming the log every
+            # coordinator-start cycle.
+            self._record_failure(f"missing-dep: {err}")
             return
         self._loop_task = asyncio.create_task(
             self._run_loop(),
@@ -241,6 +262,10 @@ class AudiVWPushManager(PushManager):
                     self._backoff_seconds,
                 )
                 self._state = PushManagerState.RECONNECTING
+                # v2.2.0 PR #14/20 — record this strike. After 3
+                # consecutive failures the breaker trips and we
+                # exit the outer loop (check below after backoff).
+                self._record_failure(f"connect-loop: {type(err).__name__}")
                 try:
                     await asyncio.wait_for(
                         self._stop_event.wait(),
@@ -250,6 +275,18 @@ class AudiVWPushManager(PushManager):
                 except asyncio.TimeoutError:
                     pass
                 self._advance_backoff()
+                # v2.2.0 PR #14/20 — exit if breaker tripped during
+                # the strike-counting above. Reading ``self.state``
+                # honours the auto-reset transition.
+                if self.state == PushManagerState.TRIPPED:
+                    _LOGGER.error(
+                        "Audi/VW push (brand=%s): circuit-breaker "
+                        "tripped — exiting reconnect loop. Next start() "
+                        "call will short-circuit until auto-reset (1h) "
+                        "or manual reset_circuit_breaker().",
+                        self._brand,
+                    )
+                    break
 
     async def _connect_and_listen(self) -> None:
         """One FCM register + Cariad subscribe + receive cycle.
@@ -270,6 +307,9 @@ class AudiVWPushManager(PushManager):
         """
         token = await self._access_token_provider()  # noqa: F841 — used in real impl
         self._state = PushManagerState.CONNECTED
+        # v2.2.0 PR #14/20 — successful connect resets the breaker.
+        # Idempotent: no-op when strike_count is already 0.
+        self._record_success()
         _LOGGER.info(
             "Audi/VW push: foundation stub — live activation pending. "
             "Brand=%s, would register FCM for VINs: %s",

--- a/tests/test_v220_audi_vw_fcm_breaker.py
+++ b/tests/test_v220_audi_vw_fcm_breaker.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.0 Phase 3 PR #14/20 — Audi/VW FCM circuit-breaker wiring.
+
+**Phase 3 closer.** Completes the cross-brand circuit-breaker
+coverage: Skoda MQTT (PR #12), CUPRA/SEAT FCM (PR #13), Audi/VW FCM
+(this PR) all now wire the 5 hook sites uniformly.
+
+After this PR every push manager in the integration has identical
+fail-safe behaviour: 3 consecutive connect failures → TRIPPED state
+→ 1h auto-reset (or manual ``reset_circuit_breaker()``).
+
+The 3-way parity test (Skoda + CUPRA/SEAT + Audi/VW) is the
+regression-shield that catches future drift — if any brand's wiring
+diverges (extra hook, missing hook, different reason-string format)
+the parity test fails.
+
+"Live activation can wait. The safety net must come first."
+— paraphrased Sheldon Cooper, on push-bus engineering discipline
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+class TestAudiVWWiringSites:
+    """Source-level checks that all 5 hook sites are wired."""
+
+    def _source(self) -> str:
+        from custom_components.vag_connect.cariad.push import audi_vw_fcm
+
+        return inspect.getsource(audi_vw_fcm)
+
+    def test_start_short_circuits_on_tripped(self) -> None:
+        src = self._source()
+        assert "if self.state == PushManagerState.TRIPPED" in src
+
+    def test_missing_deps_records_strike(self) -> None:
+        src = self._source()
+        assert 'self._record_failure(f"missing-dep' in src
+
+    def test_connect_loop_records_strike(self) -> None:
+        src = self._source()
+        assert 'self._record_failure(f"connect-loop' in src
+
+    def test_loop_exits_on_trip(self) -> None:
+        src = self._source()
+        assert (
+            "if self.state == PushManagerState.TRIPPED" in src
+            and "exiting reconnect loop" in src
+        )
+
+    def test_connect_success_resets_strikes(self) -> None:
+        src = self._source()
+        assert "self._record_success()" in src
+
+
+class TestAudiVWInheritsBreakerMixin:
+    """Class must inherit the breaker mixin from base."""
+
+    def test_class_has_record_failure(self) -> None:
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+
+        assert hasattr(AudiVWPushManager, "_record_failure")
+
+    def test_class_has_record_success(self) -> None:
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+
+        assert hasattr(AudiVWPushManager, "_record_success")
+
+    def test_class_has_reset_circuit_breaker(self) -> None:
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+
+        assert hasattr(AudiVWPushManager, "reset_circuit_breaker")
+
+    def test_class_has_is_tripped_property(self) -> None:
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+
+        assert isinstance(
+            inspect.getattr_static(AudiVWPushManager, "is_tripped"), property
+        )
+
+    def test_class_has_strike_count_property(self) -> None:
+        from custom_components.vag_connect.cariad.push.audi_vw_fcm import (
+            AudiVWPushManager,
+        )
+
+        assert isinstance(
+            inspect.getattr_static(AudiVWPushManager, "strike_count"), property
+        )
+
+
+class TestThreeWayParity:
+    """Phase 3 closer regression-shield: ALL three push managers must
+    have identical hook-counts. Any future divergence breaks this test."""
+
+    def test_all_three_brands_have_same_record_failure_count(self) -> None:
+        from custom_components.vag_connect.cariad.push import (
+            audi_vw_fcm,
+            cupra_seat_fcm,
+            skoda_mqtt,
+        )
+
+        skoda = inspect.getsource(skoda_mqtt).count("self._record_failure(")
+        cupra = inspect.getsource(cupra_seat_fcm).count(
+            "self._record_failure("
+        )
+        audi = inspect.getsource(audi_vw_fcm).count("self._record_failure(")
+        assert skoda == cupra == audi, (
+            f"hook-count drift: skoda={skoda} cupra={cupra} audi={audi}"
+        )
+
+    def test_all_three_brands_have_same_record_success_count(self) -> None:
+        from custom_components.vag_connect.cariad.push import (
+            audi_vw_fcm,
+            cupra_seat_fcm,
+            skoda_mqtt,
+        )
+
+        skoda = inspect.getsource(skoda_mqtt).count("self._record_success()")
+        cupra = inspect.getsource(cupra_seat_fcm).count(
+            "self._record_success()"
+        )
+        audi = inspect.getsource(audi_vw_fcm).count("self._record_success()")
+        assert skoda == cupra == audi, (
+            f"success-reset drift: skoda={skoda} cupra={cupra} audi={audi}"
+        )
+
+    def test_all_three_brands_short_circuit_tripped_state(self) -> None:
+        from custom_components.vag_connect.cariad.push import (
+            audi_vw_fcm,
+            cupra_seat_fcm,
+            skoda_mqtt,
+        )
+
+        marker = "if self.state == PushManagerState.TRIPPED"
+        for mod in (skoda_mqtt, cupra_seat_fcm, audi_vw_fcm):
+            assert marker in inspect.getsource(mod), (
+                f"{mod.__name__}: missing TRIPPED short-circuit"
+            )
+
+    def test_all_three_brands_log_reset_hint_on_trip(self) -> None:
+        # Operator-facing message: "wait for auto-reset (1h) or call
+        # reset_circuit_breaker()" — must be present in all three
+        # log messages so users always know how to recover regardless
+        # of brand.
+        from custom_components.vag_connect.cariad.push import (
+            audi_vw_fcm,
+            cupra_seat_fcm,
+            skoda_mqtt,
+        )
+
+        for mod in (skoda_mqtt, cupra_seat_fcm, audi_vw_fcm):
+            src = inspect.getsource(mod)
+            assert (
+                "auto-reset" in src and "reset_circuit_breaker" in src
+            ), f"{mod.__name__}: missing recovery hint in log"


### PR DESCRIPTION
## Summary

**Phase 3 closer.** Completes cross-brand circuit-breaker coverage: Skoda MQTT (PR #12), CUPRA/SEAT FCM (PR #13), Audi/VW FCM (this PR) all now wire the **identical 5 hook sites**.

After this PR every push manager in the integration has identical fail-safe behaviour: 3 consecutive connect failures → TRIPPED state → 1h auto-reset (or manual \`reset_circuit_breaker()\`).

## Hook sites (identical to PR #12 + PR #13)

| # | Site | Action |
|---|------|--------|
| 1 | \`start()\` entry | Short-circuit when \`self.state == TRIPPED\` |
| 2 | \`start()\` deps-check fail | \`_record_failure(\"missing-dep: ...\")\` |
| 3 | \`_run_loop()\` connect-exception | \`_record_failure(\"connect-loop: ...\")\` |
| 4 | Post-backoff trip check | Break outer loop |
| 5 | \`_connect_and_listen()\` CONNECTED | \`_record_success()\` |

## 3-way parity regression-shield

\`TestThreeWayParity\` compares the three push-manager modules at source-level:

- Equal \`_record_failure\` counts across all 3 brands
- Equal \`_record_success\` counts across all 3 brands
- All 3 have TRIPPED short-circuit in \`start()\`
- All 3 log the recovery hint (\"auto-reset\" + \"reset_circuit_breaker\")

Any future divergence (extra hook, missing hook, divergent reason-string format) breaks this test — keeps Phase 3 from silently drifting brand-by-brand.

## Phase 3 = COMPLETE ✅

3 PRs merged:
- #12 Circuit-breaker foundation (base class + enum + mixin)
- #13 CUPRA/SEAT FCM wiring
- **#14 Audi/VW FCM wiring (this PR)**

Cross-brand fail-safe semantics LOCKED IN **before** any tester attempts live FCM/MQTT activation. Live activation goes through the same breaker-protected \`start()\` — if the FCM key is wrong or the broker auth schema rotated, the breaker trips after 3 attempts instead of spamming the log forever.

## Test plan

- [x] 14 test cases in \`tests/test_v220_audi_vw_fcm_breaker.py\`:
  - **Source-level wiring** (5 — same as PR #13)
  - **Mixin inheritance** (5)
  - **3-way parity** (4 — failure-count + success-count + TRIPPED-short-circuit + recovery-hint)
- [x] \`python -m py_compile\` clean
- [ ] CI green

**Next:** Phase 4 (Brand-Adapters Lambo/Bentley/CUPRA-standalone, 3 PRs, beta-gated).

Marketing: *\"Live activation can wait. The safety net must come first.\"* — paraphrased Sheldon Cooper

🤖 Generated with [Claude Code](https://claude.com/claude-code)