### PR TITLE
fix(scout): close #260 chargeRate_kmph silencer + laien-friendly i18n cleanup (8 langs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,52 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased] — v2.2.2
 
+### Fixed
+
+- **Scout #260 silencer-fix + cross-language entity-name laien-cleanup**
+  (Audi, `charging.chargingStatus.value.chargeRate_kmph`, reporter
+  `j4x5mgq94b-commits` 2026-05-17). Field WAR seit v1.10.0 geparsed
+  (`vw_eu.py:916` → `d.charging_rate_kmh` → `sensor.charging_speed`
+  / DE `sensor.ladegeschwindigkeit`) — aber der **dotted path** war nie
+  in `EXPECTED_KEYS` für CARIAD-BFF `selectivestatus` registriert,
+  weshalb der Scout fälschlich gefired hat. Klassischer "silencer hat
+  parser nicht eingeholt" gap (same class as #248). **One-line fix**
+  in `_unexpected_keys.py:456` — Audi erbt automatisch via
+  `EXPECTED_KEYS["audi"] = EXPECTED_KEYS["volkswagen"]`.
+
+  **Bei der Gelegenheit: cross-language entity-name laien-cleanup**
+  (community-feedback "alle umgangssprachen benutzen damit nicht-tech
+  menschen auch verstehen"). Audit aller 9 i18n-files (strings.json +
+  8 translations) ergab:
+
+  | Was | Vorher | Nachher |
+  |---|---|---|
+  | DE `charging_rate_kmh` | `Ladegeschwindigkeit (km/h)` | `Ladegeschwindigkeit` |
+  | DE `battery_temp_max` | `HV-Batterie Temperatur (Max)` | `Akku-Temperatur (max)` |
+  | All-langs `active_charging_profile_target_soc_pct` | `... Target SoC` / `Ziel-SoC` / `SoC Cible` etc. | `... Target Charge` / `Ladeziel` / `Charge Cible` etc. |
+  | All-langs `battery_care_target_soc_pct` | same SoC pattern | same laien-friendly Charge/Ladeziel pattern |
+  | All-langs `primary_engine_soc_pct` | `Primary Engine SoC` / `12V-Batterie SoC` / `SoC moteur principal` etc. | `12V Battery Charge` / `12V-Batterie Ladestand` / `Charge batterie 12V` etc. |
+  | All-langs `min_soc` | `SoC minimum (PHEV)` in fr/es/nl/sv/cs | `Charge minimum (PHEV)` / `Minimální nabití` / `Minsta laddning` etc. |
+  | 6 langs `next_charging_timer_id` | **Raw English** "Next Charging Timer ID" untranslated | translated to native form (`Nächster Lade-Timer (ID)`, `Prochain timer (ID)`, `Próximo temporizador (ID)`, `Volgende timer (ID)`, `Następny timer (ID)`, `Další časovač (ID)`, `Nästa timer (ID)`) |
+  | 6 langs `next_charging_timer_target_soc_reachable` | **Raw English** "Next Charging Timer Target SoC Reachable" untranslated | translated to native form in all 8 langs |
+
+  **Why DE `(km/h)` was wrong**: entity is `SensorDeviceClass.SPEED`,
+  HA auto-converts km/h ↔ mph based on user's unit-system. Hardcoded
+  suffix lied to mph-locale users (would show "Ladegeschwindigkeit
+  (km/h): 31 mph" — name says km/h, value is mph).
+
+  **Why `SoC` matters**: State-of-Charge is EV-engineering jargon. A
+  non-technical user looking at a 12V starter battery sensor labeled
+  "12V-Batterie SoC" doesn't know what SoC means — but everyone
+  understands "12V-Batterie Ladestand" (charge level).
+
+  **Regression-shield** (`test_v222_260_silencer_translations.py`,
+  28 tests): asserts silencer-path present for VW + Audi-inheritance
+  honored; pinned no-SoC / no-HV-Batterie / no-`(km/h)`-DE-suffix /
+  no-untranslated-English-in-non-EN; cross-language entity-key
+  parity (en.json is the canonical superset); strings.json + en.json
+  agreement on all touched keys. **Closes #260**.
+
 ### Added
 
 - **Bubble Card ready-made templates für VAG Connect (`docs/lovelace/bubble-card/`)** —

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -448,6 +448,13 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "charging.chargingStatus", "charging.chargingStatus.value",
             "charging.chargingStatus.value.chargingState",
             "charging.chargingStatus.value.chargePower_kW",
+            # v2.2.2 (Scout #260, j4x5mgq94b-commits, Audi 2026-05-17) —
+            # ``chargeRate_kmph`` was parsed since v1.10.0
+            # (``vw_eu.py`` → ``d.charging_rate_kmh`` → ``sensor.charging_speed``)
+            # but never registered in EXPECTED_KEYS, so the Scout fired
+            # on it as "unexpected". Classic silencer-lagging-behind-parser
+            # gap. Audi inherits via ``EXPECTED_KEYS["audi"] = ...``.
+            "charging.chargingStatus.value.chargeRate_kmph",
             "charging.chargingStatus.value.chargeMode",
             "charging.chargingStatus.value.chargeType",
             "charging.chargingStatus.value.remainingChargingTimeToComplete_min",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -236,7 +236,7 @@
         "name": "Active Charging Profile"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Active Profile — Target SoC"
+        "name": "Active Profile — Target Charge"
       },
       "next_charging_time": {
         "name": "Next Charging Time"
@@ -245,7 +245,7 @@
         "name": "Charging Profiles Count"
       },
       "battery_care_target_soc_pct": {
-        "name": "Battery Care — Target SoC"
+        "name": "Battery Care — Target Charge"
       },
       "driving_score": {
         "name": "Driving Score"
@@ -332,13 +332,13 @@
         "name": "Steering Wheel Position"
       },
       "primary_engine_soc_pct": {
-        "name": "Primary Engine SoC"
+        "name": "12V Battery Charge"
       },
       "next_charging_timer_id": {
-        "name": "Next Charging Timer ID"
+        "name": "Next Timer (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Next Charging Timer Target SoC Reachable"
+        "name": "Next Timer — Target Charge Reachable"
       },
       "capabilities_count": {
         "name": "Capabilities Count"

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -221,7 +221,7 @@
         "name": "Aktivní Profil Nabíjení"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Aktivní Profil — Cílový SoC"
+        "name": "Aktivní Profil — Cílové Nabití"
       },
       "next_charging_time": {
         "name": "Další Nabíjení"
@@ -230,7 +230,7 @@
         "name": "Počet Profilů"
       },
       "battery_care_target_soc_pct": {
-        "name": "Péče o Baterii — Cílový SoC"
+        "name": "Péče o Baterii — Cílové Nabití"
       },
       "driving_score": {
         "name": "Skóre Jízdy"
@@ -314,13 +314,13 @@
         "name": "Pozice volantu"
       },
       "primary_engine_soc_pct": {
-        "name": "12V baterie SoC"
+        "name": "Nabití baterie 12V"
       },
       "next_charging_timer_id": {
-        "name": "Next Charging Timer ID"
+        "name": "Další časovač (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Next Charging Timer Target SoC Reachable"
+        "name": "Další časovač — Cílové nabití dosažitelné"
       },
       "capabilities_count": {
         "name": "Capabilities Count"
@@ -512,7 +512,7 @@
         "name": "Teplota klimatizace"
       },
       "min_soc": {
-        "name": "Minimální SoC (PHEV)"
+        "name": "Minimální nabití (PHEV)"
       },
       "max_charge_current": {
         "name": "Max. nabíjecí proud"

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -131,7 +131,7 @@
         "name": "Ladeleistung"
       },
       "charging_rate_kmh": {
-        "name": "Ladegeschwindigkeit (km/h)"
+        "name": "Ladegeschwindigkeit"
       },
       "charge_complete_eta": {
         "name": "Laden fertig um"
@@ -230,7 +230,7 @@
         "name": "Aktives Ladeprofil"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Aktives Profil — Ziel-SoC"
+        "name": "Aktives Profil — Ladeziel"
       },
       "next_charging_time": {
         "name": "Nächste Ladezeit"
@@ -239,7 +239,7 @@
         "name": "Anzahl Ladeprofile"
       },
       "battery_care_target_soc_pct": {
-        "name": "Batterie-Schutz — Ziel-SoC"
+        "name": "Batterie-Schutz — Ladeziel"
       },
       "driving_score": {
         "name": "Fahrwertung"
@@ -284,7 +284,7 @@
         "name": "Abonnement Restlaufzeit"
       },
       "battery_temp_max": {
-        "name": "HV-Batterie Temperatur (Max)"
+        "name": "Akku-Temperatur (max)"
       },
       "departure_timer_enabled_count": {
         "name": "Abfahrtstimer aktiviert"
@@ -314,13 +314,13 @@
         "name": "Lenkradposition"
       },
       "primary_engine_soc_pct": {
-        "name": "12V-Batterie SoC"
+        "name": "12V-Batterie Ladestand"
       },
       "next_charging_timer_id": {
-        "name": "Nächster Lade-Timer ID"
+        "name": "Nächster Lade-Timer (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Nächster Lade-Timer Ziel-SoC erreichbar"
+        "name": "Nächster Lade-Timer — Ladeziel erreichbar"
       },
       "capabilities_count": {
         "name": "Fähigkeiten-Anzahl"

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -221,7 +221,7 @@
         "name": "Active Charging Profile"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Active Profile — Target SoC"
+        "name": "Active Profile — Target Charge"
       },
       "next_charging_time": {
         "name": "Next Charging Time"
@@ -230,7 +230,7 @@
         "name": "Charging Profiles Count"
       },
       "battery_care_target_soc_pct": {
-        "name": "Battery Care — Target SoC"
+        "name": "Battery Care — Target Charge"
       },
       "driving_score": {
         "name": "Driving Score"
@@ -314,13 +314,13 @@
         "name": "Steering Wheel Position"
       },
       "primary_engine_soc_pct": {
-        "name": "Primary Engine SoC"
+        "name": "12V Battery Charge"
       },
       "next_charging_timer_id": {
-        "name": "Next Charging Timer ID"
+        "name": "Next Timer (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Next Charging Timer Target SoC Reachable"
+        "name": "Next Timer — Target Charge Reachable"
       },
       "capabilities_count": {
         "name": "Capabilities Count"

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -221,7 +221,7 @@
         "name": "Perfil de Carga Activo"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Perfil Activo — SoC Objetivo"
+        "name": "Perfil Activo — Carga Objetivo"
       },
       "next_charging_time": {
         "name": "Próxima Carga"
@@ -230,7 +230,7 @@
         "name": "Número de Perfiles"
       },
       "battery_care_target_soc_pct": {
-        "name": "Cuidado Batería — SoC Objetivo"
+        "name": "Cuidado Batería — Carga Objetivo"
       },
       "driving_score": {
         "name": "Puntuación de Conducción"
@@ -314,13 +314,13 @@
         "name": "Posición del volante"
       },
       "primary_engine_soc_pct": {
-        "name": "SoC motor principal"
+        "name": "Carga batería 12V"
       },
       "next_charging_timer_id": {
-        "name": "Next Charging Timer ID"
+        "name": "Próximo temporizador (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Next Charging Timer Target SoC Reachable"
+        "name": "Próximo temporizador — Carga objetivo alcanzable"
       },
       "capabilities_count": {
         "name": "Capabilities Count"
@@ -512,7 +512,7 @@
         "name": "Temperatura de climatización"
       },
       "min_soc": {
-        "name": "SoC mínimo (PHEV)"
+        "name": "Carga mínima (PHEV)"
       },
       "max_charge_current": {
         "name": "Corriente de carga máx."

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -221,7 +221,7 @@
         "name": "Profil de Charge Actif"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Profil Actif — SoC Cible"
+        "name": "Profil Actif — Charge Cible"
       },
       "next_charging_time": {
         "name": "Prochaine Charge"
@@ -230,7 +230,7 @@
         "name": "Nombre de Profils"
       },
       "battery_care_target_soc_pct": {
-        "name": "Soin Batterie — SoC Cible"
+        "name": "Soin Batterie — Charge Cible"
       },
       "driving_score": {
         "name": "Score de Conduite"
@@ -314,13 +314,13 @@
         "name": "Position du volant"
       },
       "primary_engine_soc_pct": {
-        "name": "SoC moteur principal"
+        "name": "Charge batterie 12V"
       },
       "next_charging_timer_id": {
-        "name": "Next Charging Timer ID"
+        "name": "Prochain timer (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Next Charging Timer Target SoC Reachable"
+        "name": "Prochain timer — Charge cible atteignable"
       },
       "capabilities_count": {
         "name": "Capabilities Count"
@@ -512,7 +512,7 @@
         "name": "Température de climatisation"
       },
       "min_soc": {
-        "name": "SoC minimum (PHEV)"
+        "name": "Charge minimum (PHEV)"
       },
       "max_charge_current": {
         "name": "Courant de charge max."

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -221,7 +221,7 @@
         "name": "Actief Laadprofiel"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Actief Profiel — Doel-SoC"
+        "name": "Actief Profiel — Doel-lading"
       },
       "next_charging_time": {
         "name": "Volgende Laadtijd"
@@ -230,7 +230,7 @@
         "name": "Aantal Laadprofielen"
       },
       "battery_care_target_soc_pct": {
-        "name": "Batterij-Zorg — Doel-SoC"
+        "name": "Batterij-Zorg — Doel-lading"
       },
       "driving_score": {
         "name": "Rijscore"
@@ -314,13 +314,13 @@
         "name": "Stuurpositie"
       },
       "primary_engine_soc_pct": {
-        "name": "Primary Engine SoC"
+        "name": "12V-accu lading"
       },
       "next_charging_timer_id": {
-        "name": "Next Charging Timer ID"
+        "name": "Volgende timer (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Next Charging Timer Target SoC Reachable"
+        "name": "Volgende timer — Doel-lading haalbaar"
       },
       "capabilities_count": {
         "name": "Capabilities Count"
@@ -512,7 +512,7 @@
         "name": "Klimaattemperatuur"
       },
       "min_soc": {
-        "name": "Minimum SoC (PHEV)"
+        "name": "Minimum lading (PHEV)"
       },
       "max_charge_current": {
         "name": "Max. laadstroom"

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -221,7 +221,7 @@
         "name": "Aktywny Profil Ładowania"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Aktywny Profil — Docelowy SoC"
+        "name": "Aktywny Profil — Docelowe Naładowanie"
       },
       "next_charging_time": {
         "name": "Następne Ładowanie"
@@ -230,7 +230,7 @@
         "name": "Liczba Profili"
       },
       "battery_care_target_soc_pct": {
-        "name": "Ochrona Baterii — Docelowy SoC"
+        "name": "Ochrona Baterii — Docelowe Naładowanie"
       },
       "driving_score": {
         "name": "Wynik Jazdy"
@@ -314,13 +314,13 @@
         "name": "Położenie kierownicy"
       },
       "primary_engine_soc_pct": {
-        "name": "SoC silnika głównego"
+        "name": "Naładowanie akumulatora 12V"
       },
       "next_charging_timer_id": {
-        "name": "Next Charging Timer ID"
+        "name": "Następny timer (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Next Charging Timer Target SoC Reachable"
+        "name": "Następny timer — Docelowe naładowanie osiągalne"
       },
       "capabilities_count": {
         "name": "Capabilities Count"

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -221,7 +221,7 @@
         "name": "Aktiv Laddningsprofil"
       },
       "active_charging_profile_target_soc_pct": {
-        "name": "Aktiv Profil — Mål-SoC"
+        "name": "Aktiv Profil — Mål-laddning"
       },
       "next_charging_time": {
         "name": "Nästa Laddning"
@@ -230,7 +230,7 @@
         "name": "Antal Profiler"
       },
       "battery_care_target_soc_pct": {
-        "name": "Batteri-Vård — Mål-SoC"
+        "name": "Batteri-Vård — Mål-laddning"
       },
       "driving_score": {
         "name": "Körpoäng"
@@ -314,13 +314,13 @@
         "name": "Ratt-position"
       },
       "primary_engine_soc_pct": {
-        "name": "Primary Engine SoC"
+        "name": "12V-batteri laddning"
       },
       "next_charging_timer_id": {
-        "name": "Next Charging Timer ID"
+        "name": "Nästa timer (ID)"
       },
       "next_charging_timer_target_soc_reachable": {
-        "name": "Next Charging Timer Target SoC Reachable"
+        "name": "Nästa timer — Mål-laddning nåbar"
       },
       "capabilities_count": {
         "name": "Capabilities Count"
@@ -512,7 +512,7 @@
         "name": "Klimatiseringstemperatur"
       },
       "min_soc": {
-        "name": "Minimum SoC (PHEV)"
+        "name": "Minsta laddning (PHEV)"
       },
       "max_charge_current": {
         "name": "Max laddström"

--- a/tests/test_v222_260_silencer_translations.py
+++ b/tests/test_v222_260_silencer_translations.py
@@ -1,0 +1,256 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.2 — Scout #260 silencer-fix + cross-language translation cleanup.
+
+Scout #260 (j4x5mgq94b-commits, Audi 2026-05-17) reported
+`charging.chargingStatus.value.chargeRate_kmph` as a "new field" on Audi.
+Reality: the field was already parsed since v1.10.0 (`vw_eu.py:916` →
+`d.charging_rate_kmh` → `sensor.charging_speed`) but the dotted path
+was never registered in EXPECTED_KEYS for the CARIAD-BFF
+``selectivestatus`` endpoint. Classic "silencer hasn't caught up with
+the parser" gap — Audi inherits via ``EXPECTED_KEYS["audi"] =
+EXPECTED_KEYS["volkswagen"]`` so the fix is a one-line addition.
+
+While doing the silencer audit we also pass over all 8 i18n files and
+eliminate technical jargon from entity names so non-tech users see
+laien-friendly labels:
+
+- `SoC` (State of Charge) — replaced with the natural-language
+  equivalent in each lang (DE "Ladestand"/"Ladeziel", FR "Charge",
+  ES "Carga", NL "Lading", PL "Naładowanie", CS "Nabití",
+  SV "Laddning", EN "Charge")
+- DE: `Ladegeschwindigkeit (km/h)` → `Ladegeschwindigkeit` (entity
+  is `SensorDeviceClass.SPEED` → HA auto-converts km/h ↔ mph; the
+  hardcoded `(km/h)` suffix lied to mph-locale users)
+- DE: `HV-Batterie` → `Akku` (HV = high-voltage, tech jargon)
+- 6 of 8 langs had untranslated English strings for
+  `next_charging_timer_id` and `next_charging_timer_target_soc_reachable`
+  — now translated everywhere.
+
+These tests pin the cleanup to prevent regression — if anyone adds a
+new entity with `SoC` in the name, or leaves a non-EN file with raw
+English strings, CI fails.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_COMPONENT_ROOT = _REPO_ROOT / "custom_components" / "vag_connect"
+_TRANSLATIONS = _COMPONENT_ROOT / "translations"
+_LANGS = ["en", "de", "es", "fr", "nl", "pl", "cs", "sv"]
+_ENTITY_KINDS = ("sensor", "binary_sensor", "switch", "number", "select", "button")
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestSilencerScout260:
+    """One-line silencer fix for `chargeRate_kmph` on CARIAD-BFF selectivestatus."""
+
+    def test_chargerate_kmph_path_present_in_vw(self) -> None:
+        # Use a sys.modules-stubbed import so the test runs without HA installed.
+        import importlib.util
+        import sys
+
+        spec = importlib.util.spec_from_file_location(
+            "_uk_check_v222",
+            _COMPONENT_ROOT / "cariad" / "_unexpected_keys.py",
+        )
+        # Pre-load _util as a sibling so the relative import resolves.
+        util_spec = importlib.util.spec_from_file_location(
+            "_util_check_v222",
+            _COMPONENT_ROOT / "cariad" / "_util.py",
+        )
+        util_mod = importlib.util.module_from_spec(util_spec)
+        sys.modules["_util_check_v222"] = util_mod
+        util_spec.loader.exec_module(util_mod)
+
+        # Build a fake package so the `from ._util import mask_vin` resolves.
+        import types
+
+        pkg = types.ModuleType("_uk_pkg_v222")
+        pkg.__path__ = [str(_COMPONENT_ROOT / "cariad")]
+        sys.modules["_uk_pkg_v222"] = pkg
+        sys.modules["_uk_pkg_v222._util"] = util_mod
+
+        spec2 = importlib.util.spec_from_file_location(
+            "_uk_pkg_v222._unexpected_keys",
+            _COMPONENT_ROOT / "cariad" / "_unexpected_keys.py",
+        )
+        mod = importlib.util.module_from_spec(spec2)
+        sys.modules["_uk_pkg_v222._unexpected_keys"] = mod
+        spec2.loader.exec_module(mod)
+
+        ek = mod.EXPECTED_KEYS
+        vw_paths = ek["volkswagen"]["selectivestatus"]
+        assert "charging.chargingStatus.value.chargeRate_kmph" in vw_paths, (
+            "Scout #260 path missing from VW selectivestatus silencer"
+        )
+
+    def test_audi_inherits_via_shared_dict(self) -> None:
+        # Same import bootstrap as above (separate scope so each test
+        # can run standalone — pytest may pick either first).
+        import importlib.util
+        import sys
+        import types
+
+        for k in ("_uk_audi_v222", "_uk_audi_v222._unexpected_keys", "_uk_audi_v222._util"):
+            sys.modules.pop(k, None)
+
+        util_spec = importlib.util.spec_from_file_location(
+            "_uk_audi_v222._util",
+            _COMPONENT_ROOT / "cariad" / "_util.py",
+        )
+        util_mod = importlib.util.module_from_spec(util_spec)
+        pkg = types.ModuleType("_uk_audi_v222")
+        pkg.__path__ = [str(_COMPONENT_ROOT / "cariad")]
+        sys.modules["_uk_audi_v222"] = pkg
+        sys.modules["_uk_audi_v222._util"] = util_mod
+        util_spec.loader.exec_module(util_mod)
+
+        spec = importlib.util.spec_from_file_location(
+            "_uk_audi_v222._unexpected_keys",
+            _COMPONENT_ROOT / "cariad" / "_unexpected_keys.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["_uk_audi_v222._unexpected_keys"] = mod
+        spec.loader.exec_module(mod)
+
+        ek = mod.EXPECTED_KEYS
+        # Audi inherits VW by reference — same dict identity, not a copy.
+        assert ek["audi"] is ek["volkswagen"], (
+            "Audi must inherit VW EXPECTED_KEYS by reference, not copy"
+        )
+        # Audi sees the same chargeRate_kmph path transitively.
+        assert (
+            "charging.chargingStatus.value.chargeRate_kmph"
+            in ek["audi"]["selectivestatus"]
+        )
+
+
+class TestLaienFriendlyEntityNames:
+    """No technical jargon in user-facing entity-name translations."""
+
+    @pytest.mark.parametrize("lang", _LANGS)
+    def test_no_soc_in_entity_names(self, lang: str) -> None:
+        """`SoC` (State-of-Charge) is tech jargon; replaced everywhere."""
+        d = _load(_TRANSLATIONS / f"{lang}.json")
+        offenders = []
+        for kind in _ENTITY_KINDS:
+            for key, val in d.get("entity", {}).get(kind, {}).items():
+                name = val.get("name", "")
+                if re.search(r"\bSoC\b", name):
+                    offenders.append(f"{lang}/{kind}/{key}: {name}")
+        assert not offenders, (
+            "SoC tech-jargon must be replaced with laien-friendly term:\n"
+            + "\n".join(offenders)
+        )
+
+    @pytest.mark.parametrize("lang", _LANGS)
+    def test_no_hv_batterie_in_de(self, lang: str) -> None:
+        """DE: `HV-Batterie` (high-voltage) → `Akku` (everyday word)."""
+        if lang != "de":
+            pytest.skip("DE-only cleanup")
+        d = _load(_TRANSLATIONS / f"{lang}.json")
+        for kind in _ENTITY_KINDS:
+            for key, val in d.get("entity", {}).get(kind, {}).items():
+                name = val.get("name", "")
+                assert "HV-Batterie" not in name, (
+                    f"de/{kind}/{key} still uses tech 'HV-Batterie': {name}"
+                )
+
+    def test_charging_rate_kmh_no_unit_suffix_in_de(self) -> None:
+        """DE: removed hardcoded `(km/h)` since HA auto-converts km/h ↔ mph."""
+        d = _load(_TRANSLATIONS / "de.json")
+        name = d["entity"]["sensor"]["charging_rate_kmh"]["name"]
+        assert "(km/h)" not in name, (
+            f"`charging_rate_kmh` DE name lies to mph-locale users: {name}"
+        )
+        # Sanity: the natural name is preserved.
+        assert "Ladegeschwindigkeit" in name
+
+
+class TestNoUntranslatedEnglishInNonEnFiles:
+    """6 of 8 langs had raw English strings for 2 entity names — fixed."""
+
+    # English-only phrases that should NEVER appear in a non-EN translation
+    # (anchored to specific entity contexts so we don't false-positive on
+    # proper nouns or universal acronyms like 'AdBlue' / 'PHEV').
+    _ENGLISH_RESIDUE = re.compile(
+        r"\b(Next Charging Timer|Primary Engine SoC|Charging Timer ID|"
+        r"Target SoC Reachable)\b"
+    )
+
+    @pytest.mark.parametrize("lang", [l for l in _LANGS if l != "en"])
+    def test_no_english_residue(self, lang: str) -> None:
+        d = _load(_TRANSLATIONS / f"{lang}.json")
+        offenders = []
+        for kind in _ENTITY_KINDS:
+            for key, val in d.get("entity", {}).get(kind, {}).items():
+                name = val.get("name", "")
+                if self._ENGLISH_RESIDUE.search(name):
+                    offenders.append(f"{lang}/{kind}/{key}: {name}")
+        assert not offenders, (
+            f"Untranslated English in {lang}.json:\n" + "\n".join(offenders)
+        )
+
+
+class TestCrossLangParity:
+    """Every entity key must exist in every language file (parity check)."""
+
+    def _entity_keys(self, doc: dict) -> set[str]:
+        keys: set[str] = set()
+        for kind in _ENTITY_KINDS:
+            for k in doc.get("entity", {}).get(kind, {}):
+                keys.add(f"{kind}.{k}")
+        return keys
+
+    def test_all_langs_have_same_entity_keys_as_en(self) -> None:
+        en = self._entity_keys(_load(_TRANSLATIONS / "en.json"))
+        for lang in _LANGS:
+            if lang == "en":
+                continue
+            other = self._entity_keys(_load(_TRANSLATIONS / f"{lang}.json"))
+            missing = en - other
+            extra = other - en
+            assert not missing, (
+                f"{lang}.json missing entity keys vs en.json: {sorted(missing)}"
+            )
+            # `extra` keys in non-EN are tolerated (lang-specific aliases),
+            # but warn via assertion when egregious (>5).
+            assert len(extra) < 10, (
+                f"{lang}.json has unexpected extra entity keys: {sorted(extra)}"
+            )
+
+
+class TestStringsJsonInSync:
+    """strings.json (en fallback) must agree with en.json for the touched keys."""
+
+    _TOUCHED = [
+        "active_charging_profile_target_soc_pct",
+        "battery_care_target_soc_pct",
+        "primary_engine_soc_pct",
+        "next_charging_timer_id",
+        "next_charging_timer_target_soc_reachable",
+    ]
+
+    def test_strings_and_en_agree(self) -> None:
+        strings = _load(_COMPONENT_ROOT / "strings.json")
+        en = _load(_TRANSLATIONS / "en.json")
+        for key in self._TOUCHED:
+            s = strings["entity"]["sensor"][key]["name"]
+            e = en["entity"]["sensor"][key]["name"]
+            assert s == e, (
+                f"strings.json and en.json disagree on `{key}`: "
+                f"strings={s!r} en={e!r}"
+            )
+            assert "SoC" not in s, (
+                f"strings.json still has SoC in {key}: {s}"
+            )


### PR DESCRIPTION
## Summary

- **Closes #260** — Scout reported `charging.chargingStatus.value.chargeRate_kmph` as new field on Audi. Reality: parsed since v1.10.0 but the dotted path was never registered in `EXPECTED_KEYS` for CARIAD-BFF `selectivestatus`. Classic silencer-not-caught-up-with-parser gap (same class as #248). **One-line fix**; Audi inherits via `EXPECTED_KEYS["audi"] = EXPECTED_KEYS["volkswagen"]`.
- **Cross-language entity-name laien-cleanup** across all 9 i18n files — community feedback "alle umgangssprachen benutzen damit nicht-tech menschen verstehen". Tech-jargon (`SoC`, `HV-Batterie`) replaced everywhere, plus 6-of-8 langs had raw untranslated English for 2 entities — fixed.

## Why

Scout #260 was reported by `j4x5mgq94b-commits` (Audi, 2026-05-17). The field IS already in `sensor.charging_speed` / DE `sensor.ladegeschwindigkeit` since v1.10.0 — it's just that the silencer was out of sync, so the scout pipeline fired falsely. Fixing the silencer prevents future false-positive scout reports on this path.

The translation cleanup came up while auditing the entity that maps from `chargeRate_kmph`. The DE name had `Ladegeschwindigkeit (km/h)` — but the entity is `SensorDeviceClass.SPEED`, so HA auto-converts km/h ↔ mph. Hardcoded suffix → mph-locale users see "Ladegeschwindigkeit (km/h): 31 mph" (name says km/h, value is mph). Snowballed into a full i18n audit: SoC tech jargon, DE-only HV-Batterie, untranslated English in non-EN files.

## Changes

### Silencer
- `_unexpected_keys.py:456` — added `"charging.chargingStatus.value.chargeRate_kmph"` to VW selectivestatus EXPECTED_KEYS

### Translations (9 files: strings.json + 8 langs)

| Key | Before | After |
|---|---|---|
| DE `charging_rate_kmh` | `Ladegeschwindigkeit (km/h)` | `Ladegeschwindigkeit` |
| DE `battery_temp_max` | `HV-Batterie Temperatur (Max)` | `Akku-Temperatur (max)` |
| 8 langs `active_charging_profile_target_soc_pct` | `... Target SoC` / `Ziel-SoC` / `SoC Cible` ... | `... Target Charge` / `Ladeziel` / `Charge Cible` ... |
| 8 langs `battery_care_target_soc_pct` | same SoC pattern | same laien-friendly pattern |
| 8 langs `primary_engine_soc_pct` | `Primary Engine SoC` / `12V-Batterie SoC` ... | `12V Battery Charge` / `12V-Batterie Ladestand` ... |
| 5 langs `min_soc` (fr/es/nl/sv/cs) | `SoC minimum (PHEV)` ... | `Charge minimum (PHEV)` / `Minimální nabití` ... |
| 6 langs `next_charging_timer_id` (cs/es/fr/nl/pl/sv) | **Raw English** "Next Charging Timer ID" | translated everywhere |
| 6 langs `next_charging_timer_target_soc_reachable` | **Raw English** "...Target SoC Reachable" | translated everywhere |

### Regression test
- `tests/test_v222_260_silencer_translations.py` — 28 tests covering:
  - Silencer-path present for VW + Audi inheritance honored (shared dict reference)
  - No `SoC` in any entity name across 8 langs (parametrized)
  - No `HV-Batterie` in DE entity names
  - No `(km/h)` suffix in DE `charging_rate_kmh`
  - No untranslated-English residue in 7 non-EN files
  - Cross-language entity-key parity (en.json is canonical superset)
  - strings.json ↔ en.json agreement on all touched keys

## Test plan

- [x] All 9 JSON files parse via `json.loads`
- [x] Regression test (`test_v222_260_silencer_translations.py`) — 21 pass + 7 skip-by-design = green
- [x] Direct verification: `EXPECTED_KEYS["volkswagen"]["selectivestatus"]` contains new path; Audi shares dict
- [ ] CI green
- [ ] Visual smoke: DE-locale user sees "Ladegeschwindigkeit" without unit suffix; mph-locale user sees correct mph value
- [ ] Community verification (Scout #260 reporter) — scout shouldn't re-fire on this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)