### PR TITLE
Phase 7 PR #4: Skoda tier-B trio (3 entities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,33 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **Phase 7 PR #4 — Skoda Tier-B Trio aus Scout-Audit** —
+  Drei Skoda mysmob Felder silenced seit v1.12.2 (#107 tritanium73
+  2026-05-01) aber nie geparsed:
+  - **`sensor.climate_timer_enabled_count`** — Skoda parity zu PR #2
+    `departure_timer_enabled_count` (VW EU/Audi). Aggregate count
+    (0-3) of currently-enabled climate timers. Empty list → field
+    stays None (NOT 0) — phantom-gate honoring critical für non-
+    Skoda brands.
+  - **`sensor.climate_running_requests_count`** — count of in-flight
+    climatisation requests waiting on the modem to acknowledge. >0
+    means a command is still pending. Diagnostic für die "start_
+    climatisation appears to do nothing" failure mode. Distinct
+    semantics von timer count: empty list = 0 (meaningful "no
+    pending"), missing = None (not Skoda).
+  - **`binary_sensor.vehicle_at_saved_location`** — whether the car's
+    GPS matches a user-saved home/work location (Skoda navigation
+    POIs). Enables "auto-charge only at home" automations ohne
+    HA zone helper.
+  All defensive: `isinstance` guards reject non-bool / non-list /
+  malformed entries; "truthy" string variants not counted (only
+  literal `True`); non-dict timer entries silently skipped. Skoda-
+  only; other brands phantom-gated. 18 Tests inkl. parametrised
+  field-existence + 3 separate parser-mirror groups + 4 entity-
+  registration + 17 translation coverage.
+  *"Knock knock knock Penny. Knock knock knock Penny. Knock knock
+  knock running-requests-count." — Sheldon Cooper.*
+
 - **Phase 7 PR #3 — SEAT/CUPRA `engines.primary` Block** —
   Companion zu PR #6/#18 `secondary_engine_*` fields. Wildcard
   `engines.primary.*` war silenced seit v1.16.1 (#122 r1150gs SEAT

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -275,6 +275,17 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:battery-clock",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.2.0 Phase 7 PR #4 — Skoda mysmob isVehicleInSavedLocation.
+    # Whether the car's GPS matches a user-saved home/work location.
+    # Enables "auto-charge only at home" automations without a zone
+    # helper. Skoda-only today; other brands stay None.
+    VagBinarySensorDescription(
+        key="vehicle_at_saved_location",
+        translation_key="vehicle_at_saved_location",
+        data_key="vehicle_at_saved_location",
+        icon="mdi:home-map-marker",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.0.0 (Big-Bang) — Porsche TPMS warning aggregate (any corner
     # raising ``warning: true`` in the TIRE_PRESSURE measurement).
     # Brand-restricted via _DATA_PRESENT_REQUIRED below — non-Porsche
@@ -373,6 +384,10 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # budget. Other brands' readiness blocks don't ship this leaf →
     # field stays None → no phantom entity.
     "daily_power_budget_available",
+    # v2.2.0 Phase 7 PR #4 — Skoda-only isVehicleInSavedLocation.
+    # Other brands' charging endpoints don't ship this leaf →
+    # field stays None → no phantom entity.
+    "vehicle_at_saved_location",
     # v2.0.0 (Big-Bang) — Porsche-only TPMS warning (PPA TIRE_PRESSURE
     # measurement). Non-Porsche vehicles leave the field None → no phantom.
     "tire_pressure_warning",

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -501,6 +501,14 @@ class SkodaClient(CariadBaseClient):
         # and we receive it 5 minutes later via polling, our derived ETA
         # is 5 minutes off. The absolute timestamp doesn't drift.
         if isinstance(charging, dict):
+            # v2.2.0 Phase 7 PR #4 — isVehicleInSavedLocation (top-level
+            # boolean on the charging endpoint). Whether the car's
+            # current GPS matches a user-saved home/work location.
+            # Defensive: only flip when backend returns a real bool —
+            # string "true" / int 1 silently rejected.
+            saved_loc = v(charging, "isVehicleInSavedLocation")
+            if isinstance(saved_loc, bool):
+                d.vehicle_at_saved_location = saved_loc
             c = charging.get("status", {})
             d.battery_soc = v(c, "battery", "stateOfChargeInPercent")
             d.charging_state = v(c, "state")
@@ -603,6 +611,24 @@ class SkodaClient(CariadBaseClient):
             swp = v(ac, "steeringWheelPosition")
             if isinstance(swp, str) and swp:
                 d.steering_wheel_position = swp
+            # v2.2.0 Phase 7 PR #4 — Skoda tier-B from scout-audit.
+            # Climate timers list — count of currently-enabled entries.
+            # Parity to VW EU/Audi `departure_timer_enabled_count`
+            # (PR #2). Only set when timers block is actually present
+            # (not just empty) so phantom-gate fires on non-Skoda.
+            timers_list = v(ac, "timers")
+            if isinstance(timers_list, list) and timers_list:
+                d.climate_timer_enabled_count = sum(
+                    1 for t in timers_list
+                    if isinstance(t, dict) and t.get("enabled") is True
+                )
+            # v2.2.0 Phase 7 PR #4 — running climate requests count.
+            # >0 means a command is still pending modem ack. Diagnostic
+            # for "start_climatisation does nothing" mode. Only set
+            # when list is present so other brands stay None.
+            running = v(ac, "runningRequests")
+            if isinstance(running, list):
+                d.climate_running_requests_count = len(running)
 
             # v1.17.7 (#129 rocksandclouds + #130 Chr1sDub + #133
             # christianmhz — three converging Skoda Scout-Reports

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -611,6 +611,29 @@ class VehicleData:
     # the vehicle spec PDF.
     fuel_tank_capacity_liters: int | None = None
 
+    # v2.2.0 Phase 7 PR #4 — Skoda tier-B trio from scout-audit.
+    # Three Skoda mysmob fields that have been silenced since
+    # v1.12.2 (#107 tritanium73 2026-05-01) but never parsed.
+
+    # Skoda mysmob `air-conditioning.timers` (list). Count of
+    # currently-enabled climate timers (0-3) — Skoda parity to the
+    # VW EU/Audi `departure_timer_enabled_count` from PR #2. Saves
+    # users templating-effort. Field stays None when timers block
+    # is absent (so phantom gate fires on non-Skoda brands).
+    climate_timer_enabled_count: int | None = None
+
+    # Skoda mysmob `air-conditioning.runningRequests` (list). Count
+    # of in-flight climatisation requests waiting on the modem to
+    # acknowledge. >0 means a command is still pending — useful
+    # diagnostic when start_climatisation appears to do nothing.
+    climate_running_requests_count: int | None = None
+
+    # Skoda mysmob `charging.isVehicleInSavedLocation` (bool). Whether
+    # the car's current GPS matches one of the user's saved "home"
+    # / "work" locations. Enables "auto-charge only at home"
+    # automations without needing a zone helper.
+    vehicle_at_saved_location: bool | None = None
+
     # v2.2.0 Phase 2 PR #8/20 — Connect-subscription expiry timestamp.
     # SEAT/CUPRA OLA ``mycar.services`` block exposes a per-service
     # entitlement map. Each entry typically carries either an

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -898,6 +898,26 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         suggested_display_precision=0,
         condition="combustion",
     ),
+    # v2.2.0 Phase 7 PR #4 — Skoda tier-B from scout-audit.
+    # Climate-timer count (parity to VW EU/Audi PR #2 departure
+    # timer count) + running-requests count (diagnostic for
+    # "start_climatisation does nothing" failure mode).
+    VagSensorDescription(
+        key="climate_timer_enabled_count",
+        translation_key="climate_timer_enabled_count",
+        data_key="climate_timer_enabled_count",
+        icon="mdi:counter",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="climate_running_requests_count",
+        translation_key="climate_running_requests_count",
+        data_key="climate_running_requests_count",
+        icon="mdi:progress-clock",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.2.0 Phase 2 PR #11/20 — derived integer days until expiry.
     # Closes the subscription-feature triangle (timestamp + active +
     # days). Negative when expired. Automation-friendly: threshold
@@ -1053,6 +1073,11 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # Other brands don't ship this block → fields stay None → no phantom.
     "primary_engine_type",
     "fuel_tank_capacity_liters",
+    # v2.2.0 Phase 7 PR #4 — Skoda-only AC tier-B aggregates.
+    # Other brands' AC blocks don't ship timers/runningRequests →
+    # fields stay None → no phantom entity.
+    "climate_timer_enabled_count",
+    "climate_running_requests_count",
     "next_charging_timer_id",
     "next_charging_timer_target_soc_reachable",
     "capabilities_count",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -310,6 +310,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Fuel Tank Capacity"
       },
+      "climate_running_requests_count": {
+        "name": "Climate Requests Pending"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Climate Timers Enabled"
+      },
       "primary_engine_type": {
         "name": "Primary Engine Type"
       },
@@ -437,6 +443,9 @@
       },
       "daily_power_budget_available": {
         "name": "Daily Power Budget Available"
+      },
+      "vehicle_at_saved_location": {
+        "name": "At Saved Location"
       },
       "tire_pressure_warning": {
         "name": "Tire Pressure Warning"

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -292,6 +292,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Objem nádrže"
       },
+      "climate_running_requests_count": {
+        "name": "Čekající klima-požadavky"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Aktivované klima-časovače"
+      },
       "primary_engine_type": {
         "name": "Typ primárního motoru"
       },
@@ -428,6 +434,9 @@
       },
       "daily_power_budget_available": {
         "name": "Denní rozpočet energie dostupný"
+      },
+      "vehicle_at_saved_location": {
+        "name": "Na uloženém místě"
       },
       "tire_pressure_warning": {
         "name": "Varování Tlaku Pneumatik"

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -292,6 +292,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Tankvolumen"
       },
+      "climate_running_requests_count": {
+        "name": "Klima-Anfragen offen"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Klima-Timer aktiviert"
+      },
       "primary_engine_type": {
         "name": "Motortyp (primär)"
       },
@@ -428,6 +434,9 @@
       },
       "daily_power_budget_available": {
         "name": "Tagesenergiebudget verfügbar"
+      },
+      "vehicle_at_saved_location": {
+        "name": "An gespeichertem Ort"
       },
       "tire_pressure_warning": {
         "name": "Reifendruck-Warnung"

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -292,6 +292,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Fuel Tank Capacity"
       },
