### PR TITLE
release: v2.4.0 — Marketing-Rename VAG Connect → VW Group Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,13 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 > phantom-protected). Tier-B (wildcards + alarm/siren) deferred
 > until tester scout-dumps liefern die unknown leaf-shapes.
 
-## [Unreleased] — v2.4.0
+## [Unreleased]
+
+_(nothing pending — v2.4.0 just shipped; new entries land here)_
+
+## [2.4.0] — 2026-05-23 — "Marketing-Rename: VAG Connect → VW Group Connect (Community Tribute)"
+
+> **MINOR release** — marketing-only project rename. **Zero user-breakage** by design. Spinoff aus humorvoller Community-Feedback der HA UK + HA Ideas FB-Gruppen (Si Gregory, Ben Johnson, Evets David, Stuart McBride, Jordan Waeles). DOMAIN stays `vag_connect` internally → entity-IDs unchanged, automations weiterfunktionieren, recorder history bleibt, easter-egg `vag_connect.show_vag` bleibt unter Jordan's joke-name. Display-Name + Repo-URL umbenannt für die public-identity. Siehe MIGRATION.md.
 
 ### Changed
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.3.0"
+  "version": "2.4.0"
 }


### PR DESCRIPTION
## Summary

MINOR release v2.4.0 collecting PR #278 (marketing-only rename).

## What's in v2.4.0

| PR | Title |
|---|---|
| #278 | feat(v2.4.0): marketing-rename — VAG Connect → VW Group Connect (DOMAIN unchanged) |

## Highlights

- 🪪 **Marketing-Rename**: Repo URL + Display Name umbenannt
- 🔒 **Zero user-breakage**: DOMAIN bleibt `vag_connect`, entity-IDs unchanged, automations weiterfunktionieren
- 📜 **NEW MIGRATION.md**: full story + guarantees für existing users
- 🥚 **Easter-egg preserved**: `vag_connect.show_vag` (Jordan Waeles' joke) bleibt unter dem ursprünglichen Service-Name als community tribute

## Files

- `custom_components/vag_connect/manifest.json` — 2.3.0 → 2.4.0
- `CHANGELOG.md` — `[Unreleased] — v2.4.0` → `[2.4.0] — 2026-05-23 — "Marketing-Rename..."` release block

## Test plan

- [x] PR #278 landed in main
- [ ] CI green (5 checks)
- [ ] After merge: tag `v2.4.0` (GH release auto-created)
- [ ] User to manually rename GitHub repo: Settings → Repository name → `vwgroup-connect-ha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)