### PR TITLE
docs: dedicated dashboards.md + FAQ entry across 8 README langs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,21 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ### Added
 
+- **`docs/dashboards.md` — dedicated dashboard troubleshooting + Lovelace
+  card guide** — community Q&A came up (FB group): user trying to add
+  VAG Connect entities to existing dashboard view via "Add to Dashboard"
+  hit classic HA YAML-vs-Storage confusion. Multi-week recurring question
+  → dedicated docs page deserves it. Covers: 3-cause troubleshooting für
+  "Add to Dashboard" picker-not-showing-view (YAML-mode dashboards / view
+  not created yet / Sections-layout quirks), workarounds für jede cause,
+  dedizierte VAG Connect Lovelace-Karte status (BETA — currently has
+  Mercedes-style background being redesigned), 3rd-party card empfehlungen,
+  entity-ID discovery, **per-version feature matrix für v2.2.0 + v2.2.1
+  entity additions**. Plus FAQ.md neue section + FAQ-table-row in DE/EN
+  READMEs + dashboards.md link in allen 6 anderen language READMEs (fr,
+  es, nl, pl, cs, sv). 8 README files + FAQ + new dashboards.md =
+  pure-docs PR, no code changes.
+
 - **`climate_timer_enabled_count` cross-brand expansion to VW EU/Audi
   (Closes #248)** — Skoda hatte das field seit Phase 7 PR #4 (scout
   silenced-but-unwired audit). VW EU/Audi `climatisationTimers.

--- a/README.cs.md
+++ b/README.cs.md
@@ -168,6 +168,7 @@ Aby GPS poloha, stav vozidla a topení fungovaly, musí být **"Sdílet mou polo
 
 - 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — kompletní P0/P1/P2/P3 priorizace všech otevřených issues
 - 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + architektonické rozhodnutí + externí source-refs
+- 🎨 Průvodce Dashboards + Lovelace karta BETA: [`docs/dashboards.md`](docs/dashboards.md) — řešení problémů s „Přidat na panel" + dedikovaná Lovelace karta (BETA)
 - 🤝 Session Handoff (pro přispěvatele a AI nástroje): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
 - 🔒 Pravidla soukromí a zacházení s daty: sekce [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
 - 📋 FAQ Subscription / Service Plus / diagnóza `missing-capability`: FAQ sekce v [`CONTRIBUTING.md`](CONTRIBUTING.md)

--- a/README.en.md
+++ b/README.en.md
@@ -201,7 +201,7 @@ data:
 response_variable: result
 ```
 
-More examples in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md).
+More examples in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md). Dashboard troubleshooting + dedicated VAG Connect Lovelace card (BETA): [`docs/dashboards.md`](docs/dashboards.md).
 
 ---
 
@@ -214,6 +214,7 @@ More examples in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md).
 | **What if Tank-% is missing on Golf 7 GTE?** | v1.25.0 added MBB VSR Phase 2 read-side fallback. See [Golf 7 GTE Tank Guide](docs/GOLF_7_GTE_TANK_GUIDE.md). |
 | **Token survives HACS update?** | ✅ yes, since v1.19.2 — token persistence via HA `Store` (no re-login after updates). |
 | **How do I report bugs?** | HA → Integration → 🔧 Repair → Bug Report. Diagnostics are anonymised (VINs masked, GPS rounded, tokens stripped). |
+| **"Add to Dashboard" doesn't show my dashboard / view?** | Most common cause: dashboard is in **YAML mode** (only Storage-mode dashboards appear in the picker). Or the view doesn't exist yet. Full guide + dedicated VAG Connect Lovelace card (BETA): [`docs/dashboards.md`](docs/dashboards.md). |
 
 Full FAQ in [`docs/FAQ.md`](docs/FAQ.md).
 

--- a/README.es.md
+++ b/README.es.md
@@ -168,6 +168,7 @@ Para que la posición GPS, el estado del vehículo y la calefacción estacionari
 
 - 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — priorización P0/P1/P2/P3 completa de todos los issues abiertos
 - 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — por release: mapeos de campos + decisiones de arquitectura + refs a fuentes externas