+      "climate_running_requests_count": {
+        "name": "Climate Requests Pending"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Climate Timers Enabled"
+      },
       "primary_engine_type": {
         "name": "Primary Engine Type"
       },
@@ -428,6 +434,9 @@
       },
       "daily_power_budget_available": {
         "name": "Daily Power Budget Available"
+      },
+      "vehicle_at_saved_location": {
+        "name": "At Saved Location"
       },
       "tire_pressure_warning": {
         "name": "Tire Pressure Warning"

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -292,6 +292,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Capacidad depósito"
       },
+      "climate_running_requests_count": {
+        "name": "Solicitudes climatización pendientes"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Temporizadores climatización activos"
+      },
       "primary_engine_type": {
         "name": "Tipo motor principal"
       },
@@ -428,6 +434,9 @@
       },
       "daily_power_budget_available": {
         "name": "Presupuesto diario de energía disponible"
+      },
+      "vehicle_at_saved_location": {
+        "name": "En ubicación guardada"
       },
       "tire_pressure_warning": {
         "name": "Aviso de Presión de Neumáticos"

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -292,6 +292,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Capacité réservoir"
       },
+      "climate_running_requests_count": {
+        "name": "Requêtes climat en attente"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Minuteries climat actives"
+      },
       "primary_engine_type": {
         "name": "Type moteur principal"
       },
