### PR TITLE
feat(v2.5.0): Mii parity sprint part 1 — 4 new binary_sensors from existing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,33 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - **App Atlas Phase A.2 — APK download + apktool extraction** — when a brand's version-name changes (detected by the daily watcher), the workflow now downloads the APK via APKCombo CDN, decodes it with apktool, and greps for OLA-style header keys + known backend hosts. Findings persist as `.app-atlas-apk-cache/{brand}.json` and render in each per-brand atlas page. Workflow extracts only on version-change (idempotent), keeps CI runtime under 2min/changed-brand. Phase A.3 (jadx semantic-diff between consecutive APK versions) deferred to a separate session.
 - **App Atlas Phase A.3 — jadx full decompile + cross-version semantic diff** (manual `workflow_dispatch` only — too heavy for daily). Triggers on demand when investigating a brand's version bump: downloads both versions, runs jadx full Java decompile, extracts URL constants + header-key strings + OAuth scopes, computes a targeted diff filtering out obfuscator-rename noise. Outputs a self-contained markdown report at `docs/research/app-atlas/diffs/{brand}_{old}_vs_{new}.md` and auto-opens a PR. Provides ground-truth answers to "what new endpoints / headers / scopes appeared in this version bump?" — much higher signal than the daily smali grep.
 
