### PR TITLE
feat(v2.2.3): Sprint A — easter-egg + 5 scout closures + #270 brand-preserve fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,14 +153,29 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
   Selection nach einem 400/500-Error genau dort wo der User sie
   gelassen hat.
 
-- **Scout #268 (VW EU arvcer, 2026-05-21) —
+- **Scout #268 + #271 (VW EU arvcer, 2026-05-21/22) —
   `charging.chargingStatus.requests` parsed + silenced** — Mirror der
   bestehenden `charging.chargingSettings.requests` Parser-Logik
   (v1.27.2 #181). Liefert jetzt `d.charging_status_pending` als
   diagnostic count: 0 = idle, >0 = `start_charging`/`stop_charging`
   command ist im Gateway gequeued. Neuer optional-disabled
   `sensor.{prefix}_charging_commands_pending` (Power-User opt-in).
-  Audi erbt automatisch via brand-vererbung. **Closes #268**.
+  Audi erbt automatisch via brand-vererbung. **Closes #268, #271**.
+
+- **Scout #272 (VW EU arvcer, 2026-05-23) —
+  `climatisation.climatisationStatus.requests` parsed + silenced** —
+  Dritter Member der `*_pending` Familie nach `chargingSettings.requests`
+  und `chargingStatus.requests`. Zählt gequeuete
+  `start_climatisation`/`stop_climatisation` Commands am Gateway.
+  Neuer optional-disabled `sensor.{prefix}_climate_commands_pending`.
+  Kein `condition`-Filter (jede Marke mit Remote-Climate support —
+  EV+ICE alike). Audi erbt via brand-vererbung. **Closes #272**.
+
+- **Scout #273 (VW EU gudden, 2026-05-23) —
+  `readiness.readinessStatus.error` envelope silencer-add** —
+  Defensive `.error` Wrapper Pattern (gleiches Schema wie
+  #185/#190/#191 envelopes), Parser ignoriert es clean. Nur
+  Silencer-Add nötig, kein Code-Change. **Closes #273**.
 
 - **Scouts #263, #265, #266 ack-closed (alle pre-fixed in v2.2.2)** —
   Drei Scout-Reports für `chargingRate_kmph` und

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,66 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > phantom-protected). Tier-B (wildcards + alarm/siren) deferred
 > until tester scout-dumps liefern die unknown leaf-shapes.
 
-## [Unreleased]
+## [Unreleased] — v2.2.3
 
-_(nothing pending — v2.2.2 just shipped; new entries land here)_
+### Added
+
+- **🥚 Easter-Egg Service `vag_connect.show_vag` (Community Tribute)** —
+  In honour of the "Great VAG Renaming of 2026" Facebook-thread:
+  multiple humorous comments in the **Home Assistant UK** and **HA
+  Ideas, Projects and Solutions** groups pointed out dass "VAG" — die
+  offizielle DACH-Abkürzung für Volkswagen AG — auf Englisch *quite
+  differently* gelesen wird 😅. **Si Gregory** schlug ein Rename vor,
+  **Ben Johnson** stimmte zu, **Evets David** fragte "Is it a dating
+  integration?", **Stuart McBride** sekundierte, und **Jordan Waeles**
+  toppte mit einem brillanten Pandas-style `show_vag()` joke.
+
+  Wir parken das Rename selbst noch (separate PR später) aber das
+  easter-egg shippt jetzt: Service-Call `vag_connect.show_vag` (no
+  params) erstellt eine persistente HA-Benachrichtigung mit den
+  Credits + einer Liste aller aktuell verbundenen Fahrzeuge.
+  **Always-works contract** — auch bei zero vehicles konfiguriert
+  zeigt es einen Placeholder statt zu erroren. Nutzbar via Developer
+  Tools → Services oder einer Automation. Erscheint im HA-Bell und
+  bleibt screenshotbar.
+
+### Fixed
+
+- **#270 (roberttco VW NA, 2026-05-21) — Config-flow Brand-Selection
+  bleibt nach Login-Fehler erhalten** — vorher hat der Re-Render nach
+  einer Auth-Fehlschlag-Response `_credentials_schema()` ohne Argumente
+  aufgerufen → brand/username/spin/scan_interval/force_access fielen
+  alle auf die Defaults zurück. User dachte das Rejection wäre wegen
+  ihrer Brand-Selection (statt Credentials) und probierte falsche
+  Kombinationen. Fix: `suggested = user_input or {}` wird durch den
+  Schema-Builder gefädelt, alle Felder ausser Password bleiben
+  erhalten. Password wird (per HA-Konvention) nicht zurückgespiegelt
+  — sicherheitsrelevant, muss neu eingegeben werden. Damit ist die
+  Selection nach einem 400/500-Error genau dort wo der User sie
+  gelassen hat.
+
+- **Scout #268 (VW EU arvcer, 2026-05-21) —
+  `charging.chargingStatus.requests` parsed + silenced** — Mirror der
+  bestehenden `charging.chargingSettings.requests` Parser-Logik
+  (v1.27.2 #181). Liefert jetzt `d.charging_status_pending` als
+  diagnostic count: 0 = idle, >0 = `start_charging`/`stop_charging`
+  command ist im Gateway gequeued. Neuer optional-disabled
+  `sensor.{prefix}_charging_commands_pending` (Power-User opt-in).
+  Audi erbt automatisch via brand-vererbung. **Closes #268**.
+
+- **Scouts #263, #265, #266 ack-closed (alle pre-fixed in v2.2.2)** —
+  Drei Scout-Reports für `chargingRate_kmph` und
+  `chargingSettings.error` Felder die alle schon in v2.2.2 silenced
+  wurden. Reporter (`DnnsJp74`, `j4x5mgq94b-commits`, `arvcer`) waren
+  auf älteren Versionen. Ack-Comments mit Update-Empfehlung.
+
+- **Error-Report #267 (Brinki99) ack-closed — backend hiccup** — HTTP
+  502 Bad Gateway von `emea.bff.cariad.digital` ist ein transient
+  Backend-Outage von Cariad, kein Code-Bug. Error-Reporter hat seine
+  Aufgabe erfüllt (Telemetrie sauber). Ack-Comment mit Erklärung +
+  Verweis auf nächsten Refresh-Cycle.
+
+
 
 ## [2.2.2] — 2026-05-18 — "Silencer Catch-up + Laien-friendly Names + Diesel Dashboards"
 

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -363,6 +363,80 @@ def _register_services(hass: HomeAssistant) -> None:
         """
         await _handle_refresh(_call)
 
+    async def _handle_show_vag(_call: ServiceCall) -> None:
+        """v2.2.3 — Community easter-egg ``show_vag()``.
+
+        Background (Great VAG Renaming of 2026): multiple humorous
+        comments in the Home Assistant UK + "HA Ideas, Projects and
+        Solutions" Facebook groups pointed out that "VAG" — the official
+        DACH abbreviation for Volkswagen AG — reads quite differently
+        in English. Si Gregory suggested the project rename, Ben Johnson
+        seconded it, Evets David asked "Is it a dating integration?",
+        Stuart McBride added his support, and Jordan Waeles topped it
+        with a brilliant Pandas-style ``show_vag()`` joke.
+
+        We're keeping the spirit alive: this service is the officially
+        supported easter egg honouring that thread. Creates a
+        persistent_notification with the credits + a list of currently
+        connected vehicles per config entry.
+
+        Always-works contract: with zero vehicles configured (fresh
+        install) we still render — placeholder line instead of error.
+        """
+        from homeassistant.components import persistent_notification  # noqa: PLC0415
+
+        _LOGGER.info(
+            "show_vag() called — community easter egg triggered"
+        )
+
+        # Collect display lines per vehicle across ALL config entries.
+        # Order: entry-added order → VIN-sorted within entry (stable
+        # for screenshots).
+        vehicle_lines: list[str] = []
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            coordinator: VagConnectCoordinator | None = getattr(
+                entry, "runtime_data", None
+            )
+            if coordinator is None:
+                continue
+            brand = str(entry.data.get(CONF_BRAND, "")).strip() or "(unknown brand)"
+            vehicles_map = getattr(coordinator, "vehicles", None) or {}
+            for vin in sorted(vehicles_map.keys()):
+                v = vehicles_map.get(vin) or {}
+                # Prefer human-friendly name; fallback chain mirrors
+                # device-info name resolution in entity_base.
+                display = (
+                    v.get("media_short_name")
+                    or v.get("model")
+                    or v.get("media_long_name")
+                    or "(unnamed vehicle)"
+                )
+                vehicle_lines.append(f"• {display} — {brand}")
+
+        if not vehicle_lines:
+            vehicle_lines = ["• (no vehicles configured yet)"]
+
+        vehicles_block = "\n".join(vehicle_lines)
+        message = (
+            "In honour of the Great VAG Renaming of 2026.\n"
+            "\n"
+            "Originally inspired by Jordan Waeles' immortal Pandas-style "
+            "comment. With gratitude to: Si Gregory, Ben Johnson, "
+            "Evets David, Stuart McBride, and the HA UK + HA Ideas "
+            "communities.\n"
+            "\n"
+            "Currently connected vehicles:\n"
+            f"{vehicles_block}\n"
+            "\n"
+            "Keep the wheels turning. 🏁"
+        )
+        persistent_notification.async_create(
+            hass,
+            message,
+            title="🥚 Easter Egg unlocked: show_vag()",
+            notification_id=f"{DOMAIN}_show_vag",
+        )
+
     for name, handler, schema in [
         ("lock",                           _handle_lock,                SERVICE_VIN_SCHEMA),
         ("unlock",                         _handle_unlock,              SERVICE_VIN_SCHEMA),
@@ -377,6 +451,9 @@ def _register_services(hass: HomeAssistant) -> None:
         ("refresh_vehicle",                _handle_refresh,             vol.Schema({})),
         # v1.13.0 (#63 Phase 3) — explicit semantic-clear alias.
         ("refresh_cloud_cache",            _handle_refresh_cloud_cache, vol.Schema({})),
+        # v2.2.3 — Community easter-egg ``show_vag()``. No params.
+        # In honour of Jordan Waeles + the FB-thread renaming-suggestion.
+        ("show_vag",                       _handle_show_vag,            vol.Schema({})),
         ("set_target_soc",                 _handle_set_target_soc,
             vol.Schema({
                 vol.Required("vin"):    str,
@@ -512,6 +589,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: VagConnectConfigEntry) 
             "send_destination",
             # v2.0.0 (Big-Bang)
             "find_charging_stations",
+            # v2.2.3 — Community easter-egg
+            "show_vag",
         ]:
             if hass.services.has_service(DOMAIN, svc):
                 hass.services.async_remove(DOMAIN, svc)

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -461,6 +461,11 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "charging.chargingStatus.value.chargingSettings",
             "charging.chargingStatus.value.chargingScenario",
             "charging.chargingStatus.value.carCapturedTimestamp",
+            # v2.2.3 — scout #268 (VW EU arvcer 2026-05-21): pending
+            # ``start_charging``/``stop_charging`` commands queue. Mirror
+            # of the existing ``chargingSettings.requests`` parser, now
+            # parsed into ``d.charging_status_pending`` (count diagnostic).
+            "charging.chargingStatus.requests",
             "charging.chargingSettings", "charging.chargingSettings.value",
             "charging.chargingSettings.value.targetSOC_pct",
             "charging.chargingSettings.value.maxChargeCurrentAC",

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -489,6 +489,11 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "climatisation.climatisationStatus.value.climatisationState",
             "climatisation.climatisationStatus.value.remainingClimatisationTime_min",
             "climatisation.climatisationStatus.value.carCapturedTimestamp",
+            # v2.2.3 — scout #272 (VW EU arvcer 2026-05-23): pending
+            # start/stop climatisation commands queue. Mirror of the
+            # ``charging.chargingStatus.requests`` pattern added at
+            # the same time. Parsed into ``d.climatisation_status_pending``.
+            "climatisation.climatisationStatus.requests",
             "climatisation.climatisationSettings",
             "climatisation.climatisationSettings.value",
             "climatisation.climatisationSettings.value.targetTemperature_C",
@@ -652,6 +657,14 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "vehicleHealthInspection.maintenanceStatus.error.*",
             "departureProfiles.departureProfilesStatus.error",
             "departureProfiles.departureProfilesStatus.error.*",
+            # v2.2.3 — scout #273 (VW EU gudden 2026-05-23): readiness
+            # endpoint's defensive ``.error`` envelope (Cariad-BFF
+            # "endpoint hat einen Fehler"-wrapper pattern, same shape
+            # as the other ``*.error`` siblings above). Backend hiccup,
+            # parser ignores it cleanly. No code change beyond the
+            # silencer-add.
+            "readiness.readinessStatus.error",
+            "readiness.readinessStatus.error.*",
             # v2.2.0 Phase 7 PR #5 (#245 Scout) — `measurements.
             # tirePressureStatus` 1-key container shipped alongside
             # the error rollout. Wildcard covers current + future

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1375,6 +1375,17 @@ class VWEUClient(CariadBaseClient):
         d.climatisation_active = d.climatisation_state not in (None, "OFF", "CLIMATISATION_STATUS_UNAVAILABLE")
         d.target_temperature = v(raw, "climatisation", "climatisationSettings", "value", "targetTemperature_C")
 
+        # v2.2.3 — scout #272 (VW EU arvcer 2026-05-23): third member
+        # of the ``*.requests`` queue-counter family (alongside
+        # ``chargingStatus.requests`` and ``chargingSettings.requests``
+        # parsed elsewhere in this file). Counts queued
+        # ``start_climatisation`` / ``stop_climatisation`` commands at
+        # the gateway. Same diagnostic semantic, same defensive
+        # list-check, same phantom-honest None when leaf is absent.
+        clim_pending = v(raw, "climatisation", "climatisationStatus", "requests")
+        if isinstance(clim_pending, list):
+            d.climatisation_status_pending = len(clim_pending)
+
         # v1.26.0 Welle-6 (#173) — climate-at-unlock + window-heating-enabled
         # SETTINGS (distinct from front/back STATES). Scout #144 VW ID.4 Pro.
         clim_at_unlock = v(raw, "climatisation", "climatisationSettings", "value", "climatizationAtUnlock")

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -922,6 +922,19 @@ class VWEUClient(CariadBaseClient):
         if isinstance(pending, list):
             d.charging_settings_pending = len(pending)
 
+        # v2.2.3 — scout #268 (VW EU arvcer, 2026-05-21): mirror of the
+        # above pattern for ``charging.chargingStatus.requests`` (start/
+        # stop charging commands queued on the chargingStatus side, vs.
+        # putChargingSettings on the chargingSettings side). Same shape
+        # ``[1 items]`` observed in the scout-report. Surfaced as
+        # ``charging_status_pending`` so users can verify their
+        # ``vag_connect.start_charging`` / ``stop_charging`` requests
+        # actually queued at the backend. Defensive list-check keeps
+        # the field None when the leaf is absent (phantom-gate honest).
+        status_pending = v(raw, "charging", "chargingStatus", "requests")
+        if isinstance(status_pending, list):
+            d.charging_status_pending = len(status_pending)
+
         # v1.27.2 — Plug visual feedback (LED color on the charge port) +
         # external-power availability. Both come straight from plugStatus.
         # Helpful for "is the wallbox actually delivering power right now?"

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -358,6 +358,11 @@ class VehicleData:
     # (i.e. queued ``start_charging`` / ``stop_charging`` commands).
     # Same int-count diagnostic, same None semantics.
     charging_status_pending: int | None = None
+    # v2.2.3 — Cariad scout #272 (VW EU arvcer 2026-05-23): third
+    # member of the *.requests family — counts queued
+    # ``start_climatisation`` / ``stop_climatisation`` commands at the
+    # gateway. Same shape as ``charging_*_pending`` siblings.
+    climatisation_status_pending: int | None = None
     plug_led_color: str | None = None  # none / red / green / blue
     external_power_available: bool | None = None  # plugStatus.externalPower
 

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -353,6 +353,11 @@ class VehicleData:
     # requests count. Useful diagnostic for "did my putChargingSettings POST
     # actually queue?" Plus visual feedback signals from plugStatus.
     charging_settings_pending: int | None = None
+    # v2.2.3 — Cariad scout #268 (VW EU arvcer): mirror of the
+    # ``chargingSettings.requests`` queue but for chargingStatus side
+    # (i.e. queued ``start_charging`` / ``stop_charging`` commands).
+    # Same int-count diagnostic, same None semantics.
+    charging_status_pending: int | None = None
     plug_led_color: str | None = None  # none / red / green / blue
     external_power_available: bool | None = None  # plugStatus.externalPower
 

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -224,9 +224,28 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                     data=self._build_entry_data(brand, username, password, user_input),
                 )
 
+        # v2.2.3 (#270 roberttco VW NA, 2026-05-21) — when validation
+        # fails, re-render the form with the user's previous selections
+        # preserved. Previously ``_credentials_schema()`` was called with
+        # NO arguments → brand/username/spin/scan_interval/force-access
+        # all reset to defaults, surprising the user (they thought the
+        # rejection was about their brand pick rather than credentials).
+        # Now we thread the last user_input back into the schema so only
+        # the password field requires re-entry. Password is intentionally
+        # NOT preserved (HA convention — never echo passwords to the
+        # client even via schema-default).
+        suggested = user_input or {}
         return self.async_show_form(
             step_id="user",
-            data_schema=_credentials_schema(),
+            data_schema=_credentials_schema(
+                brand=suggested.get(CONF_BRAND, ""),
+                username=suggested.get(CONF_USERNAME, ""),
+                scan_interval=int(
+                    suggested.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+                ),
+                spin=suggested.get(CONF_SPIN, ""),
+                force_access=bool(suggested.get(CONF_FORCE_ACCESS, False)),
+            ),
             errors=errors,
         )
 

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -197,6 +197,21 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
+    # v2.2.3 — Cariad scout #268 (VW EU arvcer): mirror of the above
+    # for the chargingStatus side — counts queued ``start_charging`` /
+    # ``stop_charging`` commands. Same diagnostic semantics: 0 = idle,
+    # >0 = command queued at the gateway. Disabled by default — power
+    # users opt in. Phantom-protected (None when leaf absent).
+    VagSensorDescription(
+        key="charging_status_pending",
+        translation_key="charging_status_pending",
+        data_key="charging_status_pending",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:flash-alert",
+        condition="electric",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
     # v1.27.2 — Visual feedback color of the charge-port LED.
     # none / red (error) / green (idle/done) / blue (charging) — drivable by
     # automations like "notify me when LED turns red".

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -212,6 +212,19 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
+    # v2.2.3 — Cariad scout #272 (VW EU arvcer 2026-05-23): third
+    # *_pending sibling — counts queued start/stop_climatisation
+    # commands. No ``condition`` filter (every brand with climatisation
+    # support — electric AND combustion alike). Disabled by default.
+    VagSensorDescription(
+        key="climatisation_status_pending",
+        translation_key="climatisation_status_pending",
+        data_key="climatisation_status_pending",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:air-conditioner",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
     # v1.27.2 — Visual feedback color of the charge-port LED.
     # none / red (error) / green (idle/done) / blue (charging) — drivable by
     # automations like "notify me when LED turns red".

--- a/custom_components/vag_connect/services.yaml
+++ b/custom_components/vag_connect/services.yaml
@@ -1,3 +1,20 @@
+# v2.2.3 — Community easter-egg. Spawned by humorous FB-thread
+# pointing out "VAG" reads differently in English (Si Gregory + Ben
+# Johnson + Evets David + Stuart McBride + Jordan Waeles' Pandas-style
+# show_vag() joke). Creates a persistent_notification with the credits
+# + list of currently connected vehicles. No vehicle target — account
+# level.
+show_vag:
+  name: "🥚 show_vag() — Community Easter Egg"
+  description: >-
+    Erstellt eine persistente Benachrichtigung mit den Credits der
+    Community-Mitglieder, die die VAG → VW Group Umbenennung angestoßen
+    haben (HA UK + HA Ideas Facebook-Gruppen, 2026-05). Inkludiert eine
+    Liste aller aktuell verbundenen Fahrzeuge. — Creates a persistent
+    notification crediting the community members who triggered the
+    rename discussion, plus a list of all currently connected vehicles.
+  fields: {}
+
 refresh_vehicle:
   name: Fahrzeugdaten aktualisieren (Cloud-Cache)
   description: >-

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -139,6 +139,9 @@
       "charging_settings_pending": {
         "name": "Charging Settings Pending"
       },
+      "charging_status_pending": {
+        "name": "Charging Commands Pending"
+      },
       "plug_led_color": {
         "name": "Plug LED Color"
       },

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -142,6 +142,9 @@
       "charging_status_pending": {
         "name": "Charging Commands Pending"
       },
+      "climatisation_status_pending": {
+        "name": "Climate Commands Pending"
+      },
       "plug_led_color": {
         "name": "Plug LED Color"
       },

--- a/tests/test_v223_sprint_a.py
+++ b/tests/test_v223_sprint_a.py
@@ -1,0 +1,258 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.2.3 — Sprint A: easter-egg + scout closures + config-flow UX fix.
+
+This single test-file pins the four user-facing changes that ship
+together in v2.2.3 PATCH:
+
+1. **Easter-egg `show_vag` service** (community tribute — Jordan Waeles'
+   Pandas-style joke + the HA UK / HA Ideas FB-thread renaming
+   discussion). Source-level checks: service is registered and
+   un-registered alongside its peers; services.yaml + strings.json
+   declare the new entry; persistent_notification helper is imported;
+   the no-vehicles-configured branch falls back to a placeholder line.
+
+2. **Scout #268 (VW EU arvcer)** — `charging.chargingStatus.requests`
+   is now parsed into ``d.charging_status_pending`` (mirror of the
+   existing ``charging_settings_pending`` from v1.27.2 #181) AND
+   registered in EXPECTED_KEYS so the Scout stops firing. Audi inherits
+   via the brand-vererbung at the bottom of ``_unexpected_keys.py``.
+
+3. **Scout #263 (Audi DnnsJp74)** — re-verifies that
+   ``charging.chargingSettings.error`` envelope is silenced (we
+   shipped that in v2.0.x already; DnnsJp74 was on an older version).
+   This test pins the silencer so we don't regress.
+
+4. **#270 (roberttco VW NA)** — config-flow now preserves the user's
+   brand selection (and other field values) when authentication fails
+   and the form re-renders. Previously ``_credentials_schema()`` was
+   called with no arguments → all fields reset → user was surprised by
+   their brand pick disappearing.
+
+All tests source-level (no HA runtime needed) so they run cleanly
+under the existing CI workflow without ``homeassistant`` installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INIT_PY = _REPO_ROOT / "custom_components" / "vag_connect" / "__init__.py"
+_SERVICES_YAML = _REPO_ROOT / "custom_components" / "vag_connect" / "services.yaml"
+_STRINGS_JSON = _REPO_ROOT / "custom_components" / "vag_connect" / "strings.json"
+_VW_EU_PY = _REPO_ROOT / "custom_components" / "vag_connect" / "cariad" / "api" / "vw_eu.py"
+_MODELS_PY = _REPO_ROOT / "custom_components" / "vag_connect" / "cariad" / "models.py"
+_SENSOR_PY = _REPO_ROOT / "custom_components" / "vag_connect" / "sensor.py"
+_UNEXPECTED_KEYS_PY = (
+    _REPO_ROOT / "custom_components" / "vag_connect" / "cariad" / "_unexpected_keys.py"
+)
+_CONFIG_FLOW_PY = _REPO_ROOT / "custom_components" / "vag_connect" / "config_flow.py"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 1. Easter-egg ``show_vag`` service
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestEasterEggShowVag:
+    """Source-level pins for the show_vag community easter-egg service."""
+
+    def test_handler_defined(self) -> None:
+        """The ``_handle_show_vag`` handler function exists in __init__.py."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        assert "async def _handle_show_vag" in src, (
+            "Easter-egg handler ``_handle_show_vag`` missing from __init__.py"
+        )
+
+    def test_registered_in_services_tuple(self) -> None:
+        """Service-registration tuple-list contains the ``show_vag`` entry."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        assert '"show_vag"' in src, "show_vag not registered in services tuple"
+        # Must be paired with the handler we defined above.
+        assert "_handle_show_vag" in src
+
+    def test_unregistered_on_unload(self) -> None:
+        """async_unload_entry must clean up show_vag like every other service."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        # Find the unload-services tuple-list and assert show_vag is in it.
+        # The list is built in async_unload_entry.
+        assert src.count('"show_vag"') >= 2, (
+            "show_vag must appear in BOTH the register-tuple AND the unload-cleanup-tuple"
+        )
+
+    def test_uses_persistent_notification(self) -> None:
+        """Easter-egg uses persistent_notification helper for visibility."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        assert "persistent_notification" in src
+        assert "async_create" in src
+
+    def test_no_vehicles_placeholder(self) -> None:
+        """Always-works contract — empty config still renders a line."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        assert "(no vehicles configured yet)" in src, (
+            "Easter-egg must show placeholder when zero vehicles configured "
+            "(spec: always-works contract — never error on a community feature)"
+        )
+
+    def test_log_line_present(self) -> None:
+        """Telemetry: we log when the easter-egg is triggered."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        assert "community easter egg triggered" in src
+
+    def test_credits_mention_jordan_waeles(self) -> None:
+        """Spec mandates Jordan Waeles credit (the show_vag joke author)."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        assert "Jordan Waeles" in src
+
+    def test_credits_mention_other_community_members(self) -> None:
+        """Spec mandates credits for the renaming-discussion authors."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        for name in ("Si Gregory", "Ben Johnson", "Evets David", "Stuart McBride"):
+            assert name in src, f"Missing community credit: {name}"
+
+    def test_services_yaml_entry(self) -> None:
+        """services.yaml declares the show_vag entry with name + description."""
+        src = _SERVICES_YAML.read_text(encoding="utf-8")
+        assert "show_vag:" in src
+        # Bilingual name with egg emoji per spec.
+        assert "🥚" in src
+
+    def test_no_fields_schema(self) -> None:
+        """show_vag is parameter-less (vol.Schema({}) — empty dict)."""
+        src = _INIT_PY.read_text(encoding="utf-8")
+        # Pattern: ("show_vag", _handle_show_vag, vol.Schema({}))
+        assert '"show_vag",' in src
+        # Look for ``vol.Schema({})`` near show_vag registration.
+        idx = src.find('"show_vag",')
+        # The schema should appear within the next ~120 chars (same tuple line).
+        assert "vol.Schema({})" in src[idx : idx + 200]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 2. Scout #268 — charging.chargingStatus.requests parser + silencer
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestScout268ChargingStatusRequests:
+    """#268 (VW EU arvcer 2026-05-21): parse + silence chargingStatus.requests."""
+
+    def test_path_in_expected_keys(self) -> None:
+        """The dotted path is registered in EXPECTED_KEYS so Scout stops firing."""
+        src = _UNEXPECTED_KEYS_PY.read_text(encoding="utf-8")
+        assert '"charging.chargingStatus.requests"' in src, (
+            "Scout #268 silencer-add missing — path must be registered in "
+            "EXPECTED_KEYS for the CARIAD-BFF selectivestatus endpoint"
+        )
+
+    def test_parser_in_vw_eu(self) -> None:
+        """vw_eu.py reads the field via the same ``v()`` walker pattern."""
+        src = _VW_EU_PY.read_text(encoding="utf-8")
+        assert 'd.charging_status_pending = len(' in src
+        assert '"chargingStatus", "requests"' in src
+
+    def test_dataclass_field_declared(self) -> None:
+        """models.py declares the new ``charging_status_pending`` field."""
+        src = _MODELS_PY.read_text(encoding="utf-8")
+        assert "charging_status_pending: int | None" in src
+
+    def test_sensor_entity_registered(self) -> None:
+        """sensor.py wires the new field to a diagnostic sensor entity."""
+        src = _SENSOR_PY.read_text(encoding="utf-8")
+        assert 'key="charging_status_pending"' in src
+        assert 'data_key="charging_status_pending"' in src
+        # Mirror of the charging_settings_pending sibling — disabled by
+        # default (diagnostic, opt-in for power users).
+        assert "entity_registry_enabled_default=False" in src
+
+    def test_strings_json_translation(self) -> None:
+        """strings.json declares the entity-name translation."""
+        src = _STRINGS_JSON.read_text(encoding="utf-8")
+        assert '"charging_status_pending"' in src
+
+    def test_audi_inherits_via_brand_alias(self) -> None:
+        """Audi inherits the silencer-add automatically via brand-vererbung."""
+        src = _UNEXPECTED_KEYS_PY.read_text(encoding="utf-8")
+        # The single-line ``EXPECTED_KEYS["audi"] = EXPECTED_KEYS["volkswagen"]``
+        # at the bottom of the module makes the inheritance unconditional.
+        assert 'EXPECTED_KEYS["audi"] = EXPECTED_KEYS["volkswagen"]' in src
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 3. Scout #263 — chargingSettings.error envelope regression-pin
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestScout263ChargingSettingsError:
+    """#263 (Audi DnnsJp74 2026-05-19): chargingSettings.error envelope.
+
+    Was already silenced in v2.0.x (defensive-envelope handling per
+    #185/#190/#191 pattern). This test pins it so any future refactor
+    that drops the silencer-entries causes CI to fail loudly.
+    """
+
+    def test_chargingSettings_error_silenced(self) -> None:
+        src = _UNEXPECTED_KEYS_PY.read_text(encoding="utf-8")
+        assert '"charging.chargingSettings.error"' in src
+        assert '"charging.chargingSettings.error.*"' in src
+
+    def test_chargingStatus_error_silenced(self) -> None:
+        """Sibling envelope on chargingStatus side — also must stay silenced."""
+        src = _UNEXPECTED_KEYS_PY.read_text(encoding="utf-8")
+        assert '"charging.chargingStatus.error"' in src
+        assert '"charging.chargingStatus.error.*"' in src
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 4. #270 — config-flow brand preservation on auth error
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestIssue270BrandPreservedOnError:
+    """#270 (roberttco VW NA 2026-05-21): brand reset after login error."""
+
+    def test_credentials_schema_invoked_with_suggested(self) -> None:
+        """Re-rendering the user form must pass user_input back as defaults.
+
+        Previously ``_credentials_schema()`` was called with NO args after
+        an error, resetting brand/username/spin/scan_interval/force_access
+        to their defaults. The fix threads ``user_input or {}`` back via
+        ``suggested = user_input or {}`` and forwards the values.
+        """
+        src = _CONFIG_FLOW_PY.read_text(encoding="utf-8")
+        # The fix introduces a ``suggested = user_input or {}`` line.
+        assert "suggested = user_input or {}" in src, (
+            "#270 fix missing — config_flow must capture user_input before "
+            "re-rendering the form so brand/username/spin/etc. are preserved"
+        )
+
+    def test_credentials_schema_forwards_brand(self) -> None:
+        """The schema-rebuild forwards brand from suggested."""
+        src = _CONFIG_FLOW_PY.read_text(encoding="utf-8")
+        # Brand must be the first arg passed to _credentials_schema in the
+        # re-render path (see the ``suggested.get(CONF_BRAND, "")`` call).
+        assert "brand=suggested.get(CONF_BRAND" in src
+
+    def test_credentials_schema_forwards_username(self) -> None:
+        src = _CONFIG_FLOW_PY.read_text(encoding="utf-8")
+        assert "username=suggested.get(CONF_USERNAME" in src
+
+    def test_password_not_preserved(self) -> None:
+        """Security: passwords must NEVER be echoed back to the schema."""
+        src = _CONFIG_FLOW_PY.read_text(encoding="utf-8")
+        # Find the suggested-block area and assert password is NOT in it.
+        idx = src.find("suggested = user_input or {}")
+        assert idx > 0
+        # Within ~600 chars of the suggested-block, password must not be
+        # forwarded as a default value.
+        block = src[idx : idx + 600]
+        assert "password=suggested" not in block, (
+            "HA convention forbids echoing passwords back to the client "
+            "even via schema-default — must require re-entry"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_v223_sprint_a.py
+++ b/tests/test_v223_sprint_a.py
@@ -210,6 +210,53 @@ class TestScout263ChargingSettingsError:
 # ──────────────────────────────────────────────────────────────────────
 
 
+class TestScout272ClimatisationStatusRequests:
+    """#272 (arvcer VW EU 2026-05-23) — third *_pending sibling.
+
+    Same shape as #268 chargingStatus.requests but on the climatisation
+    side. Counts queued start/stop_climatisation commands at the
+    gateway. No condition filter (electric AND combustion vehicles
+    support remote-climate).
+    """
+
+    def test_path_in_expected_keys(self) -> None:
+        src = _UNEXPECTED_KEYS_PY.read_text(encoding="utf-8")
+        assert '"climatisation.climatisationStatus.requests"' in src
+
+    def test_parser_in_vw_eu(self) -> None:
+        src = _VW_EU_PY.read_text(encoding="utf-8")
+        assert 'd.climatisation_status_pending = len(' in src
+        assert '"climatisationStatus", "requests"' in src
+
+    def test_dataclass_field_declared(self) -> None:
+        src = _MODELS_PY.read_text(encoding="utf-8")
+        assert "climatisation_status_pending: int | None" in src
+
+    def test_sensor_entity_registered(self) -> None:
+        src = _SENSOR_PY.read_text(encoding="utf-8")
+        assert 'key="climatisation_status_pending"' in src
+        assert 'data_key="climatisation_status_pending"' in src
+        assert "entity_registry_enabled_default=False" in src
+
+    def test_strings_json_translation(self) -> None:
+        src = _STRINGS_JSON.read_text(encoding="utf-8")
+        assert '"climatisation_status_pending"' in src
+
+
+class TestScout273ReadinessErrorEnvelope:
+    """#273 (gudden VW EU 2026-05-23) — readiness.readinessStatus.error.
+
+    Defensive backend-error envelope, same shape as the other ``*.error``
+    siblings already silenced (#185/#190/#191). Parser ignores it
+    cleanly — only silencer-add needed.
+    """
+
+    def test_error_envelope_silenced(self) -> None:
+        src = _UNEXPECTED_KEYS_PY.read_text(encoding="utf-8")
+        assert '"readiness.readinessStatus.error"' in src
+        assert '"readiness.readinessStatus.error.*"' in src
+
+
 class TestIssue270BrandPreservedOnError:
     """#270 (roberttco VW NA 2026-05-21): brand reset after login error."""
 


### PR DESCRIPTION
## Summary

Sprint A bundle (v2.2.3 PATCH): 1 community feature (🥚 easter-egg) + 5+ issue closures (3 fresh scouts appended after PR-open).

## Added

### 🥚 Easter-egg service `vag_connect.show_vag`

In honour of the **Home Assistant UK** and **HA Ideas, Projects and Solutions** Facebook-thread (2026-05) where multiple community members pointed out that "VAG" — the official DACH abbreviation for Volkswagen AG — reads quite differently in English.

**Credits per spec:**
- **Si Gregory** — suggested the rename
- **Ben Johnson** — seconded
- **Evets David** — "Is it a dating integration?"
- **Stuart McBride** — sekundiert
- **Jordan Waeles** — the immortal Pandas-style `show_vag()` joke that became this service

**Behaviour**: parameter-less service call → creates a `persistent_notification` with credits + list of all currently connected vehicles. **Always-works contract** — placeholder line when zero vehicles configured, never errors.

The broader rename (`vag-connect-ha` → `vwgroup-connect-ha`) stays parked for now; the easter-egg ships under the current `vag_connect.show_vag` service ID and migrates trivially if/when the rename ships.

## Fixed

| # | Reporter | Brand | Fix |
|---|---|---|---|
| #270 | roberttco | VW NA | Config-flow preserves brand/username/spin/scan_interval/force_access when re-rendering after auth error. Password intentionally NOT preserved (HA security convention). |
| #268, #271 | arvcer | VW EU | `charging.chargingStatus.requests` parsed into `d.charging_status_pending` (mirror of `chargingSettings.requests` from v1.27.2 #181). New disabled-by-default `sensor.{prefix}_charging_commands_pending`. Audi inherits. |
| **#272** | **arvcer** | **VW EU** | **NEW** — `climatisation.climatisationStatus.requests` parsed into `d.climatisation_status_pending` (3rd `*_pending` sibling). New `sensor.{prefix}_climate_commands_pending`. EV+ICE alike. |
| **#273** | **gudden** | **VW EU** | **NEW** — `readiness.readinessStatus.error` envelope silencer-add (defensive `.error` pattern matching #185/#190/#191). |
| #263, #265, #266 | DnnsJp74, j4x5mgq94b, arvcer | Audi/VW EU | Ack-close — already silenced in v2.2.2, reporters on older versions. |
| #267 | Brinki99 | VW EU | Ack-close — HTTP 502 from Cariad backend, transient outage. |

**Not in this PR** (deferred to v2.3.0 MINOR): #269 (VW NA login bug, new auth path) + #264 (Audi nav-aware charging).

## Files

- `__init__.py` — easter-egg handler + service registration + unload-cleanup
- `services.yaml` — show_vag declaration (bilingual)
- `strings.json` — 2 new entity-name translations
- `config_flow.py` — #270 suggested-threading
- `cariad/api/vw_eu.py` — #268 + #272 parsers
- `cariad/models.py` — 2 new dataclass fields
- `cariad/_unexpected_keys.py` — 3 silencer-adds (#268, #272, #273)
- `sensor.py` — 2 new diagnostic sensor entities
- `tests/test_v223_sprint_a.py` — **28 regression-pins** (NEW, was 22)
- `CHANGELOG.md` — `[Unreleased] — v2.2.3` entry

## Test plan

- [x] 28/28 local pytest pass
- [ ] CI green (5 checks)
- [ ] After merge: tag `v2.2.3` + GH release
- [ ] Post 8 ack-close comments on #263/#265/#266/#267/#268/#271/#272/#273

🤖 Generated with [Claude Code](https://claude.com/claude-code)