### PR TITLE
chore(ola-watcher): add daernsinstantfortress as 3rd consensus source + community-projects index

### DIFF
--- a/.github/workflows/upstream-ola-watcher.yml
+++ b/.github/workflows/upstream-ola-watcher.yml
@@ -6,10 +6,13 @@ name: Upstream OLA Headers Watcher
 #
 # v2.4.2 — Daily + auto-PR (was weekly + issue-only).
 #
-# v2.4.2+ — MULTI-SOURCE consensus. Checks two independent upstream
+# v2.4.2+ — MULTI-SOURCE consensus. Checks three independent upstream
 # projects per day:
 #   1. CarConnectivity-connector-seatcupra (tillsteinbach)
 #   2. PyCupra (WulfgarW) — also affected by the 2026-05-20 change
+#   3. WeConnect-Cupra-python (daernsinstantfortress) — Cariad-BFF +
+#      OLA hybrid architecture; CUPRA-only but provides 3rd vote for
+#      CUPRA-specific bumps
 #
 # Decision logic:
 #   - Both sources agree + matches ours              → ✅ no action (just log)
@@ -70,6 +73,15 @@ jobs:
                   "url": "https://raw.githubusercontent.com/WulfgarW/pycupra/main/pycupra/const.py",
                   "seat_pattern":  r"XAPPVERSION_SEAT\s*=\s*'([^']+)'",
                   "cupra_pattern": r"XAPPVERSION_CUPRA\s*=\s*'([^']+)'",
+              },
+              "daern_weconnect_cupra": {
+                  # daernsinstantfortress's CUPRA-only project. SEAT
+                  # not covered (their package is CUPRA-specific) —
+                  # missing seat votes are handled by the per-brand
+                  # consensus logic below.
+                  "url": "https://raw.githubusercontent.com/daernsinstantfortress/WeConnect-Cupra-python/main/weconnect_cupra/auth/auth_util.py",
+                  "seat_pattern":  r"NEVER_MATCH_SEAT_HERE_DAERN_IS_CUPRA_ONLY",
+                  "cupra_pattern": r'headers\["app-version"\]\s*=\s*"([^"]+)"',
               },
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ### Added
 - **Cross-Brand App Atlas** — new daily CI pipeline that tracks the current Android app version for all 7 VAG brands (SEAT, CUPRA, VW EU, Audi, Škoda, VW NA, Porsche). When a brand bumps a new app version, the watcher auto-opens a PR refreshing the atlas docs at `docs/research/app-atlas/`. Multi-source fallback (APKMirror → Uptodown) covers 6/7 brands today; VW EU needs a Phase A.1.1 follow-up. Phase A.2 will add APK download + extraction for definitive endpoint + header discovery — useful proactively across all brands, not just OLA-enforced ones. See `docs/research/app-atlas/README.md` + `LEGAL.md`.
+- **OLA watcher gains daernsinstantfortress as 3rd consensus source** — for CUPRA only (their package is CUPRA-only), but it provides a stronger 3-of-3 consensus signal on CUPRA app-version bumps. Their Cariad-BFF + OLA hybrid architecture is also noted as a possible Plan-B fallback for future OLA escalations. See new `docs/research/app-atlas/_community-projects.md` for the curated index of all parallel community projects we monitor.
 
 ## [2.4.1] — 2026-05-25 — "OLA Defense + VW NA Garage + Scout Policy"
 

