### PR TITLE
docs: switch CHANGELOG bilingual convention to EN-primary (v2.4.1+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-Alle wesentlichen Änderungen werden hier dokumentiert.
+All notable changes are documented here. / Alle wesentlichen Änderungen werden hier dokumentiert.
 
-Format: [Keep a Changelog 1.0.0](https://keepachangelog.com/de/1.0.0/)  
-Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
+Format: [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/)
+Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
-> 📖 **Bi-lingual title convention (ab v1.12.3 / since v1.12.3):** Section-Titles sind **DE / EN** geteilt durch ` / `. Body-Inhalt bleibt auf Deutsch (Audience ist primär die deutschsprachige VAG-HA-Community + DACH FB-Gruppen). Übersetzungen einzelner Body-Texte gibt es bei Bedarf via [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — dort wird das gleiche Pattern angewendet.
+> 📖 **Bi-lingual convention (v1.12.3 → v2.4.0 — DE-primary)**: section-titles were **DE / EN** joined by ` / ` and body content was German-only. Past entries are preserved as-is for historical accuracy.
+>
+> 📖 **Bi-lingual convention (v2.4.1+ — EN-primary, switched 2026-05-23)**: section-titles are now **EN / DE** joined by ` / `, body content is **English-primary** with German callouts where the original context was DACH-specific (Facebook-group threads, German tester names, brand-specific German terminology). The project's GitHub audience + the new "VW Group Connect" branding both lean international — English-primary makes the changelog readable for non-DACH users while keeping the DACH community's voice visible. Translations of individual body texts are available on request via [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — same pattern.
 
 ## Semver-Regeln für dieses Projekt (pre-1.0.0)
 
@@ -117,7 +119,24 @@ Versionierung: [Semantic Versioning 2.0.0](https://semver.org/lang/de/)
 
 ## [Unreleased]
 
-_(nothing pending — v2.4.0 just shipped; new entries land here)_
+### Changed
+
+- **Bilingual convention switched: EN-primary, DE-secondary (effective v2.4.1+)** —
+  Changelog entries, release notes and GH release titles are now
+  written **English-primary** with German callouts where the original
+  context is DACH-specific (FB-group threads, German tester names,
+  brand-specific German terminology). Past entries pre-v2.4.1 are
+  preserved DE-primary for historical accuracy (same precedent as the
+  v2.4.0 marketing-rename: never rewrite history). Rationale: the new
+  "VW Group Connect" identity + landing VW North America in v2.3.0 +
+  more international brands coming make English-primary more inclusive.
+  Convention note in the CHANGELOG header + style-guide in
+  `RELEASE_PROCESS.md` both updated. Docs-only — no version bump
+  required for this commit.
+  _(DE: Sprachkonvention umgestellt — ab v2.4.1+ Englisch als
+  Hauptsprache, Deutsch als Zweitsprache. Historische Einträge bleiben
+  unverändert in DE-primary. Begründung: neuer "VW Group Connect"
+  Identity-Schwerpunkt + zunehmend internationale Audience.)_
 
 ## [2.4.0] — 2026-05-23 — "Marketing-Rename: VAG Connect → VW Group Connect (Community Tribute)"
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -28,6 +28,30 @@ workflow enforces this.
 - short description of the change
 ```
 
+## Language convention (v2.4.1+ — EN-primary, switched 2026-05-23)
+
+CHANGELOG entries + release notes + GH release titles use **English as
+the primary language**, with German callouts where the original
+context was DACH-specific (Facebook-group threads, German tester
+names, brand-specific German terminology like "Standheizung",
+"S-PIN", "Konfigurator").
+
+**Why the switch from DE-primary (v1.12.3 → v2.4.0)**: the project's
+new "VW Group Connect" identity + growing international audience
+(VW North America landed in v2.3.0, more brands coming) make
+English-primary more inclusive. The DACH community's voice stays
+visible via inline German callouts and the dedicated DE-translated
+[`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md).
+
+**Style guide**:
+- Section title: `## [vX.Y.Z] — date — "EN Codename / DE Codename"` (EN first)
+- Body: English-primary. Insert a German sentence/paragraph only when
+  the original context was DACH-specific or when terminology has no
+  clean English equivalent.
+- Code/log strings stay as-is (already English by convention).
+- Past entries (pre-v2.4.1) are preserved DE-primary for historical
+  accuracy — never rewrite history.
+
 Commit-message prefix conventions are listed in
 [`CONTRIBUTING.md`](CONTRIBUTING.md).
 


### PR DESCRIPTION
## Summary

Per user directive 2026-05-23: future release-notes, changelog entries and GH release titles use **English as primary language**, German as secondary. Historical entries (pre-v2.4.1) stay DE-primary for historical accuracy.

## Why

The project's new **"VW Group Connect"** identity (just landed in v2.4.0) + the **VW North America** brand now actually working (v2.3.0) + more international brands coming make English-primary more inclusive for the GitHub audience. The DACH community's voice stays visible via inline German callouts + the dedicated DE-translated [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md).

## What changes

| File | Change |
|---|---|
| `CHANGELOG.md` header | Convention note updated: documents both the past DE-primary era (v1.12.3 → v2.4.0) and the new EN-primary era (v2.4.1+) |
| `CHANGELOG.md` `[Unreleased]` | Documentation entry for the convention change itself |
| `RELEASE_PROCESS.md` | New "Language convention" section with style guide for future contributors |

## Style guide (TL;DR for next CHANGELOG entry)

```markdown
## [v2.4.1] — 2026-XX-XX — "EN Codename / DE Codename"

> **PATCH release** — short EN description.
> _(DE: kurze deutsche Übersetzung falls DACH-spezifisch.)_

### Fixed

- **#XYZ (reporter brand, 2026-XX-XX) — Issue title in English** —
  English-primary description of what was fixed and why. Insert a
  German sentence only when the original context was DACH-specific
  (e.g. "Reporter ist auf der DACH FB-Gruppe gemeldet" stays German).
```

## What stays the same

- Past CHANGELOG entries (v1.x, v2.0-v2.4.0) — **untouched**, historical accuracy preserved
- `docs/research/2026-*.md` — historical archives stay as-is
- DOMAIN `vag_connect`, entity-IDs, service-calls — all internals unchanged
- Easter-egg service `vag_connect.show_vag` — Jordan Waeles' joke preserved

## Test plan

- [x] Convention note in both CHANGELOG.md + RELEASE_PROCESS.md
- [x] No code touched (docs-only)
- [ ] CI green (1 check: CHANGELOG aktualisiert? — already done, my [Unreleased] entry counts)
- [ ] After merge: convention takes effect for next real release

🤖 Generated with [Claude Code](https://claude.com/claude-code)