+- 🎨 Guía Dashboards + tarjeta Lovelace BETA: [`docs/dashboards.md`](docs/dashboards.md) — solución de problemas "Añadir al panel" + tarjeta Lovelace dedicada (BETA)
 - 🤝 Session Handoff (para colaboradores y herramientas IA): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
 - 🔒 Reglas de privacidad y manejo de datos: sección [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
 - 📋 FAQ Subscription / Service Plus / diagnóstico `missing-capability`: sección FAQ de [`CONTRIBUTING.md`](CONTRIBUTING.md)

--- a/README.fr.md
+++ b/README.fr.md
@@ -168,6 +168,7 @@ Pour que la position GPS, le statut véhicule et le préchauffage fonctionnent, 
 
 - 🗺️ Roadmap : [`docs/ROADMAP.md`](docs/ROADMAP.md) — priorisation P0/P1/P2/P3 complète de tous les issues ouverts
 - 📜 Tech Changelog : [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — par release : mappings de champs + décisions d'architecture + refs sources externes
+- 🎨 Guide Dashboards + carte Lovelace BETA : [`docs/dashboards.md`](docs/dashboards.md) — "Ajouter au tableau de bord" troubleshooting + carte Lovelace dédiée (BETA)
 - 🤝 Session Handoff (pour contributeurs & outils IA) : [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
 - 🔒 Règles de confidentialité & gestion des données : section [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
 - 📋 FAQ Subscription / Service Plus / diagnostic `missing-capability` : section FAQ de [`CONTRIBUTING.md`](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ Mehr Beispiele in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md).
 | **Was wenn Tank-% bei Golf 7 GTE fehlt?** | v1.25.0 hat MBB VSR Phase 2 read-side fallback. Siehe [Golf 7 GTE Tank-Guide](docs/GOLF_7_GTE_TANK_GUIDE.md). |
 | **Token bleibt nach HACS-Update?** | ✅ ja, seit v1.19.2 — Token-Persistence via HA `Store` (kein Re-Login mehr nach Updates). |
 | **Wie melde ich Bugs?** | HA → Integration → 🔧 Reparieren → Bug-Report. Diagnostics werden anonymisiert (VINs gemaskt, GPS gerundet, Tokens gestrippt). |
+| **„Zu Dashboard hinzufügen" zeigt mein Dashboard / meine Ansicht nicht?** | Häufigste Ursache: dein Dashboard ist im **YAML-Modus** (nur Storage-Mode-Dashboards erscheinen im Picker). Oder die Ansicht existiert noch nicht. Full guide + dedizierte VAG-Connect Lovelace-Karte (BETA): [`docs/dashboards.md`](docs/dashboards.md). |
 
-Vollständige FAQ in [`docs/FAQ.md`](docs/FAQ.md).
+Vollständige FAQ in [`docs/FAQ.md`](docs/FAQ.md). Dashboard-Troubleshooting + dedizierte Lovelace-Karte (BETA): [`docs/dashboards.md`](docs/dashboards.md).
 
 ---
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -168,6 +168,7 @@ Voor GPS-positie, voertuigstatus en standkachel moet **"Locatie delen"** ingesch
 
 - 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — volledige P0/P1/P2/P3 prioritisering van alle openstaande issues
 - 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + architectuur-beslissingen + externe source-refs
+- 🎨 Dashboards-gids + Lovelace-kaart BETA: [`docs/dashboards.md`](docs/dashboards.md) — "Toevoegen aan dashboard" troubleshooting + dedicated Lovelace-kaart (BETA)
 - 🤝 Session Handoff (voor bijdragers & AI-tools): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
 - 🔒 Privacy & data handling regels: [`CONTRIBUTING.md`](CONTRIBUTING.md) sectie (post-#53 third-party review)
 - 📋 FAQ Subscription / Service Plus / `missing-capability` diagnose: [`CONTRIBUTING.md`](CONTRIBUTING.md) FAQ-sectie

--- a/README.pl.md
+++ b/README.pl.md
@@ -168,6 +168,7 @@ Aby pozycja GPS, status pojazdu i ogrzewanie postojowe działały, **"Udostępni
 
 - 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — pełna priorytyzacja P0/P1/P2/P3 wszystkich otwartych issues
 - 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: mapowania pól + decyzje architektoniczne + refy do zewnętrznych źródeł
+- 🎨 Przewodnik Dashboards + karta Lovelace BETA: [`docs/dashboards.md`](docs/dashboards.md) — rozwiązywanie problemów "Dodaj do panelu" + dedykowana karta Lovelace (BETA)
 - 🤝 Session Handoff (dla współtwórców i narzędzi AI): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
 - 🔒 Zasady prywatności i obsługi danych: sekcja [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
 - 📋 FAQ Subscription / Service Plus / diagnoza `missing-capability`: sekcja FAQ w [`CONTRIBUTING.md`](CONTRIBUTING.md)

--- a/README.sv.md
+++ b/README.sv.md
@@ -168,6 +168,7 @@ För att GPS-position, fordonsstatus och kupévärmare ska fungera måste **"Del
 
 - 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — komplett P0/P1/P2/P3-prioritering av alla öppna issues
 - 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + arkitekturbeslut + externa source-refs
+- 🎨 Dashboards-guide + Lovelace-kort BETA: [`docs/dashboards.md`](docs/dashboards.md) — "Lägg till på instrumentpanel" felsökning + dedikerat Lovelace-kort (BETA)
 - 🤝 Session Handoff (för bidragsgivare och AI-verktyg): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
 - 🔒 Integritets- och datahanteringsregler: sektion [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
 - 📋 FAQ Subscription / Service Plus / `missing-capability` diagnos: FAQ-sektion i [`CONTRIBUTING.md`](CONTRIBUTING.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -337,8 +337,36 @@ Static data wird 24h gecached — kein Quota-Burn pro Poll.
 
 ---
 
+## 🎨 Dashboards — "Add to Dashboard" doesn't show my view
+
+Most-common HA UI stumble — you're not doing anything wrong, the
+picker just hides certain dashboards. Three usual causes:
+
+1. **Dashboard is in YAML-mode** (most common): the `Add to
+   Dashboard` flow only writes to **Storage-mode** dashboards.
+   Check *Settings → Dashboards* — column "Mode" shows YAML vs
+   Storage. YAML dashboards need manual `entities: - sensor.foo`
+   edits in the YAML file.
+2. **View doesn't exist yet**: HA only lists already-created
+   views. Create an empty view first (Dashboard → pencil → "+
+   Add View" → save), then retry.
+3. **HA 2024+ "Sections" layout view**: occasionally rejects the
+   quick-add workflow. Workaround: go into the view, edit-mode,
+   "+ Add Card" → pick the entity manually.
+
+Quickest workaround if nothing helps: navigate to the view, edit
+mode, "+ Add Card" → "Entities" → filter `vag_connect` or your
+VIN-last-6 to find your sensors.
+
+Full guide + dedicated VAG Connect Lovelace card (BETA — in
+testing, currently still has a Mercedes-style background that's
+being redesigned): [`docs/dashboards.md`](dashboards.md).
+
+---
+
 ## 📚 Where to find more details
 
+- **Dashboard troubleshooting + Lovelace cards:** `docs/dashboards.md`
 - **Per-brand technical detail:** `docs/CHANGELOG_TECHNICAL.md`
 - **Future roadmap + planned releases:** `docs/ROADMAP.md`
 - **Pre-implementation research:** `docs/research/`

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,217 @@
+# Dashboard Guide — VAG Connect entities in Home Assistant Lovelace
+
+> Audience: end-users who already have VAG Connect installed and want
+> to surface the entities on a Lovelace dashboard. Covers the most
+> frequent "Add to Dashboard does nothing" troubleshooting plus the
+> dedicated VAG Connect Lovelace card.
+
+---
+
+## 🎯 Quick start — add an entity to an existing view
+
+If you just want to drop a sensor onto a card you already have:
+
+1. Open the view you want
+2. Click the **pencil** (Edit Dashboard) in the top-right corner
+3. Click **+ Add Card** → pick the card type (Entities, Glance,
+   Gauge, Sensor)
+4. Search for your VAG entity by VIN (last 6 chars) or
+   `vag_connect` substring
+
+If you went via **Settings → Devices → VAG Connect → \[entity\] →
+Add to Dashboard** instead and your target view didn't appear, see
+the next section.
+
+---
+
+## ❓ "Add to Dashboard" doesn't show my view
+
+`Add to Dashboard` is a Home Assistant feature that opens a picker
+listing all eligible dashboards + views. There are three common
+reasons your existing view doesn't appear:
+
+### Reason 1 — Dashboard is YAML-mode (most common)
+
+`Add to Dashboard` only writes into **Storage-mode** dashboards
+(UI-editable). If your dashboard is maintained via
+`configuration.yaml` or `dashboards/*.yaml` files, HA cannot inject
+new cards into it — the picker hides those dashboards.
+
+**Check:**
+- *Settings → Dashboards*
+- Look at the **Mode** column for your dashboard
+- `Storage` = UI-editable → will appear in the picker
+- `YAML` = manual file-based → will NOT appear
+
+**Workaround for YAML dashboards:** add the entity reference
+manually to the YAML file. Example for an Entities card:
+
+```yaml
+type: entities
+entities:
+  - sensor.audi_q4_battery_soc
+  - sensor.audi_q4_range_km
+  - sensor.audi_q4_charging_state
+```
+
+### Reason 2 — The target view doesn't exist yet
+
+HA's picker only lists **already-created** views. If you see your
+dashboard but no sub-views, you need to create the empty view first:
+
+1. Open the dashboard
+2. Click the **pencil** (Edit) top-right
+3. Click **+ Add View** (the `+` tab next to your existing views)
+4. Save the empty view
+5. Re-try **Add to Dashboard** — the new view will now appear
+
+### Reason 3 — View uses the new "Sections" layout (HA 2024+)
+
+The newer Sections layout sometimes refuses cards added via the
+quick-workflow. Workaround:
+
+1. Navigate to the view
+2. Edit Mode (pencil top-right) → **+ Add Card**
+3. Select the entity manually from the picker
+
+---
+
+## 🎨 Dedicated VAG Connect Lovelace Card (BETA)
+
+We maintain a separate Lovelace card optimised for VAG Connect:
+
+**Repo:** https://github.com/its-me-prash/vag-connect-cards
+
+### Status (as of v2.2.x)
+
+- ✅ **Functional:** PHEV-range-triple, charging-state badge,
+  connection-state indicator, vehicle-render display all work
+- ⚠️ **Cosmetic — BETA:** the card currently ships with a
+  **Mercedes-style background** because the original design
+  inspiration came from a Mercedes HA card. **VAG-themed redesign
+  is in progress** — purely cosmetic, no functional impact
+- 🧪 **Iterating UX:** feedback drives the design direction; please
+  open issues on the card repo with screenshots if something
+  doesn't look right
+
+### Install
+
+1. HACS → Frontend (or Integrations on older HACS)
+2. **+ Explore & Add Repositories** → search `vag-connect-cards`
+3. If not yet listed: **Custom Repositories** → paste
+   `https://github.com/its-me-prash/vag-connect-cards` → Category:
+   Plugin → Add
+4. Install + restart HA
+5. Add to a Lovelace view via **+ Add Card → Custom: VAG Vehicle
+   Card** (or via YAML — see card-repo README)
+
+### When NOT to use the dedicated card
+
+- You want a single-purpose tile (just charge %, just range) →
+  use stock Gauge / Sensor cards
+- You're on a strict-policy install that disallows custom cards →
+  stock cards work everywhere
+- You want full UX-customisation freedom → use Mushroom + templates
+
+### Issues / Feature Requests
+
+Card-specific issues go to the card repo:
+https://github.com/its-me-prash/vag-connect-cards/issues
+
+Integration-specific issues (sensors missing, wrong values, etc.)
+stay here on the integration repo.
+
+---
+
+## 🧱 Useful 3rd-party cards with VAG Connect
+
+The integration exposes `extra_state_attributes.image_url` on the
+device-tracker + image entities, so generic vehicle cards pick it
+up automatically:
+
+- **[Ultra-Vehicle-Card](https://github.com/WJDDesigns/Ultra-Vehicle-Card)** —
+  full-featured visual dashboard card
+- **[vehicle-info-card](https://github.com/ngocjohn/vehicle-info-card)** —
+  Mercedes-MBUX-style layout (works with VAG entities too)
+- **[Mushroom](https://github.com/piitaya/lovelace-mushroom)** —
+  template cards for compact mobile-friendly tiles
+- **[card-mod](https://github.com/thomasloven/lovelace-card-mod)** —
+  style any other card with custom CSS
+- **[button-card](https://github.com/custom-cards/button-card)** —
+  custom action buttons (Lock, Unlock, Start Climate)
+
+Examples in [`docs/lovelace-example.yaml`](lovelace-example.yaml).
+
+---
+
+## 🔍 Finding the entity IDs you want
+
+VAG Connect entity-IDs follow the pattern:
+
+```
+<platform>.<vehicle_nickname_or_vin>_<field>
+```
+
+Examples (for a vehicle named "Q4 e-tron"):
+
+```
+sensor.q4_e_tron_battery_soc
+sensor.q4_e_tron_range_km
+sensor.q4_e_tron_charging_state
+binary_sensor.q4_e_tron_doors_locked
+device_tracker.q4_e_tron
+image.q4_e_tron
+button.q4_e_tron_start_climatisation
+lock.q4_e_tron_central_locking
+```
+
+**Quickest way to discover them:**
+
+1. *Developer Tools → States* (left sidebar bottom)
+2. Filter: `vag_connect` (or your nickname / VIN-last-6)
+3. Copy the `entity_id` column
+
+---
+
+## 📦 Per-version feature highlights (what's available where)
+
+| HA Entity | Since | Brands |
+|---|---|---|
+| `binary_sensor.doors_locked` | v1.0.0 | All 6 |
+| `binary_sensor.ignition_on` | v2.2.0 | Skoda |
+| `binary_sensor.daily_power_budget_available` | v2.2.0 | VW EU + Audi |
+| `binary_sensor.subscription_active` | v2.2.0 | SEAT/CUPRA + VW EU + Audi |
+| `binary_sensor.vehicle_at_saved_location` | v2.2.0 | Skoda |
+| `binary_sensor.battery_protection_limit_on` | v2.2.1 | Skoda |
+| `sensor.subscription_expiry_at` | v2.2.0 | SEAT/CUPRA + VW EU + Audi |
+| `sensor.subscription_days_remaining` | v2.2.0 | SEAT/CUPRA + VW EU + Audi |
+| `sensor.car_type` | v2.2.1 | **all 6 brands** (derived cross-brand) |
+| `sensor.primary_engine_type` | v2.2.0–v2.2.1 | All 4 Cariad + CUPRA/SEAT |
+| `sensor.secondary_engine_type` | v2.2.0–v2.2.1 | Skoda + CUPRA/SEAT + VW EU + Audi |
+| `sensor.electric_range_km` | v1.10.0 + v2.2.1 (Porsche) | 5 brands |
+| `sensor.combustion_range_km` | v1.10.0 + v2.2.1 (Porsche) | 5 brands |
+| `sensor.battery_temp_max` | v2.2.0 | VW EU + Audi |
+| `sensor.steering_wheel_position` | v2.2.0 | Skoda |
+| `sensor.climate_timer_enabled_count` | v2.2.0 + v2.2.2 (VW EU/Audi) | Skoda + VW EU + Audi |
+| `sensor.departure_timer_enabled_count` | v2.2.0 | VW EU + Audi |
+
+Many entities are **phantom-protected** — they only appear if your
+specific vehicle's backend actually publishes that field. If you
+don't see one of the diagnostic sensors above, it usually means
+your model / firmware doesn't ship that data.
+
+---
+
+## 🆘 Still stuck?
+
+- Check [`docs/FAQ.md`](FAQ.md) for general installation +
+  configuration questions
+- Open a [Discussion](https://github.com/its-me-prash/vag-connect-ha/discussions)
+  if you're unsure whether it's a bug or a config issue
+- Open an [Issue](https://github.com/its-me-prash/vag-connect-ha/issues)
+  with the **HA version**, **integration version**, and your
+  **dashboard mode** (Storage / YAML) — saves a back-and-forth round
+
+---
+
+*Last updated: 2026-05-17 (v2.2.1 + v2.2.2 in-flight)*


### PR DESCRIPTION
## Summary

Community Q&A came up (FB group): user trying to add VAG Connect entities to an existing dashboard view via \"Add to Dashboard\" — the picker didn't show their view, classic HA YAML-vs-Storage confusion. Multi-week recurring question — needs proper docs.

## What's added

- **\`docs/dashboards.md\`** (new) — comprehensive guide covering:
  - Quick-start: how to add entities to an existing view
  - 3-cause troubleshooting for \"Add to Dashboard\" not showing the view (YAML-mode / view not created yet / Sections-layout quirks)
  - Workarounds for each cause
  - Dedicated VAG Connect Lovelace card status (BETA — currently has Mercedes-style background being redesigned to VAG theme)
  - 3rd-party card recommendations
  - Entity-ID discovery
  - **Per-version feature highlights matrix** for v2.2.0 + v2.2.1 entity additions

- **\`docs/FAQ.md\`** — new section \"Dashboards — Add to Dashboard doesn't show my view\" with 3-cause summary

- **\`README.md\` + \`README.en.md\`** — new FAQ table row + deep-link to dashboards.md

- **\`README.fr.md\` + \`.es.md\` + \`.nl.md\` + \`.pl.md\` + \`.cs.md\` + \`.sv.md\`** — translated link to dashboards.md in each language's docs-links section

## Pure docs PR

- No code changes, no tests needed
- No version bump required (ships in next planned release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)