--- a/docs/research/app-atlas/_community-projects.md
+++ b/docs/research/app-atlas/_community-projects.md
@@ -1,0 +1,96 @@
+# Community Projects — Comparison + Resource Index
+
+> Auto-curated reference of parallel VAG-brand Home Assistant /
+> Python integrations. We track these as **upstream signal sources**
+> for our cross-brand work (cf. App Atlas `README.md`).
+>
+> Last reviewed: 2026-05-25
+
+---
+
+## OLA backend (SEAT + CUPRA)
+
+Three independent community projects target the SEAT/CUPRA OLA
+backend (`ola.prod.code.seat.cloud.vwgroup.com`). All three were
+broken by the 2026-05-20 app-header enforcement; all three fixed it
+with the same `app-market` + `app-brand` + `app-version` + `origin`
+header injection.
+
+| Project | Maintainer | Brand coverage | Architecture |
+|---|---|---|---|
+| [CarConnectivity-connector-seatcupra](https://github.com/tillsteinbach/CarConnectivity-connector-seatcupra) | tillsteinbach | SEAT + CUPRA | Direct OLA, Android-app client_id, full OAuth + token refresh |
+| [PyCupra](https://github.com/WulfgarW/pycupra) ([pip](https://pypi.org/project/pycupra/)) | WulfgarW | SEAT + CUPRA | Direct OLA, similar architecture, separate auth-session manager |
+| [WeConnect-Cupra-python](https://github.com/daernsinstantfortress/WeConnect-Cupra-python) ([pip](https://pypi.org/project/weconnect-cupra-daern/)) + [HA integration](https://github.com/daernsinstantfortress/cupra_we_connect) | daernsinstantfortress | CUPRA only | **Cariad-BFF + OLA hybrid** — uses browser-IDP client_id (`3c756d46-...@apps_vw-dilab_com`), different signin-service path |
+
+**Why we monitor all three**:
+- Three independent maintainers confirming a header value = high confidence
+- Earliest-warning when one of them detects API breakage before the others
+- Catches per-brand divergence (e.g. CarConnectivity ships SEAT `2.17.0`
+  while PyCupra ships `2.13.3` — both work in the wild, real-world example of why multi-source matters)
+
+**Why daernsinstantfortress is architecturally interesting for us long-term**:
+- Their CUPRA-via-Cariad-BFF route is a backup architecture we don't have today
+- If OLA enforcement ever escalates beyond what the 4-layer defense-in-depth can handle, this path is a viable Plan B
+- Phase B follow-up: investigate if we can add Cariad-BFF as a CUPRA fallback parallel to OLA
+
+---
+
+## VW EU + Audi (Cariad-BFF backend)
+
+| Project | Maintainer | Brand coverage | Status |
+|---|---|---|---|
+| [mitch-dc/volkswagen_we_connect_id](https://github.com/mitch-dc/volkswagen_we_connect_id) | mitch-dc | VW EU | Active, large community |
+| [audi_connect_ha](https://github.com/arjenvrh/audi_connect_ha) | arjenvrh | Audi | Active |
+| [volkswagencarnet](https://github.com/robinostlund/volkswagencarnet) | robinostlund | VW + Audi (legacy MBB) | Maintenance mode |
+| [tillsteinbach/CarConnectivity-connector-volkswagen](https://github.com/tillsteinbach/CarConnectivity-connector-volkswagen) | tillsteinbach | VW EU | Newer, sibling of seatcupra connector |
+| [tillsteinbach/CarConnectivity-connector-audi](https://github.com/tillsteinbach/CarConnectivity-connector-audi) | tillsteinbach | Audi | Newer |
+
+These are not currently monitored by automation (no Cariad-BFF
+header-enforcement detected yet), but we cross-check during major
+refactors.
+
+---
+
+## VW NA (con-veh.net backend)
+
+| Project | Maintainer | Notes |
+|---|---|---|
+| [matpoulin/CarConnectivity-connector-volkswagen-na](https://github.com/matpoulin/CarConnectivity-connector-volkswagen-na) | matpoulin | Only known active VW NA reference — used as primary research source for our v2.3.0 #269 auth fix + v2.4.1 #285 garage-envelope fix |
+
+---
+
+## Škoda (mysmob backend)
+
+| Project | Maintainer | Notes |
+|---|---|---|
+| [skodaconnect/homeassistant-myskoda](https://github.com/skodaconnect/homeassistant-myskoda) | skodaconnect | Most active Skoda reference |
+| [Skode/myskoda](https://github.com/Skode/myskoda) | Skode | Newer alternative |
+
+---
+
+## Porsche (PPA backend)
+
+| Project | Maintainer | Notes |
+|---|---|---|
+| [andig/evcc vehicle/porsche](https://github.com/andig/evcc/tree/master/vehicle/porsche) | andig | Go reference, cross-vehicle EVCC project |
+
+---
+
+## Cross-brand multi-OEM EVCC
+
+| Project | Notes |
+|---|---|
+| [andig/evcc](https://github.com/andig/evcc) | Go-based EV-charging coordinator. Covers 30+ vehicle brands incl. all VAG brands. Excellent reference for API patterns even though it's a different runtime. |
+
+---
+
+## How we use this
+
+- **Daily**: OLA watcher polls the 3 OLA-aware projects (`upstream-ola-watcher.yml`)
+- **On scout reports**: cross-reference against the relevant brand's projects to validate findings
+- **Architecture audits**: review their auth flows + endpoint maps when planning major refactors
+- **Code attribution**: when we port a fix-pattern from one of these projects, cite them in the commit message + cariad/api/{brand}.py docstring (per `RELEASE_PROCESS.md`)
+
+We are **not** a fork of any of these — we have our own clean-room
+implementation. They are colleagues + signal-sources, not upstreams
+we depend on at runtime.

--- a/tests/test_v241_sprint_d.py
+++ b/tests/test_v241_sprint_d.py
@@ -236,6 +236,10 @@ class TestOLAUpstreamWatcher:
         # PyCupra is the second source — also affected by the
         # 2026-05-20 OLA enforcement, independent maintainer.
         assert "WulfgarW/pycupra" in src
+        # daernsinstantfortress is the third source — CUPRA-only,
+        # Cariad-BFF + OLA hybrid architecture, provides extra
+        # CUPRA-side vote for stronger consensus.
+        assert "daernsinstantfortress/WeConnect-Cupra-python" in src
         # Sources dict / per-source mapping must be present.
         assert "SOURCES" in src or "carconnectivity" in src and "pycupra" in src
 


### PR DESCRIPTION
## Summary

Per user direction: cross-check `daernsinstantfortress/cupra_we_connect` as additional community signal source.

## Investigation findings

| Aspect | Value |
|---|---|
| Repo | [github.com/daernsinstantfortress/cupra_we_connect](https://github.com/daernsinstantfortress/cupra_we_connect) (104 stars, Apache-2.0, active) |
| Backing pip | `weconnect-cupra-daern` from [WeConnect-Cupra-python](https://github.com/daernsinstantfortress/WeConnect-Cupra-python) |
| Brand coverage | **CUPRA only** |
| Architecture | **Cariad-BFF + OLA hybrid** (different from CarConnectivity/PyCupra's pure-OLA approach) |
| 2026-05-20 OLA impact | Yes — broken (closed issue #169) |
| Fix shipped | 2026-05-21 in PR #43 — same 4 OLA headers, identical values |

## Watcher upgrade

The OLA watcher's `SOURCES` dict now has 3 entries:

| Source | SEAT | CUPRA |
|---|---|---|
| CarConnectivity | `2.17.0` | `2.15.0` |
| PyCupra | `2.13.3` | `2.15.0` |
| **daern** (NEW) | _(N/A — CUPRA-only)_ | **`2.15.0`** |

CUPRA now has **3-of-3 consensus** on `2.15.0`. SEAT still has 2-source divergence (CarConnectivity vs PyCupra) which correctly triggers the existing divergence-issue path.

## New community-projects index

`docs/research/app-atlas/_community-projects.md` — curated reference of all parallel community projects per backend:
- OLA (3 projects)
- VW EU + Audi Cariad-BFF (5 projects)
- VW NA (1)
- Skoda (2)
- Porsche (1)
- Cross-brand EVCC (1)

Used as signal-sources for our atlas + scout work + future research.

## Bonus discovery

Daern's Cariad-BFF + OLA hybrid is a possible **Plan-B fallback architecture** if OLA enforcement ever escalates beyond what our 4-layer defense-in-depth can handle. Documented as a Phase B exploration item in the atlas community-projects page.

## Files

- `.github/workflows/upstream-ola-watcher.yml` — 3rd source added to `SOURCES`
- `tests/test_v241_sprint_d.py` — `test_workflow_is_multi_source` updated (12/12 still green)
- `docs/research/app-atlas/_community-projects.md` — NEW (curated index)
- `CHANGELOG.md` — compact one-liner under `[Unreleased]`

## Test plan

- [x] 12/12 watcher tests + 37/37 atlas tests still green locally
- [ ] Admin-merge (chore/tooling, no integration code touched)
- [ ] Tomorrow's daily run will use the new 3rd source automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)