### PR TITLE
release: v2.2.2 — Silencer Catch-up + Laien-friendly Names + Diesel Dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,21 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > phantom-protected). Tier-B (wildcards + alarm/siren) deferred
 > until tester scout-dumps liefern die unknown leaf-shapes.
 
-## [Unreleased] — v2.2.2
+## [Unreleased]
+
+_(nothing pending — v2.2.2 just shipped; new entries land here)_
+
+## [2.2.2] — 2026-05-18 — "Silencer Catch-up + Laien-friendly Names + Diesel Dashboards"
+
+> **PATCH-Release**: 5 follow-up PRs nach v2.2.1 stable.
+> 1 Scout-closure (#260), 1 cross-brand parser-expansion (#256, closes
+> #248), 3 docs-PRs (#257 dashboards.md + FAQ in 8 langs, #258 6
+> Bubble-Card-templates, #259 Audi S6 TDI diesel popup variant), plus
+> cross-language entity-name laien-cleanup (`SoC` → "Ladestand"/"Charge"
+> equivalent in 8 langs, DE `(km/h)` mph-bug fix, `HV-Batterie` → `Akku`,
+> 6 langs hatten raw English untranslated für 2 entities — gefixt).
+>
+> Keine Breaking Changes. HACS pre-release & stable channels.
 
 ### Fixed
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.2.1"
+  "version": "2.2.2"
 }


### PR DESCRIPTION
## Summary

PATCH release v2.2.2 collecting 5 follow-up PRs after v2.2.1 stable. No breaking changes — HACS pre-release + stable channels.

## What's in v2.2.2

| PR | Title | Closes |
|---|---|---|
| #256 | climatisationTimers cross-brand expansion (VW EU/Audi) | #248 |
| #257 | Dedicated dashboards.md + FAQ across 8 README langs | — |
| #258 | 6 ready-made Bubble Card YAML templates | — |
| #259 | Audi S6 TDI diesel popup variant | — |
| #261 | Scout #260 silencer-fix + cross-lang i18n laien-cleanup | #260 |

## Cross-language entity-name cleanup highlights

- `SoC` (tech jargon) → laien-friendly equivalent in all 8 langs (DE `Ladestand`/`Ladeziel`, FR `Charge`, ES `Carga`, NL `Lading`, PL `Naładowanie`, CS `Nabití`, SV `Laddning`, EN `Charge`)
- DE `Ladegeschwindigkeit (km/h)` → `Ladegeschwindigkeit` (fixed mph-locale bug — HA auto-converts via `SensorDeviceClass.SPEED`)
- DE `HV-Batterie Temperatur (Max)` → `Akku-Temperatur (max)` (HV = tech)
- 6 langs had raw English untranslated for 2 entities (`next_charging_timer_id`, `next_charging_timer_target_soc_reachable`) → translated to native form

## Files

- `custom_components/vag_connect/manifest.json` — version bump 2.2.1 → 2.2.2
- `CHANGELOG.md` — `[Unreleased]` collapsed into `[2.2.2]` release block

## Test plan

- [x] Manifest version matches CHANGELOG release header
- [x] All 5 collected PRs landed in main (verified via `git log`)
- [ ] CI green on this release PR (5 checks)
- [ ] After merge: tag `v2.2.2` + GH release
- [ ] HACS picks up the new tag (auto via manifest version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)