### PR TITLE
chore(atlas): --force-extract flag + workflow_dispatch input for bootstrap

### DIFF
--- a/.github/workflows/app-atlas-builder.yml
+++ b/.github/workflows/app-atlas-builder.yml
@@ -23,6 +23,11 @@ on:
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
+    inputs:
+      force_extract:
+        description: "Force APK extraction for all brands (overrides version-change cache). Use to (re)build apk-cache from scratch."
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -58,8 +63,15 @@ jobs:
       - name: Run atlas builder (Phase A.1 polling + A.2 APK extraction)
         # APK extraction only fires when a brand's version-name changed
         # since last cache — so most days this stays under 1 minute.
+        # When triggered via workflow_dispatch with force_extract=true,
+        # extracts every brand regardless of cache state (~5-10min total).
         run: |
-          python scripts/app_atlas/build_atlas.py --with-apk-extraction
+          FORCE_FLAG=""
+          if [ "${{ inputs.force_extract }}" = "true" ]; then
+            FORCE_FLAG="--force-extract"
+            echo "::notice::force_extract=true — extracting all 7 brands regardless of cache"
+          fi
+          python scripts/app_atlas/build_atlas.py --with-apk-extraction $FORCE_FLAG
 
       - name: Detect changes
         id: changes

--- a/scripts/app_atlas/build_atlas.py
+++ b/scripts/app_atlas/build_atlas.py
@@ -402,7 +402,17 @@ def main(argv: list[str] | None = None) -> int:
                         "on PATH. Adds significant CI runtime (~30s-2min per changed "
                         "brand) — only enable in the scheduled workflow, not for "
                         "local debugging.")
+    p.add_argument("--force-extract", action="store_true",
+                   help="Phase A.2 override: extract APKs for ALL brands "
+                        "regardless of version-change cache state. Use this to "
+                        "(re)build the apk-cache from scratch — e.g. after adding "
+                        "a new brand, or for the initial population. Implies "
+                        "--with-apk-extraction. CI-only; locally it requires "
+                        "apktool on PATH for every brand.")
     args = p.parse_args(argv)
+    # --force-extract implies --with-apk-extraction.
+    if args.force_extract:
+        args.with_apk_extraction = True
 
     config = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
     cache = load_cache()
@@ -439,9 +449,15 @@ def main(argv: list[str] | None = None) -> int:
         else:
             _LOGGER.warning("Could not determine current version for %s — all sources failed", brand)
 
-        # Phase A.2 — APK extraction when version changed.
-        if (args.with_apk_extraction and current and current != prev_ver
-                and not args.dry_run):
+        # Phase A.2 — APK extraction when version changed (or when
+        # --force-extract is set, regardless of cache state).
+        should_extract = (
+            args.with_apk_extraction
+            and current
+            and not args.dry_run
+            and (args.force_extract or current != prev_ver)
+        )
+        if should_extract:
             try:
                 from .apk_extractor import extract_brand_apk  # noqa: PLC0415
             except ImportError:

--- a/tests/test_app_atlas.py
+++ b/tests/test_app_atlas.py
@@ -263,6 +263,20 @@ class TestPhaseA2Integration:
         # The guard condition `current != prev_ver` must gate extraction.
         assert "current != prev_ver" in src
 
+    def test_force_extract_flag_bypasses_cache(self) -> None:
+        """--force-extract overrides the version-change idempotency check."""
+        src = _SCRIPT_PATH.read_text(encoding="utf-8")
+        assert "--force-extract" in src
+        assert "force_extract" in src
+        # The override must actually short-circuit the cache check.
+        assert "args.force_extract or current != prev_ver" in src
+
+    def test_force_extract_implies_with_apk_extraction(self) -> None:
+        """Setting --force-extract without --with-apk-extraction shouldn't
+        require the user to also pass the flag — implied automatically."""
+        src = _SCRIPT_PATH.read_text(encoding="utf-8")
+        assert "args.with_apk_extraction = True" in src
+
     def test_apk_findings_cache_used(self) -> None:
         """APK findings persist to .app-atlas-apk-cache/{brand}.json."""
         src = _SCRIPT_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Bootstrap helper for the Phase A.2 APK cache. Current state: only version-name polling has run; no APK extractions yet because the daily workflow only triggers extraction on version-CHANGE.

To get the initial population — actually download all 7 APKs, run apktool, populate `.app-atlas-apk-cache/` — we need a way to bypass the version-change cache check.

## Changes

- `--force-extract` CLI flag on `build_atlas.py` (implies `--with-apk-extraction`)
- `workflow_dispatch` input `force_extract` (boolean) on the atlas builder workflow
- +2 test pins (75/75 green)

## How to use

1. After this PR merges
2. Go to Actions → "App Atlas Builder" → Run workflow
3. Set `force_extract = true`
4. Wait ~5-10min (7 APKs × ~1min each = full atlas bootstrap)
5. Auto-PR opens with `.app-atlas-apk-cache/*.json` for all 7 brands + refreshed atlas pages

## Test plan

- [x] 75/75 atlas tests green
- [ ] Admin-merge
- [ ] Manually trigger workflow with force_extract=true
- [ ] Review the bootstrap auto-PR
- [ ] Synthesize findings → decide if Phase A.3.1 (per-version APKCombo navigation) is actually needed based on what real data shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)