### PR TITLE
v2.2.0 final: Legen wait for it dary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,10 +85,22 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > - Coverage stayed >74% throughout (gate at 65%)
 > - Cross-brand parity tests catch any future drift
 
+## [2.2.0] — 2026-05-17 — "Legen — wait for it — dary" (Final)
+
+> v2.2.0 final ships **byte-additive** to v2.2.0-rc1 — just one manifest
+> version-string bump plus the 5 Phase-7 patches that landed during the
+> rc1 beta window. Phase 7 is **pure additive**: 11 new diagnostic
+> entities (all brand-restricted + phantom-protected — zero risk to
+> existing users) plus 38 new scout-silencing entries closing #245
+> (systemic Cariad-BFF per-block `.error` container rollout).
+>
+> Phase 7 sweep — scout-audit cross-references `_unexpected_keys.py`
+> against actual parser-reads to identify silenced-but-unwired fields.
+> 4 entity-batches + 1 pre-release silencing patch.
+
 ## [Unreleased]
 
-> Post-v2.2.0-rc1. Phase 7 sweep — expose silenced-but-unwired scout fields
-> as HA entities. First batch of quick wins; more in subsequent PRs.
+> (Empty — next entries land here after v2.2.0 graduation.)
 
 ### Added
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.2.0-rc1"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
## Summary

**v2.2.0 final.** Manifest bump 2.2.0-rc1 → 2.2.0. Byte-additive to rc1 modulo the 5 Phase-7 patches that landed during the rc1 beta window.

## What's new since v2.2.0-rc1

Phase 7 sweep — scout-audit cross-references \`_unexpected_keys.py\` against actual parser-reads to identify silenced-but-unwired fields.

| PR | Entities added | Brands |
|----|---------------|--------|
| #242 | 4 (ignition_on, primary_engine_soc_pct, steering_wheel_position, battery_temp_max) | Skoda + VW EU/Audi |
| #243 | 2 (departure_timer_enabled_count, daily_power_budget_available) | VW EU/Audi |
| #244 | 2 (primary_engine_type, fuel_tank_capacity_liters) | SEAT/CUPRA |
| #246 | 3 (climate_timer_enabled_count, climate_running_requests_count, vehicle_at_saved_location) | Skoda |
| #247 | 0 (silencing-only) — 38 new EXPECTED_KEYS entries closing #245 | VW EU/Audi |

**Total: 11 new diagnostic entities across 4 brands** — all brand-restricted at parser level + phantom-protected. Zero risk to existing users.

## Promotion criteria (all met)

- [x] v2.2.0-rc1 in HACS pre-release channel since 2026-05-16
- [x] 0 P0 issues filed against rc1
- [x] 0 P0 issues filed against the 4 Phase-7 entity PRs
- [x] Scout #245 silenced before reaching production users (#247 pre-release patch)
- [x] No new auth-failure clusters

Marketing: *\"Suit up. It's time.\"* — Barney Stinson

🤖 Generated with [Claude Code](https://claude.com/claude-code)