### PR TITLE
feat(v2.4.0): marketing-rename — VAG Connect → VW Group Connect (DOMAIN unchanged)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: VAG Connect Version
+      label: VW Group Connect Version
       placeholder: "e.g. 1.8.0"
     validations:
       required: true
@@ -144,10 +144,10 @@ body:
     attributes:
       label: Diagnostics / Diagnose-Daten (optional)
       description: |
-        Settings → Devices & Services → VAG Connect → ⋮ → Download diagnostics.
+        Settings → Devices & Services → VW Group Connect → ⋮ → Download diagnostics.
         Sensitive data (VIN, password, S-PIN, GPS, email, address, user_id) is auto-redacted by v1.8.x+.
 
-        HA → Einstellungen → Integrationen → VAG Connect → 3-Punkte-Menü → Diagnose herunterladen.
+        HA → Einstellungen → Integrationen → VW Group Connect → 3-Punkte-Menü → Diagnose herunterladen.
         Sensible Daten (VIN, Passwort, S-PIN, GPS, Email, Adresse, user_id) werden ab v1.8.x automatisch geschwärzt.
 
         If you are on an older version: please open the JSON, mask VINs and email manually before pasting.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Discussions & Questions / Diskussionen & Fragen
-    url: https://github.com/its-me-prash/vag-connect-ha/discussions
+    url: https://github.com/its-me-prash/vwgroup-connect-ha/discussions
     about: General questions, dashboard examples, community exchange / Allgemeine Fragen, Dashboard-Beispiele und Community-Austausch
   - name: 📖 HA Community Forum
     url: https://community.home-assistant.io
     about: General Home Assistant questions / Allgemeine Home Assistant Fragen
   - name: 🔒 Security vulnerability / Sicherheitslücke
-    url: https://github.com/its-me-prash/vag-connect-ha/security/advisories/new
+    url: https://github.com/its-me-prash/vwgroup-connect-ha/security/advisories/new
     about: Report privately via GitHub Security Advisories / Privat per GitHub Security Advisories melden — see SECURITY.md

--- a/.github/ISSUE_TEMPLATE/error_report.yml
+++ b/.github/ISSUE_TEMPLATE/error_report.yml
@@ -23,7 +23,7 @@ body:
   - type: input
     id: vag_connect_version
     attributes:
-      label: VAG Connect Version
+      label: VW Group Connect Version
       placeholder: "v1.13.0"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new_brand.yml
+++ b/.github/ISSUE_TEMPLATE/new_brand.yml
@@ -1,5 +1,5 @@
 name: 🚗 Brand live-test report / Live-Test einer Marke
-description: Report whether your brand / model works with VAG Connect / Berichte ob deine Marke / dein Modell mit VAG Connect funktioniert
+description: Report whether your brand / model works with VW Group Connect / Berichte ob deine Marke / dein Modell mit VW Group Connect funktioniert
 labels: ["testing"]
 body:
   - type: markdown
@@ -17,7 +17,7 @@ body:
         - **Škoda Enyaq, Superb iV, Karoq** (platform broadening)
 
         Not implemented and not planned: Bentley, Lamborghini, Bugatti, Ducati,
