### PR TITLE
chore: 2026-05-27 cross-project sweep — CNG silencer + docs refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- Pre-emptive scout silencer for CUPRA TGI variants (Compressed Natural Gas — Leon TGI / Ibiza TGI) — `cngLevel` / `cngLevelInPct` / `cng_level_pct` / `cngRange` / `cngRangeInKm` / `cng_range_km` registered in `cupra:charging` set. Mirrors the `diesel_range` pattern from v1.9.1 #91. Will be promoted from T5 silencer to T1 parsed + entity (sensor.cng_range_km / sensor.cng_level_pct) when a CUPRA TGI tester reports. Source: pycupra v0.2.31 (WulfgarW, 2026-05-26).
+- `_community-projects.md` refreshed with the 2026-05-27 cross-project sweep snapshot — documents the 3-of-3 OLA-projects convergence on the 2026-05-20 app-header fix, mitch-dc's continued archive status, and skodaconnect/homeassistant-myskoda PR #1102 (split-coordinator + MQTT-event-filtering pattern noted as v3.0 architecture reference).
+
 ### Changed
 - OLA upstream watcher now runs **daily** (was weekly) and auto-opens a PR with the new app-version constants when CarConnectivity upstream drifts — instead of just opening an issue. Previous primary values are appended to the fallback chain automatically, so the multi-version retry logic self-extends. PRs require manual review + merge (no auto-merge — keeps a human safety check in case upstream pushes a mistaken bump).
 

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -420,6 +420,17 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             # EXPECTED_KEYS just never got the silencer-side entry —
             # silencer-lag-behind-parser gap. T1 (parsed + entity exists).
             "rateInKmph",
+            # v2.4.3 (pre-emptive, 2026-05-27 cross-project sweep) — pycupra
+            # v0.2.31 (WulfgarW, 2026-05-26) added Compressed Natural Gas
+            # (CNG) instruments for CUPRA Leon TGI / Ibiza TGI variants.
+            # We don't have a CUPRA TGI tester live yet but ship the
+            # silencer pre-emptively to avoid scout spam when one shows up.
+            # T5 (community-discovered field, not yet parser-wired — when
+            # a tester reports we'll promote to T1 with sensor.cng_range_km
+            # + sensor.cng_level_pct entities, mirroring the existing
+            # diesel_range pattern from v1.9.1 #91).
+            "cngLevel", "cngLevelInPct", "cng_level_pct",
+            "cngRange", "cngRangeInKm", "cng_range_km",
             "remainingTimeInMinutes", "remainingTime",
             "remainingTimeToFullyChargedInMinutes", "remainingChargingTime",
             "chargeType", "chargingType", "type",

--- a/docs/research/app-atlas/_community-projects.md
+++ b/docs/research/app-atlas/_community-projects.md
@@ -4,7 +4,37 @@
 > Python integrations. We track these as **upstream signal sources**
 > for our cross-brand work (cf. App Atlas `README.md`).
 >
-> Last reviewed: 2026-05-25
+> Last reviewed: 2026-05-27
+
+## 2026-05-27 Cross-project convergence snapshot
+
+7-day sweep confirmed the **multi-source consensus pattern works in
+practice**:
+
+- **3 of 3 OLA-aware projects converged on the same 2026-05-20 fix**
+  within 4 days (tillsteinbach v0.6.3 / daernsinstantfortress v0.50.17 /
+  pycupra login bugfix) — all 4 app-fingerprint headers
+  (`app-market`, `app-brand`, `app-version=2.15.0`, `origin=app`).
+  We shipped the same fix as v2.4.1 with a 4-layer defense-in-depth on
+  top (centralized constants + OptionsFlow override + multi-version
+  fallback chain + HA Repair-card escalation) — the architectural
+  upgrade above just-headers.
+- **evcc** additionally adds `User-Agent: OLACupra/2.15.0 (Android 12...)`
+  on top of the 4 headers. We have brand-specific iOS-style UAs since
+  v2.4.1 (`_ola_headers._OLA_USER_AGENT_BY_BRAND`) — different platform
+  signature but functionally equivalent.
+- **mitch-dc/volkswagen_we_connect_id**: stays archived (2025-10-29). No
+  fork has resurrected it with momentum (max stars on any fork = 5).
+- **lendy007/skodaconnect**: archived since 2024-09-10 (not listed below;
+  active successor is `skodaconnect/homeassistant-myskoda`).
+- **skodaconnect/homeassistant-myskoda** very active this week:
+  [PR #1102](https://github.com/skodaconnect/homeassistant-myskoda/pull/1102)
+  splits coordinator into fast/slow + MQTT events no longer trigger full
+  refresh — directly relevant to our v3.0 push-tech architecture, see
+  research deliverable `docs/research/app-atlas/_v3.0-myskoda-architecture.md`.
+- **pycupra v0.2.31** added CNG instruments (`cng_level`, `cng_range`)
+  for CUPRA TGI variants — silenced pre-emptively in `_unexpected_keys.py`
+  cupra:charging set.
 
 ---
 


### PR DESCRIPTION
## Summary

Two small adds from the 2026-05-27 community-project sweep. No code-behaviour change, no API call change, no version bump.

### Changes

| File | Change | Why |
|---|---|---|
| `_unexpected_keys.py` | +6 CNG-field silencer entries on cupra:charging | pycupra v0.2.31 (2026-05-26) added CNG instruments for CUPRA TGI variants — pre-emptive silencer so first TGI tester doesn't get scout-spam. Promote to T1 with sensor.cng_range_km + sensor.cng_level_pct when a tester reports. |
| `_community-projects.md` | review-date bump + 2026-05-27 sweep snapshot section | Cross-project state-of-the-world: 3-of-3 OLA convergence on the 2026-05-20 fix confirmed, mitch-dc still archived, skodaconnect/myskoda PR #1102 noted for v3.0 architecture relevance |

### Cross-project intel highlights (full report in commit body)

- **3 of 3 OLA-aware projects** shipped the same `app-market` + `app-brand` + `app-version=2.15.0` + `origin=app` headers fix within 4 days of the 2026-05-20 OLA enforcement. We did the same as v2.4.1 with a 4-layer defense-in-depth on top — architectural upgrade above just-headers.
- **evcc** additionally adds `User-Agent: OLACupra/2.15.0 (Android 12...)`. We have brand-specific iOS-style UAs since v2.4.1 (`_ola_headers._OLA_USER_AGENT_BY_BRAND`) — functionally equivalent, different platform signature.
- **mitch-dc** stays archived 2025-10-29; no fork has resurrected it.
- **skodaconnect/homeassistant-myskoda PR #1102** splits coordinator into fast/slow + MQTT events no longer trigger full refresh → directly relevant to our v3.0 push-tech architecture work.

### Risk

Zero. Additive data-table changes + doc-only. CI validates EXPECTED_KEYS shape; new silencer strings are safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)