### PR TITLE
release: v2.3.0 — VW North America Login Fix + Audi Route-aware Charging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,29 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > phantom-protected). Tier-B (wildcards + alarm/siren) deferred
 > until tester scout-dumps liefern die unknown leaf-shapes.
 
-## [Unreleased] — v2.3.0
+## [Unreleased]
+
+_(nothing pending — v2.3.0 just shipped; new entries land here)_
+
+## [2.3.0] — 2026-05-23 — "VW North America Login Fix + Audi Route-aware Charging"
+
+> **MINOR release** — first brand-level new-functionality since v2.2.x.
+> Sprint B aus der A→B→C roadmap. 2 issues closed:
+>
+> | # | Reporter | Brand | Impact |
+> |---|---|---|---|
+> | **#269** | roberttco | VW NA | VW US/CA login war **komplett broken** seit brand-add (kein NA user konnte je konfigurieren). Jetzt fixed via 4-fold IDP override. |
+> | **#264** | moltke69 | Audi | 7 neue Cariad-BFF route-aware charging fields — 2 neue sensor entities + 5 silencer-adds + climate-timer shape-fallback. |
+>
+> Audi erbt alle Änderungen automatisch via brand-vererbung. Side-effect
+> close: **#270 (config-flow brand reset)** war ein Symptom des
+> unterliegenden #269 auth-fehlers; NA users hitten den UX-bug nicht mehr
+> nachdem login funktioniert. UX-side workaround war schon in v2.2.3.
+>
+> Keine breaking changes für EU-Marken (Audi/VW EU/Skoda/SEAT/CUPRA/
+> Bentley/Lambo/Porsche) — IDKAuth-overrides sind kwargs mit None-default,
+> Fall-back auf die existierenden Modul-Konstanten. HACS pre-release +
+> stable channels.
 
 ### Fixed
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.2.3"
+  "version": "2.3.0"
 }


### PR DESCRIPTION
## Summary

MINOR release v2.3.0 collecting Sprint B (PR #276).

## What's in v2.3.0

| PR | Closes | Title |
|---|---|---|
| #276 | #269, #264, #270 (side-effect) | Sprint B — VW NA login fix + Audi nav-aware charging |

## Highlights

- 🇺🇸 **VW North America login finally works** (#269) — 4-fold IDP override (authorize URL, token URL, IDP host, signin GUID). First-time working brand for US/CA users.
- 🔋 **Audi route-aware smart charging** (#264) — 2 new sensors (disabled-by-default) tracking the navigation-aware SoC target + ETA. Plus 7 silencer-adds and a climate-timer shape-fallback for the new departureTimers parent block.
- 🔄 **EU brands unaffected** — IDKAuth-overrides are kwargs with `None` defaults, falling back to the existing module constants.

## Files

- `custom_components/vag_connect/manifest.json` — 2.2.3 → 2.3.0
- `CHANGELOG.md` — `[Unreleased] — v2.3.0` → `[2.3.0] — 2026-05-23` release block

## Test plan

- [x] Manifest version matches CHANGELOG release header
- [x] PR #276 landed in main
- [ ] CI green (7 checks)
- [ ] After merge: tag `v2.3.0` (GH release auto-created by release workflow)
- [ ] Post comments on #269 (roberttco — please beta-test) + #264 (moltke69 — thanks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)