### PR TITLE
Phase 8 PR #5 (v2.2.1): car_type cross-brand derivation helper — 6/6 brand coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,35 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **Phase 8 PR #5 — `car_type` cross-brand derivation helper** —
+  **Different pattern als PR #1-#4.** Statt parser-hooks pro backend
+  zu erweitern, addet diese PR einen single derivation-helper der
+  am Ende jedes brand parsers fires. Füllt `d.car_type` für backends
+  die kein direct field shippen (CUPRA/SEAT OLA, Porsche PPA, VW NA
+  Kombi). Hybrid + electric + diesel + gasoline ableitbar aus
+  `has_battery` + `has_combustion` + `primary_engine_type`.
+
+  **Critical contract**: NEVER overwrites a directly-read value.
+  Skoda + VW EU/Audi (haben direct backend field) bleiben unverändert;
+  CUPRA/SEAT/Porsche/VW NA bekommen den derived value. Wired in
+  ALLEN 5 brand parsers als end-of-parse fallback (no-op wenn
+  direct read schon succeeded, populiert wenn nicht).
+
+  **Cross-brand coverage matrix nach diesem PR**:
+  - `car_type`: vorher 3 brands (Skoda + VW EU + Audi) → jetzt
+    **alle 6 brands** (alle Cariad + OLA + PPA + Kombi)
+  - **6/6 brand coverage** für ein previously-unwired field —
+    pure derivation, zero backend changes nötig
+
+  Derivation rules: hybrid > electric > diesel > gasoline; unknown
+  engine type (CNG/LPG/H2) → bleibt None (don't guess). 22 Tests
+  inkl. never-overwrite contract + end-to-end real-world scenarios
+  (Cupra Born EV, Formentor PHEV, Porsche Taycan/Cayenne diesel +
+  e-Hybrid, VW NA ID.4).
+  *"Statistically speaking, given enough booleans, even a chimpanzee
+  could derive whether the car is electric, hybrid, or combustion."
+  — Sheldon Cooper.*
+
 - **Phase 8 PR #4 — VW EU/Audi `primary_engine_fuel_level_pct` mirror** —
   Pure cross-brand expansion. Skoda hatte das field seit Phase 8 PR #1
   heute (von `driving-range.primaryEngineRange.currentFuelLevelInPercent`).

--- a/custom_components/vag_connect/cariad/_util.py
+++ b/custom_components/vag_connect/cariad/_util.py
@@ -423,3 +423,52 @@ def compute_connection_state(
     if age_s < _CONNECTION_STANDBY_THRESHOLD_S:
         return "standby", latest_ts
     return "offline", latest_ts
+
+
+# v2.2.1 Phase 8 PR #5 — cross-brand `car_type` derivation helper.
+#
+# Skoda (Phase 8 PR #1) and VW EU/Audi (Phase 8 PR #2) read `car_type`
+# directly from the backend (`driving-range.carType` / `measurements.
+# fuelLevelStatus.value.carType`). CUPRA/SEAT, Porsche, VW NA don't
+# expose a direct field — but we can DERIVE it from the existing
+# parsed data (`has_battery`, `has_combustion`, `primary_engine_type`).
+#
+# Derivation rules (order matters):
+#   1. has_battery + has_combustion → "hybrid"
+#   2. has_battery only → "electric"
+#   3. has_combustion only → derive from primary_engine_type:
+#      "DIESEL" / "diesel" → "diesel"
+#      "PETROL" / "GASOLINE" / "gasoline" → "gasoline"
+#      anything else → leave None (don't guess)
+#   4. neither flag set → leave None (insufficient signal)
+#
+# Defensive: NEVER overwrites a directly-read value. Only assigns
+# when `d.car_type` is currently None. This way Skoda/VW EU/Audi
+# users keep their authoritative backend value; CUPRA/SEAT/Porsche/
+# VW NA users get the derived value.
+def derive_car_type_if_missing(d: Any) -> None:
+    """Cross-brand `car_type` derivation. Assigns ``d.car_type`` only
+    when currently None; never overwrites a directly-read value.
+
+    Safe to call at the end of any brand parser — pure-function on
+    already-populated dataclass fields, never raises.
+    """
+    if getattr(d, "car_type", None) is not None:
+        return  # already set by direct backend read — don't overwrite
+    has_bat = bool(getattr(d, "has_battery", False))
+    has_comb = bool(getattr(d, "has_combustion", False))
+    if has_bat and has_comb:
+        d.car_type = "hybrid"
+        return
+    if has_bat:
+        d.car_type = "electric"
+        return
+    if has_comb:
+        pet = (getattr(d, "primary_engine_type", None) or "").lower()
+        if "diesel" in pet:
+            d.car_type = "diesel"
+        elif "petrol" in pet or "gasoline" in pet:
+            d.car_type = "gasoline"
+        # else: don't guess (could be CNG/LPG/H2 etc — wait for
+        # explicit backend field or scout report)
+    # neither flag set: insufficient signal, leave None

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -227,6 +227,14 @@ class PorscheClient:
                     for c in ("frontLeft", "frontRight", "rearLeft", "rearRight")
                 )
 
+        # v2.2.1 Phase 8 PR #5 — cross-brand car_type derivation.
+        # Porsche PPA doesn't ship a direct `carType` enum — derive
+        # from has_battery + has_combustion (already set above from
+        # `VEHICLE.engine` BEV/PHEV/COMBUSTION). Never overwrites.
+        from .._util import derive_car_type_if_missing  # noqa: PLC0415
+
+        derive_car_type_if_missing(d)
+
         return d
 
     async def get_capabilities(self, vin: str) -> dict[str, Any]:  # noqa: ARG002

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -775,6 +775,15 @@ class SeatCupraClient(CariadBaseClient):
         d.is_electric = d.has_battery and not d.has_combustion
         d.is_hybrid = d.has_battery and d.has_combustion
 
+        # v2.2.1 Phase 8 PR #5 — cross-brand car_type derivation.
+        # CUPRA/SEAT OLA doesn't ship a direct `carType` field —
+        # derive from has_battery + has_combustion + primary_engine_type.
+        # Never overwrites a directly-read value (would be no-op if
+        # OLA ever ships the field — defensive forward-compat).
+        from .._util import derive_car_type_if_missing  # noqa: PLC0415
+
+        derive_car_type_if_missing(d)
+
         # ── carCapturedTimestamp → connection_state (v1.8.12 Multi-Brand) ────
         # OLA backend returns ``carCapturedTimestamp`` on multiple
         # sub-responses (verified live in

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -895,6 +895,17 @@ class SkodaClient(CariadBaseClient):
             if isinstance(cls, str) and cls:
                 d.driving_score_class = cls
 
+        # v2.2.1 Phase 8 PR #5 — cross-brand car_type derivation fallback.
+        # Skoda already reads `driving-range.carType` directly (Phase 8
+        # PR #1), so this is a NO-OP for Skoda users with the standard
+        # response shape. The helper only fires if the direct read
+        # returned None (e.g. older firmware or rotated schema) — gives
+        # those Skoda users a derived car_type from has_battery +
+        # has_combustion + primary_engine_type.
+        from .._util import derive_car_type_if_missing  # noqa: PLC0415
+
+        derive_car_type_if_missing(d)
+
         return d
 
     # ── Static info enrichment (v1.20.0 Bundle 2 Phase A) ───────────────────

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1608,4 +1608,14 @@ class VWEUClient(CariadBaseClient):
                 if isinstance(addr_block.get("city"), str):
                     d.parking_city = addr_block["city"]
 
+        # v2.2.1 Phase 8 PR #5 — cross-brand car_type derivation
+        # fallback. VW EU already reads `carType` directly from
+        # `fuelStatus` or `measurements` (Phase 8 PR #2), so this is
+        # a NO-OP when the backend ships the field. Fires only on
+        # rotated/missing-field firmware to give those users a
+        # derived value. Audi inherits this automatically.
+        from .._util import derive_car_type_if_missing  # noqa: PLC0415
+
+        derive_car_type_if_missing(d)
+
         return d

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -199,6 +199,14 @@ class VWNAClient:
 
         d.is_electric    = d.has_battery and not d.has_combustion
         d.is_hybrid      = d.has_battery and d.has_combustion
+
+        # v2.2.1 Phase 8 PR #5 — cross-brand car_type derivation.
+        # VW NA Kombi doesn't ship a direct `carType` enum — derive
+        # from has_battery + has_combustion. Never overwrites.
+        from .._util import derive_car_type_if_missing  # noqa: PLC0415
+
+        derive_car_type_if_missing(d)
+
         return d
 
     async def get_capabilities(self, vin: str) -> dict[str, Any]:  # noqa: ARG002

--- a/tests/test_v221_phase8_pr5_car_type_derivation.py
+++ b/tests/test_v221_phase8_pr5_car_type_derivation.py
@@ -1,0 +1,300 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.1 Phase 8 PR #5 — cross-brand car_type derivation helper.
+
+**Different pattern from PR #1-#4.** Instead of expanding parser
+hooks per backend, this adds a single derivation helper that fires
+at the end of every brand parser. Fills `d.car_type` for backends
+that don't expose a direct field (CUPRA/SEAT, Porsche, VW NA).
+
+Derivation rules (order matters):
+  1. has_battery + has_combustion → "hybrid"
+  2. has_battery only → "electric"
+  3. has_combustion only → derive from primary_engine_type:
+     - DIESEL → "diesel"
+     - PETROL / GASOLINE → "gasoline"
+     - anything else → leave None (don't guess)
+  4. neither flag set → leave None (insufficient signal)
+
+**Critical contract**: NEVER overwrites a directly-read value.
+Skoda + VW EU/Audi keep their authoritative backend reads;
+CUPRA/SEAT/Porsche/VW NA get the derived value.
+
+"Statistically speaking, given enough booleans, even a chimpanzee
+could derive whether the car is electric, hybrid, or combustion."
+— Sheldon Cooper, on engine-type inference
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _make_vehicle(**kwargs):
+    """Builder for a VehicleData with only the fields we care about."""
+    from custom_components.vag_connect.cariad.models import VehicleData
+
+    d = VehicleData(vin="X")
+    for key, value in kwargs.items():
+        setattr(d, key, value)
+    return d
+
+
+class TestNeverOverwriteDirectRead:
+    """Critical contract: if car_type is already set, helper is no-op."""
+
+    def test_already_set_diesel_preserved(self) -> None:
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(
+            car_type="diesel",
+            has_battery=True,
+            has_combustion=True,
+            primary_engine_type="PETROL",
+        )
+        derive_car_type_if_missing(d)
+        # Stayed diesel despite has_battery+has_combustion=hybrid
+        # derivation rule — direct read wins.
+        assert d.car_type == "diesel"
+
+    def test_already_set_hybrid_preserved(self) -> None:
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(
+            car_type="hybrid", has_battery=False, has_combustion=True
+        )
+        derive_car_type_if_missing(d)
+        assert d.car_type == "hybrid"
+
+    def test_empty_string_overwritten(self) -> None:
+        # Edge case: if a parser accidentally assigned empty string
+        # (not None), the helper SHOULD treat it as missing — wait,
+        # actually the helper checks `is not None`, so empty string
+        # WOULD be preserved. Document the behaviour.
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(
+            car_type="", has_battery=True, has_combustion=False
+        )
+        derive_car_type_if_missing(d)
+        # Empty string is NOT None, so it's preserved (by contract).
+        # Parsers must use `if isinstance(s, str) and s:` guard to
+        # avoid assigning empty strings (they all do).
+        assert d.car_type == ""
+
+
+class TestHybridDerivation:
+    def test_battery_plus_combustion_yields_hybrid(self) -> None:
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(has_battery=True, has_combustion=True)
+        derive_car_type_if_missing(d)
+        assert d.car_type == "hybrid"
+
+    def test_battery_plus_combustion_ignores_engine_type(self) -> None:
+        # Hybrid rule has precedence over the combustion-only path
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(
+            has_battery=True,
+            has_combustion=True,
+            primary_engine_type="DIESEL",
+        )
+        derive_car_type_if_missing(d)
+        assert d.car_type == "hybrid"
+
+
+class TestElectricDerivation:
+    def test_battery_only_yields_electric(self) -> None:
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(has_battery=True, has_combustion=False)
+        derive_car_type_if_missing(d)
+        assert d.car_type == "electric"
+
+
+class TestCombustionDerivation:
+    def test_diesel_uppercase(self) -> None:
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(
+            has_battery=False,
+            has_combustion=True,
+            primary_engine_type="DIESEL",
+        )
+        derive_car_type_if_missing(d)
+        assert d.car_type == "diesel"
+
+    def test_petrol_yields_gasoline(self) -> None:
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(
+            has_battery=False,
+            has_combustion=True,
+            primary_engine_type="PETROL",
+        )
+        derive_car_type_if_missing(d)
+        assert d.car_type == "gasoline"
+
+    def test_gasoline_yields_gasoline(self) -> None:
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(
+            has_battery=False,
+            has_combustion=True,
+            primary_engine_type="gasoline",
+        )
+        derive_car_type_if_missing(d)
+        assert d.car_type == "gasoline"
+
+    def test_unknown_engine_type_leaves_none(self) -> None:
+        # CNG / LPG / H2 etc — don't guess, wait for explicit
+        # backend field or scout report
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(
+            has_battery=False,
+            has_combustion=True,
+            primary_engine_type="CNG",
+        )
+        derive_car_type_if_missing(d)
+        assert d.car_type is None
+
+    def test_no_engine_type_with_combustion_leaves_none(self) -> None:
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(has_battery=False, has_combustion=True)
+        derive_car_type_if_missing(d)
+        assert d.car_type is None
+
+
+class TestInsufficientSignal:
+    def test_neither_flag_set_stays_none(self) -> None:
+        # Parser hasn't determined drivetrain at all (e.g. backend
+        # didn't ship battery_soc or engine block on a stale poll)
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(has_battery=False, has_combustion=False)
+        derive_car_type_if_missing(d)
+        assert d.car_type is None
+
+
+class TestSafeOnAnyInputShape:
+    """Helper must never raise — pure-function defensiveness."""
+
+    def test_missing_attributes_safe(self) -> None:
+        # VehicleData missing some attributes (defensive
+        # getattr with defaults in the helper)
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        class _Bare:
+            pass
+
+        d = _Bare()
+        # Should not raise; just no-op (car_type not even an attribute)
+        derive_car_type_if_missing(d)
+
+
+class TestBrandParserWiring:
+    """All 5 parser modules now call the helper at end-of-parse."""
+
+    @pytest.mark.parametrize(
+        "module_name",
+        [
+            "skoda",
+            "vw_eu",
+            "seat_cupra",
+            "porsche",
+            "vw_na",
+        ],
+    )
+    def test_parser_calls_derive_helper(self, module_name: str) -> None:
+        import importlib
+        import inspect
+
+        mod = importlib.import_module(
+            f"custom_components.vag_connect.cariad.api.{module_name}"
+        )
+        src = inspect.getsource(mod)
+        assert "derive_car_type_if_missing" in src, (
+            f"{module_name}: parser doesn't call derive_car_type_if_missing"
+        )
+
+
+class TestEndToEndDerivationExamples:
+    """Mirror real-world scenarios end-to-end through the helper."""
+
+    def _derive(self, **kwargs):
+        from custom_components.vag_connect.cariad._util import (
+            derive_car_type_if_missing,
+        )
+
+        d = _make_vehicle(**kwargs)
+        derive_car_type_if_missing(d)
+        return d.car_type
+
+    def test_cupra_born_ev_only(self) -> None:
+        # Born MY26: has_battery=True, has_combustion=False
+        assert self._derive(has_battery=True, has_combustion=False) == "electric"
+
+    def test_cupra_formentor_phev(self) -> None:
+        # Formentor e-Hybrid: both
+        assert (
+            self._derive(
+                has_battery=True,
+                has_combustion=True,
+                primary_engine_type="PETROL",
+            )
+            == "hybrid"
+        )
+
+    def test_porsche_taycan_ev_only(self) -> None:
+        assert self._derive(has_battery=True, has_combustion=False) == "electric"
+
+    def test_porsche_cayenne_diesel(self) -> None:
+        assert (
+            self._derive(
+                has_battery=False,
+                has_combustion=True,
+                primary_engine_type="DIESEL",
+            )
+            == "diesel"
+        )
+
+    def test_porsche_cayenne_e_hybrid(self) -> None:
+        assert (
+            self._derive(
+                has_battery=True,
+                has_combustion=True,
+                primary_engine_type="PETROL",
+            )
+            == "hybrid"
+        )
+
+    def test_vw_na_id4_ev_only(self) -> None:
+        assert self._derive(has_battery=True, has_combustion=False) == "electric"


### PR DESCRIPTION
## Summary

**Different pattern from PR #1-#4.** Instead of expanding parser hooks per backend, this PR adds a single derivation helper that fires at the end of every brand parser. Fills \`d.car_type\` for backends that don't expose a direct field.

## Derivation rules (order matters)

1. \`has_battery\` + \`has_combustion\` → \`\"hybrid\"\`
2. \`has_battery\` only → \`\"electric\"\`
3. \`has_combustion\` only → derive from \`primary_engine_type\`:
   - DIESEL → \`\"diesel\"\`
   - PETROL / GASOLINE → \`\"gasoline\"\`
   - anything else (CNG/LPG/H2) → leave None (don't guess)
4. neither flag set → leave None (insufficient signal)

## Critical contract: never overwrite a direct read

The helper checks \`if d.car_type is not None: return\`. Skoda (Phase 8 PR #1) and VW EU/Audi (Phase 8 PR #2) already read \`car_type\` from authoritative backend fields — those stay unchanged. CUPRA/SEAT/Porsche/VW NA get the derived value.

## Cross-brand coverage matrix after this PR

| Field | Before | After |
|-------|--------|-------|
| \`car_type\` | 3 brands (Skoda + VW EU + Audi) | **6/6 brands** (all of them) |

**6/6 brand coverage for a previously-unwired field** — pure derivation, zero backend changes needed.

## Implementation

- Helper \`derive_car_type_if_missing(d)\` in \`cariad/_util.py\` (defensive \`getattr\` chain, never raises)
- Wired in all 5 brand parsers as end-of-parse fallback:
  - \`skoda.py\` + \`vw_eu.py\` (no-op when direct read succeeded — defensive forward-compat)
  - \`seat_cupra.py\` + \`porsche.py\` + \`vw_na.py\` (always fires)

## Test plan

- [x] 22 test cases:
  - Never-overwrite contract (3)
  - Hybrid derivation (2 — both flags + hybrid-precedence)
  - Electric derivation (1)
  - Combustion derivation (5 — diesel/petrol/gasoline/unknown-CNG/no-engine-type)
  - Insufficient signal (1)
  - Safe-on-any-input (1)
  - Brand parser wiring (5 — parametrised)
  - End-to-end scenarios (5 — Cupra Born, Formentor PHEV, Taycan, Cayenne diesel, Cayenne e-Hybrid, ID.4)
- [x] \`python -m py_compile\` clean on all 6 touched files + test
- [ ] CI green

Marketing: *\"Statistically speaking, given enough booleans, even a chimpanzee could derive whether the car is electric, hybrid, or combustion.\"* — Sheldon Cooper

🤖 Generated with [Claude Code](https://claude.com/claude-code)