### PR TITLE
Closes #248: climatisationTimers cross-brand expansion (VW EU/Audi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,11 +115,35 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > phantom-protected). Tier-B (wildcards + alarm/siren) deferred
 > until tester scout-dumps liefern die unknown leaf-shapes.
 
-## [Unreleased]
-
-> (Empty)
+## [Unreleased] — v2.2.2
 
 ### Added
+
+- **`climate_timer_enabled_count` cross-brand expansion to VW EU/Audi
+  (Closes #248)** — Skoda hatte das field seit Phase 7 PR #4 (scout
+  silenced-but-unwired audit). VW EU/Audi `climatisationTimers.
+  climatisationTimersStatus.value.timers[*]` mirrors das departureTimers-
+  pattern aus Phase 7 PR #2 aber war nie geparsed. Dieser PR wires
+  die parser hook für VW EU/Audi mit defensive guards (list-check
+  + isinstance dict + is True comparison).
+  
+  **Cross-brand coverage matrix**: `climate_timer_enabled_count`
+  vorher 1 brand (Skoda) → jetzt **3 brands** (Skoda + VW EU + Audi).
+  
+  **Background von #248 (arvcer scout-report 2026-05-17)**: alle 4
+  reported fields waren bereits silenced+parsed in main seit
+  v1.17.5/v1.19.3. 3 von 4 fields populating dataclass-fields
+  (`next_charging_timer_id`, `next_charging_timer_target_soc_reachable`,
+  `secondary_engine_type`). Das 4. (`climatisationTimers.
+  climatisationTimersStatus.value` — silenced container `{2 keys}`)
+  ist jetzt aktiv geparsed via dieser cross-brand expansion. Defensive:
+  assumption ist mirror of departureTimers shape; wenn actual leaves
+  differ, list-check guard hält das field None (phantom-gate honest).
+  10 Tests inkl. aggregation-defensiveness + cross-brand parity
+  regression-shield. **Closes #248**.
+  *"Two timers? Well, that's twice the timer." — Sheldon Cooper.*
+
+## [2.2.1] — 2026-05-17 — Phase 8 "alles parsen statt silencen" + Cross-Brand Expansion (continued)
 
 - **Phase 8 PR #5 — `car_type` cross-brand derivation helper** —
   **Different pattern als PR #1-#4.** Statt parser-hooks pro backend

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1566,6 +1566,26 @@ class VWEUClient(CariadBaseClient):
                 1 for t in timers if t.get("enabled") is True
             )
 
+        # v2.2.2 cross-brand expansion (#248 arvcer scout — climatisation
+        # Timers reported as silenced-but-unwired). Mirror of departure
+        # timers shape: `climatisationTimers.climatisationTimersStatus.
+        # value.timers[*]`. Populates `d.climate_timer_enabled_count`
+        # which Skoda already has from Phase 7 PR #4. VW EU/Audi parity.
+        # Defensive: shape unverified per scout reporting `{2 keys}`
+        # — assumption is mirror of departureTimers (timers + carCaptured
+        # Timestamp). If the actual leaves differ on production, the
+        # list-check guard keeps the field None (no false-positive
+        # zero count) — phantom-gate stays honest.
+        clim_timers: list[dict[str, Any]] = v(
+            raw, "climatisationTimers", "climatisationTimersStatus",
+            "value", "timers",
+        ) or []
+        if clim_timers:
+            d.climate_timer_enabled_count = sum(
+                1 for t in clim_timers
+                if isinstance(t, dict) and t.get("enabled") is True
+            )
+
         # ── Parking position ──────────────────────────────────────────────────
         # v1.27.1 hotfix: Cariad-BFF ``/vehicle/v1/vehicles/{vin}/parkingposition``
         # returns ``{"data": {"lat": ..., "lon": ..., "carCapturedTimestamp": ...}}``.