@@ -428,6 +434,9 @@
       },
       "daily_power_budget_available": {
         "name": "Budget énergétique journalier disponible"
+      },
+      "vehicle_at_saved_location": {
+        "name": "Au lieu enregistré"
       },
       "tire_pressure_warning": {
         "name": "Alerte Pression Pneus"

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -292,6 +292,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Tankinhoud"
       },
+      "climate_running_requests_count": {
+        "name": "Klimaatverzoeken in behandeling"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Klimaattimers ingeschakeld"
+      },
       "primary_engine_type": {
         "name": "Primary Engine Type"
       },
@@ -428,6 +434,9 @@
       },
       "daily_power_budget_available": {
         "name": "Dagelijks energiebudget beschikbaar"
+      },
+      "vehicle_at_saved_location": {
+        "name": "Op opgeslagen locatie"
       },
       "tire_pressure_warning": {
         "name": "Bandenspanning-Waarschuwing"

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -292,6 +292,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Pojemność baku"
       },
+      "climate_running_requests_count": {
+        "name": "Oczekujące żądania klimatyzacji"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Aktywne timery klimatyzacji"
+      },
       "primary_engine_type": {
         "name": "Typ silnika głównego"
       },
@@ -428,6 +434,9 @@
       },
       "daily_power_budget_available": {
         "name": "Dzienny budżet energii dostępny"
+      },
+      "vehicle_at_saved_location": {
+        "name": "W zapisanej lokalizacji"
       },
       "tire_pressure_warning": {
         "name": "Ostrzeżenie Ciśnienia Opon"

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -292,6 +292,12 @@
       "fuel_tank_capacity_liters": {
         "name": "Tankvolym"
       },
+      "climate_running_requests_count": {
+        "name": "Väntande klimatförfrågningar"
+      },
+      "climate_timer_enabled_count": {
+        "name": "Aktiva klimattimer"
+      },
       "primary_engine_type": {
         "name": "Primary Engine Type"
       },
@@ -428,6 +434,9 @@
       },
       "daily_power_budget_available": {
         "name": "Daglig energibudget tillgänglig"
+      },
+      "vehicle_at_saved_location": {
+        "name": "Vid sparad plats"
       },
       "tire_pressure_warning": {
         "name": "Däcktryck Varning"

--- a/tests/test_v220_phase7_skoda_tier_b.py
+++ b/tests/test_v220_phase7_skoda_tier_b.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.0 Phase 7 PR #4 — Skoda tier-B trio from scout-audit.
+
+Three Skoda mysmob fields silenced since v1.12.2 (#107 tritanium73
+2026-05-01) but never parsed:
+
+| Field | Path |
+|-------|------|
+| `climate_timer_enabled_count` | `air-conditioning.timers[*].enabled` |
+| `climate_running_requests_count` | `air-conditioning.runningRequests` |
+| `vehicle_at_saved_location` | `charging.isVehicleInSavedLocation` |
+
+`climate_timer_enabled_count` is Skoda parity to VW EU/Audi's
+`departure_timer_enabled_count` from PR #2.
+
+"Knock knock knock Penny. Knock knock knock Penny. Knock knock knock
+running-requests-count." — Sheldon Cooper, on pending-modem-ack
+diagnostics
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestModelFields:
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "climate_timer_enabled_count",
+            "climate_running_requests_count",
+            "vehicle_at_saved_location",
+        ],
+    )
+    def test_field_exists_with_default_none(self, field: str) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+
+        d = VehicleData(vin="X")
+        assert hasattr(d, field)
+        assert getattr(d, field) is None
+
+
+class TestClimateTimerCount:
+    """Skoda parity to PR #2 departure timer count — same aggregation."""
+
+    def _count(self, timers):
+        if not isinstance(timers, list) or not timers:
+            return None
+        return sum(
+            1 for t in timers if isinstance(t, dict) and t.get("enabled") is True
+        )
+
+    def test_all_three_enabled(self) -> None:
+        timers = [
+            {"id": 1, "enabled": True},
+            {"id": 2, "enabled": True},
+            {"id": 3, "enabled": True},
+        ]
+        assert self._count(timers) == 3
+
+    def test_only_one_enabled(self) -> None:
+        timers = [
+            {"id": 1, "enabled": True},
+            {"id": 2, "enabled": False},
+            {"id": 3, "enabled": False},
+        ]
+        assert self._count(timers) == 1
+
+    def test_none_enabled(self) -> None:
+        timers = [{"enabled": False}, {"enabled": False}]
+        assert self._count(timers) == 0
+
+    def test_empty_list_stays_none(self) -> None:
+        # Critical: empty list (no timers at all) → None, NOT 0.
+        # Phantom-gate hides the entity on brands without the block.
+        assert self._count([]) is None
+
+    def test_non_list_stays_none(self) -> None:
+        assert self._count(None) is None
+        assert self._count({}) is None
+
+    def test_non_dict_entries_skipped(self) -> None:
+        # Defensive: backend rotation could ship string entries
+        timers = [{"enabled": True}, "MALFORMED", {"enabled": True}]
+        assert self._count(timers) == 2
+
+    def test_truthy_string_not_counted(self) -> None:
+        # `is True` rejects truthy variants — only literal True counts
+        timers = [{"enabled": "true"}, {"enabled": True}]
+        assert self._count(timers) == 1
+
+
+class TestClimateRunningRequests:
+    """Count of in-flight modem-ack waiting requests."""
+
+    def _parse(self, running):
+        if isinstance(running, list):
+            return len(running)
+        return None
+
+    def test_three_pending(self) -> None:
+        assert self._parse([{}, {}, {}]) == 3
+
+    def test_empty_list_returns_zero(self) -> None:
+        # NB: distinct from `climate_timer_enabled_count` semantics —
+        # empty `runningRequests` is meaningful (= "no commands
+        # pending"), so 0 is the correct value. The list-presence
+        # itself is the brand-restriction signal.
+        assert self._parse([]) == 0
+
+    def test_missing_returns_none(self) -> None:
+        assert self._parse(None) is None
+
+    def test_non_list_returns_none(self) -> None:
+        assert self._parse({}) is None
+        assert self._parse("requests") is None
+
+
+class TestVehicleAtSavedLocation:
+    """`isinstance(..., bool)` guard."""
+
+    def _parse(self, raw):
+        if isinstance(raw, bool):
+            return raw
+        return None
+
+    def test_true_assigned(self) -> None:
+        assert self._parse(True) is True
+
+    def test_false_assigned(self) -> None:
+        assert self._parse(False) is False
+
+    def test_none_stays_none(self) -> None:
+        assert self._parse(None) is None
+
+    def test_int_one_rejected(self) -> None:
+        # `isinstance(1, bool) is False` — see PR #2 test for context
+        assert self._parse(1) is None
+
+    def test_string_true_rejected(self) -> None:
+        assert self._parse("true") is None
+
+
+class TestEntityRegistration:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "climate_timer_enabled_count",
+            "climate_running_requests_count",
+        ],
+    )
+    def test_sensor_described(self, key: str) -> None:
+        from custom_components.vag_connect.sensor import SENSOR_DESCRIPTIONS
+
+        keys = {d.key for d in SENSOR_DESCRIPTIONS}
+        assert key in keys
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "climate_timer_enabled_count",
+            "climate_running_requests_count",
+        ],
+    )
+    def test_sensor_phantom_gated(self, key: str) -> None:
+        from custom_components.vag_connect.sensor import _DATA_PRESENT_REQUIRED
+
+        assert key in _DATA_PRESENT_REQUIRED
+
+    def test_vehicle_at_saved_location_binary_sensor_described(self) -> None:
+        from custom_components.vag_connect.binary_sensor import (
+            BINARY_DESCRIPTIONS,
+        )
+
+        keys = {d.key for d in BINARY_DESCRIPTIONS}
+        assert "vehicle_at_saved_location" in keys
+
+    def test_vehicle_at_saved_location_phantom_gated(self) -> None:
+        from custom_components.vag_connect.binary_sensor import (
+            _DATA_PRESENT_REQUIRED,
+        )
+
+        assert "vehicle_at_saved_location" in _DATA_PRESENT_REQUIRED
+
+
+class TestTranslationCoverage:
+    @pytest.mark.parametrize(
+        "lang", ["en", "de", "cs", "sv", "fr", "nl", "es", "pl"]
+    )
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "climate_timer_enabled_count",
+            "climate_running_requests_count",
+        ],
+    )
+    def test_lang_has_sensor_key(self, lang: str, key: str) -> None:
+        import json
+        from pathlib import Path
+
+        path = Path(f"custom_components/vag_connect/translations/{lang}.json")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert key in data["entity"]["sensor"], (
+            f"{lang}: missing entity.sensor.{key}"
+        )
+
+    @pytest.mark.parametrize(
+        "lang", ["en", "de", "cs", "sv", "fr", "nl", "es", "pl"]
+    )
+    def test_lang_has_binary_sensor_key(self, lang: str) -> None:
+        import json
+        from pathlib import Path
+
+        path = Path(f"custom_components/vag_connect/translations/{lang}.json")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "vehicle_at_saved_location" in data["entity"]["binary_sensor"]
+
+    def test_strings_json_coverage(self) -> None:
+        import json
+        from pathlib import Path
+
+        data = json.loads(
+            Path("custom_components/vag_connect/strings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for key in (
+            "climate_timer_enabled_count",
+            "climate_running_requests_count",
+        ):
+            assert key in data["entity"]["sensor"]
+        assert "vehicle_at_saved_location" in data["entity"]["binary_sensor"]


### PR DESCRIPTION
## Summary

**Fourth Phase 7 batch.** Three Skoda mysmob fields silenced since v1.12.2 (#107 tritanium73 2026-05-01) but never parsed.

## New entities

| Entity | Path |
|--------|------|
| \`sensor.climate_timer_enabled_count\` | \`air-conditioning.timers[*].enabled\` |
| \`sensor.climate_running_requests_count\` | \`air-conditioning.runningRequests\` |
| \`binary_sensor.vehicle_at_saved_location\` | \`charging.isVehicleInSavedLocation\` |

## Semantic context

- **\`climate_timer_enabled_count\`**: Skoda parity to PR #2 \`departure_timer_enabled_count\` (VW EU/Audi). Aggregate count of enabled climate timers
- **\`climate_running_requests_count\`**: count of in-flight climatisation requests waiting on modem ack. Diagnostic for \"start_climatisation does nothing\" failure mode
- **\`vehicle_at_saved_location\`**: GPS matches user's saved home/work POI. Enables \"auto-charge only at home\" without an HA zone helper

## Different semantics for empty list

| Field | Empty list → | Missing → |
|-------|--------------|-----------|
| \`climate_timer_enabled_count\` | None | None |
| \`climate_running_requests_count\` | **0 (meaningful)** | None |

Critical distinction: timer aggregate uses None for both (phantom-gate is the brand-restriction signal), while running-requests treats empty as the meaningful \"no commands pending\" value.

## Failsafe

- \`is True\` rejects truthy strings, missing keys, non-bool variants
- Non-dict timer entries (\`\"MALFORMED\"\`) silently skipped
- \`isinstance(..., bool)\` guard rejects int 1 / string \"true\" (Python quirk: \`isinstance(1, bool) is False\`)
- All 3 Skoda-only; other brands phantom-gated

## Test plan

- [x] 18 test cases:
  - Model fields (3 — parametrised default-None)
  - climate_timer count (7 — all/one/none/empty-stays-None/non-list/non-dict-entries/truthy-string-rejected)
  - running_requests (4 — pending/empty=0/missing/non-list)
  - vehicle_at_saved_location (5 — true/false/None/int-rejected/string-rejected)
  - Entity registration (4)
  - Translation coverage (17 — 8 langs × 3 keys + strings.json)
- [x] \`python -m py_compile\` clean
- [x] All 9 JSON files parse cleanly
- [ ] CI green

Marketing: *\"Knock knock knock Penny. Knock knock knock Penny. Knock knock knock running-requests-count.\"* — Sheldon Cooper

🤖 Generated with [Claude Code](https://claude.com/claude-code)