### PR TITLE
chore(ola-watcher): daily cron + auto-PR + fallback-chain auto-growth

### DIFF
--- a/.github/workflows/upstream-ola-watcher.yml
+++ b/.github/workflows/upstream-ola-watcher.yml
@@ -1,69 +1,87 @@
 name: Upstream OLA Headers Watcher
 
-# v2.4.1 (#281+#282) — VW Group's OLA backend started enforcing app-
-# identifying headers on 2026-05-20. CarConnectivity-connector-seatcupra
-# fixed it in v0.6.3 by hardcoding the headers per brand. The header
-# VALUES will eventually drift as the SEAT/CUPRA apps update their
-# version numbers.
+# v2.4.1 — VW Group's OLA backend started enforcing app-identifying
+# headers on 2026-05-20 (#281, #282). CarConnectivity-connector-
+# seatcupra fixed it in v0.6.3 by hardcoding the headers per brand.
+# The header VALUES will eventually drift as the SEAT/CUPRA apps
+# update.
 #
-# This workflow monitors the upstream CarConnectivity reference
-# implementation weekly. If their app-version differs from ours, it
-# opens an issue prompting us to bump the version in our
-# cariad/_ola_headers.py. Goal: stay within ~1 week of upstream.
+# v2.4.2 — Daily + auto-PR (was weekly + issue-only). When upstream
+# CarConnectivity bumps an app-version, this workflow:
+#   1. Detects the drift (compare our _ola_headers.py to upstream)
+#   2. Branches off main
+#   3. Patches _ola_headers.py with the new primary values
+#   4. Moves the previous primary into _OLA_HEADERS_BY_BRAND_FALLBACK
+#      (so the multi-version fallback chain grows automatically —
+#      defense-in-depth Layer 3 self-extends)
+#   5. Opens a Pull Request
+#   6. Repo maintainer reviews + merges (no auto-merge — preserves
+#      human safety check in case upstream is mid-experiment)
+#
+# Idempotent: if an auto-PR with the same SEAT+CUPRA values is
+# already open, the workflow skips creation. Re-runs while the PR is
+# open are no-ops.
 
 on:
   schedule:
-    # Every Monday at 08:00 UTC.
-    - cron: "0 8 * * 1"
+    # Every day at 08:00 UTC. Lag from upstream change → our PR is
+    # at most 24h.
+    - cron: "0 8 * * *"
   workflow_dispatch:
-    # Allow manual trigger from the Actions tab.
+    # Allow manual trigger from the Actions tab (e.g. to immediately
+    # check after a known upstream release).
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
   issues: write
 
 jobs:
-  compare-ola-headers:
+  compare-and-pr:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Default checkout depth=1 is fine — we don't need history.
+          # But we DO need write access for the auto-PR commit.
+          token: ${{ github.token }}
 
       - name: Fetch CarConnectivity upstream my_cupra_session.py
         id: upstream
         run: |
-          # Pull the CarConnectivity-connector-seatcupra session config
-          # from their main branch.
           URL="https://raw.githubusercontent.com/tillsteinbach/CarConnectivity-connector-seatcupra/main/src/carconnectivity_connectors/seatcupra/auth/my_cupra_session.py"
           curl -fsSL "$URL" -o upstream_session.py
 
-          # Extract the app-version values for each brand. The pattern in
-          # upstream is:
+          # Extract app-version per brand. Upstream pattern:
           #   'app-brand': 'seat',  'app-version': '2.17.0',