--- a/tests/test_v222_climatisation_timers_crossbrand.py
+++ b/tests/test_v222_climatisation_timers_crossbrand.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.2 — VW EU/Audi climatisationTimers cross-brand expansion.
+
+Triggered by Scout #248 (arvcer, 2026-05-17). The 4 reported paths
+were already silenced+parsed in main since v1.17.5/v1.19.3 (arvcer's
+installation is on an older version). 3 of 4 fields are actively
+populating dataclass fields; the 4th (`climatisationTimers.
+climatisationTimersStatus.value`) was a silenced container with
+2-key shape but never drilled.
+
+This PR mirrors the existing `departureTimers` parser pattern
+(Phase 7 PR #2) for climatisationTimers, populating the existing
+`climate_timer_enabled_count` field (cross-brand from Skoda PR #4
+Phase 7) on VW EU + Audi.
+
+Defensive: shape unverified per scout `{2 keys}`. Assumption is
+mirror of departureTimers (timers list + carCapturedTimestamp).
+If actual leaves differ, list-check guard keeps field None
+(phantom-gate honest, no false-positive zero count).
+
+"Two timers? Well, that's twice the timer." — Sheldon Cooper.
+"""
+
+from __future__ import annotations
+
+
+class TestClimatisationTimerCountAggregation:
+    """Mirror of vw_eu.py climatisationTimers walker."""
+
+    def _count(self, timers):
+        if not timers:
+            return None
+        return sum(
+            1 for t in timers if isinstance(t, dict) and t.get("enabled") is True
+        )
+
+    def test_all_three_enabled(self) -> None:
+        timers = [{"enabled": True}, {"enabled": True}, {"enabled": True}]
+        assert self._count(timers) == 3
+
+    def test_only_one_enabled(self) -> None:
+        timers = [{"enabled": True}, {"enabled": False}]
+        assert self._count(timers) == 1
+
+    def test_none_enabled(self) -> None:
+        assert self._count([{"enabled": False}, {"enabled": False}]) == 0
+
+    def test_empty_list_stays_none(self) -> None:
+        # Critical: phantom-gate fires on non-PHEV non-EV that doesn't
+        # ship the climate timers block at all
+        assert self._count([]) is None
+
+    def test_non_dict_entries_safely_skipped(self) -> None:
+        # Defensive: backend rotation might ship string entries
+        timers = [{"enabled": True}, "MALFORMED", {"enabled": True}]
+        assert self._count(timers) == 2
+
+    def test_truthy_string_not_counted(self) -> None:
+        # is True rejects "true" / 1 — only literal bool
+        timers = [{"enabled": "true"}, {"enabled": True}]
+        assert self._count(timers) == 1
+
+
+class TestVWEuClimatisationParserWiring:
+    """Source-level checks for the new wiring."""
+
+    def _source(self) -> str:
+        import inspect
+
+        from custom_components.vag_connect.cariad.api import vw_eu
+
+        return inspect.getsource(vw_eu)
+
+    def test_climatisation_timers_read(self) -> None:
+        src = self._source()
+        assert 'v(\n            raw, "climatisationTimers"' in src or (
+            '"climatisationTimers"' in src
+            and '"climatisationTimersStatus"' in src
+        )
+
+    def test_climate_timer_count_assigned(self) -> None:
+        src = self._source()
+        assert "d.climate_timer_enabled_count" in src
+
+
+class TestCrossBrandReuse:
+    """`climate_timer_enabled_count` from Phase 7 PR #4 (Skoda).
+    This PR adds VW EU/Audi parser hook — same dataclass field,
+    expanded brand coverage. No new entity description, no new
+    translation needed."""
+
+    def test_existing_dataclass_field(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+
+        d = VehicleData(vin="X")
+        assert hasattr(d, "climate_timer_enabled_count")
+
+    def test_sensor_description_unchanged(self) -> None:
+        from custom_components.vag_connect.sensor import SENSOR_DESCRIPTIONS
+
+        keys = {d.key for d in SENSOR_DESCRIPTIONS}
+        assert "climate_timer_enabled_count" in keys
+
+    def test_phantom_gate_still_applies(self) -> None:
+        from custom_components.vag_connect.sensor import _DATA_PRESENT_REQUIRED
+
+        assert "climate_timer_enabled_count" in _DATA_PRESENT_REQUIRED
+
+
+class TestBrandCoverageMatrix:
+    """After this PR, climate_timer_enabled_count is populated by
+    at least 2 brand parsers (Skoda + VW EU/Audi)."""
+
+    def test_skoda_parser_assigns_field(self) -> None:
+        import inspect
+
+        from custom_components.vag_connect.cariad.api import skoda
+
+        assert "climate_timer_enabled_count" in inspect.getsource(skoda)
+
+    def test_vw_eu_parser_assigns_field(self) -> None:
+        import inspect
+
+        from custom_components.vag_connect.cariad.api import vw_eu
+
+        assert "climate_timer_enabled_count" in inspect.getsource(vw_eu)


### PR DESCRIPTION
## Summary

Scout #248 from @arvcer reported 4 fields. Investigation revealed **3 of 4 were already silenced+parsed in main** since v1.17.5/v1.19.3.

The 4th — \`climatisationTimers.climatisationTimersStatus.value\` silenced container with \`{2 keys}\` shape — was never drilled. This PR wires it as **cross-brand expansion** of the existing Skoda \`climate_timer_enabled_count\` field (Phase 7 PR #4).

## Status of all 4 fields from #248

| Path | Status |
|------|--------|
| \`automation.chargingProfiles.value.nextChargingTimer.id\` | ✓ already wired → \`next_charging_timer_id\` |
| \`automation.chargingProfiles.value.nextChargingTimer.targetSOCreachable\` | ✓ already wired → \`next_charging_timer_target_soc_reachable\` |
| \`measurements.fuelLevelStatus.value.secondaryEngineType\` | ✓ wired in PR #251 today → \`secondary_engine_type\` |
| \`climatisationTimers.climatisationTimersStatus.value\` | **✓ NOW WIRED via this PR** → \`climate_timer_enabled_count\` |

## Cross-brand expansion

| Field | Before | After |
|-------|--------|-------|
| \`climate_timer_enabled_count\` | 1 brand (Skoda) | **3 brands** (+ VW EU + Audi) |

## Failsafe

- Shape unverified per scout \`{2 keys}\` — assumption is mirror of departureTimers (timers list + carCapturedTimestamp). If actual leaves differ, list-check guard keeps field None (phantom-gate honest)
- \`isinstance(t, dict)\` rejects malformed entries
- \`is True\` comparison rejects truthy strings / int 1

## Test plan

- [x] 10 test cases:
  - Aggregation defensiveness (6)
  - VW EU parser wiring (2)
  - Cross-brand reuse regression-shield (3)
  - Brand-coverage matrix regression (2)
- [x] \`python -m py_compile\` clean
- [ ] CI green

**Closes #248.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)