### PR TITLE
v2.2.1 final: Phase 8 alles parsen + cross-brand expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,17 +98,26 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > against actual parser-reads to identify silenced-but-unwired fields.
 > 4 entity-batches + 1 pre-release silencing patch.
 
-## [Unreleased] — v2.2.1 (Phase 8 "alles parsen statt silencen")
+## [2.2.1] — 2026-05-17 — Phase 8 "alles parsen statt silencen" + Cross-Brand Expansion
 
 > **Strategic shift (2026-05-17 post-v2.2.0):** Statt scout-fields zu
 > silencen wenn der walker sie reportet, wird jeder Field mit klarem
-> semantischen Wert als HA-entity geparsed. *"Wenn ein field es wert
-> ist silenced zu werden, ist es wert geparsed zu werden."* — User-
-> Direktive nach v2.2.0 stable release.
+> semantischen Wert als HA-entity geparsed UND auf alle applicable
+> brands cross-checked. *"Wenn ein field es wert ist silenced zu
+> werden, ist es wert geparsed zu werden. Und wenn 1 user es auf
+> 1 brand reportet, profitieren alle brands wo das equivalent
+> existiert."* — User-Direktive nach v2.2.0 stable release.
 >
-> Phase 8 ist die direkte Konsequenz dieses Shifts: reverse-audit der
-> EXPECTED_KEYS table zeigt 11+ silenced-but-unwired fields mit clear
-> business value. Diese werden in Batches als entities gewired.
+> **Phase 8 tier-A complete**: 5 PRs merged auf top of v2.2.0.
+> 11 new diagnostic entities + 4 cross-brand expansions + **erstes
+> 6/6 brand coverage** durch derivation-helper-pattern. Zero
+> behaviour changes für existing users (pure-additive, alle
+> phantom-protected). Tier-B (wildcards + alarm/siren) deferred
+> until tester scout-dumps liefern die unknown leaf-shapes.
+
+## [Unreleased]
+
+> (Empty)
 
 ### Added
 
@@ -248,10 +257,6 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   variants. 20+ Tests inkl. cross-brand-reuse regression-shield.
   *"Why have a key on the keyring if you never use it?"
   — Lisa Simpson.*
-
-## [Unreleased-Below-2.2.1]
-
-> (Empty)
 
 ### Added
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.2.0"
+  "version": "2.2.1"
 }


### PR DESCRIPTION
## Summary

**v2.2.1 final.** Manifest bump 2.2.0 → 2.2.1. Ships the 5 Phase-8 PRs merged in the day after v2.2.0 stable.

## Strategic shift (2026-05-17)

User directive post-v2.2.0: *\"silencer hat noch nicht mit dem parser nachgezogen — nichts mehr silencen und alles parsen\"*. And: *\"1 user reportet auf 1 brand → eventually alle brands wo das equivalent existiert profitieren\"*.

## 5 PRs since v2.2.0

| PR | Pattern | Net change |
|----|---------|------------|
| #250 | New entities + cross-brand reuse | Skoda: 5 entities; \`primary_engine_type\` 1→3 brands |
| #251 | Cross-brand parser hook | Engine-metadata 4 fields → VW EU + Audi |
| #252 | Cross-brand parser hook | Range-split → Porsche (5-brand coverage) |
| #253 | Walker refactor | \`primary_engine_fuel_level_pct\` → 3 brands |
| #254 | Derivation helper | \`car_type\` → **6/6 brand coverage** (first ever) |

## Failsafe

- Every PR pure-additive — zero behaviour changes for existing users
- All new entities phantom-protected via \`_DATA_PRESENT_REQUIRED\`
- All cross-brand expansions use defensive multi-variant key spellings
- Derivation helper NEVER overwrites direct-read values (contract enforced by test)
- 4 brand-coverage matrix regression-shields catch any future drift

## Test plan

- [x] All 5 Phase 8 PRs had clean CI + individual merge verification
- [x] Cross-brand matrix tests prevent regression
- [x] 0 P0 issues against v2.2.0 in the 24h since stable release
- [ ] CI green on this release PR

Marketing: *\"Suit up, Phase 8 is shipped. And by 'shipped' I mean HACS-distributed across 6 backends with parity.\"* — Barney Stinson

🤖 Generated with [Claude Code](https://claude.com/claude-code)