### PR TITLE
release: v2.2.3 — Easter Egg + Sprint A Quick-wins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,35 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > phantom-protected). Tier-B (wildcards + alarm/siren) deferred
 > until tester scout-dumps liefern die unknown leaf-shapes.
 
-## [Unreleased] — v2.2.3
+## [Unreleased]
+
+_(nothing pending — v2.2.3 just shipped; new entries land here)_
+
+## [2.2.3] — 2026-05-23 — "Easter Egg + Sprint A Quick-wins"
+
+> **PATCH-Release**: 1 community-feature (🥚 easter-egg tribute) + 5
+> Scout-Closures + 1 config-flow UX-Fix in einer PR (#274). Spinoff
+> aus dem rename-thread auf den HA UK + HA Ideas Facebook groups —
+> Rename selber bleibt geparkt, easter-egg shippt vorab.
+>
+> Was drin ist:
+>
+> | # | Reporter | Brand | Fix |
+> |---|---|---|---|
+> | #270 | roberttco | VW NA | config-flow brand-preserve nach auth-error |
+> | #268 + #271 | arvcer | VW EU | chargingStatus.requests parser+silencer |
+> | #272 | arvcer | VW EU | climatisationStatus.requests parser+silencer |
+> | #273 | gudden | VW EU | readiness.error envelope silencer |
+> | #263, #265, #266 | DnnsJp74, j4x5mgq94b, arvcer | Audi/VW EU | ack-close (pre-fixed in v2.2.2) |
+> | #267 | Brinki99 | VW EU | ack-close (transient Cariad 502) |
+>
+> Audi erbt alle silencer-adds via brand-vererbung. Keine Breaking
+> Changes. HACS pre-release & stable channels.
+>
+> Codename: "Easter Egg + Sprint A Quick-wins" — weil das easter-egg
+> der zentrale community-moment ist und Sprint A der erste schritt
+> einer geplanten Sprint-A→B→C release-kadenz (B = v2.3.0 mit VW NA
+> auth-fix + Audi nav-aware charging).
 
 ### Added
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.2.2"
+  "version": "2.2.3"
 }


### PR DESCRIPTION
## Summary

PATCH release v2.2.3 collecting PR #274 (Sprint A bundle).

## What's in v2.2.3

| PR | Title | Closes |
|---|---|---|
| #274 | Sprint A — easter-egg + 5 scout closures + #270 brand-preserve | #268, #270, #271, #272, #273 (+ ack-closes on #263/#265/#266/#267) |

## Highlights

- 🥚 **Easter-egg service `vag_connect.show_vag`** — community tribute (Si Gregory, Ben Johnson, Evets David, Stuart McBride, Jordan Waeles)
- 🐛 **VW NA config-flow UX fix** (#270) — brand-selection survives auth errors
- 🔧 **3 `*_pending` parser sibs** — chargingStatus.requests (#268+#271) + climatisationStatus.requests (#272). Counts queued commands at gateway.
- 🤫 **3 silencer-adds** — closes 5 scout-reports total. Audi inherits via brand-vererbung.

## Files

- `custom_components/vag_connect/manifest.json` — 2.2.2 → 2.2.3
- `CHANGELOG.md` — `[Unreleased]` → `[2.2.3]` release block

## Test plan

- [x] Manifest version matches CHANGELOG release header
- [x] PR #274 landed in main
- [ ] CI green (7 checks)
- [ ] After merge: tag `v2.2.3` + GH release
- [ ] Post 8 ack-close comments on triaged issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)