### PR TITLE
Phase 7 PR #2: VW EU/Audi tier-B diagnostics (2 entities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,31 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **Phase 7 PR #2 — VW EU/Audi Tier-B Diagnostics** —
+  Zwei CARIAD-BFF Felder die der parser bereits READS für adjacent
+  features (timers list, readiness block) aber nie als aggregate /
+  diagnostic entities exposed:
+  - **`sensor.departure_timer_enabled_count`** (VW EU + Audi):
+    aggregate count (0-3) of currently-enabled departure timers.
+    Saves users die templating-effort von 3 binary states summen.
+    Defensive: nur gesetzt wenn die timers list tatsächlich present
+    ist (nicht just empty) — phantom-gate bleibt honest. Multi-
+    variant truthy-check rejected (only literal `True` counts —
+    string "true" / int 1 zählen nicht).
+  - **`binary_sensor.daily_power_budget_available`** (VW EU + Audi):
+    telematics modem daily power budget. Wenn OFF, der modem rationiert
+    wake-ups um 12V zu schonen → long poll intervals sind das user-
+    visible symptom. Diagnostic für "if power-budget exhausted →
+    warn 12V check" automations. `isinstance(..., bool)` guard
+    rejected non-bool variants (Python's `isinstance(1, bool) is
+    False` ist hier ein feature).
+  Both VW EU + Audi only; other brands' parsers don't populate
+  these aggregates → fields stay None → kein phantom entity.
+  17 Tests inkl. parser-mirror defensives + entity-registration +
+  9-language coverage.
+  *"Three timers and only one is enabled? Yes, that is mathematically
+  one. I do not need to count higher to know this." — Sheldon Cooper.*
+
 - **Phase 7 PR #1 — Quick-Wins-Batch (4 sensors aus scout-audit)** —
   Scout-Audit (cross-reference `_unexpected_keys.py` ↔ tatsächliche
   parser-reads) identifizierte ~12 fields die silenced waren aber nie

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -264,6 +264,17 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:key-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.2.0 Phase 7 PR #2 — VW EU + Audi telematics modem daily
+    # power budget. When OFF the modem is rationing wake-ups to
+    # preserve 12V → user sees long poll intervals. Diagnostic
+    # category — power-users monitor this to plan a 12V check.
+    VagBinarySensorDescription(
+        key="daily_power_budget_available",
+        translation_key="daily_power_budget_available",
+        data_key="daily_power_budget_available",
+        icon="mdi:battery-clock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.0.0 (Big-Bang) — Porsche TPMS warning aggregate (any corner
     # raising ``warning: true`` in the TIRE_PRESSURE measurement).
     # Brand-restricted via _DATA_PRESENT_REQUIRED below — non-Porsche
@@ -358,6 +369,10 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # v2.2.0 Phase 7 PR #1 — Skoda-only `readiness.ignitionOn`.
     # Other brands leave field None → no phantom entity.
     "ignition_on",
+    # v2.2.0 Phase 7 PR #2 — VW EU + Audi only telematics power-
+    # budget. Other brands' readiness blocks don't ship this leaf →
+    # field stays None → no phantom entity.
+    "daily_power_budget_available",
     # v2.0.0 (Big-Bang) — Porsche-only TPMS warning (PPA TIRE_PRESSURE
     # measurement). Non-Porsche vehicles leave the field None → no phantom.
     "tire_pressure_warning",

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1406,6 +1406,18 @@ class VWEUClient(CariadBaseClient):
 
         # ── Readiness / online ─────────────────────────────────────────────────
         d.is_online = v(raw, "readiness", "readinessStatus", "value", "connectionState", "isOnline") is True
+        # v2.2.0 Phase 7 PR #2 — telematics modem daily power budget.
+        # When False the modem is rationing wake-ups to preserve 12V —
+        # long poll intervals are the user-visible symptom. Surfaced
+        # as binary_sensor so users can build "if power-budget
+        # exhausted → warn" automations. Defensive: only assign when
+        # backend returns a real bool (not None / missing).
+        power_budget = v(
+            raw, "readiness", "readinessStatus", "value",
+            "connectionState", "dailyPowerBudgetAvailable",
+        )
+        if isinstance(power_budget, bool):
+            d.daily_power_budget_available = power_budget
 
         # ── Vehicle health / service ──────────────────────────────────────────
         # ── Warning lights ────────────────────────────────────────────────────
@@ -1493,6 +1505,15 @@ class VWEUClient(CariadBaseClient):
             time_str = timer.get("departureTime", {}).get("time") if timer.get("departureTime") else None
             setattr(d, f"departure_timer_{i}_enabled", enabled)
             setattr(d, f"departure_timer_{i}_time", time_str)
+        # v2.2.0 Phase 7 PR #2 — aggregate count of enabled timers.
+        # Saves users the templating effort of summing 3 separate
+        # binary states. Defensive: only set when the timers list
+        # is actually present (not just empty) — keeps the
+        # phantom-protection gate honest.
+        if timers:
+            d.departure_timer_enabled_count = sum(
+                1 for t in timers if t.get("enabled") is True
+            )
 
         # ── Parking position ──────────────────────────────────────────────────
         # v1.27.1 hotfix: Cariad-BFF ``/vehicle/v1/vehicles/{vin}/parkingposition``

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -575,6 +575,23 @@ class VehicleData:
     # charging want both extremes.
     battery_temp_max: float | None = None
 
+    # v2.2.0 Phase 7 PR #2 — tier-B diagnostics from scout-audit.
+    # Two VW EU + Audi fields that we already PARSE (timers list,
+    # readiness block) but never expose as aggregate / diagnostic.
+
+    # Count of currently-enabled departure timers (0-3). Aggregate of
+    # the per-timer `departure_timer_N_enabled` fields. Saves users
+    # the templating effort of summing 3 binary states. Read from
+    # `departureTimers.departureTimersStatus.value.timers[*].enabled`.
+    departure_timer_enabled_count: int | None = None
+
+    # Telematics modem daily power budget remaining (boolean). When
+    # False, the modem is rationing wake-ups to preserve 12V — long
+    # poll intervals are the user-visible symptom. From
+    # `readiness.readinessStatus.value.connectionState.
+    # dailyPowerBudgetAvailable`.
+    daily_power_budget_available: bool | None = None
+
     # v2.2.0 Phase 2 PR #8/20 — Connect-subscription expiry timestamp.
     # SEAT/CUPRA OLA ``mycar.services`` block exposes a per-service
     # entitlement map. Each entry typically carries either an

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -868,6 +868,17 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=1,
     ),