-          # appearing twice (one block per brand).
-          # Use grep -A to grab a few lines after the brand match.
-          UPSTREAM_SEAT=$(grep -A2 "'app-brand': 'seat'" upstream_session.py | \
+          UP_SEAT=$(grep -A2 "'app-brand': 'seat'" upstream_session.py | \
             grep "app-version" | head -1 | sed -E "s/.*'app-version': '([^']+)'.*/\1/")
-          UPSTREAM_CUPRA=$(grep -A2 "'app-brand': 'cupra'" upstream_session.py | \
+          UP_CUPRA=$(grep -A2 "'app-brand': 'cupra'" upstream_session.py | \
             grep "app-version" | head -1 | sed -E "s/.*'app-version': '([^']+)'.*/\1/")
 
-          echo "Upstream SEAT: $UPSTREAM_SEAT"
-          echo "Upstream CUPRA: $UPSTREAM_CUPRA"
+          echo "Upstream SEAT: $UP_SEAT"
+          echo "Upstream CUPRA: $UP_CUPRA"
 
-          echo "seat=$UPSTREAM_SEAT" >> "$GITHUB_OUTPUT"
-          echo "cupra=$UPSTREAM_CUPRA" >> "$GITHUB_OUTPUT"
+          if [ -z "$UP_SEAT" ] || [ -z "$UP_CUPRA" ]; then
+            echo "::error::Could not parse upstream session config — pattern may have changed"
+            exit 1
+          fi
+
+          echo "seat=$UP_SEAT" >> "$GITHUB_OUTPUT"
+          echo "cupra=$UP_CUPRA" >> "$GITHUB_OUTPUT"
 
       - name: Read our current values
         id: ours
+        env:
+          UP_SEAT: ${{ steps.upstream.outputs.seat }}
+          UP_CUPRA: ${{ steps.upstream.outputs.cupra }}
         run: |
-          # Our values live in custom_components/vag_connect/cariad/
-          # _ola_headers.py. Extract them with the same approach.
           F="custom_components/vag_connect/cariad/_ola_headers.py"
           if [ ! -f "$F" ]; then
             echo "::error::$F missing — has the OLA headers module been removed?"
             exit 1
           fi
 
-          # Pattern: "app-version": "2.17.0", inside a "seat" / "cupra" block.
           OURS_SEAT=$(python3 -c "
           import re, pathlib
           text = pathlib.Path('$F').read_text()
@@ -83,12 +101,102 @@ jobs:
           echo "seat=$OURS_SEAT" >> "$GITHUB_OUTPUT"
           echo "cupra=$OURS_CUPRA" >> "$GITHUB_OUTPUT"
 
-      - name: Compare and open issue on drift
-        if: |
-          (steps.upstream.outputs.seat != steps.ours.outputs.seat ||
-           steps.upstream.outputs.cupra != steps.ours.outputs.cupra) &&
-          steps.upstream.outputs.seat != '' &&
-          steps.upstream.outputs.cupra != ''
+          # Decide whether action is needed.
+          if [ "$UP_SEAT" = "$OURS_SEAT" ] && [ "$UP_CUPRA" = "$OURS_CUPRA" ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "✅ In sync with upstream — no action needed."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Drift detected — will check for existing PR + open new one if needed."
+          fi
+
+      - name: Check for existing auto-PR (idempotency)
+        id: existing
+        if: steps.ours.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UP_SEAT: ${{ steps.upstream.outputs.seat }}
+          UP_CUPRA: ${{ steps.upstream.outputs.cupra }}
+        run: |
+          # Look for an open PR whose title encodes the SAME target
+          # values. If found, skip — repeated runs while a PR is open
+          # are no-ops (avoids spamming the maintainer with duplicates).
+          TITLE="chore(ola-headers): auto-bump to SEAT=$UP_SEAT, CUPRA=$UP_CUPRA"
+          EXISTING=$(gh pr list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already open with these target values — no action."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Patch _ola_headers.py + grow fallback chain
+        if: steps.ours.outputs.drift == 'true' && steps.existing.outputs.skip != 'true'
+        env:
+          UP_SEAT: ${{ steps.upstream.outputs.seat }}
+          UP_CUPRA: ${{ steps.upstream.outputs.cupra }}
+          OUR_SEAT: ${{ steps.ours.outputs.seat }}
+          OUR_CUPRA: ${{ steps.ours.outputs.cupra }}
+        run: |
+          # Python in-place edit:
+          #   1. Bump the primary "app-version" for each brand
+          #   2. Prepend the OLD primary value as a new entry in
+          #      _OLA_HEADERS_BY_BRAND_FALLBACK[brand]
+          # Defense-in-depth Layer 3 self-grows.
+          python3 << 'PYTHON'
+          import os, pathlib, re
+
+          F = pathlib.Path("custom_components/vag_connect/cariad/_ola_headers.py")
+          text = F.read_text()
+
+          up_seat   = os.environ["UP_SEAT"]
+          up_cupra  = os.environ["UP_CUPRA"]
+          our_seat  = os.environ["OUR_SEAT"]
+          our_cupra = os.environ["OUR_CUPRA"]
+
+          # Bump primary values (one re.sub per brand).
+          if up_seat != our_seat:
+              text = re.sub(
+                  r'("seat":\s*\{[^}]*?"app-version":\s*)"[^"]+"',
+                  rf'\1"{up_seat}"',
+                  text, count=1, flags=re.DOTALL,
+              )
+          if up_cupra != our_cupra:
+              text = re.sub(
+                  r'("cupra":\s*\{[^}]*?"app-version":\s*)"[^"]+"',
+                  rf'\1"{up_cupra}"',
+                  text, count=1, flags=re.DOTALL,
+              )
+
+          # Grow the fallback chain by prepending the OLD value.
+          # Pattern: "seat": [\n  ...\n  ], — insert dict at top.
+          # If the chain doesn't exist yet (currently empty list with
+          # only comments), the re.sub inserts the first entry.
+          def grow_fallback(text: str, brand: str, old_value: str) -> str:
+              if not old_value:
+                  return text
+              entry = (
+                  f'        {{"app-market": "android", "app-brand": "{brand}", '
+                  f'"app-version": "{old_value}", "origin": "app"}},\n'
+                  f'        # ↑ auto-added by upstream-ola-watcher on bump.'
+              )
+              # Match the brand-fallback list opening: "seat": [ ... ]
+              # The replacement prepends our new entry right after the
+              # opening bracket, keeping any existing entries.
+              pattern = rf'("{brand}":\s*\[\n)'
+              return re.sub(pattern, rf'\1{entry}\n', text, count=1)
+
+          if up_seat != our_seat:
+              text = grow_fallback(text, "seat", our_seat)
+          if up_cupra != our_cupra:
+              text = grow_fallback(text, "cupra", our_cupra)
+
+          F.write_text(text)
+          print(f"✅ Patched {F}")
+          PYTHON
+
+      - name: Open Pull Request
+        if: steps.ours.outputs.drift == 'true' && steps.existing.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           UP_SEAT: ${{ steps.upstream.outputs.seat }}
@@ -96,53 +204,90 @@ jobs:
           OUR_SEAT: ${{ steps.ours.outputs.seat }}
           OUR_CUPRA: ${{ steps.ours.outputs.cupra }}
         run: |
-          # Idempotent: only open the issue if one with this title
-          # doesn't already exist (open or recently closed).
-          TITLE="OLA headers drift detected — upstream CarConnectivity has newer app-version"
+          # Configure git as the bot author for the auto-commit.
+          git config user.name "vw-group-connect-bot"
+          git config user.email "noreply@github.com"
 
-          EXISTING=$(gh issue list --search "in:title \"$TITLE\"" --state all --limit 5 --json number,state --jq '.[] | select(.state == "OPEN") | .number' | head -1)
-          if [ -n "$EXISTING" ]; then
-            echo "Issue #$EXISTING already open — adding a comment instead."
-            gh issue comment "$EXISTING" --body "Watcher re-detected drift on $(date -u +%Y-%m-%d):
+          # Branch off main with a date-stamped name.
+          DATE=$(date -u +%Y%m%d)
+          BRANCH="auto/ola-bump-${DATE}-seat${UP_SEAT}-cupra${UP_CUPRA}"
+          git checkout -b "$BRANCH"
 
-| Brand | Upstream | Ours |
+          # Include the changelog entry for the bump.
+          # Insert at the top of [Unreleased] section.
+          python3 << 'PYTHON'
+          import os, pathlib, datetime
+          F = pathlib.Path("CHANGELOG.md")
+          text = F.read_text(encoding="utf-8")
+          marker = "## [Unreleased]"
+          if marker in text:
+              up_seat  = os.environ["UP_SEAT"]
+              up_cupra = os.environ["UP_CUPRA"]
+              our_seat  = os.environ["OUR_SEAT"]
+              our_cupra = os.environ["OUR_CUPRA"]
+              date = datetime.date.today().isoformat()
+              line = (
+                  f"\n### Changed\n"
+                  f"- OLA app-version bumped to match upstream CarConnectivity "
+                  f"(SEAT `{our_seat}` → `{up_seat}`, CUPRA `{our_cupra}` → `{up_cupra}`) "
+                  f"on {date}. Old values appended to fallback chain.\n"
+              )
+              # Insert after the "(nothing pending...)" placeholder OR
+              # right after the Unreleased header line.
+              idx = text.index(marker) + len(marker)
+              # If "_(nothing pending...)_" is on the next blank line, replace it.
+              if "_(nothing pending" in text[idx : idx + 200]:
+                  # Skip past the placeholder block (it spans 2 lines).
+                  end = text.index("\n## ", idx)
+                  text = text[: idx] + line + text[end :]
+              else:
+                  text = text[: idx] + line + text[idx :]
+              F.write_text(text, encoding="utf-8")
+              print("✅ CHANGELOG.md updated")
+          PYTHON
+
+          git add custom_components/vag_connect/cariad/_ola_headers.py CHANGELOG.md
+          git commit -m "chore(ola-headers): auto-bump SEAT=${UP_SEAT}, CUPRA=${UP_CUPRA}
+
+          Upstream CarConnectivity-connector-seatcupra bumped app-version
+          constants. Auto-PR mirrors the change + appends previous primary
+          values to the fallback chain (defense-in-depth Layer 3 self-
+          extension).
+
+          Maintainer review checklist:
+          - [ ] Verify upstream commit-source looks legitimate (not mid-
+                experiment / not a vandalism PR)
+          - [ ] Glance at the resulting _ola_headers.py — fallback chain
+                ordering looks right
+          - [ ] CI green
+          - [ ] Merge"
+
+          git push -u origin "$BRANCH"
+
+          # Open the PR.
+          gh pr create \
+            --title "chore(ola-headers): auto-bump to SEAT=$UP_SEAT, CUPRA=$UP_CUPRA" \
+            --label "auto-ola-bump" \
+            --body "Upstream CarConnectivity-connector-seatcupra bumped its app-version constants. This PR mirrors the change in our \`cariad/_ola_headers.py\`.
+
+| Brand | Old | New |
 |---|---|---|
-| SEAT | \`$UP_SEAT\` | \`$OUR_SEAT\` |
-| CUPRA | \`$UP_CUPRA\` | \`$OUR_CUPRA\` |
+| SEAT  | \`$OUR_SEAT\`  | \`$UP_SEAT\`  |
+| CUPRA | \`$OUR_CUPRA\` | \`$UP_CUPRA\` |
 
-Source: https://github.com/tillsteinbach/CarConnectivity-connector-seatcupra/blob/main/src/carconnectivity_connectors/seatcupra/auth/my_cupra_session.py"
-          else
-            gh issue create \
-              --title "$TITLE" \
-              --label "chore" \
-              --body "Weekly upstream watcher detected that CarConnectivity-connector-seatcupra has updated their app-version constants. Our \`cariad/_ola_headers.py\` should be bumped to match.
+**What this PR does:**
+1. Bumps the primary values in \`_OLA_HEADERS_BY_BRAND\`
+2. Prepends the OLD primary values into \`_OLA_HEADERS_BY_BRAND_FALLBACK\` — Layer 3 fallback chain self-extends
+3. Adds a one-line CHANGELOG entry under \`[Unreleased]\`
 
-| Brand | Upstream | Ours |
-|---|---|---|
-| SEAT | \`$UP_SEAT\` | \`$OUR_SEAT\` |
-| CUPRA | \`$UP_CUPRA\` | \`$OUR_CUPRA\` |
+**Why auto-PR not auto-merge:** preserves a human safety check in case upstream is mid-experiment / mistaken bump / vandalism. If the PR looks right, just merge it.
 
-**Why this matters**: VW Group's OLA backend started enforcing app-identifying headers on 2026-05-20 (see #281, #282). The header VALUES must match what the official SEAT/CUPRA apps send. Upstream maintainers stay closer to the apps than we do, so we mirror their values with ~1 week lag.
+**Source**: https://github.com/tillsteinbach/CarConnectivity-connector-seatcupra/blob/main/src/carconnectivity_connectors/seatcupra/auth/my_cupra_session.py
 
-**Action**: bump \`_OLA_HEADERS_BY_BRAND\` in \`custom_components/vag_connect/cariad/_ola_headers.py\`:
-
-\`\`\`python
-\"seat\":  {\"app-market\": \"android\", \"app-brand\": \"seat\",  \"app-version\": \"$UP_SEAT\", \"origin\": \"app\"},
-\"cupra\": {\"app-market\": \"android\", \"app-brand\": \"cupra\", \"app-version\": \"$UP_CUPRA\", \"origin\": \"app\"},
-\`\`\`
-
-Source: https://github.com/tillsteinbach/CarConnectivity-connector-seatcupra/blob/main/src/carconnectivity_connectors/seatcupra/auth/my_cupra_session.py
-
-_Auto-filed by \`.github/workflows/upstream-ola-watcher.yml\`._"
-            echo "Issue created."
-          fi
+_Auto-filed by \`.github/workflows/upstream-ola-watcher.yml\` on $(date -u +%Y-%m-%d). Idempotent — workflow won't re-create this PR while it's open._"
 
       - name: Report no drift
-        if: |
-          steps.upstream.outputs.seat == steps.ours.outputs.seat &&
-          steps.upstream.outputs.cupra == steps.ours.outputs.cupra &&
-          steps.upstream.outputs.seat != '' &&
-          steps.upstream.outputs.cupra != ''
+        if: steps.ours.outputs.drift == 'false'
         run: |
           echo "✅ OLA headers in sync with upstream CarConnectivity"
-          echo "SEAT=${{ steps.upstream.outputs.seat }} CUPRA=${{ steps.upstream.outputs.cupra }}"
+          echo "SEAT=${{ steps.ours.outputs.seat }} CUPRA=${{ steps.ours.outputs.cupra }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
-_(nothing pending — v2.4.1 just shipped; new entries land here)_
+### Changed
+- OLA upstream watcher now runs **daily** (was weekly) and auto-opens a PR with the new app-version constants when CarConnectivity upstream drifts — instead of just opening an issue. Previous primary values are appended to the fallback chain automatically, so the multi-version retry logic self-extends. PRs require manual review + merge (no auto-merge — keeps a human safety check in case upstream pushes a mistaken bump).
 
 ## [2.4.1] — 2026-05-25 — "OLA Defense + VW NA Garage + Scout Policy"
 

--- a/tests/test_v241_sprint_d.py
+++ b/tests/test_v241_sprint_d.py
@@ -207,26 +207,76 @@ class TestOLARepairIssue:
 
 
 class TestOLAUpstreamWatcher:
-    """CI workflow: weekly comparison with CarConnectivity upstream."""
+    """CI workflow: daily comparison + auto-PR (v2.4.2+).
+
+    v2.4.1 shipped this watcher as weekly + issue-only. v2.4.2 upgrades
+    it to daily + auto-PR with fallback-chain growth. These tests pin
+    the upgraded behavior.
+    """
 
     def test_workflow_file_exists(self) -> None:
         assert _OLA_WATCHER_YML.exists()
 
-    def test_workflow_runs_weekly(self) -> None:
+    def test_workflow_runs_daily(self) -> None:
+        """Daily cron — drift detected within 24h instead of 7d."""
         src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
         assert "schedule:" in src
-        assert "cron:" in src
+        # Daily means '* * *' in the last three cron fields.
+        assert '"0 8 * * *"' in src, "Cron should be daily (0 8 * * *)"
 
     def test_workflow_fetches_upstream(self) -> None:
         src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
         assert "tillsteinbach/CarConnectivity-connector-seatcupra" in src
         assert "my_cupra_session.py" in src
 
-    def test_workflow_opens_issue_on_drift(self) -> None:
+    def test_workflow_has_write_permissions(self) -> None:
+        """Auto-PR needs contents:write + pull-requests:write."""
         src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
-        assert "gh issue create" in src
-        assert "gh issue comment" in src  # Idempotent: comment if already open
-        assert "_ola_headers.py" in src  # References file users need to bump
+        assert "contents: write" in src
+        assert "pull-requests: write" in src
+
+    def test_workflow_opens_pr_on_drift(self) -> None:
+        """v2.4.2 behavior: open a Pull Request, not just an issue."""
+        src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
+        assert "gh pr create" in src
+        assert "auto-ola-bump" in src  # Label for filtering
+
+    def test_workflow_patches_headers_file(self) -> None:
+        """Auto-PR actually edits the file (not just describes the diff)."""
+        src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
+        assert "_ola_headers.py" in src
+        # Python in-place edit via re.sub.
+        assert "re.sub(" in src
+        assert '"app-version"' in src
+
+    def test_workflow_grows_fallback_chain(self) -> None:
+        """Old primary value is appended to the fallback chain
+        automatically (defense-in-depth Layer 3 self-extension)."""
+        src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
+        assert "grow_fallback" in src or "_OLA_HEADERS_BY_BRAND_FALLBACK" in src
+
+    def test_workflow_idempotent_pr_dedup(self) -> None:
+        """Repeated runs while a PR is open don't spam duplicate PRs."""
+        src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
+        assert "gh pr list" in src
+        # The skip-if-existing flag-out.
+        assert 'skip=true' in src or 'skip=false' in src
+
+    def test_workflow_updates_changelog(self) -> None:
+        """Auto-PR includes a CHANGELOG entry under [Unreleased]."""
+        src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
+        assert "CHANGELOG.md" in src
+        assert "[Unreleased]" in src
+
+    def test_workflow_does_not_auto_merge(self) -> None:
+        """Safety: maintainer must review + merge by hand."""
+        src = _OLA_WATCHER_YML.read_text(encoding="utf-8")
+        # Explicit: workflow should NOT contain gh pr merge.
+        assert "gh pr merge" not in src, (
+            "Auto-merge is unsafe — if upstream pushes a mistaken "
+            "bump or experimental value, we'd ship it immediately. "
+            "Keep human review in the loop."
+        )
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

User feedback 2026-05-25: weekly watcher + issue-only is too slow + needs manual work. Upgraded to **daily + auto-PR**.

| Aspect | Before (v2.4.1) | After |
|---|---|---|
| Frequency | Mondays 08:00 UTC | **Daily 08:00 UTC** (≤24h drift detection) |
| Action on drift | Open issue / comment | **Auto-PR** that patches `_ola_headers.py` directly |
| Fallback chain | Manual maintenance | **Self-grows** — old primary value auto-appended |
| CHANGELOG entry | Manual | Auto-added under `[Unreleased]` |
| Maintainer effort | Read issue → edit file → commit | **Review PR → 1-click merge** |
| Auto-merge? | N/A | **No** — preserves human safety check (upstream could push experimental / mistaken bumps) |
| Idempotency | Issue dedup | PR dedup (skip when matching open PR exists) |

## How the auto-PR works

1. Daily 08:00 UTC: fetch upstream `my_cupra_session.py`, compare SEAT + CUPRA `app-version` against ours
2. If drift: check for existing open PR with same target values → skip if found
3. Otherwise: patch `cariad/_ola_headers.py`:
   - Bump primary `app-version` for affected brand(s)
   - Prepend OLD primary into `_OLA_HEADERS_BY_BRAND_FALLBACK[brand]` (Layer 3 self-grows!)
4. Add CHANGELOG entry under `[Unreleased]`
5. Commit (as `vw-group-connect-bot`) + push + open PR with `auto-ola-bump` label

## Tests

`TestOLAUpstreamWatcher` rewritten with 10 pins (was 4):
- daily cron assertion
- contents:write + pull-requests:write permissions
- `gh pr create` + `auto-ola-bump` label
- re.sub patching of `_ola_headers.py`
- fallback-chain growth (`_OLA_HEADERS_BY_BRAND_FALLBACK`)
- idempotency (skip when PR open)
- CHANGELOG.md update
- **safety pin**: `gh pr merge` is NOT in the workflow

## Files

- `.github/workflows/upstream-ola-watcher.yml` — full rewrite (~+170 LoC)
- `tests/test_v241_sprint_d.py` — `TestOLAUpstreamWatcher` updated (+6 new tests)
- `CHANGELOG.md` — one-liner under `[Unreleased]` per new compact style

## Test plan

- [x] 81/81 v2.4.1 test suite still green locally (was 75 + 6 new watcher pins)
- [ ] CI green (5 checks)
- [ ] Admin-merge (chore/tooling, no version bump, no HACS release)
- [ ] First daily run tomorrow 08:00 UTC will validate end-to-end in the wild

🤖 Generated with [Claude Code](https://claude.com/claude-code)