+## [2.5.0] — 2026-05-27 — "Have You Met Mii?" (PyCupra Parity Sprint Part 1)
+
+### Added
+- **4 new binary_sensors** for entity-parity with PyCupra (closes parser-side-data-but-no-entity gap raised by @goncal in #306 for SEAT Mii Electric and the broader CUPRA Mii/Born/Tavascan VZ user pool):
+  - `binary_sensor.hood_open` (DOOR class) — was in `VehicleData.hood_open` since v1.10.x, just no entity wrapper
+  - `binary_sensor.trunk_open` (DOOR class) — was in `VehicleData.trunk_open`, no entity
+  - `binary_sensor.trunk_locked` (LOCK class, diagnostic) — was in `VehicleData.trunk_locked`, no entity
+  - `binary_sensor.sunroof_open` (WINDOW class, phantom-protected via `_DATA_PRESENT_REQUIRED` so cars without sunroof don't show meaningless OFF entity)
+- i18n strings for the 4 new entities (English `strings.json`; translation contributions welcome)
+
+### Hints toward v3.0 — "Suit Up: The Push Tech Edition" 🎩
+v2.5.0 is **part 1** of the "Have You Met Mii?" parity sprint. PyCupra extracts ~12 more data points from the OLA backend that we currently return null for (odometer via `/v1/vehicles/{vin}/mileage`, target_soc + max_charge_current via `/v1/vehicles/{vin}/charging/info`, service intervals via `/v1/vehicles/{vin}/maintenance`, trip data via `/v2/vehicles/{vin}/driving-data/CUSTOM`, vehicle renders via `/v2/vehicles/{vin}/renders`) — these are completely **new endpoint calls** for us, scoped to v3.0-beta1.
+
+v3.0 bundle (research+planning):
+- Split-coordinator (myskoda PR #1102 pattern port — fast/slow tiers)
+- Universal FCM push manager (all 7 brands have Firebase config in dex — extracted via App Atlas Phase A.4.1)
+- Skoda MQTT (mysmob via myskoda-lib pattern) + Audi dual-channel (Paho MQTT + FCM)
+- `vag_connect.send_destination` service (HA → car nav)
+- Vehicle render Image entity
+- Trip-history Calendar + sensors
+- Editable departure-timer entities (Time/Select/MultiSelect with recurringOn weekday pattern)
+- Auxiliary heating (Standheizung) switch + temp Number — `/auxiliaryheating/` endpoint confirmed in Audi + VW EU APK
+- BLE `binary_sensor.car_nearby` + ESPHome BLE proxy guide
+
+### Risk
+Zero — additive data-table changes only. All 4 new entities source from `VehicleData` fields that have been parsed (but unused) since earlier releases. No new API calls, no behavior change. Existing pytest suite tests EXPECTED_KEYS shape; adding entities is safe.
+
 ## [2.4.2] — 2026-05-27 — "Retro-Silencer Sweep + ActiveVentilation Interim"
 
 ### Fixed

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -412,12 +412,52 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.5.0 (#306 goncal Mii electric, parity with PyCupra) — three
+    # boolean fields that were parsed into VehicleData since v1.x but
+    # never surfaced as HA entities. PyCupra ships them as binary_sensors
+    # for the same VIN; we already had the data, just no entity wrapper.
+    # All three are top-level booleans (no nested-dict-lookup needed).
+    VagBinarySensorDescription(
+        key="hood_open",
+        translation_key="hood_open",
+        data_key="hood_open",
+        device_class=BinarySensorDeviceClass.DOOR,
+        icon="mdi:car-cog",
+    ),
+    VagBinarySensorDescription(
+        key="trunk_open",
+        translation_key="trunk_open",
+        data_key="trunk_open",
+        device_class=BinarySensorDeviceClass.DOOR,
+        icon="mdi:car-back",
+    ),
+    VagBinarySensorDescription(
+        key="trunk_locked",
+        translation_key="trunk_locked",
+        data_key="trunk_locked",
+        device_class=BinarySensorDeviceClass.LOCK,
+        icon="mdi:lock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # v2.5.0 — sunroof state for vehicles that have one. Phantom-protected
+    # below (None data → no entity), so most cars without sunroof don't
+    # show a meaningless OFF entity. Mirrors PyCupra parity for #306.
+    VagBinarySensorDescription(
+        key="sunroof_open",
+        translation_key="sunroof_open",
+        data_key="sunroof_open",
+        device_class=BinarySensorDeviceClass.WINDOW,
+        icon="mdi:car-select",
+    ),
 )
 BINARY_DESCRIPTIONS = BINARY_DESCRIPTIONS + _NEW_BINARY
 
 # v1.11.0 — same phantom-entity-prevention pattern as sensor.py.
 _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "lights_on",
+    # v2.5.0 (#306 goncal Mii) — sunroof is option-dependent. Many cars
+    # don't have a sunroof; parser leaves field None → no phantom entity.
+    "sunroof_open",
     # v1.12.0 (#23) — vehicles without lvBattery job don't get the warning.
     "warning_12v_low",
     # v1.15.0 — Skoda-only OTA. Cross-brand support deferred (Research

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.4.2"
+  "version": "2.5.0"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -450,6 +450,12 @@
       "trunk_locked": {
         "name": "Trunk Locked"
       },
+      "trunk_open": {
+        "name": "Trunk Open"
+      },
+      "hood_open": {
+        "name": "Hood Open"
+      },
       "sunroof_open": {
         "name": "Sunroof Open"
       },


### PR DESCRIPTION
## Summary

Closes part of #306 (@goncal SEAT Mii Electric "key entities not populated"). Side-by-side PyCupra comparison data showed PyCupra ships per-VIN entities for fields our `VehicleData` already parses but never wraps as HA entities. This PR closes the easy quarter (zero parser changes).

## New entities (4 binary_sensors)

| Entity | Class | Sourced from existing field |
|---|---|---|
| `binary_sensor.hood_open` | DOOR | `hood_open` (parsed since v1.10.x) |
| `binary_sensor.trunk_open` | DOOR | `trunk_open` (parsed since v1.10.x) |
| `binary_sensor.trunk_locked` | LOCK (diagnostic) | `trunk_locked` |
| `binary_sensor.sunroof_open` | WINDOW (phantom-protected) | `sunroof_open` |

Plus i18n strings (English) — translation contributions welcome.

## What's NEXT — v3.0-beta1 "Have You Met Push?" 🎩

Agent-driven port analysis of PyCupra source identified the remaining null fields and the exact OLA endpoint paths to fetch them. These are completely **new HTTP endpoint calls** for our integration, so they need proper client + error-handling and are scoped to v3.0-beta1:

| Currently null | PyCupra extracts | New endpoint path |
|---|---|---|
| `odometer_km` | `mileageKm` (flat) | `/v1/vehicles/{vin}/mileage` |
| `service_km` / `service_due_in_days` | `inspectionDueKm` / `inspectionDueDays` | `/v1/vehicles/{vin}/maintenance` |
| `oil_service_km` / `oil_service_due_in_days` | `oilServiceDueKm` / `oilServiceDueDays` | `/v1/vehicles/{vin}/maintenance` |
| `target_soc` | `settings.targetSoc` | `/v1/vehicles/{vin}/charging/info` |
| `max_charge_current` | `settings.maxChargeCurrentAcInAmperes` | `/v1/vehicles/{vin}/charging/info` |
| `charge_mode` | `charging.mode` | `/v1/vehicles/{vin}/charging/status` |
| Trip data (4 fields) | `dailySummary[].values[]` | `/v2/vehicles/{vin}/driving-data/CUSTOM` |
| `render_url` (image) | `front` URL | `/v2/vehicles/{vin}/renders` |
| `target_temperature` | `targetTemperatureInCelsius` | `/v2/vehicles/{vin}/climatisation/settings` |

## v3.0 bundle preview

"Suit Up: The Push Tech Edition" 🎩 ships:
- Split-coordinator (myskoda PR #1102 pattern port — universal across 7 brands)
- Universal FCM push (all 7 brands have Firebase config in dex — confirmed via App Atlas Phase A.4.1 extraction)
- Skoda MQTT (mysmob) + Audi dual-channel (Paho MQTT + FCM — both confirmed in APK)
- `vag_connect.send_destination` service (HA → car nav, first-of-all for VAG)
- Vehicle render Image entity (per-VIN PNG)
- Trip-history Calendar + sensors
- Editable departure-timer entities (Time/Select/MultiSelect with recurringOn weekday pattern, à la PyCupra schema)
- Auxiliary heating (Standheizung) switch + temp Number — `/auxiliaryheating/` endpoint confirmed in Audi + VW EU APK
- BLE `binary_sensor.car_nearby` + ESPHome BLE proxy guide

## Risk

Zero — pure entity adds from already-parsed dataclass fields. No new API calls, no behavior change. Existing pytest suite tests entity shape; additive changes are safe.

## Test plan

- [ ] CI green (5 checks)
- [ ] manifest.json version 2.4.2 → 2.5.0
- [ ] CHANGELOG.md `## [2.5.0]` entry
- [ ] Existing test suite passes (additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)