+    # v2.2.0 Phase 7 PR #2 — VW EU + Audi aggregate count of enabled
+    # departure timers (0-3). Saves users the templating effort of
+    # summing 3 separate binary states. Diagnostic category.
+    VagSensorDescription(
+        key="departure_timer_enabled_count",
+        translation_key="departure_timer_enabled_count",
+        data_key="departure_timer_enabled_count",
+        icon="mdi:counter",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.2.0 Phase 2 PR #11/20 — derived integer days until expiry.
     # Closes the subscription-feature triangle (timestamp + active +
     # days). Negative when expired. Automation-friendly: threshold
@@ -1015,6 +1026,10 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "primary_engine_soc_pct",       # Skoda-only (driving-range)
     "steering_wheel_position",      # Skoda-only (air-conditioning)
     "battery_temp_max",             # VW EU + Audi only (CARIAD-BFF)
+    # v2.2.0 Phase 7 PR #2 — VW EU + Audi only (CARIAD-BFF
+    # departureTimers block). Other brands' parsers don't populate
+    # this aggregate → field stays None → no phantom entity.
+    "departure_timer_enabled_count",
     "next_charging_timer_id",
     "next_charging_timer_target_soc_reachable",
     "capabilities_count",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -304,6 +304,9 @@
       "battery_temp_max": {
         "name": "Battery Temperature (Max)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Departure Timers Enabled"
+      },
       "steering_wheel_position": {
         "name": "Steering Wheel Position"
       },
@@ -425,6 +428,9 @@
       },
       "ignition_on": {
         "name": "Ignition"
+      },
+      "daily_power_budget_available": {
+        "name": "Daily Power Budget Available"
       },
       "tire_pressure_warning": {
         "name": "Tire Pressure Warning"

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -286,6 +286,9 @@
       "battery_temp_max": {
         "name": "Teplota baterie (Max)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Aktivované odjezdové časovače"
+      },
       "steering_wheel_position": {
         "name": "Pozice volantu"
       },
@@ -416,6 +419,9 @@
       },
       "ignition_on": {
         "name": "Zapalování"
+      },
+      "daily_power_budget_available": {
+        "name": "Denní rozpočet energie dostupný"
       },
       "tire_pressure_warning": {
         "name": "Varování Tlaku Pneumatik"

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -286,6 +286,9 @@
       "battery_temp_max": {
         "name": "HV-Batterie Temperatur (Max)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Abfahrtstimer aktiviert"
+      },
       "steering_wheel_position": {
         "name": "Lenkradposition"
       },
@@ -416,6 +419,9 @@
       },
       "ignition_on": {
         "name": "Zündung"
+      },
+      "daily_power_budget_available": {
+        "name": "Tagesenergiebudget verfügbar"
       },
       "tire_pressure_warning": {
         "name": "Reifendruck-Warnung"

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -286,6 +286,9 @@
       "battery_temp_max": {
         "name": "Battery Temperature (Max)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Departure Timers Enabled"
+      },
       "steering_wheel_position": {
         "name": "Steering Wheel Position"
       },
@@ -416,6 +419,9 @@
       },
       "ignition_on": {
         "name": "Ignition"
+      },
+      "daily_power_budget_available": {
+        "name": "Daily Power Budget Available"
       },
       "tire_pressure_warning": {
         "name": "Tire Pressure Warning"

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -286,6 +286,9 @@
       "battery_temp_max": {
         "name": "Temperatura batería (Máx)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Temporizadores de salida activos"
+      },
       "steering_wheel_position": {
         "name": "Posición del volante"
       },
@@ -416,6 +419,9 @@
       },
       "ignition_on": {
         "name": "Encendido"
+      },
+      "daily_power_budget_available": {
+        "name": "Presupuesto diario de energía disponible"
       },
       "tire_pressure_warning": {
         "name": "Aviso de Presión de Neumáticos"

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -286,6 +286,9 @@
       "battery_temp_max": {
         "name": "Température batterie (Max)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Minuteries de départ activées"
+      },
       "steering_wheel_position": {
         "name": "Position du volant"
       },
@@ -416,6 +419,9 @@
       },
       "ignition_on": {
         "name": "Allumage"
+      },
+      "daily_power_budget_available": {
+        "name": "Budget énergétique journalier disponible"
       },
       "tire_pressure_warning": {
         "name": "Alerte Pression Pneus"

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -286,6 +286,9 @@
       "battery_temp_max": {
         "name": "Accutemperatuur (Max)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Vertrektimers ingeschakeld"
+      },
       "steering_wheel_position": {
         "name": "Stuurpositie"
       },
@@ -416,6 +419,9 @@
       },
       "ignition_on": {
         "name": "Contact"
+      },
+      "daily_power_budget_available": {
+        "name": "Dagelijks energiebudget beschikbaar"
       },
       "tire_pressure_warning": {
         "name": "Bandenspanning-Waarschuwing"

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -286,6 +286,9 @@
       "battery_temp_max": {
         "name": "Temperatura akumulatora (Maks)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Aktywne timery odjazdu"
+      },
       "steering_wheel_position": {
         "name": "Położenie kierownicy"
       },
@@ -416,6 +419,9 @@
       },
       "ignition_on": {
         "name": "Zapłon"
+      },
+      "daily_power_budget_available": {
+        "name": "Dzienny budżet energii dostępny"
       },
       "tire_pressure_warning": {
         "name": "Ostrzeżenie Ciśnienia Opon"

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -286,6 +286,9 @@
       "battery_temp_max": {
         "name": "Batteritemperatur (Max)"
       },
+      "departure_timer_enabled_count": {
+        "name": "Aktiva avresetimer"
+      },
       "steering_wheel_position": {
         "name": "Ratt-position"
       },
@@ -416,6 +419,9 @@
       },
       "ignition_on": {
         "name": "Tändning"
+      },
+      "daily_power_budget_available": {
+        "name": "Daglig energibudget tillgänglig"
       },
       "tire_pressure_warning": {
         "name": "Däcktryck Varning"

--- a/tests/test_v220_phase7_vw_diagnostics.py
+++ b/tests/test_v220_phase7_vw_diagnostics.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.0 Phase 7 PR #2 — VW EU/Audi tier-B diagnostics.
+
+Two CARIAD-BFF fields that the parser already READS for adjacent
+features (timers list, readiness block) but never exposes as
+aggregate / diagnostic entities:
+
+| Field | Type | Source path |
+|-------|------|-------------|
+| `departure_timer_enabled_count` | int (0-3) | `departureTimers.departureTimersStatus.value.timers[*].enabled` |
+| `daily_power_budget_available` | bool | `readiness.readinessStatus.value.connectionState.dailyPowerBudgetAvailable` |
+
+Both VW EU + Audi only. Other brands' parsers don't populate these
+aggregates → fields stay None → no phantom entities.
+
+"Three timers and only one is enabled? Yes, that is mathematically
+one. I do not need to count higher to know this." — Sheldon Cooper,
+on aggregate counters
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestModelFields:
+    def test_departure_timer_enabled_count_default(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+
+        d = VehicleData(vin="X")
+        assert hasattr(d, "departure_timer_enabled_count")
+        assert d.departure_timer_enabled_count is None
+
+    def test_daily_power_budget_available_default(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+
+        d = VehicleData(vin="X")
+        assert hasattr(d, "daily_power_budget_available")
+        assert d.daily_power_budget_available is None
+
+
+class TestDepartureTimerCountAggregation:
+    """Mirror of vw_eu.py aggregation — `sum(1 for t if t.enabled is True)`."""
+
+    def _count(self, timers):
+        if not timers:
+            return None  # not set
+        return sum(1 for t in timers if t.get("enabled") is True)
+
+    def test_all_three_enabled(self) -> None:
+        timers = [{"enabled": True}, {"enabled": True}, {"enabled": True}]
+        assert self._count(timers) == 3
+
+    def test_only_first_enabled(self) -> None:
+        timers = [{"enabled": True}, {"enabled": False}, {"enabled": False}]
+        assert self._count(timers) == 1
+
+    def test_none_enabled(self) -> None:
+        timers = [{"enabled": False}, {"enabled": False}, {"enabled": False}]
+        assert self._count(timers) == 0
+
+    def test_empty_list_stays_none(self) -> None:
+        # Critical for phantom protection — empty list means no timer
+        # block was returned at all (likely non-EV brand) — field
+        # must stay None so the gate hides the entity.
+        assert self._count([]) is None
+
+    def test_missing_enabled_key_treated_as_false(self) -> None:
+        # Defensive: backend could omit `enabled` on a malformed timer.
+        # `.get("enabled") is True` returns False → counts as not-enabled.
+        timers = [{"enabled": True}, {"departureTime": "ignored"}]
+        assert self._count(timers) == 1
+
+    def test_string_enabled_treated_as_false(self) -> None:
+        # Defensive: `is True` rejects truthy strings like "ON" — only
+        # the literal boolean True counts.
+        timers = [{"enabled": "true"}, {"enabled": True}]
+        assert self._count(timers) == 1
+
+
+class TestDailyPowerBudgetParser:
+    """`isinstance(..., bool)` guard rejects non-bool variants."""
+
+    def _parse(self, raw_value):
+        # Mirror of the vw_eu.py parser logic
+        if isinstance(raw_value, bool):
+            return raw_value
+        return None
+
+    def test_true_assigned(self) -> None:
+        assert self._parse(True) is True
+
+    def test_false_assigned(self) -> None:
+        assert self._parse(False) is False
+
+    def test_none_stays_none(self) -> None:
+        assert self._parse(None) is None
+
+    def test_string_true_rejected(self) -> None:
+        # Defensive: string variants must NOT trip — only literal bool
+        assert self._parse("true") is None
+        assert self._parse("ON") is None
+
+    def test_int_one_rejected(self) -> None:
+        # Subtle: `isinstance(1, bool)` is False in Python — int 1 is
+        # NOT treated as a bool by isinstance. Good for our guard.
+        assert self._parse(1) is None
+        assert self._parse(0) is None
+
+
+class TestEntityRegistration:
+    def test_daily_power_budget_described(self) -> None:
+        from custom_components.vag_connect.binary_sensor import (
+            BINARY_DESCRIPTIONS,
+        )
+
+        keys = {d.key for d in BINARY_DESCRIPTIONS}
+        assert "daily_power_budget_available" in keys
+
+    def test_daily_power_budget_phantom_gated(self) -> None:
+        from custom_components.vag_connect.binary_sensor import (
+            _DATA_PRESENT_REQUIRED,
+        )
+
+        assert "daily_power_budget_available" in _DATA_PRESENT_REQUIRED
+
+    def test_departure_count_sensor_described(self) -> None:
+        from custom_components.vag_connect.sensor import SENSOR_DESCRIPTIONS
+
+        keys = {d.key for d in SENSOR_DESCRIPTIONS}
+        assert "departure_timer_enabled_count" in keys
+
+    def test_departure_count_sensor_phantom_gated(self) -> None:
+        from custom_components.vag_connect.sensor import (
+            _DATA_PRESENT_REQUIRED,
+        )
+
+        assert "departure_timer_enabled_count" in _DATA_PRESENT_REQUIRED
+
+
+class TestTranslationCoverage:
+    @pytest.mark.parametrize(
+        "lang", ["en", "de", "cs", "sv", "fr", "nl", "es", "pl"]
+    )
+    def test_lang_has_sensor_key(self, lang: str) -> None:
+        import json
+        from pathlib import Path
+
+        path = Path(f"custom_components/vag_connect/translations/{lang}.json")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "departure_timer_enabled_count" in data["entity"]["sensor"]
+
+    @pytest.mark.parametrize(
+        "lang", ["en", "de", "cs", "sv", "fr", "nl", "es", "pl"]
+    )
+    def test_lang_has_binary_sensor_key(self, lang: str) -> None:
+        import json
+        from pathlib import Path
+
+        path = Path(f"custom_components/vag_connect/translations/{lang}.json")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert (
+            "daily_power_budget_available" in data["entity"]["binary_sensor"]
+        )
+
+    def test_strings_json_coverage(self) -> None:
+        import json
+        from pathlib import Path
+
+        data = json.loads(
+            Path("custom_components/vag_connect/strings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert "departure_timer_enabled_count" in data["entity"]["sensor"]
+        assert (
+            "daily_power_budget_available" in data["entity"]["binary_sensor"]
+        )


### PR DESCRIPTION
## Summary

**Second Phase 7 batch.** Two CARIAD-BFF fields the parser already READS for adjacent features (timers list, readiness block) but never exposes as aggregate / diagnostic entities.

## New entities

| Entity | Brand | Source path |
|--------|-------|-------------|
| \`sensor.departure_timer_enabled_count\` | VW EU + Audi | \`departureTimers.departureTimersStatus.value.timers[*].enabled\` |
| \`binary_sensor.daily_power_budget_available\` | VW EU + Audi | \`readiness.readinessStatus.value.connectionState.dailyPowerBudgetAvailable\` |

## Semantic context

- **\`departure_timer_enabled_count\`**: aggregate count (0-3). Saves users the templating effort of summing 3 separate binary states
- **\`daily_power_budget_available\`**: when OFF the telematics modem is rationing wake-ups to preserve 12V → long poll intervals are the user-visible symptom. Power-users monitor this to plan a 12V health check **before** the modem actually goes offline

## Failsafe

- **departure_timer_enabled_count**:
  - Empty timers list → field stays None (NOT 0) → phantom gate hides the entity. Zero-enabled and no-list-at-all are semantically different
  - Counter uses \`t.get(\"enabled\") is True\` — rejects string \"true\" / int 1 / missing key
- **daily_power_budget_available**:
  - \`isinstance(..., bool)\` guard — rejects string \"true\" / int 1 (because \`isinstance(1, bool) is False\` in Python — a feature here)

## Test plan

- [x] 17 test cases:
  - Model fields (2)
  - Departure-timer count aggregation (6 — all/one/none/empty/missing-key/string-rejected)
  - Daily-power-budget parser (5 — true/false/None/string/int rejected)
  - Entity registration (4 — both described + both phantom-gated)
  - Translation coverage (9 — 8 langs × both keys + strings.json)
- [x] \`python -m py_compile\` clean
- [ ] CI green

Marketing: *\"Three timers and only one is enabled? Yes, that is mathematically one. I do not need to count higher to know this.\"* — Sheldon Cooper

🤖 Generated with [Claude Code](https://claude.com/claude-code)