-        MAN, Scania — see [`docs/research/LUXURY_BRANDS.md`](https://github.com/its-me-prash/vag-connect-ha/blob/main/docs/research/LUXURY_BRANDS.md).
+        MAN, Scania — see [`docs/research/LUXURY_BRANDS.md`](https://github.com/its-me-prash/vwgroup-connect-ha/blob/main/docs/research/LUXURY_BRANDS.md).
 
         Nicht implementiert und auch nicht geplant: Bentley, Lamborghini,
         Bugatti, Ducati, MAN, Scania — siehe `docs/research/LUXURY_BRANDS.md`.
@@ -59,7 +59,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: VAG Connect Version
+      label: VW Group Connect Version
       placeholder: "e.g. 1.8.0"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/scout_report.yml
+++ b/.github/ISSUE_TEMPLATE/scout_report.yml
@@ -30,7 +30,7 @@ body:
   - type: input
     id: vag_connect_version
     attributes:
-      label: VAG Connect Version
+      label: VW Group Connect Version
       placeholder: "v1.13.0"
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           # Last 3 prior versions for the "Recent releases" pointer
           recent_prior = [(v, d) for v, d in all_entries if v != version][:3]
 
-          repo = "its-me-prash/vag-connect-ha"
+          repo = "its-me-prash/vwgroup-connect-ha"
 
           lines: list[str] = []
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,65 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > phantom-protected). Tier-B (wildcards + alarm/siren) deferred
 > until tester scout-dumps liefern die unknown leaf-shapes.
 
-## [Unreleased]
+## [Unreleased] — v2.4.0
 
-_(nothing pending — v2.3.0 just shipped; new entries land here)_
+### Changed
+
+- **🪪 Marketing-Rename: "VAG Connect" → "VW Group Connect"** (repo URL
+  `vag-connect-ha` → `vwgroup-connect-ha`). Spinoff aus dem
+  Community-Feedback der **Home Assistant UK** + **HA Ideas, Projects
+  and Solutions** Facebook-Gruppen (2026-05). "VAG" — die offizielle
+  DACH-Abkürzung für Volkswagen AG — liest sich auf Englisch *quite
+  differently* 😅. Si Gregory schlug das Rename vor, Ben Johnson +
+  Evets David + Stuart McBride + Jordan Waeles bekräftigten.
+
+  **Marketing-only by design**: nur Repo-URL + Display-Name geändert.
+  Code-Internals + DOMAIN + Entity-IDs + Service-Calls + HACS-Install
+  alles **unverändert** — kein User-Breakage, keine Automation muss
+  umgeschrieben werden, Recorder-History bleibt erhalten.
+
+  | Aspect | Vorher | Jetzt |
+  |---|---|---|
+  | Repo URL | `github.com/its-me-prash/vag-connect-ha` | `github.com/its-me-prash/vwgroup-connect-ha` |
+  | HACS Display | "VAG Connect" | "VW Group Connect" |
+  | Manifest `name` | "VAG Connect" | "VW Group Connect" |
+  | Integration `domain` | `vag_connect` | **`vag_connect`** (unchanged!) |
+  | Entity-IDs | `sensor.audi_q4_battery_soc` etc. | **unchanged** |
+  | Service-Calls | `vag_connect.lock` etc. | **unchanged** |
+  | Easter-egg | `vag_connect.show_vag` (Jordan's joke) | **preserved** |
+
+  **Was wirklich geändert wurde** (~80 files, ~200 string replacements):
+  manifest.json, hacs.json, strings.json + 8 translations, 8 READMEs,
+  SECURITY/PRIVACY/CONTRIBUTING/RELEASE_PROCESS/ROADMAP/NOTICE,
+  .github workflows + issue templates, docs/dashboards.md + FAQ.md +
+  bubble-card/README.md, coordinator user-agent string.
+
+  **Bewusst NICHT geändert** (history preservation):
+  - CHANGELOG.md historische Einträge (47 Vorkommen) — die beschreiben
+    was wirklich unter dem alten Namen ausgeliefert wurde, retroaktiv
+    umschreiben wäre historisch falsch
+  - `docs/research/*-2026-*.md` (17 Dateien) — zeitstempel-archivierte
+    Research-Notes, gleiche Begründung
+  - `docs/CHANGELOG_TECHNICAL.md` — historisch
+  - Bruno-Files (URL-Pinning + historische Attribution)
+  - Tests (`from custom_components.vag_connect.*` Imports)
+  - Scripts (interne Utility-Scripts)
+
+  **Plus**: neue `MIGRATION.md` am Repo-Root erklärt das ganze Bild +
+  alle Garantien für Bestandsuser. Rename-Notice-Block am Top von
+  allen 8 READMEs mit den vollständigen Community-Credits + Verweis
+  auf das easter-egg.
+
+  Falls je ein echter DOMAIN-Rename nötig wird (Architektur-Reason,
+  nicht Marketing) → das käme als v4.0.0 MAJOR mit proper
+  `async_migrate_entry` für migration ohne Datenverlust. Bis dahin:
+  marketing-only, zero-breakage.
+
+  41 source-level regression-pins in `tests/test_v240_marketing_rename.py`
+  inkl. der kritischen Garantie-Tests dass DOMAIN + Folder + Service-IDs
+  unverändert sind.
+
+
 
 ## [2.3.0] — 2026-05-23 — "VW North America Login Fix + Audi Route-aware Charging"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to VAG Connect
+# Contributing to VW Group Connect
 
 > Thanks for taking the time to look at the code. This integration is
 > community-maintained and grows from the contributions of users who file
@@ -10,11 +10,11 @@
 ## Bug reports
 
 Use the issue templates:
-<https://github.com/its-me-prash/vag-connect-ha/issues/new/choose>
+<https://github.com/its-me-prash/vwgroup-connect-ha/issues/new/choose>
 
 A good bug report contains:
 
-- VAG Connect version (`manifest.json`)
+- VW Group Connect version (`manifest.json`)
 - Home Assistant version
 - Brand and rough vehicle model
 - Country / region (some endpoints differ)
@@ -23,7 +23,7 @@ A good bug report contains:
 - Whether an S-PIN is configured
 - Sanitised logs (filter `vag_connect` in HA logs)
 - Anonymised diagnostics (download via Settings → Devices & Services →
-  VAG Connect → ⋮ → Diagnose herunterladen)
+  VW Group Connect → ⋮ → Diagnose herunterladen)
 
 **Please remove tokens, full VINs, GPS coordinates, email addresses and
 S-PIN values before pasting anything in a public issue.** Diagnostics
@@ -119,9 +119,9 @@ nicht ob die offizielle My CUPRA-App das gleich oder über phone-GPS macht.
 
 ## FAQ — Subscription / Service Plus / paid plans (closes #47)
 
-**Q: Do I need "Security & Service Plus" or another paid subscription for VAG Connect to work?**
+**Q: Do I need "Security & Service Plus" or another paid subscription for VW Group Connect to work?**
 
-In **most countries: No.** VAG Connect uses the same free API as the manufacturer apps (myAudi, WeConnect, MyŠkoda, MyCupra). If you can log in to the app, you can use VAG Connect for vehicle status, GPS, door/window state, climate state.
+In **most countries: No.** VW Group Connect uses the same free API as the manufacturer apps (myAudi, WeConnect, MyŠkoda, MyCupra). If you can log in to the app, you can use VW Group Connect for vehicle status, GPS, door/window state, climate state.
 
 **Some countries / some vehicles: certain commands are paywalled.** Confirmed examples:
 
@@ -143,7 +143,7 @@ Check the error body. Common patterns since v1.9.1 `classify_command_failure`:
 | `404 Not Found` | Endpoint doesn't exist for vehicle's API profile (PPC/PPE 2024+) | v1.8.5 v1→v2 fallback handles most; rest needs new code. |
 | `403` no body / generic | Could be auth token expired, retry exceeded, or temp rate limit | Restart integration. |
 
-**Q: My MyCupra/myAudi app shows the function works — why does VAG Connect fail?**
+**Q: My MyCupra/myAudi app shows the function works — why does VW Group Connect fail?**
 
 Three independent reasons (#53 lesson):
 
@@ -166,8 +166,8 @@ Also confirmed by user-report on #53 (Gerhard, CUPRA Born) and others: the integ
 ## Pull requests
 
 ```bash
-git clone https://github.com/its-me-prash/vag-connect-ha
-cd vag-connect-ha
+git clone https://github.com/its-me-prash/vwgroup-connect-ha
+cd vwgroup-connect-ha
 pip install pytest pytest-asyncio pytest-cov ruff mypy aiohttp voluptuous homeassistant
 python -m pytest tests/        # all green
 python -m ruff check custom_components/
@@ -252,7 +252,7 @@ Some brands are implemented but lack real-world verification:
 | VW US/CA | Implemented, **no live test** — `new_brand.yml` template |
 
 If you have a vehicle and want to help, open the
-[`new_brand.yml`](https://github.com/its-me-prash/vag-connect-ha/issues/new?template=new_brand.yml)
+[`new_brand.yml`](https://github.com/its-me-prash/vwgroup-connect-ha/issues/new?template=new_brand.yml)
 template.
 
 ---

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,140 @@
+# Migration Guide — `vag-connect-ha` → `vwgroup-connect-ha`
+
+> **TL;DR**: Nothing breaks. The repo URL + display name changed; the
+> code internals (DOMAIN, entity-IDs, service-calls, automations) all
+> stayed the same. You don't need to do anything for existing setups —
+> HACS auto-updates over the GitHub repo-rename redirect, your entities
+> keep their IDs, your automations keep firing, your dashboards keep
+> rendering. Read on for context + the optional cleanup steps.
+
+---
+
+## What changed in v2.4.0
+
+| Aspect | Before | After |
+|---|---|---|
+| Repo URL | `github.com/its-me-prash/vag-connect-ha` | `github.com/its-me-prash/vwgroup-connect-ha` |
+| Display name (HACS, integration card, config-flow titles) | `VAG Connect` | `VW Group Connect` |
+| Manifest `name` | `VAG Connect` | `VW Group Connect` |
+| HACS `name` | `VAG Connect` | `VW Group Connect` |
+
+## What did **NOT** change (intentional)
+
+| Aspect | Stays |
+|---|---|
+| Integration DOMAIN | `vag_connect` (unchanged — entity-IDs depend on this) |
+| Entity-IDs | `sensor.audi_q4_battery_soc`, `lock.audi_q4_central_locking`, etc. — **identical** |
+| Service-call prefixes | `vag_connect.lock`, `vag_connect.unlock`, `vag_connect.show_vag`, etc. — **identical** |
+| Python imports | `from custom_components.vag_connect.*` — **identical** |
+| HACS install directory | `custom_components/vag_connect/` — **identical** |
+| Easter-egg service name | `vag_connect.show_vag` (per Jordan Waeles' original joke — preserved) |
+| Long-term recorder history | All sensor history is keyed on entity-ID, which is unchanged → **preserved** |
+| Your automations / scripts / dashboards | **All continue working** without edits |
+
+## Why a marketing-only rename?
+
+Because the internal DOMAIN is bound to every existing user's config
+entries, entity registry rows, and history database. Renaming the DOMAIN
+would force every user to:
+
+- Remove + reinstall the integration
+- Lose their entity-ID history (graphs reset)
+- Rewrite every automation that references a service or entity
+- Re-configure dashboards
+- Re-pair any external systems that reference the old entity-IDs
+
+That's a hostile experience for a marketing change. The rename was
+prompted by a humorous community thread (see CHANGELOG v2.2.3 for full
+credits), not by a real architectural issue — so we keep the joke alive
+inside (service-name `vag_connect.show_vag` stays, code namespace
+`vag_connect` stays) while presenting the cleaner display name to new
+users discovering the integration.
+
+If a real architectural reason ever requires a full DOMAIN rename, it
+will ship as a v4.0.0 MAJOR with a proper `async_migrate_entry` flow.
+Until then: marketing-only.
+
+---
+
+## What HACS users need to do
+
+### Existing installations
+
+**Nothing.** GitHub's repo-rename keeps the old URL `vag-connect-ha`
+working as a permanent redirect, so HACS continues to fetch updates
+from the new URL automatically. The next HACS update will:
+
+1. Pull the new commit (manifest version bumped to 2.4.0)
+2. Display the new name "VW Group Connect" in the HACS card and the
+   HA integration card
+3. Leave all your entities, automations, services, dashboards
+   **untouched**
+
+### New installations
+
+Use the new URL when adding the custom repository:
+
+```
+https://github.com/its-me-prash/vwgroup-connect-ha
+```
+
+The old `vag-connect-ha` URL also works (GitHub redirect) — both
+resolve to the same integration.
+
+---
+
+## Optional cleanup (for the perfectionists)
+
+If you want your local references to match the new name:
+
+### Update your custom HACS repo URL (optional)
+
+HACS → Frontend → ⋮ → Custom repositories → find the old
+`vag-connect-ha` URL → edit to `vwgroup-connect-ha`. **Not required**
+— the old URL keeps working forever.
+
+### Update your automation comments (optional)
+
+If you have YAML comments mentioning "VAG Connect" by name, you can
+update them to "VW Group Connect". The service-call names themselves
+(`vag_connect.lock` etc.) **must stay** — those are bound to the
+DOMAIN and renaming them would break the call.
+
+### Discord / Forum / Facebook references
+
+Continue to call it whatever your community prefers — `vag-connect-ha`
+and `VW Group Connect` both refer to the same integration. The HA UK
++ HA Ideas + DACH FB-Gruppen know it under both names now.
+
+---
+
+## History preservation note
+
+CHANGELOG entries pre-v2.4.0 (i.e. v1.x and v2.0.x through v2.3.x)
+reference the project under its previous name `VAG Connect`. They
+have **not** been retroactively rewritten — those releases really
+shipped under that name, and rewriting history would be inaccurate.
+
+The `docs/research/2026-*.md` files are similarly preserved as-is;
+they were research notes timestamped during the original-name era and
+keep their original references for archival accuracy.
+
+---
+
+## Credits
+
+The rename was prompted by community feedback on:
+
+- **Home Assistant UK** Facebook group
+- **HA Ideas, Projects and Solutions** Facebook group
+
+Specifically:
+- **Si Gregory** — suggested the rename
+- **Ben Johnson** — seconded
+- **Evets David** — "Is it a dating integration?" (the question that
+  made the case unmistakable)
+- **Stuart McBride** — added supporting input
+- **Jordan Waeles** — the immortal Pandas-style `show_vag()` joke that
+  became an officially supported easter-egg service in v2.2.3
+
+Thank you all. 🏁

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,8 +1,8 @@
-# NOTICE — VAG Connect for Home Assistant
+# NOTICE — VW Group Connect for Home Assistant
 
 ## No Runtime Dependencies
 
-VAG Connect has zero external runtime dependencies (`requirements: []`).
+VW Group Connect has zero external runtime dependencies (`requirements: []`).
 The integration communicates directly with manufacturer APIs using Home
 Assistant's built-in `aiohttp` session.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,11 +1,11 @@
 # Privacy / Datenschutz
 
-> **TL;DR:** VAG Connect runs entirely inside your Home Assistant instance.
+> **TL;DR:** VW Group Connect runs entirely inside your Home Assistant instance.
 > Your credentials and vehicle data never leave Home Assistant unless they
 > go directly to the manufacturer's official API. We do not collect
 > telemetry, we do not have a server, we do not have your data.
 
-> **Kurzfassung:** VAG Connect läuft komplett in deiner Home Assistant
+> **Kurzfassung:** VW Group Connect läuft komplett in deiner Home Assistant
 > Instanz. Deine Zugangsdaten und Fahrzeugdaten verlassen Home Assistant
 > nur direkt zu den offiziellen Hersteller-APIs. Wir sammeln keine
 > Telemetrie, wir haben keinen Server, wir haben deine Daten nicht.
@@ -34,7 +34,7 @@ The following calls only happen if **you explicitly enable them**:
 
 | Feature | Third party | Default | How to enable |
 |---|---|---|---|
-| Reverse geocoding (parking address) | OpenStreetMap Nominatim | **OFF** | HA → VAG Connect → Configure → "Reverse Geocoding" |
+| Reverse geocoding (parking address) | OpenStreetMap Nominatim | **OFF** | HA → VW Group Connect → Configure → "Reverse Geocoding" |
 
 When reverse geocoding is on, the rounded vehicle coordinate (3 decimals,
 ~110m precision) is sent to `nominatim.openstreetmap.org` with a
@@ -71,7 +71,7 @@ do not re-download on every restart.
 
 ## EU / GDPR (DSGVO) considerations
 
-VAG Connect itself is **not a data processor under Article 28 GDPR**
+VW Group Connect itself is **not a data processor under Article 28 GDPR**
 because it does not run on a service we operate. It runs on your Home
 Assistant instance, owned and controlled by you, the data subject.
 
@@ -81,13 +81,13 @@ process any personal data of users.
 The EU Data Act (mandatory in-vehicle data access for third parties)
 takes effect in September 2026 and may give vehicle owners formal,
 documented API access — see issue
-[#59](https://github.com/its-me-prash/vag-connect-ha/issues/59).
+[#59](https://github.com/its-me-prash/vwgroup-connect-ha/issues/59).
 
 ---
 
 ## EU Cyber Resilience Act (CRA)
 
-VAG Connect is a community-maintained, non-commercial open-source
+VW Group Connect is a community-maintained, non-commercial open-source
 integration. It is not "commercial software" under the CRA, but the
 maintainer voluntarily follows CRA-aligned practices:
 

--- a/README.cs.md
+++ b/README.cs.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/its-me-prash/vag-connect-ha/main/custom_components/vag_connect/logo.png" alt="VAG Connect" width="180">
+  <img src="https://raw.githubusercontent.com/its-me-prash/vwgroup-connect-ha/main/custom_components/vag_connect/logo.png" alt="VW Group Connect" width="180">
 </p>
 
-<h1 align="center">VAG Connect</h1>
+<h1 align="center">VW Group Connect</h1>
 
 <p align="center">
   <strong>Integrace Home Assistant pro Audi · VW · Škoda · SEAT · CUPRA</strong>
@@ -10,10 +10,10 @@
 
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
 
@@ -29,6 +29,21 @@
 </p>
 
 ---
+
+> ### 📛 Note on the rename
+> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
+> Turns out that abbreviation reads *quite* differently to English speakers 😅
+>
+> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
+> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
+> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
+> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+>
+> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
+> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+>
+> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
+> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
 
 ---
 
@@ -76,7 +91,7 @@
 
 Chtěl jsem plně ovládat své Audi v Home Assistant. Tak jsem to postavil.
 
-**VAG Connect** je samostatná integrace Home Assistant pro všechny značky VAG. Bez externích závislostí, bez Dockeru, bez externích služeb.
+**VW Group Connect** je samostatná integrace Home Assistant pro všechny značky VAG. Bez externích závislostí, bez Dockeru, bez externích služeb.
 
 Od v0.14.1 integrace **přímo** komunikuje s CARIAD API — vlastní async klient, plně autonomní. Architektura cloud-polling, 80+ entit napříč 10 platformami, 14 služeb.
 
@@ -84,7 +99,7 @@ Od v0.14.1 integrace **přímo** komunikuje s CARIAD API — vlastní async klie
 
 ## Aktuální stav a upřímné limity / Current Status & Honest Limits (v1.12.3)
 
-VAG Connect se aktivně vyvíjí. Abys věděl, co funguje a co přijde:
+VW Group Connect se aktivně vyvíjí. Abys věděl, co funguje a co přijde:
 
 ### ✅ Co funguje TEĎ (všech 7 značek)
 
@@ -157,7 +172,7 @@ Body-sniffing `classify_command_failure` pro `missing-capability` / `subscriptio
 ### 🚫 Vědomé limity / Conscious limits
 
 - **Image platforma:** neexistuje oficiální CARIAD render-image API. Image entita přejde v budoucí release na URL dodávané uživatelem.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nová architektura E³ 1.2, ještě veřejně reverse-engineered (ani v audi_connect_ha ani v CarConnectivity). VAG Connect tato vozidla detekuje a dělá **graceful degradation** místo 404 chyb.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nová architektura E³ 1.2, ještě veřejně reverse-engineered (ani v audi_connect_ha ani v CarConnectivity). VW Group Connect tato vozidla detekuje a dělá **graceful degradation** místo 404 chyb.
 - **Ford / značky mimo VAG:** mimo rozsah — viz [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) pro Ford.
 
 ### 🔧 Předpoklad ochrany soukromí
@@ -187,7 +202,7 @@ Aby GPS poloha, stav vozidla a topení fungovaly, musí být **"Sdílet mou polo
 | Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
 | VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
 
-> **Porsche & VW NA:** Obě značky jsou od v1.0.0 k dispozici jako Beta. Hledáme testery — zpětnou vazbu hlaste jako [Issue](https://github.com/its-me-prash/vag-connect-ha/issues)!
+> **Porsche & VW NA:** Obě značky jsou od v1.0.0 k dispozici jako Beta. Hledáme testery — zpětnou vazbu hlaste jako [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
 
 ---
 
@@ -228,9 +243,9 @@ Aby GPS poloha, stav vozidla a topení fungovaly, musí být **"Sdílet mou polo
 ### HACS
 
 1. HACS → Integrace → ⋮ → Vlastní repozitáře
-2. URL: `https://github.com/its-me-prash/vag-connect-ha` — Kategorie: Integrace
-3. Nainstalovat **VAG Connect** → Restartovat Home Assistant
-4. Nastavení → Integrace → **+ Integrace** → **VAG Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Kategorie: Integrace
+3. Nainstalovat **VW Group Connect** → Restartovat Home Assistant
+4. Nastavení → Integrace → **+ Integrace** → **VW Group Connect**
 
 ### Manual
 
@@ -270,7 +285,7 @@ Restartujte Home Assistant.
 
 Apache License 2.0 — [LICENSE](LICENSE)
 
-**VAG Connect™** je neregistrovaná ochranná známka (™, ne ®). Prosíme, nepoužívejte tento název ve forkách, abyste předešli záměně.
+**VW Group Connect™** je neregistrovaná ochranná známka (™, ne ®). Prosíme, nepoužívejte tento název ve forkách, abyste předešli záměně.
 
 Tato integrace je nezávislý komunitní projekt bez jakéhokoliv spojení s Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG nebo jakoukoliv pobočkou Volkswagen Group.
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/its-me-prash/vag-connect-ha/main/custom_components/vag_connect/logo.png" alt="VAG Connect" width="180">
+  <img src="https://raw.githubusercontent.com/its-me-prash/vwgroup-connect-ha/main/custom_components/vag_connect/logo.png" alt="VW Group Connect" width="180">
 </p>
 
-<h1 align="center">VAG Connect</h1>
+<h1 align="center">VW Group Connect</h1>
 
 <p align="center">
   <strong>Home Assistant integration for Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
@@ -11,10 +11,10 @@
 
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha" alt="Version"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2024.4%2B-blue" alt="Home Assistant"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
   <a href="https://www.home-assistant.io/docs/quality_scale/"><img src="https://img.shields.io/badge/quality_scale-platinum-d4af37" alt="Quality Scale Platinum"></a>
 </p>
 
@@ -27,6 +27,23 @@
   <a href="README.cs.md">Čeština</a> ·
   <a href="README.sv.md">Svenska</a>
 </p>
+
+---
+
+> ### 📛 Note on the rename
+> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
+> Turns out that abbreviation reads *quite* differently to English speakers 😅
+>
+> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
+> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
+> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
+> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+>
+> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
+> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+>
+> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
+> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
 
 ---
 
@@ -101,23 +118,23 @@ Connects Home Assistant **directly** to your vehicle cloud account (myAudi, We C
 
 ### Option 1: One-click install (recommended)
 
-[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vag-connect-ha&category=integration)
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vwgroup-connect-ha&category=integration)
 
 ### Option 2: HACS custom repository (manual)
 
 1. **HACS → Integrations → ⋮ → Custom repositories**
-2. URL: `https://github.com/its-me-prash/vag-connect-ha`
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha`
 3. Category: **Integration**
-4. Search **VAG Connect** + install
+4. Search **VW Group Connect** + install
 5. **Restart Home Assistant**
 
 ### Option 3: Manual install
 
 ```bash
 cd /config/custom_components
-git clone https://github.com/its-me-prash/vag-connect-ha.git
-mv vag-connect-ha/custom_components/vag_connect .
-rm -rf vag-connect-ha
+git clone https://github.com/its-me-prash/vwgroup-connect-ha.git
+mv vwgroup-connect-ha/custom_components/vag_connect .
+rm -rf vwgroup-connect-ha
 # Restart HA
 ```
 
@@ -125,7 +142,7 @@ rm -rf vag-connect-ha
 
 ## ⚙️ Configuration
 
-**Settings → Devices & Services → Add Integration → "VAG Connect"**
+**Settings → Devices & Services → Add Integration → "VW Group Connect"**
 
 | Field | Example | Description |
 |---|---|---|
@@ -134,7 +151,7 @@ rm -rf vag-connect-ha
 | Password | `••••••••` | Your account password |
 | S-PIN | `1234` *(optional)* | 4-digit PIN for Lock/Unlock on some brands |
 
-**Options** (Settings → Devices & Services → VAG Connect → ⋮ → Configure):
+**Options** (Settings → Devices & Services → VW Group Connect → ⋮ → Configure):
 
 - **Polling interval** (5-60 min) — Default 10 min. Lower = fresher, but burns API quota faster.
 - **Read-only mode** — when enabled, only status sensors are spawned; no switches/buttons that send commands.
@@ -201,7 +218,7 @@ data:
 response_variable: result
 ```
 
-More examples in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md). Dashboard troubleshooting + dedicated VAG Connect Lovelace card (BETA): [`docs/dashboards.md`](docs/dashboards.md).
+More examples in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md). Dashboard troubleshooting + dedicated VW Group Connect Lovelace card (BETA): [`docs/dashboards.md`](docs/dashboards.md).
 
 ---
 
@@ -214,7 +231,7 @@ More examples in [`docs/FAQ.md#lovelace-examples`](docs/FAQ.md). Dashboard troub
 | **What if Tank-% is missing on Golf 7 GTE?** | v1.25.0 added MBB VSR Phase 2 read-side fallback. See [Golf 7 GTE Tank Guide](docs/GOLF_7_GTE_TANK_GUIDE.md). |
 | **Token survives HACS update?** | ✅ yes, since v1.19.2 — token persistence via HA `Store` (no re-login after updates). |
 | **How do I report bugs?** | HA → Integration → 🔧 Repair → Bug Report. Diagnostics are anonymised (VINs masked, GPS rounded, tokens stripped). |
-| **"Add to Dashboard" doesn't show my dashboard / view?** | Most common cause: dashboard is in **YAML mode** (only Storage-mode dashboards appear in the picker). Or the view doesn't exist yet. Full guide + dedicated VAG Connect Lovelace card (BETA): [`docs/dashboards.md`](docs/dashboards.md). |
+| **"Add to Dashboard" doesn't show my dashboard / view?** | Most common cause: dashboard is in **YAML mode** (only Storage-mode dashboards appear in the picker). Or the view doesn't exist yet. Full guide + dedicated VW Group Connect Lovelace card (BETA): [`docs/dashboards.md`](docs/dashboards.md). |
 
 Full FAQ in [`docs/FAQ.md`](docs/FAQ.md).
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/its-me-prash/vag-connect-ha/main/custom_components/vag_connect/logo.png" alt="VAG Connect" width="180">
+  <img src="https://raw.githubusercontent.com/its-me-prash/vwgroup-connect-ha/main/custom_components/vag_connect/logo.png" alt="VW Group Connect" width="180">
 </p>
 
-<h1 align="center">VAG Connect</h1>
+<h1 align="center">VW Group Connect</h1>
 
 <p align="center">
   <strong>Integración de Home Assistant para Audi · VW · Škoda · SEAT · CUPRA</strong>
@@ -10,10 +10,10 @@
 
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
 
@@ -29,6 +29,21 @@
 </p>
 
 ---
+
+> ### 📛 Note on the rename
+> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
+> Turns out that abbreviation reads *quite* differently to English speakers 😅
+>
+> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
+> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
+> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
+> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+>
+> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
+> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+>
+> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
+> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
 
 ---
 
@@ -76,7 +91,7 @@
 
 Quería controlar mi Audi en Home Assistant — completamente. Así que construí esto.
 
-**VAG Connect** es una integración autónoma de Home Assistant para todas las marcas VAG. Sin dependencias externas, sin Docker, sin servicios externos.
+**VW Group Connect** es una integración autónoma de Home Assistant para todas las marcas VAG. Sin dependencias externas, sin Docker, sin servicios externos.
 
 Desde v0.14.1, la integración habla **directamente** con la API CARIAD — cliente async propio, completamente autónomo. Arquitectura cloud-polling, 80+ entidades en 10 plataformas, 14 servicios.
 
@@ -84,7 +99,7 @@ Desde v0.14.1, la integración habla **directamente** con la API CARIAD — clie
 
 ## Estado actual y límites honestos / Current Status & Honest Limits (v1.12.3)
 
-VAG Connect se desarrolla activamente. Para que sepas qué funciona y qué viene:
+VW Group Connect se desarrolla activamente. Para que sepas qué funciona y qué viene:
 
 ### ✅ Qué funciona AHORA (todas las 7 marcas)
 
@@ -157,7 +172,7 @@ Body-sniffing `classify_command_failure` para marcadores `missing-capability` / 
 ### 🚫 Límites conscientes / Conscious limits
 
 - **Plataforma image:** no existe API CARIAD render-image oficial. La entidad image cambiará a URLs proporcionadas por el usuario en una futura release.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nueva arquitectura E³ 1.2, aún no reverse-engineereada públicamente (ni en audi_connect_ha ni en CarConnectivity). VAG Connect detecta estos vehículos y hace **graceful degradation** en lugar de errores 404.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nueva arquitectura E³ 1.2, aún no reverse-engineereada públicamente (ni en audi_connect_ha ni en CarConnectivity). VW Group Connect detecta estos vehículos y hace **graceful degradation** en lugar de errores 404.
 - **Ford / marcas no-VAG:** fuera de alcance — ver [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) para Ford.
 
 ### 🔧 Requisito de privacidad
@@ -187,7 +202,7 @@ Para que la posición GPS, el estado del vehículo y la calefacción estacionari
 | Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
 | VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
 
-> **Porsche & VW NA:** Ambas marcas están disponibles como Beta desde v1.0.0. Buscamos testers — reporta feedback como [Issue](https://github.com/its-me-prash/vag-connect-ha/issues)!
+> **Porsche & VW NA:** Ambas marcas están disponibles como Beta desde v1.0.0. Buscamos testers — reporta feedback como [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
 
 ---
 
@@ -228,9 +243,9 @@ Para que la posición GPS, el estado del vehículo y la calefacción estacionari
 ### HACS
 
 1. HACS → Integraciones → ⋮ → Repositorios personalizados
-2. URL: `https://github.com/its-me-prash/vag-connect-ha` — Categoría: Integración
-3. Instalar **VAG Connect** → Reiniciar Home Assistant
-4. Ajustes → Integraciones → **+ Integración** → **VAG Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Categoría: Integración
+3. Instalar **VW Group Connect** → Reiniciar Home Assistant
+4. Ajustes → Integraciones → **+ Integración** → **VW Group Connect**
 
 ### Manual
 
@@ -270,7 +285,7 @@ Reinicia Home Assistant.
 
 Apache License 2.0 — [LICENSE](LICENSE)
 
-**VAG Connect™** es una marca no registrada (™, no ®). Por favor no uses este nombre en forks para evitar confusión.
+**VW Group Connect™** es una marca no registrada (™, no ®). Por favor no uses este nombre en forks para evitar confusión.
 
 Esta integración es un proyecto comunitario independiente sin afiliación con Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG ni ninguna filial del Grupo Volkswagen.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/its-me-prash/vag-connect-ha/main/custom_components/vag_connect/logo.png" alt="VAG Connect" width="180">
+  <img src="https://raw.githubusercontent.com/its-me-prash/vwgroup-connect-ha/main/custom_components/vag_connect/logo.png" alt="VW Group Connect" width="180">
 </p>
 
-<h1 align="center">VAG Connect</h1>
+<h1 align="center">VW Group Connect</h1>
 
 <p align="center">
   <strong>Intégration Home Assistant pour Audi · VW · Škoda · SEAT · CUPRA</strong>
@@ -10,10 +10,10 @@
 
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
 
@@ -29,6 +29,21 @@
 </p>
 
 ---
+
+> ### 📛 Note on the rename
+> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
+> Turns out that abbreviation reads *quite* differently to English speakers 😅
+>
+> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
+> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
+> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
+> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+>
+> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
+> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+>
+> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
+> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
 
 ---
 
@@ -76,7 +91,7 @@
 
 Je voulais contrôler mon Audi dans Home Assistant — complètement. Alors j'ai construit ça.
 
-**VAG Connect** est une intégration Home Assistant autonome pour toutes les marques VAG. Aucune dépendance externe, aucun Docker, aucun service externe. Installez l'intégration, entrez vos identifiants, c'est prêt.
+**VW Group Connect** est une intégration Home Assistant autonome pour toutes les marques VAG. Aucune dépendance externe, aucun Docker, aucun service externe. Installez l'intégration, entrez vos identifiants, c'est prêt.
 
 Depuis v0.14.1, l'intégration parle **directement** à l'API CARIAD — client async propre, entièrement autonome. Architecture cloud-polling, 80+ entités sur 10 plateformes, 14 services.
 
@@ -84,7 +99,7 @@ Depuis v0.14.1, l'intégration parle **directement** à l'API CARIAD — client 
 
 ## État actuel et limites honnêtes / Current Status & Honest Limits (v1.12.3)
 
-VAG Connect évolue activement. Pour que tu saches ce qui fonctionne et ce qui arrive :
+VW Group Connect évolue activement. Pour que tu saches ce qui fonctionne et ce qui arrive :
 
 ### ✅ Ce qui FONCTIONNE maintenant (toutes les 7 marques)
 
@@ -157,7 +172,7 @@ Body-sniffing `classify_command_failure` pour les marqueurs `missing-capability`
 ### 🚫 Limites conscientes / Conscious limits
 
 - **Plateforme image :** aucune API CARIAD render-image officielle n'existe. L'entité image basculera vers des URL fournies par l'utilisateur dans une future release.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nouvelle architecture E³ 1.2, pas encore reverse-engineerée publiquement (même pas dans audi_connect_ha ou CarConnectivity). VAG Connect détecte ces véhicules et fait du **graceful degradation** au lieu d'erreurs 404.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nouvelle architecture E³ 1.2, pas encore reverse-engineerée publiquement (même pas dans audi_connect_ha ou CarConnectivity). VW Group Connect détecte ces véhicules et fait du **graceful degradation** au lieu d'erreurs 404.
 - **Ford / marques non-VAG :** hors périmètre — voir [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) pour Ford.
 
 ### 🔧 Prérequis confidentialité
@@ -187,7 +202,7 @@ Pour que la position GPS, le statut véhicule et le préchauffage fonctionnent, 
 | Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
 | VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
 
-> **Porsche & VW NA :** Les deux marques sont disponibles en Beta depuis v1.0.0. Testeurs recherchés — signalez vos retours via un [Issue](https://github.com/its-me-prash/vag-connect-ha/issues) !
+> **Porsche & VW NA :** Les deux marques sont disponibles en Beta depuis v1.0.0. Testeurs recherchés — signalez vos retours via un [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues) !
 
 ---
 
@@ -228,9 +243,9 @@ Pour que la position GPS, le statut véhicule et le préchauffage fonctionnent, 
 ### HACS
 
 1. HACS → Intégrations → ⋮ → Dépôts personnalisés
-2. URL : `https://github.com/its-me-prash/vag-connect-ha` — Catégorie : Intégration
-3. Installer **VAG Connect** → Redémarrer Home Assistant
-4. Paramètres → Intégrations → **+ Intégration** → **VAG Connect**
+2. URL : `https://github.com/its-me-prash/vwgroup-connect-ha` — Catégorie : Intégration
+3. Installer **VW Group Connect** → Redémarrer Home Assistant
+4. Paramètres → Intégrations → **+ Intégration** → **VW Group Connect**
 
 ### Manual
 
@@ -270,7 +285,7 @@ Redémarrez Home Assistant.
 
 Apache License 2.0 — [LICENSE](LICENSE)
 
-**VAG Connect™** est une marque non déposée (™, pas ®). Veuillez ne pas utiliser ce nom dans les forks afin d'éviter toute confusion.
+**VW Group Connect™** est une marque non déposée (™, pas ®). Veuillez ne pas utiliser ce nom dans les forks afin d'éviter toute confusion.
 
 Cette intégration est un projet communautaire indépendant sans affiliation avec Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG ou toute filiale VAG.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/its-me-prash/vag-connect-ha/main/custom_components/vag_connect/logo.png" alt="VAG Connect" width="180">
+  <img src="https://raw.githubusercontent.com/its-me-prash/vwgroup-connect-ha/main/custom_components/vag_connect/logo.png" alt="VW Group Connect" width="180">
 </p>
 
-<h1 align="center">VAG Connect</h1>
+<h1 align="center">VW Group Connect</h1>
 
 <p align="center">
   <strong>Home Assistant Integration für Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
@@ -11,10 +11,10 @@
 
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha" alt="Version"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Lizenz"></a>
   <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2024.4%2B-blue" alt="Home Assistant"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
   <a href="https://www.home-assistant.io/docs/quality_scale/"><img src="https://img.shields.io/badge/quality_scale-platinum-d4af37" alt="Quality Scale Platinum"></a>
 </p>
 
@@ -27,6 +27,23 @@
   <a href="README.cs.md">Čeština</a> ·
   <a href="README.sv.md">Svenska</a>
 </p>
+
+---
+
+> ### 📛 Note on the rename / Hinweis zur Umbenennung
+> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
+> Turns out that abbreviation reads *quite* differently to English speakers 😅
+>
+> **Was läuft weiter wie bisher**: alle Entitäten (z.B. `sensor.audi_q4_battery_soc`),
+> alle Service-Calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), alle Automations,
+> die HACS-Installation — **nichts bricht**. Marketing/Anzeigename ändern sich,
+> Code-Internals bleiben unverändert. Siehe [`MIGRATION.md`](MIGRATION.md).
+>
+> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
+> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+>
+> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
+> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
 
 ---
 
@@ -101,23 +118,23 @@ Verbindet Home Assistant **direkt** mit deinem Fahrzeug-Cloud-Account (myAudi, W
 
 ### Option 1: One-Click Install (empfohlen)
 
-[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vag-connect-ha&category=integration)
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vwgroup-connect-ha&category=integration)
 
 ### Option 2: HACS Custom Repository (manuell)
 
 1. **HACS → Integrationen → ⋮ → Benutzerdefinierte Repositories**
-2. URL: `https://github.com/its-me-prash/vag-connect-ha`
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha`
 3. Kategorie: **Integration**
-4. **VAG Connect** suchen + installieren
+4. **VW Group Connect** suchen + installieren
 5. **Home Assistant neu starten**
 
 ### Option 3: Manuelle Installation
 
 ```bash
 cd /config/custom_components
-git clone https://github.com/its-me-prash/vag-connect-ha.git
-mv vag-connect-ha/custom_components/vag_connect .
-rm -rf vag-connect-ha
+git clone https://github.com/its-me-prash/vwgroup-connect-ha.git
+mv vwgroup-connect-ha/custom_components/vag_connect .
+rm -rf vwgroup-connect-ha
 # HA neu starten
 ```
 
@@ -125,7 +142,7 @@ rm -rf vag-connect-ha
 
 ## ⚙️ Konfiguration
 
-**Settings → Devices & Services → Integration hinzufügen → "VAG Connect"**
+**Settings → Devices & Services → Integration hinzufügen → "VW Group Connect"**
 
 | Feld | Beispiel | Beschreibung |
 |---|---|---|
@@ -134,7 +151,7 @@ rm -rf vag-connect-ha
 | Passwort | `••••••••` | Dein Account-Passwort |
 | S-PIN | `1234` *(optional)* | 4-stellige PIN für Lock/Unlock auf manchen Brands |
 
-**Optionen** (Settings → Devices & Services → VAG Connect → ⋮ → Konfigurieren):
+**Optionen** (Settings → Devices & Services → VW Group Connect → ⋮ → Konfigurieren):
 
 - **Polling-Intervall** (5-60 min) — Default 10 min. Niedriger = aktueller, frisst aber API-Quota schneller.
 - **Read-only Modus** — wenn aktiv: nur Status-Sensoren, keine Schalter/Buttons die Befehle senden würden.

--- a/README.nl.md
+++ b/README.nl.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/its-me-prash/vag-connect-ha/main/custom_components/vag_connect/logo.png" alt="VAG Connect" width="180">
+  <img src="https://raw.githubusercontent.com/its-me-prash/vwgroup-connect-ha/main/custom_components/vag_connect/logo.png" alt="VW Group Connect" width="180">
 </p>
 
-<h1 align="center">VAG Connect</h1>
+<h1 align="center">VW Group Connect</h1>
 
 <p align="center">
   <strong>Home Assistant Integratie voor Audi · VW · Škoda · SEAT · CUPRA</strong>
@@ -10,10 +10,10 @@
 
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
 
@@ -29,6 +29,21 @@
 </p>
 
 ---
+
+> ### 📛 Note on the rename
+> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
+> Turns out that abbreviation reads *quite* differently to English speakers 😅
+>
+> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
+> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
+> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
+> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+>
+> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
+> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+>
+> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
+> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
 
 ---
 
@@ -76,7 +91,7 @@
 
 Ik wilde mijn Audi volledig in Home Assistant besturen. Dus bouwde ik dit.
 
-**VAG Connect** is een zelfstandige Home Assistant integratie voor alle VAG-merken. Geen externe afhankelijkheden, geen Docker, geen externe diensten.
+**VW Group Connect** is een zelfstandige Home Assistant integratie voor alle VAG-merken. Geen externe afhankelijkheden, geen Docker, geen externe diensten.
 
 Vanaf v0.14.1 communiceert de integratie **rechtstreeks** met de CARIAD API — eigen async-client, volledig zelfstandig. Cloud-polling architectuur, 80+ entities over 10 platforms, 14 services.
 
@@ -84,7 +99,7 @@ Vanaf v0.14.1 communiceert de integratie **rechtstreeks** met de CARIAD API — 
 
 ## Huidige status & eerlijke beperkingen / Current Status & Honest Limits (v1.12.3)
 
-VAG Connect ontwikkelt zich actief verder. Zodat je weet wat werkt en wat eraan komt:
+VW Group Connect ontwikkelt zich actief verder. Zodat je weet wat werkt en wat eraan komt:
 
 ### ✅ Wat NU werkt (alle 7 merken)
 
@@ -157,7 +172,7 @@ Field-name fallback-keten: `battery.currentSocPercentage` (Born 2026) → `curre
 ### 🚫 Bewuste beperkingen / Conscious limits
 
 - **Image-platform:** geen officiële CARIAD render-image API. De image-entity zal in een toekomstige release overgaan naar door gebruiker geleverde URLs.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nieuwe E³ 1.2 architectuur, nog niet publiek reverse-engineered (ook niet in audi_connect_ha of CarConnectivity). VAG Connect detecteert deze voertuigen en doet **graceful degradation** in plaats van 404-fouten.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nieuwe E³ 1.2 architectuur, nog niet publiek reverse-engineered (ook niet in audi_connect_ha of CarConnectivity). VW Group Connect detecteert deze voertuigen en doet **graceful degradation** in plaats van 404-fouten.
 - **Ford / niet-VAG merken:** buiten scope — zie [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) voor Ford.
 
 ### 🔧 Privacy-vereiste
@@ -187,7 +202,7 @@ Voor GPS-positie, voertuigstatus en standkachel moet **"Locatie delen"** ingesch
 | Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
 | VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
 
-> **Porsche & VW NA:** Beide merken zijn sinds v1.0.0 beschikbaar als Beta. Testers gezocht — meld feedback als [Issue](https://github.com/its-me-prash/vag-connect-ha/issues)!
+> **Porsche & VW NA:** Beide merken zijn sinds v1.0.0 beschikbaar als Beta. Testers gezocht — meld feedback als [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
 
 ---
 
@@ -228,9 +243,9 @@ Voor GPS-positie, voertuigstatus en standkachel moet **"Locatie delen"** ingesch
 ### HACS
 
 1. HACS → Integraties → ⋮ → Aangepaste opslagplaatsen
-2. URL: `https://github.com/its-me-prash/vag-connect-ha` — Categorie: Integratie
-3. **VAG Connect** installeren → Home Assistant opnieuw opstarten
-4. Instellingen → Integraties → **+ Integratie** → **VAG Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Categorie: Integratie
+3. **VW Group Connect** installeren → Home Assistant opnieuw opstarten
+4. Instellingen → Integraties → **+ Integratie** → **VW Group Connect**
 
 ### Manual
 
@@ -270,7 +285,7 @@ Herstart Home Assistant.
 
 Apache License 2.0 — [LICENSE](LICENSE)
 
-**VAG Connect™** is een niet-geregistreerd handelsmerk (™, niet ®). Gebruik deze naam niet in forks om verwarring te voorkomen.
+**VW Group Connect™** is een niet-geregistreerd handelsmerk (™, niet ®). Gebruik deze naam niet in forks om verwarring te voorkomen.
 
 Deze integratie is een onafhankelijk communityproject zonder enige verbinding met Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG of andere VAG-dochterondernemingen.
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/its-me-prash/vag-connect-ha/main/custom_components/vag_connect/logo.png" alt="VAG Connect" width="180">
+  <img src="https://raw.githubusercontent.com/its-me-prash/vwgroup-connect-ha/main/custom_components/vag_connect/logo.png" alt="VW Group Connect" width="180">
 </p>
 
-<h1 align="center">VAG Connect</h1>
+<h1 align="center">VW Group Connect</h1>
 
 <p align="center">
   <strong>Integracja Home Assistant dla Audi · VW · Škoda · SEAT · CUPRA</strong>
@@ -10,10 +10,10 @@
 
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
 
@@ -29,6 +29,21 @@
 </p>
 
 ---
+
+> ### 📛 Note on the rename
+> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
+> Turns out that abbreviation reads *quite* differently to English speakers 😅
+>
+> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
+> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
+> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
+> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+>
+> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
+> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+>
+> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
+> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
 
 ---
 
@@ -76,7 +91,7 @@
 
 Chciałem w pełni sterować moim Audi z poziomu Home Assistant. Więc to zbudowałem.
 
-**VAG Connect** to samodzielna integracja Home Assistant dla wszystkich marek VAG. Bez zewnętrznych zależności, bez Dockera, bez zewnętrznych usług.
+**VW Group Connect** to samodzielna integracja Home Assistant dla wszystkich marek VAG. Bez zewnętrznych zależności, bez Dockera, bez zewnętrznych usług.
 
 Od v0.14.1 integracja **bezpośrednio** komunikuje się z API CARIAD — własny klient async, w pełni autonomiczny. Architektura cloud-polling, 80+ encji w 10 platformach, 14 usług.
 
@@ -84,7 +99,7 @@ Od v0.14.1 integracja **bezpośrednio** komunikuje się z API CARIAD — własny
 
 ## Bieżący stan i uczciwe ograniczenia / Current Status & Honest Limits (v1.12.3)
 
-VAG Connect aktywnie się rozwija. Abyś wiedział, co działa i co nadchodzi:
+VW Group Connect aktywnie się rozwija. Abyś wiedział, co działa i co nadchodzi:
 
 ### ✅ Co działa TERAZ (wszystkie 7 marek)
 
@@ -157,7 +172,7 @@ Body-sniffing `classify_command_failure` dla markerów `missing-capability` / `s
 ### 🚫 Świadome ograniczenia / Conscious limits
 
 - **Platforma image:** nie istnieje oficjalne API CARIAD render-image. Encja image przejdzie na URL-e dostarczone przez użytkownika w przyszłej release.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nowa architektura E³ 1.2, jeszcze nie zreverse-engineered publicznie (nawet w audi_connect_ha ani CarConnectivity). VAG Connect wykrywa te pojazdy i robi **graceful degradation** zamiast błędów 404.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nowa architektura E³ 1.2, jeszcze nie zreverse-engineered publicznie (nawet w audi_connect_ha ani CarConnectivity). VW Group Connect wykrywa te pojazdy i robi **graceful degradation** zamiast błędów 404.
 - **Ford / marki spoza VAG:** poza zakresem — patrz [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) dla Forda.
 
 ### 🔧 Wymóg prywatności
@@ -187,7 +202,7 @@ Aby pozycja GPS, status pojazdu i ogrzewanie postojowe działały, **"Udostępni
 | Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
 | VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
 
-> **Porsche & VW NA:** Obie marki są dostępne jako Beta od v1.0.0. Szukamy testerów — zgłoś opinię jako [Issue](https://github.com/its-me-prash/vag-connect-ha/issues)!
+> **Porsche & VW NA:** Obie marki są dostępne jako Beta od v1.0.0. Szukamy testerów — zgłoś opinię jako [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
 
 ---
 
@@ -228,9 +243,9 @@ Aby pozycja GPS, status pojazdu i ogrzewanie postojowe działały, **"Udostępni
 ### HACS
 
 1. HACS → Integracje → ⋮ → Niestandardowe repozytoria
-2. URL: `https://github.com/its-me-prash/vag-connect-ha` — Kategoria: Integracja
-3. Zainstaluj **VAG Connect** → Uruchom ponownie Home Assistant
-4. Ustawienia → Integracje → **+ Integracja** → **VAG Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Kategoria: Integracja
+3. Zainstaluj **VW Group Connect** → Uruchom ponownie Home Assistant
+4. Ustawienia → Integracje → **+ Integracja** → **VW Group Connect**
 
 ### Manual
 
@@ -270,7 +285,7 @@ Uruchom ponownie Home Assistant.
 
 Apache License 2.0 — [LICENSE](LICENSE)
 
-**VAG Connect™** jest niezastrzeżonym znakiem towarowym (™, nie ®). Prosimy nie używać tej nazwy w forkach, aby uniknąć nieporozumień.
+**VW Group Connect™** jest niezastrzeżonym znakiem towarowym (™, nie ®). Prosimy nie używać tej nazwy w forkach, aby uniknąć nieporozumień.
 
 Ta integracja jest niezależnym projektem społecznościowym bez powiązania z Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG ani żadną filią Grupy Volkswagen.
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/its-me-prash/vag-connect-ha/main/custom_components/vag_connect/logo.png" alt="VAG Connect" width="180">
+  <img src="https://raw.githubusercontent.com/its-me-prash/vwgroup-connect-ha/main/custom_components/vag_connect/logo.png" alt="VW Group Connect" width="180">
 </p>
 
-<h1 align="center">VAG Connect</h1>
+<h1 align="center">VW Group Connect</h1>
 
 <p align="center">
   <strong>Home Assistant Integration för Audi · VW · Škoda · SEAT · CUPRA</strong>
@@ -10,10 +10,10 @@
 
 <p align="center">
   <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vag-connect-ha?style=for-the-badge"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vag-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vag-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vag-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
   <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
 </p>
 
@@ -29,6 +29,21 @@
 </p>
 
 ---
+
+> ### 📛 Note on the rename
+> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
+> Turns out that abbreviation reads *quite* differently to English speakers 😅
+>
+> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
+> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
+> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
+> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+>
+> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
+> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+>
+> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
+> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
 
 ---
 
@@ -76,7 +91,7 @@
 
 Jag ville styra min Audi i Home Assistant — fullständigt. Så jag byggde detta.
 
-**VAG Connect** är en fristående Home Assistant-integration för alla VAG-märken. Inga externa beroenden, ingen Docker, inga externa tjänster.
+**VW Group Connect** är en fristående Home Assistant-integration för alla VAG-märken. Inga externa beroenden, ingen Docker, inga externa tjänster.
 
 Från v0.14.1 kommunicerar integrationen **direkt** med CARIAD API — egen async-klient, helt fristående. Cloud-polling-arkitektur, 80+ entiteter över 10 plattformar, 14 tjänster.
 
@@ -84,7 +99,7 @@ Från v0.14.1 kommunicerar integrationen **direkt** med CARIAD API — egen asyn
 
 ## Nuvarande status och ärliga begränsningar / Current Status & Honest Limits (v1.12.3)
 
-VAG Connect utvecklas aktivt vidare. Så att du vet vad som fungerar och vad som kommer:
+VW Group Connect utvecklas aktivt vidare. Så att du vet vad som fungerar och vad som kommer:
 
 ### ✅ Vad som fungerar NU (alla 7 märken)
 
@@ -157,7 +172,7 @@ Body-sniffing `classify_command_failure` för `missing-capability` / `subscripti
 ### 🚫 Medvetna begränsningar / Conscious limits
 
 - **Image-plattform:** inget officiellt CARIAD render-image API existerar. Image-entiteten kommer i en framtida release att gå över till användar-tillhandahållna URL:er.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — ny E³ 1.2-arkitektur, ännu inte offentligt reverse-engineered (varken i audi_connect_ha eller CarConnectivity). VAG Connect upptäcker dessa fordon och gör **graceful degradation** istället för 404-fel.
+- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — ny E³ 1.2-arkitektur, ännu inte offentligt reverse-engineered (varken i audi_connect_ha eller CarConnectivity). VW Group Connect upptäcker dessa fordon och gör **graceful degradation** istället för 404-fel.
 - **Ford / icke-VAG-märken:** utanför scope — se [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) för Ford.
 
 ### 🔧 Integritetskrav
@@ -187,7 +202,7 @@ För att GPS-position, fordonsstatus och kupévärmare ska fungera måste **"Del
 | Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
 | VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
 
-> **Porsche & VW NA:** Båda märkena har varit tillgängliga som Beta sedan v1.0.0. Testare sökes — rapportera feedback som [Issue](https://github.com/its-me-prash/vag-connect-ha/issues)!
+> **Porsche & VW NA:** Båda märkena har varit tillgängliga som Beta sedan v1.0.0. Testare sökes — rapportera feedback som [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
 
 ---
 
@@ -228,9 +243,9 @@ För att GPS-position, fordonsstatus och kupévärmare ska fungera måste **"Del
 ### HACS
 
 1. HACS → Integrationer → ⋮ → Anpassade förråd
-2. URL: `https://github.com/its-me-prash/vag-connect-ha` — Kategori: Integration
-3. Installera **VAG Connect** → Starta om Home Assistant
-4. Inställningar → Integrationer → **+ Integration** → **VAG Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Kategori: Integration
+3. Installera **VW Group Connect** → Starta om Home Assistant
+4. Inställningar → Integrationer → **+ Integration** → **VW Group Connect**
 
 ### Manual
 
@@ -270,7 +285,7 @@ Starta om Home Assistant.
 
 Apache License 2.0 — [LICENSE](LICENSE)
 
-**VAG Connect™** är ett oregistrerat varumärke (™, inte ®). Använd inte detta namn i forks för att undvika förvirring.
+**VW Group Connect™** är ett oregistrerat varumärke (™, inte ®). Använd inte detta namn i forks för att undvika förvirring.
 
 Denna integration är ett oberoende gemenskapsprojekt utan koppling till Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG eller något VAG-dotterbolag.
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -89,7 +89,7 @@ git push origin main
 ### 5. Tag
 
 ```bash
-git tag -a v1.9.0 -m "VAG Connect v1.9.0"
+git tag -a v1.9.0 -m "VW Group Connect v1.9.0"
 git push origin v1.9.0
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# vag-connect-ha Roadmap
+# vwgroup-connect-ha Roadmap
 
 > Living document. Updated quarterly. Last update: 2026-05-11.
 
@@ -38,8 +38,8 @@ and [strategic roadmap](docs/research/2026-05_strategic-roadmap-v1.27-to-v2.0.md
 
 ## Get involved
 
-- 🐛 Bug? → [Issues](https://github.com/its-me-prash/vag-connect-ha/issues)
-- 🧪 Tester for Skoda/SEAT/CUPRA hardware? → comment on [#13](https://github.com/its-me-prash/vag-connect-ha/issues/13)
+- 🐛 Bug? → [Issues](https://github.com/its-me-prash/vwgroup-connect-ha/issues)
+- 🧪 Tester for Skoda/SEAT/CUPRA hardware? → comment on [#13](https://github.com/its-me-prash/vwgroup-connect-ha/issues/13)
 - 💬 Pre-Cariad PHEV owner? → check the [audit doc](docs/research/2026-05_pre-cariad-mbb-and-golf-7-gte-audit.md)
   and run `scripts/verify_cariad_full.py` to inventory your VIN's data
 - 📋 Want detailed competitor analysis + ecosystem trends? → [strategic roadmap](docs/research/2026-05_strategic-roadmap-v1.27-to-v2.0.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-> **Reporting context:** VAG Connect is a Home Assistant integration that
+> **Reporting context:** VW Group Connect is a Home Assistant integration that
 > talks to manufacturer APIs on behalf of vehicle owners. It handles
 > credentials, OAuth tokens, S-PINs, vehicle GPS positions, and VINs. We
 > take security reports seriously.
@@ -31,7 +31,7 @@ versions (typically the last 4 monthly releases). Any HA below the
 Use one of the following private channels:
 
 1. **GitHub Security Advisories (preferred)**
-   <https://github.com/its-me-prash/vag-connect-ha/security/advisories/new>
+   <https://github.com/its-me-prash/vwgroup-connect-ha/security/advisories/new>
    — sends an encrypted private report to the maintainer.
 
 2. **Direct contact**
@@ -41,7 +41,7 @@ Use one of the following private channels:
 
 Please include, where possible:
 
-- Affected version(s) of VAG Connect
+- Affected version(s) of VW Group Connect
 - Affected Home Assistant version (if relevant)
 - Steps to reproduce
 - Impact assessment (what does an attacker gain?)
@@ -100,7 +100,7 @@ mitigation within **14 days** for high-severity issues.
   poll requests. This is a server-side rate-limit, not a vulnerability.
 - HA users on the same Home Assistant instance being able to read each
   other's vehicle data. This is a **Home Assistant access-control
-  matter**, not a VAG Connect issue.
+  matter**, not a VW Group Connect issue.
 
 ---
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2037,7 +2037,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             "https://nominatim.openstreetmap.org/reverse"
             f"?lat={lat}&lon={lon}&format=json&addressdetails=1"
         )
-        headers = {"User-Agent": "VAGConnect/1.x (+https://github.com/its-me-prash/vag-connect-ha)"}
+        headers = {"User-Agent": "VAGConnect/1.x (+https://github.com/its-me-prash/vwgroup-connect-ha)"}
         try:
             async with session.get(
                 url, headers=headers, timeout=ClientTimeout(total=5)

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -1,15 +1,15 @@
 {
   "domain": "vag_connect",
-  "name": "VAG Connect",
+  "name": "VW Group Connect",
   "codeowners": [
     "@its-me-prash"
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/its-me-prash/vag-connect-ha",
+  "documentation": "https://github.com/its-me-prash/vwgroup-connect-ha",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/its-me-prash/vag-connect-ha/issues",
+  "issue_tracker": "https://github.com/its-me-prash/vwgroup-connect-ha/issues",
   "loggers": [
     "custom_components.vag_connect"
   ],

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Set up VAG Connect",
+        "title": "Set up VW Group Connect",
         "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
         "data": {
           "brand": "Vehicle Brand",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "Reconfigure VAG Connect",
+        "title": "Reconfigure VW Group Connect",
         "description": "Change credentials or settings without removing the integration.",
         "data": {
           "brand": "Vehicle Brand",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Settings",
+        "title": "VW Group Connect — Settings",
         "data": {
           "scan_interval": "Update Interval",
           "spin": "S-PIN",
@@ -628,23 +628,23 @@
     },
     "auth_failed": {
       "title": "Authentication failed — {brand}",
-      "description": "Connection to {brand} ({username}) failed.\n\nSettings → Devices & Services → VAG Connect → ⋮ → Reconfigure."
+      "description": "Connection to {brand} ({username}) failed.\n\nSettings → Devices & Services → VW Group Connect → ⋮ → Reconfigure."
     },
     "vehicle_data_scout_findings": {
       "title": "Vehicle Data Scout — {count} new field(s) on {brand}",
-      "description": "The Vehicle Data Scout detected **{count}** new field(s) in the {brand} API response that VAG Connect doesn't read yet.\n\nThis usually means your vehicle has a feature or firmware version we haven't mapped — your help would teach the integration to support it.\n\n**1-click report:**\n📤 Click **Learn more** below to open a pre-filled GitHub issue.\n\n**For Facebook / forum:** open Settings → Devices → VAG Connect → Diagnostics → Download — paste the masked report.\n\n_Privacy: VINs masked, GPS rounded to 1 decimal, userIDs/JWTs/emails stripped. Nothing is sent automatically._"
+      "description": "The Vehicle Data Scout detected **{count}** new field(s) in the {brand} API response that VW Group Connect doesn't read yet.\n\nThis usually means your vehicle has a feature or firmware version we haven't mapped — your help would teach the integration to support it.\n\n**1-click report:**\n📤 Click **Learn more** below to open a pre-filled GitHub issue.\n\n**For Facebook / forum:** open Settings → Devices → VW Group Connect → Diagnostics → Download — paste the masked report.\n\n_Privacy: VINs masked, GPS rounded to 1 decimal, userIDs/JWTs/emails stripped. Nothing is sent automatically._"
     },
     "error_reporter_findings": {
       "title": "Error Reporter — {count} recent error(s) on {brand}",
-      "description": "The Error Reporter captured **{count}** recent integration error(s) for {brand}.\n\nReporting them helps us find bugs that only show up on specific vehicles or firmware versions.\n\n**1-click report:**\n📤 Click **Learn more** below to open a pre-filled GitHub issue.\n\n**For Facebook / forum:** open Settings → Devices → VAG Connect → Diagnostics → Download — the report is included with VINs and tokens masked.\n\n_Privacy: VINs masked, Bearer/JWT/UUID/email tokens stripped from messages and tracebacks. No credentials are included._"
+      "description": "The Error Reporter captured **{count}** recent integration error(s) for {brand}.\n\nReporting them helps us find bugs that only show up on specific vehicles or firmware versions.\n\n**1-click report:**\n📤 Click **Learn more** below to open a pre-filled GitHub issue.\n\n**For Facebook / forum:** open Settings → Devices → VW Group Connect → Diagnostics → Download — the report is included with VINs and tokens masked.\n\n_Privacy: VINs masked, Bearer/JWT/UUID/email tokens stripped from messages and tracebacks. No credentials are included._"
     },
     "quota_low": {
       "title": "API quota low — {remaining} requests remaining today",
-      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VAG Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
     },
     "quota_critical": {
       "title": "API quota CRITICAL — {remaining} requests remaining today",
-      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VAG Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
     }
   },
   "exceptions": {
@@ -652,7 +652,7 @@
       "message": "Vehicle with VIN {vin} not found. Check that the integration is started."
     },
     "spin_required": {
-      "message": "S-PIN is required for this action. Configure it under Settings → Devices & Services → VAG Connect → Configure."
+      "message": "S-PIN is required for this action. Configure it under Settings → Devices & Services → VW Group Connect → Configure."
     },
     "feature_not_supported": {
       "message": "The feature {feature} is not supported by your vehicle or the current API client. The action was not sent."
@@ -664,7 +664,7 @@
       "message": "Wake-up cooldown active ({remaining_s}s remaining). To protect the 12V battery, wake-ups are limited to one every {cooldown_min} minutes per vehicle."
     },
     "read_only_mode_active": {
-      "message": "Read-only mode is enabled in the integration options. Disable it under Settings → Devices & Services → VAG Connect → Configure if you want to send vehicle commands."
+      "message": "Read-only mode is enabled in the integration options. Disable it under Settings → Devices & Services → VW Group Connect → Configure if you want to send vehicle commands."
     }
   }
 }

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Nastavit VAG Connect",
+        "title": "Nastavit VW Group Connect",
         "description": "Připojte své vozidlo k Home Assistant.\n\nVyberte značku a zadejte přihlašovací údaje z aplikace výrobce.",
         "data": {
           "brand": "Značka vozidla",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "Znovu nakonfigurovat VAG Connect",
+        "title": "Znovu nakonfigurovat VW Group Connect",
         "description": "Změňte přihlašovací údaje nebo nastavení bez odebrání integrace.",
         "data": {
           "brand": "Značka vozidla",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Nastavení",
+        "title": "VW Group Connect — Nastavení",
         "data": {
           "scan_interval": "Interval aktualizace",
           "spin": "S-PIN",
@@ -607,23 +607,23 @@
     },
     "auth_failed": {
       "title": "Přihlášení selhalo — {brand}",
-      "description": "Nastavení → Zařízení a služby → VAG Connect → ⋮ → Znovu nakonfigurovat."
+      "description": "Nastavení → Zařízení a služby → VW Group Connect → ⋮ → Znovu nakonfigurovat."
     },
     "vehicle_data_scout_findings": {
       "title": "Pozorovatel API — {count} nových polí v {brand}",
-      "description": "Pozorovatel API zjistil **{count}** nových polí v odpovědi API {brand}, která VAG Connect zatím nečte.\n\nObvykle to znamená, že vaše vozidlo má funkci nebo verzi firmwaru, kterou jsme ještě nepřiřadili — vaše pomoc naučí integraci její podpoře.\n\n**Hlášení jedním kliknutím:**\n📤 Klikněte níže na **Více informací** a otevřete předvyplněný GitHub issue.\n\n**Pro Facebook / fórum:** Nastavení → Zařízení → VAG Connect → Diagnostika → Stáhnout — vložte maskovanou zprávu.\n\n_Soukromí: VINy maskované, GPS zaokrouhleno na 1 desetinné místo, userIDs/JWT/e-maily odstraněny. Nic se neodesílá automaticky._"
+      "description": "Pozorovatel API zjistil **{count}** nových polí v odpovědi API {brand}, která VW Group Connect zatím nečte.\n\nObvykle to znamená, že vaše vozidlo má funkci nebo verzi firmwaru, kterou jsme ještě nepřiřadili — vaše pomoc naučí integraci její podpoře.\n\n**Hlášení jedním kliknutím:**\n📤 Klikněte níže na **Více informací** a otevřete předvyplněný GitHub issue.\n\n**Pro Facebook / fórum:** Nastavení → Zařízení → VW Group Connect → Diagnostika → Stáhnout — vložte maskovanou zprávu.\n\n_Soukromí: VINy maskované, GPS zaokrouhleno na 1 desetinné místo, userIDs/JWT/e-maily odstraněny. Nic se neodesílá automaticky._"
     },
     "error_reporter_findings": {
       "title": "Hlásič chyb — {count} nedávných chyb v {brand}",
-      "description": "Hlásič chyb zachytil **{count}** nedávných chyb integrace s {brand}.\n\nNahlášení nám pomáhá najít chyby, které se objevují pouze u konkrétních vozidel nebo verzí firmwaru.\n\n**Hlášení jedním kliknutím:**\n📤 Klikněte níže na **Více informací** a otevřete předvyplněný GitHub issue.\n\n**Pro Facebook / fórum:** Nastavení → Zařízení → VAG Connect → Diagnostika → Stáhnout — zpráva je obsažena, VINy a tokeny maskované.\n\n_Soukromí: VINy maskované, tokeny Bearer/JWT/UUID/e-mail odstraněny ze zpráv a tracebacků. Žádná přihlašovací data._"
+      "description": "Hlásič chyb zachytil **{count}** nedávných chyb integrace s {brand}.\n\nNahlášení nám pomáhá najít chyby, které se objevují pouze u konkrétních vozidel nebo verzí firmwaru.\n\n**Hlášení jedním kliknutím:**\n📤 Klikněte níže na **Více informací** a otevřete předvyplněný GitHub issue.\n\n**Pro Facebook / fórum:** Nastavení → Zařízení → VW Group Connect → Diagnostika → Stáhnout — zpráva je obsažena, VINy a tokeny maskované.\n\n_Soukromí: VINy maskované, tokeny Bearer/JWT/UUID/e-mail odstraněny ze zpráv a tracebacků. Žádná přihlašovací data._"
     },
     "quota_low": {
       "title": "API quota low — {remaining} requests remaining today",
-      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VAG Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
     },
     "quota_critical": {
       "title": "API quota CRITICAL — {remaining} requests remaining today",
-      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VAG Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
     }
   },
   "exceptions": {
@@ -631,7 +631,7 @@
       "message": "Vozidlo s VIN {vin} nebylo nalezeno."
     },
     "spin_required": {
-      "message": "Pro tuto akci je vyžadován S-PIN. Nastavte ho v Nastavení → Zařízení a služby → VAG Connect → Konfigurovat."
+      "message": "Pro tuto akci je vyžadován S-PIN. Nastavte ho v Nastavení → Zařízení a služby → VW Group Connect → Konfigurovat."
     },
     "feature_not_supported": {
       "message": "Funkce {feature} není podporována vaším vozidlem nebo aktuálním API klientem. Akce nebyla odeslána."
@@ -643,7 +643,7 @@
       "message": "Cooldown probuzení aktivní (zbývá {remaining_s}s). K ochraně 12V baterie jsou probuzení omezena na jedno každých {cooldown_min} minut na vozidlo."
     },
     "read_only_mode_active": {
-      "message": "Režim jen pro čtení je povolen v možnostech integrace. Vypněte jej v Nastavení → Zařízení a služby → VAG Connect → Konfigurovat, abyste mohli odesílat příkazy do vozidla."
+      "message": "Režim jen pro čtení je povolen v možnostech integrace. Vypněte jej v Nastavení → Zařízení a služby → VW Group Connect → Konfigurovat, abyste mohli odesílat příkazy do vozidla."
     }
   }
 }

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "VAG Connect einrichten",
+        "title": "VW Group Connect einrichten",
         "description": "Verbinde dein Fahrzeug mit Home Assistant. Wähle deine Marke und gib die Zugangsdaten aus der jeweiligen App ein.",
         "data": {
           "brand": "Fahrzeugmarke",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "VAG Connect neu konfigurieren",
+        "title": "VW Group Connect neu konfigurieren",
         "description": "Ändere Zugangsdaten oder Einstellungen ohne die Integration zu entfernen.",
         "data": {
           "brand": "Fahrzeugmarke",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Einstellungen",
+        "title": "VW Group Connect — Einstellungen",
         "data": {
           "scan_interval": "Aktualisierungsintervall (Minuten)",
           "spin": "S-PIN",
@@ -607,23 +607,23 @@
     },
     "auth_failed": {
       "title": "Anmeldung fehlgeschlagen — {brand}",
-      "description": "Die Verbindung zu {brand} ({username}) ist fehlgeschlagen.\n\nEinstellungen → Geräte & Dienste → VAG Connect → ⋮ → Neu konfigurieren."
+      "description": "Die Verbindung zu {brand} ({username}) ist fehlgeschlagen.\n\nEinstellungen → Geräte & Dienste → VW Group Connect → ⋮ → Neu konfigurieren."
     },
     "vehicle_data_scout_findings": {
       "title": "API-Beobachter — {count} neue Felder bei {brand}",
-      "description": "Der API-Beobachter hat **{count}** neue Felder in der {brand}-API entdeckt, die VAG Connect noch nicht ausliest.\n\nMeistens bedeutet das: Dein Fahrzeug hat eine Funktion oder Firmware-Version, die wir noch nicht kennen — deine Hilfe würde uns die Unterstützung beibringen.\n\n**1-Klick-Bericht:**\n📤 Klicke unten auf **Mehr erfahren**, um ein vorausgefülltes GitHub-Issue zu öffnen.\n\n**Für Facebook / Forum:** Einstellungen → Geräte → VAG Connect → Diagnose → Herunterladen — dort den maskierten Bericht reinkopieren.\n\n_Datenschutz: VINs maskiert, GPS auf 1 Dezimalstelle gerundet, userIDs/JWTs/E-Mails entfernt. Es wird nichts automatisch gesendet._"
+      "description": "Der API-Beobachter hat **{count}** neue Felder in der {brand}-API entdeckt, die VW Group Connect noch nicht ausliest.\n\nMeistens bedeutet das: Dein Fahrzeug hat eine Funktion oder Firmware-Version, die wir noch nicht kennen — deine Hilfe würde uns die Unterstützung beibringen.\n\n**1-Klick-Bericht:**\n📤 Klicke unten auf **Mehr erfahren**, um ein vorausgefülltes GitHub-Issue zu öffnen.\n\n**Für Facebook / Forum:** Einstellungen → Geräte → VW Group Connect → Diagnose → Herunterladen — dort den maskierten Bericht reinkopieren.\n\n_Datenschutz: VINs maskiert, GPS auf 1 Dezimalstelle gerundet, userIDs/JWTs/E-Mails entfernt. Es wird nichts automatisch gesendet._"
     },
     "error_reporter_findings": {
       "title": "Fehler-Berichter — {count} aktuelle Fehler bei {brand}",
-      "description": "Der Fehler-Berichter hat **{count}** aktuelle Fehler in der Integration mit {brand} aufgezeichnet.\n\nDas Melden hilft uns, Fehler zu finden, die nur bei bestimmten Fahrzeugen oder Firmware-Versionen auftreten.\n\n**1-Klick-Bericht:**\n📤 Klicke unten auf **Mehr erfahren**, um ein vorausgefülltes GitHub-Issue zu öffnen.\n\n**Für Facebook / Forum:** Einstellungen → Geräte → VAG Connect → Diagnose → Herunterladen — der Bericht ist enthalten, VINs und Tokens maskiert.\n\n_Datenschutz: VINs maskiert, Bearer/JWT/UUID/E-Mail-Tokens aus Nachrichten und Tracebacks entfernt. Keine Zugangsdaten enthalten._"
+      "description": "Der Fehler-Berichter hat **{count}** aktuelle Fehler in der Integration mit {brand} aufgezeichnet.\n\nDas Melden hilft uns, Fehler zu finden, die nur bei bestimmten Fahrzeugen oder Firmware-Versionen auftreten.\n\n**1-Klick-Bericht:**\n📤 Klicke unten auf **Mehr erfahren**, um ein vorausgefülltes GitHub-Issue zu öffnen.\n\n**Für Facebook / Forum:** Einstellungen → Geräte → VW Group Connect → Diagnose → Herunterladen — der Bericht ist enthalten, VINs und Tokens maskiert.\n\n_Datenschutz: VINs maskiert, Bearer/JWT/UUID/E-Mail-Tokens aus Nachrichten und Tracebacks entfernt. Keine Zugangsdaten enthalten._"
     },
     "quota_low": {
       "title": "API-Quota niedrig — {remaining} Anfragen heute übrig",
-      "description": "Dein VAG-Account nähert sich dem täglichen API-Limit ({remaining} von {limit} übrig, {pct}%).\n\nUm einen Quota-Lockout zu vermeiden (das Hersteller-Backend kann bei Erreichen des Tageslimits den Account temporär sperren), kannst du:\n\n1. **Update-Intervall erhöhen** — Einstellungen → Geräte & Dienste → VAG Connect → Konfigurieren → Update-Intervall (typisch 5–10 min)\n2. **Andere VAG-Integrationen reduzieren**, die parallel auf dem gleichen Account laufen (jede zählt gegen das gleiche Limit)\n3. **Tägliches Reset abwarten** — meistens um Mitternacht in der Hersteller-Heimatzone\n\nDiese Warnung verschwindet automatisch, sobald sich das Kontingent erholt hat."
+      "description": "Dein VAG-Account nähert sich dem täglichen API-Limit ({remaining} von {limit} übrig, {pct}%).\n\nUm einen Quota-Lockout zu vermeiden (das Hersteller-Backend kann bei Erreichen des Tageslimits den Account temporär sperren), kannst du:\n\n1. **Update-Intervall erhöhen** — Einstellungen → Geräte & Dienste → VW Group Connect → Konfigurieren → Update-Intervall (typisch 5–10 min)\n2. **Andere VAG-Integrationen reduzieren**, die parallel auf dem gleichen Account laufen (jede zählt gegen das gleiche Limit)\n3. **Tägliches Reset abwarten** — meistens um Mitternacht in der Hersteller-Heimatzone\n\nDiese Warnung verschwindet automatisch, sobald sich das Kontingent erholt hat."
     },
     "quota_critical": {
       "title": "API-Quota KRITISCH — {remaining} Anfragen heute übrig",
-      "description": "Dein VAG-Account hat weniger als 25 API-Anfragen heute übrig ({remaining} von {limit}, {pct}%). Das Hersteller-Backend kann den Account temporär sperren wenn das Limit erschöpft wird.\n\n**Sofort-Maßnahmen:**\n1. **Polling pausieren** — Einstellungen → Geräte & Dienste → VAG Connect → Konfigurieren → Update-Intervall → auf 30 min oder höher setzen\n2. Manuelle Refreshes / Fahrzeug-Wakeups vermeiden bis das Kontingent zurückgesetzt ist\n\nDiese Warnung verschwindet automatisch, sobald sich das Kontingent erholt hat."
+      "description": "Dein VAG-Account hat weniger als 25 API-Anfragen heute übrig ({remaining} von {limit}, {pct}%). Das Hersteller-Backend kann den Account temporär sperren wenn das Limit erschöpft wird.\n\n**Sofort-Maßnahmen:**\n1. **Polling pausieren** — Einstellungen → Geräte & Dienste → VW Group Connect → Konfigurieren → Update-Intervall → auf 30 min oder höher setzen\n2. Manuelle Refreshes / Fahrzeug-Wakeups vermeiden bis das Kontingent zurückgesetzt ist\n\nDiese Warnung verschwindet automatisch, sobald sich das Kontingent erholt hat."
     }
   },
   "exceptions": {
@@ -631,7 +631,7 @@
       "message": "Fahrzeug mit VIN {vin} nicht gefunden. Prüfe ob die Integration gestartet ist."
     },
     "spin_required": {
-      "message": "S-PIN ist für diese Aktion erforderlich. Konfiguriere ihn unter Einstellungen → Geräte & Dienste → VAG Connect → Konfigurieren."
+      "message": "S-PIN ist für diese Aktion erforderlich. Konfiguriere ihn unter Einstellungen → Geräte & Dienste → VW Group Connect → Konfigurieren."
     },
     "feature_not_supported": {
       "message": "Die Funktion {feature} wird vom Fahrzeug oder dem aktuellen API-Client nicht unterstützt. Die Aktion wurde nicht gesendet."
@@ -643,7 +643,7 @@
       "message": "Wake-Up-Cooldown aktiv ({remaining_s}s verbleibend). Zum Schutz der 12V-Batterie sind Wake-Ups auf einen alle {cooldown_min} Minuten pro Fahrzeug begrenzt."
     },
     "read_only_mode_active": {
-      "message": "Read-only Modus ist in den Integrations-Optionen aktiviert. Deaktiviere ihn unter Einstellungen → Geräte & Dienste → VAG Connect → Konfigurieren um Fahrzeug-Befehle zu senden."
+      "message": "Read-only Modus ist in den Integrations-Optionen aktiviert. Deaktiviere ihn unter Einstellungen → Geräte & Dienste → VW Group Connect → Konfigurieren um Fahrzeug-Befehle zu senden."
     }
   }
 }

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Set up VAG Connect",
+        "title": "Set up VW Group Connect",
         "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
         "data": {
           "brand": "Vehicle Brand",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "Reconfigure VAG Connect",
+        "title": "Reconfigure VW Group Connect",
         "description": "Change credentials or settings without removing the integration.",
         "data": {
           "brand": "Vehicle Brand",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Settings",
+        "title": "VW Group Connect — Settings",
         "data": {
           "scan_interval": "Update Interval",
           "spin": "S-PIN",
@@ -607,23 +607,23 @@
     },
     "auth_failed": {
       "title": "Authentication failed — {brand}",
-      "description": "Connection to {brand} ({username}) failed.\n\nSettings → Devices & Services → VAG Connect → ⋮ → Reconfigure."
+      "description": "Connection to {brand} ({username}) failed.\n\nSettings → Devices & Services → VW Group Connect → ⋮ → Reconfigure."
     },
     "vehicle_data_scout_findings": {
       "title": "Vehicle Data Scout — {count} new field(s) on {brand}",
-      "description": "The Vehicle Data Scout detected **{count}** new field(s) in the {brand} API response that VAG Connect doesn't read yet.\n\nThis usually means your vehicle has a feature or firmware version we haven't mapped — your help would teach the integration to support it.\n\n**1-click report:**\n📤 Click **Learn more** below to open a pre-filled GitHub issue.\n\n**For Facebook / forum:** open Settings → Devices → VAG Connect → Diagnostics → Download — paste the masked report.\n\n_Privacy: VINs masked, GPS rounded to 1 decimal, userIDs/JWTs/emails stripped. Nothing is sent automatically._"
+      "description": "The Vehicle Data Scout detected **{count}** new field(s) in the {brand} API response that VW Group Connect doesn't read yet.\n\nThis usually means your vehicle has a feature or firmware version we haven't mapped — your help would teach the integration to support it.\n\n**1-click report:**\n📤 Click **Learn more** below to open a pre-filled GitHub issue.\n\n**For Facebook / forum:** open Settings → Devices → VW Group Connect → Diagnostics → Download — paste the masked report.\n\n_Privacy: VINs masked, GPS rounded to 1 decimal, userIDs/JWTs/emails stripped. Nothing is sent automatically._"
     },
     "error_reporter_findings": {
       "title": "Error Reporter — {count} recent error(s) on {brand}",
-      "description": "The Error Reporter captured **{count}** recent integration error(s) for {brand}.\n\nReporting them helps us find bugs that only show up on specific vehicles or firmware versions.\n\n**1-click report:**\n📤 Click **Learn more** below to open a pre-filled GitHub issue.\n\n**For Facebook / forum:** open Settings → Devices → VAG Connect → Diagnostics → Download — the report is included with VINs and tokens masked.\n\n_Privacy: VINs masked, Bearer/JWT/UUID/email tokens stripped from messages and tracebacks. No credentials are included._"
+      "description": "The Error Reporter captured **{count}** recent integration error(s) for {brand}.\n\nReporting them helps us find bugs that only show up on specific vehicles or firmware versions.\n\n**1-click report:**\n📤 Click **Learn more** below to open a pre-filled GitHub issue.\n\n**For Facebook / forum:** open Settings → Devices → VW Group Connect → Diagnostics → Download — the report is included with VINs and tokens masked.\n\n_Privacy: VINs masked, Bearer/JWT/UUID/email tokens stripped from messages and tracebacks. No credentials are included._"
     },
     "quota_low": {
       "title": "API quota low — {remaining} requests remaining today",
-      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VAG Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
     },
     "quota_critical": {
       "title": "API quota CRITICAL — {remaining} requests remaining today",
-      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VAG Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
     }
   },
   "exceptions": {
@@ -631,7 +631,7 @@
       "message": "Vehicle with VIN {vin} not found. Check that the integration is started."
     },
     "spin_required": {
-      "message": "S-PIN is required for this action. Configure it under Settings → Devices & Services → VAG Connect → Configure."
+      "message": "S-PIN is required for this action. Configure it under Settings → Devices & Services → VW Group Connect → Configure."
     },
     "feature_not_supported": {
       "message": "The feature {feature} is not supported by your vehicle or the current API client. The action was not sent."
@@ -643,7 +643,7 @@
       "message": "Wake-up cooldown active ({remaining_s}s remaining). To protect the 12V battery, wake-ups are limited to one every {cooldown_min} minutes per vehicle."
     },
     "read_only_mode_active": {
-      "message": "Read-only mode is enabled in the integration options. Disable it under Settings → Devices & Services → VAG Connect → Configure if you want to send vehicle commands."
+      "message": "Read-only mode is enabled in the integration options. Disable it under Settings → Devices & Services → VW Group Connect → Configure if you want to send vehicle commands."
     }
   }
 }

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Configurar VAG Connect",
+        "title": "Configurar VW Group Connect",
         "description": "Conecta tu vehículo a Home Assistant.\n\nElige tu marca e introduce las credenciales de la app del fabricante.",
         "data": {
           "brand": "Marca del vehículo",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "Reconfigurar VAG Connect",
+        "title": "Reconfigurar VW Group Connect",
         "description": "Cambia credenciales o configuración sin eliminar la integración.",
         "data": {
           "brand": "Marca del vehículo",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Configuración",
+        "title": "VW Group Connect — Configuración",
         "data": {
           "scan_interval": "Intervalo de actualización",
           "spin": "S-PIN",
@@ -607,23 +607,23 @@
     },
     "auth_failed": {
       "title": "Autenticación fallida — {brand}",
-      "description": "Ajustes → Dispositivos y servicios → VAG Connect → ⋮ → Reconfigurar."
+      "description": "Ajustes → Dispositivos y servicios → VW Group Connect → ⋮ → Reconfigurar."
     },
     "vehicle_data_scout_findings": {
       "title": "Observador de API — {count} campo(s) nuevo(s) en {brand}",
-      "description": "El Observador de API ha detectado **{count}** campo(s) nuevo(s) en la respuesta de la API de {brand} que VAG Connect aún no lee.\n\nNormalmente significa que tu vehículo tiene una función o versión de firmware que no hemos mapeado — tu ayuda enseñaría a la integración a soportarla.\n\n**Reporte en 1 clic:**\n📤 Pulsa **Más información** abajo para abrir un issue de GitHub prellenado.\n\n**Para Facebook / foro:** Ajustes → Dispositivos → VAG Connect → Diagnóstico → Descargar — pega el informe enmascarado.\n\n_Privacidad: VIN enmascarados, GPS redondeado a 1 decimal, userIDs/JWT/correos eliminados. Nada se envía automáticamente._"
+      "description": "El Observador de API ha detectado **{count}** campo(s) nuevo(s) en la respuesta de la API de {brand} que VW Group Connect aún no lee.\n\nNormalmente significa que tu vehículo tiene una función o versión de firmware que no hemos mapeado — tu ayuda enseñaría a la integración a soportarla.\n\n**Reporte en 1 clic:**\n📤 Pulsa **Más información** abajo para abrir un issue de GitHub prellenado.\n\n**Para Facebook / foro:** Ajustes → Dispositivos → VW Group Connect → Diagnóstico → Descargar — pega el informe enmascarado.\n\n_Privacidad: VIN enmascarados, GPS redondeado a 1 decimal, userIDs/JWT/correos eliminados. Nada se envía automáticamente._"
     },
     "error_reporter_findings": {
       "title": "Reportador de errores — {count} error(es) reciente(s) en {brand}",
-      "description": "El Reportador de errores ha capturado **{count}** error(es) reciente(s) de la integración {brand}.\n\nReportarlos ayuda a encontrar fallos que solo aparecen en vehículos o versiones de firmware específicos.\n\n**Reporte en 1 clic:**\n📤 Pulsa **Más información** abajo para abrir un issue de GitHub prellenado.\n\n**Para Facebook / foro:** Ajustes → Dispositivos → VAG Connect → Diagnóstico → Descargar — el informe se incluye, VIN y tokens enmascarados.\n\n_Privacidad: VIN enmascarados, tokens Bearer/JWT/UUID/correo eliminados de mensajes y trazas. No se incluyen credenciales._"
+      "description": "El Reportador de errores ha capturado **{count}** error(es) reciente(s) de la integración {brand}.\n\nReportarlos ayuda a encontrar fallos que solo aparecen en vehículos o versiones de firmware específicos.\n\n**Reporte en 1 clic:**\n📤 Pulsa **Más información** abajo para abrir un issue de GitHub prellenado.\n\n**Para Facebook / foro:** Ajustes → Dispositivos → VW Group Connect → Diagnóstico → Descargar — el informe se incluye, VIN y tokens enmascarados.\n\n_Privacidad: VIN enmascarados, tokens Bearer/JWT/UUID/correo eliminados de mensajes y trazas. No se incluyen credenciales._"
     },
     "quota_low": {
       "title": "API quota low — {remaining} requests remaining today",
-      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VAG Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
     },
     "quota_critical": {
       "title": "API quota CRITICAL — {remaining} requests remaining today",
-      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VAG Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
     }
   },
   "exceptions": {
@@ -631,7 +631,7 @@
       "message": "Vehículo con VIN {vin} no encontrado."
     },
     "spin_required": {
-      "message": "Se requiere S-PIN para esta acción. Configúralo en Ajustes → Dispositivos y servicios → VAG Connect → Configurar."
+      "message": "Se requiere S-PIN para esta acción. Configúralo en Ajustes → Dispositivos y servicios → VW Group Connect → Configurar."
     },
     "feature_not_supported": {
       "message": "La función {feature} no es compatible con tu vehículo o el cliente API actual. La acción no se envió."
@@ -643,7 +643,7 @@
       "message": "Tiempo de espera de Wake-up activo ({remaining_s}s restantes). Para proteger la batería 12V, los Wake-ups se limitan a uno cada {cooldown_min} minutos por vehículo."
     },
     "read_only_mode_active": {
-      "message": "El modo solo lectura está activado en las opciones de integración. Desactívalo en Ajustes → Dispositivos y servicios → VAG Connect → Configurar para enviar comandos al vehículo."
+      "message": "El modo solo lectura está activado en las opciones de integración. Desactívalo en Ajustes → Dispositivos y servicios → VW Group Connect → Configurar para enviar comandos al vehículo."
     }
   }
 }

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Configurer VAG Connect",
+        "title": "Configurer VW Group Connect",
         "description": "Connectez votre véhicule à Home Assistant.\n\nChoisissez votre marque et entrez les identifiants de l'application fabricant.",
         "data": {
           "brand": "Marque du véhicule",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "Reconfigurer VAG Connect",
+        "title": "Reconfigurer VW Group Connect",
         "description": "Modifiez les identifiants ou paramètres sans supprimer l'intégration.",
         "data": {
           "brand": "Marque du véhicule",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Paramètres",
+        "title": "VW Group Connect — Paramètres",
         "data": {
           "scan_interval": "Intervalle de mise à jour",
           "spin": "S-PIN",
@@ -607,23 +607,23 @@
     },
     "auth_failed": {
       "title": "Connexion échouée — {brand}",
-      "description": "Paramètres → Appareils et services → VAG Connect → ⋮ → Reconfigurer."
+      "description": "Paramètres → Appareils et services → VW Group Connect → ⋮ → Reconfigurer."
     },
     "vehicle_data_scout_findings": {
       "title": "Observateur d'API — {count} nouveau(x) champ(s) sur {brand}",
-      "description": "L'Observateur d'API a détecté **{count}** nouveau(x) champ(s) dans la réponse de l'API {brand} que VAG Connect ne lit pas encore.\n\nCela signifie souvent que votre véhicule possède une fonction ou une version de firmware non mappée — votre aide nous permettrait de la prendre en charge.\n\n**Rapport en 1 clic :**\n📤 Cliquez sur **En savoir plus** ci-dessous pour ouvrir un ticket GitHub pré-rempli.\n\n**Pour Facebook / forum :** Paramètres → Appareils → VAG Connect → Diagnostics → Télécharger — collez le rapport masqué.\n\n_Confidentialité : VIN masqués, GPS arrondi à 1 décimale, userIDs/JWT/e-mails supprimés. Rien n'est envoyé automatiquement._"
+      "description": "L'Observateur d'API a détecté **{count}** nouveau(x) champ(s) dans la réponse de l'API {brand} que VW Group Connect ne lit pas encore.\n\nCela signifie souvent que votre véhicule possède une fonction ou une version de firmware non mappée — votre aide nous permettrait de la prendre en charge.\n\n**Rapport en 1 clic :**\n📤 Cliquez sur **En savoir plus** ci-dessous pour ouvrir un ticket GitHub pré-rempli.\n\n**Pour Facebook / forum :** Paramètres → Appareils → VW Group Connect → Diagnostics → Télécharger — collez le rapport masqué.\n\n_Confidentialité : VIN masqués, GPS arrondi à 1 décimale, userIDs/JWT/e-mails supprimés. Rien n'est envoyé automatiquement._"
     },
     "error_reporter_findings": {
       "title": "Rapporteur d'erreurs — {count} erreur(s) récente(s) sur {brand}",
-      "description": "Le Rapporteur d'erreurs a capturé **{count}** erreur(s) récente(s) de l'intégration {brand}.\n\nLes signaler nous aide à trouver des bugs qui n'apparaissent que sur certains véhicules ou versions de firmware.\n\n**Rapport en 1 clic :**\n📤 Cliquez sur **En savoir plus** ci-dessous pour ouvrir un ticket GitHub pré-rempli.\n\n**Pour Facebook / forum :** Paramètres → Appareils → VAG Connect → Diagnostics → Télécharger — le rapport est inclus, VIN et tokens masqués.\n\n_Confidentialité : VIN masqués, tokens Bearer/JWT/UUID/e-mail supprimés des messages et tracebacks. Aucun identifiant n'est inclus._"
+      "description": "Le Rapporteur d'erreurs a capturé **{count}** erreur(s) récente(s) de l'intégration {brand}.\n\nLes signaler nous aide à trouver des bugs qui n'apparaissent que sur certains véhicules ou versions de firmware.\n\n**Rapport en 1 clic :**\n📤 Cliquez sur **En savoir plus** ci-dessous pour ouvrir un ticket GitHub pré-rempli.\n\n**Pour Facebook / forum :** Paramètres → Appareils → VW Group Connect → Diagnostics → Télécharger — le rapport est inclus, VIN et tokens masqués.\n\n_Confidentialité : VIN masqués, tokens Bearer/JWT/UUID/e-mail supprimés des messages et tracebacks. Aucun identifiant n'est inclus._"
     },
     "quota_low": {
       "title": "API quota low — {remaining} requests remaining today",
-      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VAG Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
     },
     "quota_critical": {
       "title": "API quota CRITICAL — {remaining} requests remaining today",
-      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VAG Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
     }
   },
   "exceptions": {
@@ -631,7 +631,7 @@
       "message": "Véhicule avec VIN {vin} introuvable."
     },
     "spin_required": {
-      "message": "Le S-PIN est requis pour cette action. Configurez-le dans Paramètres → Appareils et services → VAG Connect → Configurer."
+      "message": "Le S-PIN est requis pour cette action. Configurez-le dans Paramètres → Appareils et services → VW Group Connect → Configurer."
     },
     "feature_not_supported": {
       "message": "La fonctionnalité {feature} n'est pas prise en charge par votre véhicule ou le client API actuel. L'action n'a pas été envoyée."
@@ -643,7 +643,7 @@
       "message": "Délai d'attente Wake-up actif ({remaining_s}s restant). Pour protéger la batterie 12V, les Wake-ups sont limités à un toutes les {cooldown_min} minutes par véhicule."
     },
     "read_only_mode_active": {
-      "message": "Le mode lecture seule est activé dans les options d'intégration. Désactive-le sous Paramètres → Appareils et services → VAG Connect → Configurer pour envoyer des commandes au véhicule."
+      "message": "Le mode lecture seule est activé dans les options d'intégration. Désactive-le sous Paramètres → Appareils et services → VW Group Connect → Configurer pour envoyer des commandes au véhicule."
     }
   }
 }

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "VAG Connect instellen",
+        "title": "VW Group Connect instellen",
         "description": "Verbind je voertuig met Home Assistant.\n\nKies je merk en voer de inloggegevens van de fabrieksapp in.",
         "data": {
           "brand": "Voertuigmerk",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "VAG Connect opnieuw configureren",
+        "title": "VW Group Connect opnieuw configureren",
         "description": "Wijzig inloggegevens of instellingen zonder de integratie te verwijderen.",
         "data": {
           "brand": "Voertuigmerk",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Instellingen",
+        "title": "VW Group Connect — Instellingen",
         "data": {
           "scan_interval": "Update-interval",
           "spin": "S-PIN",
@@ -607,23 +607,23 @@
     },
     "auth_failed": {
       "title": "Aanmelden mislukt — {brand}",
-      "description": "Instellingen → Apparaten en diensten → VAG Connect → ⋮ → Opnieuw configureren."
+      "description": "Instellingen → Apparaten en diensten → VW Group Connect → ⋮ → Opnieuw configureren."
     },
     "vehicle_data_scout_findings": {
       "title": "API-waarnemer — {count} nieuw(e) veld(en) bij {brand}",
-      "description": "De API-waarnemer ontdekte **{count}** nieuw(e) veld(en) in de {brand}-API die VAG Connect nog niet uitleest.\n\nMeestal betekent dit dat je voertuig een functie of firmwareversie heeft die we nog niet kennen — jouw hulp leert de integratie deze te ondersteunen.\n\n**1-klik rapport:**\n📤 Klik hieronder op **Meer info** om een vooraf ingevulde GitHub-issue te openen.\n\n**Voor Facebook / forum:** Instellingen → Apparaten → VAG Connect → Diagnose → Downloaden — plak het gemaskeerde rapport.\n\n_Privacy: VINs gemaskeerd, GPS afgerond op 1 decimaal, userIDs/JWT/e-mails verwijderd. Er wordt niets automatisch verzonden._"
+      "description": "De API-waarnemer ontdekte **{count}** nieuw(e) veld(en) in de {brand}-API die VW Group Connect nog niet uitleest.\n\nMeestal betekent dit dat je voertuig een functie of firmwareversie heeft die we nog niet kennen — jouw hulp leert de integratie deze te ondersteunen.\n\n**1-klik rapport:**\n📤 Klik hieronder op **Meer info** om een vooraf ingevulde GitHub-issue te openen.\n\n**Voor Facebook / forum:** Instellingen → Apparaten → VW Group Connect → Diagnose → Downloaden — plak het gemaskeerde rapport.\n\n_Privacy: VINs gemaskeerd, GPS afgerond op 1 decimaal, userIDs/JWT/e-mails verwijderd. Er wordt niets automatisch verzonden._"
     },
     "error_reporter_findings": {
       "title": "Foutmelder — {count} recente fout(en) bij {brand}",
-      "description": "De Foutmelder heeft **{count}** recente integratiefout(en) voor {brand} vastgelegd.\n\nMelden helpt ons bugs te vinden die alleen op specifieke voertuigen of firmwareversies optreden.\n\n**1-klik rapport:**\n📤 Klik hieronder op **Meer info** om een vooraf ingevulde GitHub-issue te openen.\n\n**Voor Facebook / forum:** Instellingen → Apparaten → VAG Connect → Diagnose → Downloaden — het rapport is bijgevoegd, VINs en tokens gemaskeerd.\n\n_Privacy: VINs gemaskeerd, Bearer/JWT/UUID/e-mail-tokens uit berichten en tracebacks verwijderd. Geen referenties opgenomen._"
+      "description": "De Foutmelder heeft **{count}** recente integratiefout(en) voor {brand} vastgelegd.\n\nMelden helpt ons bugs te vinden die alleen op specifieke voertuigen of firmwareversies optreden.\n\n**1-klik rapport:**\n📤 Klik hieronder op **Meer info** om een vooraf ingevulde GitHub-issue te openen.\n\n**Voor Facebook / forum:** Instellingen → Apparaten → VW Group Connect → Diagnose → Downloaden — het rapport is bijgevoegd, VINs en tokens gemaskeerd.\n\n_Privacy: VINs gemaskeerd, Bearer/JWT/UUID/e-mail-tokens uit berichten en tracebacks verwijderd. Geen referenties opgenomen._"
     },
     "quota_low": {
       "title": "API quota low — {remaining} requests remaining today",
-      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VAG Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
     },
     "quota_critical": {
       "title": "API quota CRITICAL — {remaining} requests remaining today",
-      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VAG Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
     }
   },
   "exceptions": {
@@ -631,7 +631,7 @@
       "message": "Voertuig met VIN {vin} niet gevonden."
     },
     "spin_required": {
-      "message": "S-PIN is vereist voor deze actie. Configureer het onder Instellingen → Apparaten en diensten → VAG Connect → Configureren."
+      "message": "S-PIN is vereist voor deze actie. Configureer het onder Instellingen → Apparaten en diensten → VW Group Connect → Configureren."
     },
     "feature_not_supported": {
       "message": "De functie {feature} wordt niet ondersteund door uw voertuig of de huidige API-client. De actie is niet verzonden."
@@ -643,7 +643,7 @@
       "message": "Wake-up cooldown actief ({remaining_s}s resterend). Om de 12V-accu te beschermen zijn wake-ups beperkt tot één elke {cooldown_min} minuten per voertuig."
     },
     "read_only_mode_active": {
-      "message": "Alleen-lezen modus is ingeschakeld in de integratie-opties. Schakel het uit onder Instellingen → Apparaten en diensten → VAG Connect → Configureren om voertuigcommando's te verzenden."
+      "message": "Alleen-lezen modus is ingeschakeld in de integratie-opties. Schakel het uit onder Instellingen → Apparaten en diensten → VW Group Connect → Configureren om voertuigcommando's te verzenden."
     }
   }
 }

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Skonfiguruj VAG Connect",
+        "title": "Skonfiguruj VW Group Connect",
         "description": "Połącz swój pojazd z Home Assistant.\n\nWybierz markę i wprowadź dane logowania z aplikacji producenta.",
         "data": {
           "brand": "Marka pojazdu",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "Skonfiguruj ponownie VAG Connect",
+        "title": "Skonfiguruj ponownie VW Group Connect",
         "description": "Zmień dane logowania lub ustawienia bez usuwania integracji.",
         "data": {
           "brand": "Marka pojazdu",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Ustawienia",
+        "title": "VW Group Connect — Ustawienia",
         "data": {
           "scan_interval": "Interwał aktualizacji",
           "spin": "S-PIN",
@@ -607,23 +607,23 @@
     },
     "auth_failed": {
       "title": "Logowanie nieudane — {brand}",
-      "description": "Ustawienia → Urządzenia i usługi → VAG Connect → ⋮ → Skonfiguruj ponownie."
+      "description": "Ustawienia → Urządzenia i usługi → VW Group Connect → ⋮ → Skonfiguruj ponownie."
     },
     "vehicle_data_scout_findings": {
       "title": "Obserwator API — {count} nowe pole(a) w {brand}",
-      "description": "Obserwator API wykrył **{count}** nowe pole(a) w odpowiedzi API {brand}, których VAG Connect jeszcze nie odczytuje.\n\nZazwyczaj oznacza to, że Twój pojazd ma funkcję lub wersję firmware, której nie zmapowaliśmy — Twoja pomoc nauczy integrację jej obsługi.\n\n**Raport jednym kliknięciem:**\n📤 Kliknij **Dowiedz się więcej** poniżej, aby otworzyć wstępnie wypełnione zgłoszenie GitHub.\n\n**Dla Facebooka / forum:** Ustawienia → Urządzenia → VAG Connect → Diagnostyka → Pobierz — wklej zamaskowany raport.\n\n_Prywatność: VIN-y zamaskowane, GPS zaokrąglony do 1 miejsca, userIDs/JWT/e-maile usunięte. Nic nie jest wysyłane automatycznie._"
+      "description": "Obserwator API wykrył **{count}** nowe pole(a) w odpowiedzi API {brand}, których VW Group Connect jeszcze nie odczytuje.\n\nZazwyczaj oznacza to, że Twój pojazd ma funkcję lub wersję firmware, której nie zmapowaliśmy — Twoja pomoc nauczy integrację jej obsługi.\n\n**Raport jednym kliknięciem:**\n📤 Kliknij **Dowiedz się więcej** poniżej, aby otworzyć wstępnie wypełnione zgłoszenie GitHub.\n\n**Dla Facebooka / forum:** Ustawienia → Urządzenia → VW Group Connect → Diagnostyka → Pobierz — wklej zamaskowany raport.\n\n_Prywatność: VIN-y zamaskowane, GPS zaokrąglony do 1 miejsca, userIDs/JWT/e-maile usunięte. Nic nie jest wysyłane automatycznie._"
     },
     "error_reporter_findings": {
       "title": "Raporter błędów — {count} ostatnich błędów dla {brand}",
-      "description": "Raporter błędów uchwycił **{count}** ostatnich błędów integracji z {brand}.\n\nZgłaszanie pomaga znaleźć błędy występujące tylko w określonych pojazdach lub wersjach firmware.\n\n**Raport jednym kliknięciem:**\n📤 Kliknij **Dowiedz się więcej** poniżej, aby otworzyć wstępnie wypełnione zgłoszenie GitHub.\n\n**Dla Facebooka / forum:** Ustawienia → Urządzenia → VAG Connect → Diagnostyka → Pobierz — raport zawarty, VIN-y i tokeny zamaskowane.\n\n_Prywatność: VIN-y zamaskowane, tokeny Bearer/JWT/UUID/e-mail usunięte z wiadomości i tracebacków. Brak danych logowania._"
+      "description": "Raporter błędów uchwycił **{count}** ostatnich błędów integracji z {brand}.\n\nZgłaszanie pomaga znaleźć błędy występujące tylko w określonych pojazdach lub wersjach firmware.\n\n**Raport jednym kliknięciem:**\n📤 Kliknij **Dowiedz się więcej** poniżej, aby otworzyć wstępnie wypełnione zgłoszenie GitHub.\n\n**Dla Facebooka / forum:** Ustawienia → Urządzenia → VW Group Connect → Diagnostyka → Pobierz — raport zawarty, VIN-y i tokeny zamaskowane.\n\n_Prywatność: VIN-y zamaskowane, tokeny Bearer/JWT/UUID/e-mail usunięte z wiadomości i tracebacków. Brak danych logowania._"
     },
     "quota_low": {
       "title": "API quota low — {remaining} requests remaining today",
-      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VAG Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
     },
     "quota_critical": {
       "title": "API quota CRITICAL — {remaining} requests remaining today",
-      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VAG Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
     }
   },
   "exceptions": {
@@ -631,7 +631,7 @@
       "message": "Pojazd z VIN {vin} nie znaleziony."
     },
     "spin_required": {
-      "message": "S-PIN jest wymagany do tej akcji. Skonfiguruj go w Ustawienia → Urządzenia i usługi → VAG Connect → Konfiguruj."
+      "message": "S-PIN jest wymagany do tej akcji. Skonfiguruj go w Ustawienia → Urządzenia i usługi → VW Group Connect → Konfiguruj."
     },
     "feature_not_supported": {
       "message": "Funkcja {feature} nie jest obsługiwana przez Twój pojazd lub obecnego klienta API. Akcja nie została wysłana."
@@ -643,7 +643,7 @@
       "message": "Cooldown wybudzania aktywny (pozostało {remaining_s}s). Aby chronić akumulator 12V, wybudzanie ograniczone do jednego co {cooldown_min} minut na pojazd."
     },
     "read_only_mode_active": {
-      "message": "Tryb tylko do odczytu jest włączony w opcjach integracji. Wyłącz go w Ustawienia → Urządzenia i usługi → VAG Connect → Skonfiguruj, aby wysyłać polecenia do pojazdu."
+      "message": "Tryb tylko do odczytu jest włączony w opcjach integracji. Wyłącz go w Ustawienia → Urządzenia i usługi → VW Group Connect → Skonfiguruj, aby wysyłać polecenia do pojazdu."
     }
   }
 }

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Konfigurera VAG Connect",
+        "title": "Konfigurera VW Group Connect",
         "description": "Anslut ditt fordon till Home Assistant.\n\nVälj ditt märke och ange inloggningsuppgifterna från tillverkarens app.",
         "data": {
           "brand": "Fordonsvarumärke",
@@ -30,7 +30,7 @@
         }
       },
       "reconfigure": {
-        "title": "Omkonfigurera VAG Connect",
+        "title": "Omkonfigurera VW Group Connect",
         "description": "Ändra inloggningsuppgifter eller inställningar utan att ta bort integrationen.",
         "data": {
           "brand": "Fordonsvarumärke",
@@ -71,7 +71,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "VAG Connect — Inställningar",
+        "title": "VW Group Connect — Inställningar",
         "data": {
           "scan_interval": "Uppdateringsintervall",
           "spin": "S-PIN",
@@ -607,23 +607,23 @@
     },
     "auth_failed": {
       "title": "Inloggning misslyckades — {brand}",
-      "description": "Inställningar → Enheter och tjänster → VAG Connect → ⋮ → Omkonfigurera."
+      "description": "Inställningar → Enheter och tjänster → VW Group Connect → ⋮ → Omkonfigurera."
     },
     "vehicle_data_scout_findings": {
       "title": "API-spanare — {count} nytt fält på {brand}",
-      "description": "API-spanaren upptäckte **{count}** nya fält i {brand}-API-svaret som VAG Connect inte läser ännu.\n\nVanligtvis betyder det att ditt fordon har en funktion eller firmware-version vi inte har kartlagt — din hjälp lär integrationen att stödja den.\n\n**1-klick-rapport:**\n📤 Klicka på **Läs mer** nedan för att öppna ett förifyllt GitHub-ärende.\n\n**För Facebook / forum:** Inställningar → Enheter → VAG Connect → Diagnostik → Ladda ner — klistra in den maskerade rapporten.\n\n_Integritet: VIN maskerade, GPS avrundad till 1 decimal, userIDs/JWT/e-post borttagna. Ingenting skickas automatiskt._"
+      "description": "API-spanaren upptäckte **{count}** nya fält i {brand}-API-svaret som VW Group Connect inte läser ännu.\n\nVanligtvis betyder det att ditt fordon har en funktion eller firmware-version vi inte har kartlagt — din hjälp lär integrationen att stödja den.\n\n**1-klick-rapport:**\n📤 Klicka på **Läs mer** nedan för att öppna ett förifyllt GitHub-ärende.\n\n**För Facebook / forum:** Inställningar → Enheter → VW Group Connect → Diagnostik → Ladda ner — klistra in den maskerade rapporten.\n\n_Integritet: VIN maskerade, GPS avrundad till 1 decimal, userIDs/JWT/e-post borttagna. Ingenting skickas automatiskt._"
     },
     "error_reporter_findings": {
       "title": "Felrapportör — {count} senaste fel på {brand}",
-      "description": "Felrapportören fångade **{count}** senaste integrationsfel för {brand}.\n\nAtt rapportera dem hjälper oss hitta buggar som bara uppstår på vissa fordon eller firmware-versioner.\n\n**1-klick-rapport:**\n📤 Klicka på **Läs mer** nedan för att öppna ett förifyllt GitHub-ärende.\n\n**För Facebook / forum:** Inställningar → Enheter → VAG Connect → Diagnostik → Ladda ner — rapporten ingår, VIN och tokens maskerade.\n\n_Integritet: VIN maskerade, Bearer/JWT/UUID/e-post-tokens borttagna från meddelanden och tracebacks. Inga inloggningsuppgifter._"
+      "description": "Felrapportören fångade **{count}** senaste integrationsfel för {brand}.\n\nAtt rapportera dem hjälper oss hitta buggar som bara uppstår på vissa fordon eller firmware-versioner.\n\n**1-klick-rapport:**\n📤 Klicka på **Läs mer** nedan för att öppna ett förifyllt GitHub-ärende.\n\n**För Facebook / forum:** Inställningar → Enheter → VW Group Connect → Diagnostik → Ladda ner — rapporten ingår, VIN och tokens maskerade.\n\n_Integritet: VIN maskerade, Bearer/JWT/UUID/e-post-tokens borttagna från meddelanden och tracebacks. Inga inloggningsuppgifter._"
     },
     "quota_low": {
       "title": "API quota low — {remaining} requests remaining today",
-      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VAG Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account is approaching the daily API request limit ({remaining} of {limit} remaining, {pct}%).\n\nTo protect against quota lockout (the manufacturer backend can soft-suspend the account when the daily cap is reached), consider:\n\n1. **Increase the update interval** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval (currently typically 5–10 min)\n2. **Reduce other VAG integrations** running on the same account (each counts against the same quota)\n3. **Wait for daily reset** — usually around midnight in the manufacturer's home time zone\n\nThis warning auto-clears when the remaining count recovers."
     },
     "quota_critical": {
       "title": "API quota CRITICAL — {remaining} requests remaining today",
-      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VAG Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
+      "description": "Your VAG account has fewer than 25 API requests remaining today ({remaining} of {limit}, {pct}%). The manufacturer backend may soft-suspend the account if you exhaust the budget.\n\n**Immediate action:**\n1. **Pause polling** — Settings → Devices & Services → VW Group Connect → Configure → Update Interval → set to 30 min or higher\n2. Avoid manual refreshes / vehicle wake-ups until the budget resets\n\nThis warning auto-clears when the remaining count recovers."
     }
   },
   "exceptions": {
@@ -631,7 +631,7 @@
       "message": "Fordon med VIN {vin} hittades inte."
     },
     "spin_required": {
-      "message": "S-PIN krävs för denna åtgärd. Konfigurera den under Inställningar → Enheter och tjänster → VAG Connect → Konfigurera."
+      "message": "S-PIN krävs för denna åtgärd. Konfigurera den under Inställningar → Enheter och tjänster → VW Group Connect → Konfigurera."
     },
     "feature_not_supported": {
       "message": "Funktionen {feature} stöds inte av ditt fordon eller den nuvarande API-klienten. Åtgärden skickades inte."
@@ -643,7 +643,7 @@
       "message": "Wake-up nedkylning aktiv ({remaining_s}s kvar). För att skydda 12V-batteriet är väckningar begränsade till en var {cooldown_min}:e minut per fordon."
     },
     "read_only_mode_active": {
-      "message": "Skrivskyddat läge är aktiverat i integrationsalternativen. Inaktivera det under Inställningar → Enheter och tjänster → VAG Connect → Konfigurera för att skicka fordonskommandon."
+      "message": "Skrivskyddat läge är aktiverat i integrationsalternativen. Inaktivera det under Inställningar → Enheter och tjänster → VW Group Connect → Konfigurera för att skicka fordonskommandon."
     }
   }
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -19,7 +19,7 @@ the cloud on its own schedule:
 - when the driver presses the "send to cloud now" button in the
   vehicle's infotainment system
 
-VAG Connect polls the cloud at your configured interval (default
+VW Group Connect polls the cloud at your configured interval (default
 **10 minutes** in v1.17.0+) and surfaces whatever the cloud already
 knows. **No 12V battery cost.**
 
@@ -42,7 +42,7 @@ These actions trigger an actual radio link to the vehicle:
 
 ### Wake protection
 
-VAG Connect protects your 12V battery automatically (since v1.12.0):
+VW Group Connect protects your 12V battery automatically (since v1.12.0):
 
 - **3 wakes per day per vehicle** soft cap (UTC midnight reset)
 - **5-minute wake cooldown** per vehicle (since v1.13.0)
@@ -83,7 +83,7 @@ restricts what the cloud is allowed to know about your vehicle.
 - Check that the vehicle has cell coverage and is awake
 - Verify in the app that the privacy setting actually saved
 - Open a GitHub issue with anonymized diagnostics
-  (HA Settings → Devices & Services → VAG Connect → ⋮ → Diagnostics)
+  (HA Settings → Devices & Services → VW Group Connect → ⋮ → Diagnostics)
 
 ---
 
@@ -95,7 +95,7 @@ roughly **1,500 calls/day** for SEAT/CUPRA, similar for the other
 brands. The exact limit varies per backend and is not officially
 documented.
 
-### Why does VAG Connect default to 10-minute polling (v1.17.0+)?
+### Why does VW Group Connect default to 10-minute polling (v1.17.0+)?
 
 | Poll interval | Polls/day | % of 1,500 quota | Headroom for app |
 |---|---|---|---|
@@ -118,14 +118,14 @@ until the cloud resets at ~02:00 local.
 
 ## 🔁 How do I update credentials after a manufacturer password change?
 
-VAG Connect supports HA's standard re-authentication flow since
+VW Group Connect supports HA's standard re-authentication flow since
 v1.8.x. **Since v1.19.2 IDK tokens are persisted via HA's Store
 helper** — HACS-Updates und HA-Restarts zwingen dich nicht mehr
 zu Re-Auth, solange das hinterlegte Password noch gültig ist.
 
 1. After your password change, the integration's next poll fails
    with a "Reauthenticate" notice
-2. **Settings → Devices & Services → VAG Connect → Reconfigure**
+2. **Settings → Devices & Services → VW Group Connect → Reconfigure**
 3. Enter the new password
 4. The entry updates in place
 
@@ -150,7 +150,7 @@ this sequence:
 
 ## 🆔 Entity-ID stability across versions
 
-VAG Connect follows this policy (since v1.13.0):
+VW Group Connect follows this policy (since v1.13.0):
 
 - **Bug fixes that change a sensor's value** but keep the same
   meaning → keep the entity_id, ship as a PATCH or MINOR.
@@ -173,11 +173,11 @@ when we ship semantic improvements.
 
 ## 🛡️ Read-only Mode
 
-If you want VAG Connect to give you vehicle telemetry **without any
+If you want VW Group Connect to give you vehicle telemetry **without any
 risk of accidental commands** (e.g. for guest dashboards, automations
 that should never actuate), enable Read-only Mode:
 
-1. **Settings → Devices & Services → VAG Connect → Configure**
+1. **Settings → Devices & Services → VW Group Connect → Configure**
 2. Toggle **"Read-only Mode"** on
 3. Reload the integration
 
@@ -200,7 +200,7 @@ Two possible reasons (since v1.17.0 we surface a notification for
 each):
 
 1. **Vehicle removed from your account** — sold, ownership
-   transferred, or the manufacturer deactivated it. VAG Connect
+   transferred, or the manufacturer deactivated it. VW Group Connect
    detects this on the next poll, removes the device + entities,
    and fires a persistent_notification with the reason.
    - Long-term-statistics data **is preserved** in HA's recorder
@@ -220,11 +220,11 @@ each):
 
 ## 📞 How do I report a bug?
 
-1. **Settings → Devices & Services → VAG Connect → ⋮ → Diagnose herunterladen**
+1. **Settings → Devices & Services → VW Group Connect → ⋮ → Diagnose herunterladen**
 2. The downloaded JSON has VINs masked, GPS rounded, tokens redacted,
    user_ids SHA-256-hashed (since v1.15.0). Safe to post publicly.
 3. Open an issue at
-   [github.com/its-me-prash/vag-connect-ha/issues/new](https://github.com/its-me-prash/vag-connect-ha/issues/new)
+   [github.com/its-me-prash/vwgroup-connect-ha/issues/new](https://github.com/its-me-prash/vwgroup-connect-ha/issues/new)
 4. Pick the right template — `Bug Report`, `Vehicle Data Scout`
    (for new field discoveries), or `Error Reporter` (for ring-buffer
    error dumps that the integration auto-collects)
@@ -253,7 +253,7 @@ each):
 
 ## 🚀 Push Updates (v1.18.0+ Foundation, Phase 2 pending)
 
-Since v1.18.0 (Skoda MQTT) and v1.19.0 (CUPRA/SEAT FCM), VAG Connect
+Since v1.18.0 (Skoda MQTT) and v1.19.0 (CUPRA/SEAT FCM), VW Group Connect
 ships **opt-in Push-Foundation** für Real-Time-Updates ohne 12V-
 Wake-Cycle:
 
@@ -281,7 +281,7 @@ Aktuell läuft die Foundation-Stub: Manager startet, schläft im Connect-Loop, a
 
 ## 📊 API Quota Sensor (v1.19.1+) + Quota Repair-Issue (v1.19.4+)
 
-Seit v1.19.1 zeigt VAG Connect den **API Quota** des Tages an:
+Seit v1.19.1 zeigt VW Group Connect den **API Quota** des Tages an:
 
 - `sensor.<vehicle>_requests_remaining_today` (Diagnostic) — verbleibende Anfragen heute
 - Wenn dein Backend X-RateLimit-Remaining Header sendet (alle modernen VAG-APIs tun das), siehst du wieviel Quota du noch hast
@@ -358,7 +358,7 @@ Quickest workaround if nothing helps: navigate to the view, edit
 mode, "+ Add Card" → "Entities" → filter `vag_connect` or your
 VIN-last-6 to find your sensors.
 
-Full guide + dedicated VAG Connect Lovelace card (BETA — in
+Full guide + dedicated VW Group Connect Lovelace card (BETA — in
 testing, currently still has a Mercedes-style background that's
 being redesigned): [`docs/dashboards.md`](dashboards.md).
 
@@ -371,4 +371,4 @@ being redesigned): [`docs/dashboards.md`](dashboards.md).
 - **Future roadmap + planned releases:** `docs/ROADMAP.md`
 - **Pre-implementation research:** `docs/research/`
 - **Brand Captains community:** `BRAND_CAPTAINS.md`
-- **GitHub Issues:** https://github.com/its-me-prash/vag-connect-ha/issues
+- **GitHub Issues:** https://github.com/its-me-prash/vwgroup-connect-ha/issues

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,9 +1,9 @@
-# Dashboard Guide — VAG Connect entities in Home Assistant Lovelace
+# Dashboard Guide — VW Group Connect entities in Home Assistant Lovelace
 
-> Audience: end-users who already have VAG Connect installed and want
+> Audience: end-users who already have VW Group Connect installed and want
 > to surface the entities on a Lovelace dashboard. Covers the most
 > frequent "Add to Dashboard does nothing" troubleshooting plus the
-> dedicated VAG Connect Lovelace card.
+> dedicated VW Group Connect Lovelace card.
 
 ---
 
@@ -18,7 +18,7 @@ If you just want to drop a sensor onto a card you already have:
 4. Search for your VAG entity by VIN (last 6 chars) or
    `vag_connect` substring
 
-If you went via **Settings → Devices → VAG Connect → \[entity\] →
+If you went via **Settings → Devices → VW Group Connect → \[entity\] →
 Add to Dashboard** instead and your target view didn't appear, see
 the next section.
 
@@ -76,9 +76,9 @@ quick-workflow. Workaround:
 
 ---
 
-## 🎨 Dedicated VAG Connect Lovelace Card (BETA)
+## 🎨 Dedicated VW Group Connect Lovelace Card (BETA)
 
-We maintain a separate Lovelace card optimised for VAG Connect:
+We maintain a separate Lovelace card optimised for VW Group Connect:
 
 **Repo:** https://github.com/its-me-prash/vag-connect-cards
 
@@ -125,7 +125,7 @@ stay here on the integration repo.
 
 ## 🫧 Ready-made Bubble Card templates (recommended starter)
 
-If you want the **fastest path to a beautiful VAG Connect dashboard**
+If you want the **fastest path to a beautiful VW Group Connect dashboard**
 without writing YAML from scratch, install
 [**Bubble Card**](https://github.com/Clooos/Bubble-Card) via HACS
 and drop in our pre-built templates:
@@ -155,11 +155,11 @@ What's in the folder:
 Bubble Card gives you the glass-morphism / gradient aesthetic shown
 in the upstream [card gallery](https://github.com/Clooos/Bubble-Card#screenshots).
 Our templates configure all buttons, pop-ups and quick-actions
-that match how VAG Connect exposes vehicle state.
+that match how VW Group Connect exposes vehicle state.
 
 ---
 
-## 🧱 Other 3rd-party cards that work with VAG Connect
+## 🧱 Other 3rd-party cards that work with VW Group Connect
 
 The integration exposes `extra_state_attributes.image_url` on the
 device-tracker + image entities, so generic vehicle cards pick it
@@ -182,7 +182,7 @@ Examples in [`docs/lovelace-example.yaml`](lovelace-example.yaml).
 
 ## 🔍 Finding the entity IDs you want
 
-VAG Connect entity-IDs follow the pattern:
+VW Group Connect entity-IDs follow the pattern:
 
 ```
 <platform>.<vehicle_nickname_or_vin>_<field>
@@ -242,9 +242,9 @@ your model / firmware doesn't ship that data.
 
 - Check [`docs/FAQ.md`](FAQ.md) for general installation +
   configuration questions
-- Open a [Discussion](https://github.com/its-me-prash/vag-connect-ha/discussions)
+- Open a [Discussion](https://github.com/its-me-prash/vwgroup-connect-ha/discussions)
   if you're unsure whether it's a bug or a config issue
-- Open an [Issue](https://github.com/its-me-prash/vag-connect-ha/issues)
+- Open an [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)
   with the **HA version**, **integration version**, and your
   **dashboard mode** (Storage / YAML) — saves a back-and-forth round
 

--- a/docs/lovelace/bubble-card/README.md
+++ b/docs/lovelace/bubble-card/README.md
@@ -1,4 +1,4 @@
-# Bubble Card Templates for VAG Connect
+# Bubble Card Templates for VW Group Connect
 
 > Pre-built Lovelace YAML snippets that use [**Bubble Card**](https://github.com/Clooos/Bubble-Card)
 > to give your VAG vehicles a beautiful, glass-morphism dashboard out
@@ -20,7 +20,7 @@ Drop these snippets into your dashboard and get:
 
 ## 📦 Prerequisites
 
-1. **VAG Connect** integration installed and at least one vehicle configured
+1. **VW Group Connect** integration installed and at least one vehicle configured
 2. **Bubble Card** installed via HACS:
    - HACS → Frontend → "+ Explore & Add Repositories"
    - Search "Bubble Card" → install
@@ -106,10 +106,10 @@ Update HA if you're on an older release.
 - [Bubble Card docs](https://github.com/Clooos/Bubble-Card/wiki) —
   full reference for all card types and styling options
 - [`its-me-prash/vag-connect-cards`](https://github.com/its-me-prash/vag-connect-cards) —
-  dedicated VAG Connect Lovelace card (BETA — alternative to
+  dedicated VW Group Connect Lovelace card (BETA — alternative to
   Bubble Card if you want a single-purpose VAG dashboard)
 
 ---
 
-*Templates contributed by the VAG Connect community. Issues +
+*Templates contributed by the VW Group Connect community. Issues +
 improvements welcome via PR.*

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "VAG Connect",
+  "name": "VW Group Connect",
   "content_in_root": false,
   "hide_default_branch": true,
   "homeassistant": "2024.4.0",

--- a/tests/test_v240_marketing_rename.py
+++ b/tests/test_v240_marketing_rename.py
@@ -1,0 +1,274 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+"""v2.4.0 — Marketing-only rename: ``VAG Connect`` → ``VW Group Connect``.
+
+Context: humorous community feedback on the Home Assistant UK + HA
+Ideas, Projects and Solutions Facebook groups (2026-05). "VAG" — the
+official DACH abbreviation for Volkswagen AG — reads quite differently
+to English speakers. Si Gregory suggested the rename, Ben Johnson +
+Evets David + Stuart McBride + Jordan Waeles all chimed in.
+
+The rename is **marketing-only** per user decision in the planning
+phase:
+- The integration ``DOMAIN`` stays ``vag_connect`` (entity-IDs depend
+  on it; renaming would break every existing user's automations +
+  recorder history)
+- The custom-components folder stays ``custom_components/vag_connect/``
+- All service-call prefixes stay ``vag_connect.lock`` etc.
+- The easter-egg service stays ``vag_connect.show_vag`` (Jordan Waeles'
+  Pandas-style joke — preserved by design)
+
+What CHANGES:
+- Repo URL ``vag-connect-ha`` → ``vwgroup-connect-ha`` (operational
+  files only; historical CHANGELOG entries + dated research docs are
+  preserved for accuracy)
+- Display name ``VAG Connect`` → ``VW Group Connect`` (manifest, hacs,
+  strings, 8 translations, 8 READMEs)
+- New ``MIGRATION.md`` at repo root with the full story
+- Rename-notice block at top of each of the 8 READMEs
+
+These tests pin both the rename AND the things that must NOT have
+changed, so a future refactor can't accidentally drift either side.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MANIFEST = _REPO_ROOT / "custom_components" / "vag_connect" / "manifest.json"
+_HACS_JSON = _REPO_ROOT / "hacs.json"
+_STRINGS = _REPO_ROOT / "custom_components" / "vag_connect" / "strings.json"
+_TRANSLATIONS_DIR = _REPO_ROOT / "custom_components" / "vag_connect" / "translations"
+_CONST_PY = _REPO_ROOT / "custom_components" / "vag_connect" / "const.py"
+_MIGRATION = _REPO_ROOT / "MIGRATION.md"
+_README_MD = _REPO_ROOT / "README.md"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 1. Display name renamed in user-facing strings
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestDisplayNameRenamed:
+    """Manifest, HACS, strings.json + 8 translations now say "VW Group Connect"."""
+
+    def test_manifest_name(self) -> None:
+        m = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+        assert m["name"] == "VW Group Connect"
+
+    def test_hacs_json_name(self) -> None:
+        h = json.loads(_HACS_JSON.read_text(encoding="utf-8"))
+        assert h["name"] == "VW Group Connect"
+
+    def test_strings_json_no_vag_connect(self) -> None:
+        """strings.json must no longer contain the old display name."""
+        text = _STRINGS.read_text(encoding="utf-8")
+        # "VAG Connect" (integration name) must be gone.
+        # "VAG account" / "VAG IDP" (manufacturer ecosystem refs) stay.
+        assert "VAG Connect" not in text
+
+    @pytest.mark.parametrize(
+        "lang",
+        ["de", "en", "fr", "es", "nl", "pl", "cs", "sv"],
+    )
+    def test_translation_no_vag_connect(self, lang: str) -> None:
+        text = (_TRANSLATIONS_DIR / f"{lang}.json").read_text(encoding="utf-8")
+        assert "VAG Connect" not in text, (
+            f"{lang}.json still contains 'VAG Connect' — bulk-replace missed it"
+        )
+
+    @pytest.mark.parametrize(
+        "lang",
+        ["de", "en", "fr", "es", "nl", "pl", "cs", "sv"],
+    )
+    def test_translation_has_vw_group_connect(self, lang: str) -> None:
+        """Sanity check the new name is actually present."""
+        text = (_TRANSLATIONS_DIR / f"{lang}.json").read_text(encoding="utf-8")
+        assert "VW Group Connect" in text
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 2. Repo URL renamed in operational docs
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestRepoUrlRenamed:
+    """Manifest URLs + workflow + README badges + docs use the new repo URL."""
+
+    def test_manifest_documentation_url(self) -> None:
+        m = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+        assert m["documentation"] == "https://github.com/its-me-prash/vwgroup-connect-ha"
+
+    def test_manifest_issue_tracker_url(self) -> None:
+        m = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+        assert m["issue_tracker"] == "https://github.com/its-me-prash/vwgroup-connect-ha/issues"
+
+    def test_readme_md_uses_new_url(self) -> None:
+        text = _README_MD.read_text(encoding="utf-8")
+        # The HACS badge + release badge MUST use the new URL.
+        assert "github.com/its-me-prash/vwgroup-connect-ha" in text
+
+    def test_readme_md_no_old_url_outside_notice(self) -> None:
+        """The old URL is allowed inside the rename-notice + MIGRATION link.
+
+        Everywhere else (badges, install buttons, doc links) it must
+        be the new URL.
+        """
+        text = _README_MD.read_text(encoding="utf-8")
+        # Count old URL occurrences. Allowed: 1 in the rename-notice
+        # block describing the old name (markdown-bold backticks).
+        # Actually our notice uses just the slug `vag-connect-ha`, not
+        # a full URL, so there should be ZERO full-URL occurrences.
+        # (The slug alone in backticks is fine and lives in the notice.)
+        assert "github.com/its-me-prash/vag-connect-ha" not in text, (
+            "README.md still references the OLD full repo URL — that "
+            "should only appear in the slug form inside the rename-notice"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 3. Rename-notice block present in all 8 READMEs
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestRenameNoticeInReadmes:
+    """Each README has the community-credits rename-notice block."""
+
+    @pytest.mark.parametrize(
+        "fname",
+        [
+            "README.md",
+            "README.en.md",
+            "README.fr.md",
+            "README.es.md",
+            "README.nl.md",
+            "README.pl.md",
+            "README.cs.md",
+            "README.sv.md",
+        ],
+    )
+    def test_notice_present(self, fname: str) -> None:
+        text = (_REPO_ROOT / fname).read_text(encoding="utf-8")
+        assert "Note on the rename" in text, f"{fname} missing rename-notice"
+        # Community credits per spec.
+        for name in ("Si Gregory", "Ben Johnson", "Evets David", "Jordan Waeles"):
+            assert name in text, f"{fname} missing credit for {name}"
+        # Reference the easter-egg service so users find it.
+        assert "vag_connect.show_vag" in text, f"{fname} missing easter-egg ref"
+        # Reference MIGRATION.md for full story.
+        assert "MIGRATION.md" in text, f"{fname} missing MIGRATION.md link"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 4. MIGRATION.md exists with the right structure
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestMigrationDoc:
+    def test_file_exists(self) -> None:
+        assert _MIGRATION.exists(), "MIGRATION.md missing from repo root"
+
+    def test_contains_tldr(self) -> None:
+        text = _MIGRATION.read_text(encoding="utf-8")
+        assert "Nothing breaks" in text or "nothing breaks" in text.lower()
+
+    def test_documents_what_stays(self) -> None:
+        text = _MIGRATION.read_text(encoding="utf-8")
+        # Critical promises to users:
+        assert "DOMAIN" in text
+        assert "vag_connect" in text
+        assert "Entity-IDs" in text or "entity-IDs" in text.lower()
+
+    def test_credits_community(self) -> None:
+        text = _MIGRATION.read_text(encoding="utf-8")
+        for name in ("Si Gregory", "Ben Johnson", "Evets David", "Jordan Waeles", "Stuart McBride"):
+            assert name in text, f"MIGRATION.md missing credit for {name}"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 5. CRITICAL — internal DOMAIN + folder + service-IDs unchanged
+# ──────────────────────────────────────────────────────────────────────
+#
+# The point of the marketing-only rename is that NO user breakage
+# happens. These tests pin the things that MUST stay the same. If any
+# of them fail, the rename has accidentally gone beyond marketing-only
+# scope.
+
+
+class TestNothingActuallyChanged:
+    def test_domain_constant_unchanged(self) -> None:
+        text = _CONST_PY.read_text(encoding="utf-8")
+        assert 'DOMAIN = "vag_connect"' in text, (
+            "CRITICAL: DOMAIN was changed from vag_connect — this would "
+            "break every existing user's config entries, entity-IDs, "
+            "and automations. The marketing-only rename must NOT touch "
+            "the DOMAIN. If this is intentional, ship as v4.0.0 MAJOR "
+            "with proper async_migrate_entry."
+        )
+
+    def test_manifest_domain_unchanged(self) -> None:
+        m = json.loads(_MANIFEST.read_text(encoding="utf-8"))
+        assert m["domain"] == "vag_connect"
+
+    def test_custom_components_folder_unchanged(self) -> None:
+        assert (_REPO_ROOT / "custom_components" / "vag_connect").is_dir(), (
+            "CRITICAL: custom_components/vag_connect/ was renamed — HACS "
+            "+ HA both bind to this folder name. Renaming would break "
+            "every existing install."
+        )
+
+    def test_easter_egg_service_name_preserved(self) -> None:
+        """show_vag service-ID stays vag_connect.show_vag (Jordan's joke)."""
+        init_py = (_REPO_ROOT / "custom_components" / "vag_connect" / "__init__.py").read_text(
+            encoding="utf-8"
+        )
+        services_yaml = (_REPO_ROOT / "custom_components" / "vag_connect" / "services.yaml").read_text(
+            encoding="utf-8"
+        )
+        assert '"show_vag"' in init_py
+        assert "show_vag:" in services_yaml
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 6. Historical preservation — CHANGELOG + dated research preserved
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestHistoryPreserved:
+    """Past CHANGELOG entries + dated research docs were intentionally
+    NOT rewritten — they describe what actually shipped at the time."""
+
+    def test_changelog_keeps_old_name(self) -> None:
+        """CHANGELOG.md still has historical references to "VAG Connect"."""
+        text = (_REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        # At least one historical entry must still say "VAG Connect"
+        # — that's the whole point of history-preservation.
+        assert "VAG Connect" in text, (
+            "CHANGELOG.md historical entries were unexpectedly rewritten — "
+            "the history-preservation decision (v2.4.0 plan) requires "
+            "past releases keep their original name references for accuracy."
+        )
+
+    def test_dated_research_preserved(self) -> None:
+        """At least one docs/research/*-2026-*.md still references vag_connect."""
+        research_dir = _REPO_ROOT / "docs" / "research"
+        if not research_dir.is_dir():
+            pytest.skip("docs/research/ not present in this checkout")
+        any_preserved = False
+        for f in research_dir.glob("2026-*.md"):
+            if "vag_connect" in f.read_text(encoding="utf-8"):
+                any_preserved = True
+                break
+        # Soft assertion — research dir might not have 2026-* files in
+        # a fresh checkout. We just check the prefix-based ones exist
+        # if any do.
+        if not any_preserved:
+            pytest.skip("no 2026-* research files contain vag_connect refs to check")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

MINOR release v2.4.0 — marketing-only rename of the project per community feedback. **Zero user-breakage** by design.

## Why

Humorous community feedback on the **Home Assistant UK** + **HA Ideas, Projects and Solutions** Facebook groups (2026-05) pointed out that "VAG" — the official DACH abbreviation for Volkswagen AG — reads quite differently to English speakers. **Si Gregory** suggested the rename, **Ben Johnson** + **Evets David** + **Stuart McBride** + **Jordan Waeles** all chimed in. **Jordan Waeles**' immortal Pandas-style `show_vag()` joke already became an easter-egg in v2.2.3 — this PR completes the picture by renaming the marketing identity.

## Marketing-only by design

The integration **DOMAIN** stays `vag_connect`. Renaming it would force every existing user to re-install, lose entity-IDs, lose recorder history, rewrite automations — hostile UX for a marketing change. So:

| Aspect | Before | After |
|---|---|---|
| Repo URL | `vag-connect-ha` | `vwgroup-connect-ha` |
| HACS Display | `VAG Connect` | `VW Group Connect` |
| Manifest `name` | `VAG Connect` | `VW Group Connect` |
| Integration `domain` | `vag_connect` | **`vag_connect`** (unchanged!) |
| Entity-IDs | `sensor.audi_q4_battery_soc` | **unchanged** |
| Service-Calls | `vag_connect.lock` etc. | **unchanged** |
| Easter-egg | `vag_connect.show_vag` (Jordan's joke) | **preserved** |

If a real DOMAIN rename is ever required, it ships as v4.0.0 MAJOR with proper `async_migrate_entry`. Not now.

## Files (38 changed, +864 / -270)

**Display name + URL changes (operational only):**
- `manifest.json` + `hacs.json` — name, documentation, issue_tracker URLs
- `strings.json` + 8 translation files — 88 "VAG Connect" hits replaced
- 8 READMEs — name + URL + new rename-notice block with community credits
- `SECURITY.md`, `PRIVACY.md`, `CONTRIBUTING.md`, `RELEASE_PROCESS.md`, `ROADMAP.md`, `NOTICE.md`
- `.github/workflows/release.yml` + 5 issue templates
- `docs/dashboards.md`, `docs/FAQ.md`, `docs/lovelace/bubble-card/README.md`
- `coordinator.py` user-agent string (1 line)
- `CHANGELOG.md` — `[Unreleased] — v2.4.0` entry

**New files:**
- `MIGRATION.md` at repo root — full story + guarantees for existing users
- `tests/test_v240_marketing_rename.py` — 41 regression-pins

**Preserved per history-preservation decision (NOT rewritten):**
- `CHANGELOG.md` past entries (47 historical hits to "VAG Connect")
- `docs/research/*-2026-*.md` (17 timestamped research files)
- `docs/CHANGELOG_TECHNICAL.md`
- Bruno files (URL-pinning + historical attribution)
- Tests (Python imports stay `from custom_components.vag_connect.*`)
- Scripts (internal utilities)

## Critical guarantees (pinned by tests)

`tests/test_v240_marketing_rename.py::TestNothingActuallyChanged` pins:
- `DOMAIN = "vag_connect"` in const.py — UNCHANGED
- `manifest.json` domain field — UNCHANGED
- `custom_components/vag_connect/` directory — EXISTS
- Easter-egg service `vag_connect.show_vag` — preserved

If any future refactor accidentally drifts these, CI fails loudly.

## Test plan

- [x] 41/41 source-level regression-pins green locally
- [x] All 9 JSON files (manifest, hacs, strings, 8 translations) parse cleanly
- [x] Old repo URL appears ONLY inside the rename-notice block (verified via grep)
- [x] Display name "VAG Connect" appears ONLY in historical files (CHANGELOG, dated research)
- [ ] CI green (7 checks)
- [ ] After merge: tag `v2.4.0` (GH release auto-created by workflow)
- [ ] Manually rename the GitHub repo: Settings → Repository name → `vwgroup-connect-ha` (out-of-scope for this PR per spec — GitHub keeps the old URL as a permanent redirect, so HACS users continue to auto-update)

## After this ships

User reads MIGRATION.md → understands nothing breaks → continues as before. New users see "VW Group Connect" everywhere. HA UK + HA Ideas community gets the result of their suggestion. Jordan Waeles' easter-egg stays the immortal community in-joke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)