### PR TITLE
feat(v2.5.12): wire refresh_audi_market_config + atlas pipeline audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,26 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ### Fixed
 - **App Atlas Builder workflow PR creation** — repo setting `Allow GitHub Actions to create and approve pull requests` was disabled. The daily atlas builder runs detected version changes correctly (creating `auto/atlas-*` branches) but failed at the final `gh pr create` step with `GitHub Actions is not permitted to create or approve pull requests`. Setting now enabled via API. Next daily run (08:00 UTC) will properly open the auto-PR.
 
+## [2.5.12] — 2026-05-30 — "Market-Config Activation + Atlas Pipeline Audit"
+
+Follow-up to v2.5.11 — wires the Audi market-config helper that was added (but inert) in v2.5.11, plus opens tracking issues for the atlas-builder pipeline gaps surfaced during today's deep audit. Also a major strategic update on #336 (VW GIS migration) capturing 3-agent industry-wide intel.
+
+### Fixed
+- **`refresh_audi_market_config()` was never called in v2.5.11** — the helper module was implemented but no lifecycle path invoked it, so the 24h cache stayed permanently empty and `oauth_client_id_chain()` / `token_url()` never saw market-config values. v2.5.12 wires the call into both `_exchange_code()` (initial login) and `refresh()` (token-refresh path) for the Audi brand. Best-effort, throttled to 24h TTL — no extra latency on the steady-state polling cycle. Now actually does what v2.5.11 promised.
+
+### Documented
+- **Atlas-builder APK extraction pipeline broken since 2026-05-25** — opened tracking issue #345. Daily workflow polls versions correctly (3 new versions detected today: Audi 5.5.0, CUPRA 2.18.0, MyVW US 2026.5.27-9076) but APK download silently 403s on APKCombo's Cloudflare for all 7 brands. Workflow takes 30s instead of 5-10min. Findings we use in `.app-atlas-apk-cache/{brand}.json` are all from **manual local extractions** during v2.5.5/v2.5.6 sprint — CI has never auto-committed APK findings.
+- **Strategic update on #336 (VW GIS Migration)** — consolidated 3-agent industry research:
+  - Confirmed **2026-05-27 wall** is `client_assertion` (cryptographic origin-proof), not just endpoint rotation. Source: byteiota.com + HN #48319509 + Skoda Facebook statement.
+  - **Industry consensus across 10+ competitor projects**: nobody is migrating to `drivesomethinggreater.com` Data Hub (B2B-only, VAT-ID gate, undisclosed DDA pricing, FOSS-incompatible per myskoda dvx76 analysis).
+  - **`mikrohard/hass-vw-eu-data-act`** (~24h old, 3 stars) is the **only existing HA integration on the consumer EU Data Act portal**. Recommended Plan B coordination target.
+  - **2026-09-12 EU Data Act Article 3 enforcement** = the only firm regulatory date in the entire narrative. Roadmap re-positions v2.5.x as the bridge to a Data-Act-API v3.0.
+
+### Notes
+- v2.5.12 is a small follow-up. No user-visible behaviour change in the steady-state. The wire-up matters when VW rotates the Audi auth config again — then the market-config layer now has 24h to discover the new URL/client_id without code release.
+- See [issue #345](https://github.com/its-me-prash/vwgroup-connect-ha/issues/345) for atlas pipeline fix plan.
+- See [issue #336](https://github.com/its-me-prash/vwgroup-connect-ha/issues/336) for GIS migration strategy doc.
+
 ## [2.5.11] — 2026-05-30 — "Field-tested Auth Hardening"
 
 Three patches driven by a deep audit of `audi_connect_ha` PR #736, `evcc` PR #30292, and `CarConnectivity-connector-seatcupra` v0.6.3 — comparing what those projects actually shipped against what we have today. Findings: one latent bug, one future-proofing gap, one missed alternate. All three patches are additive + backward-compatible. No user-visible behaviour change today; all three reduce the blast radius of the NEXT VW backend rotation.

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -909,6 +909,26 @@ class IDKAuth:
         if self._brand.name in ("seat", "cupra"):
             token_url = "https://ola.prod.code.seat.cloud.vwgroup.com/authorization/api/v1/token"
         else:
+            # v2.5.12 — trigger Audi market-config refresh on refresh-token
+            # path too. Throttled internally (24h TTL) so this is a no-op
+            # after the first call per process. Ensures long-running HA
+            # instances pick up Audi CDN updates over their lifetime, not
+            # only at initial login.
+            if self._brand.name == "audi":
+                try:
+                    from ._auth_config_resolver import (  # noqa: PLC0415
+                        AuthConfigResolver,
+                    )
+                    _audi_resolver = AuthConfigResolver(
+                        "audi",
+                        hardcoded_client_id=self._brand.client_id,
+                        hardcoded_qmauth_secret=_QM_SECRET,
+                        hardcoded_qmauth_client_id=_QM_CLIENT_ID,
+                        hardcoded_token_url=_CARIAD_TOKEN_URL,
+                    )
+                    await _audi_resolver.refresh_audi_market_config(self._session)
+                except Exception:  # noqa: BLE001 — defense-in-depth
+                    pass
             token_url = self._get_token_endpoint()
 
         data: dict[str, str] = {
@@ -1225,6 +1245,16 @@ class IDKAuth:
         if self._brand.name in ("audi", "volkswagen"):
             try:
                 await resolver.refresh_via_discovery(self._session)
+            except Exception:  # noqa: BLE001 — defense-in-depth
+                pass
+        # v2.5.12 — wire up the v2.5.11 Audi market-config layer.
+        # Throttled to once per 24 h per (country, language) — first
+        # call per HA process startup fetches the CDN, subsequent calls
+        # within the TTL are a no-op. Only Audi brand actually fetches
+        # (resolver.refresh_audi_market_config() returns {} for non-Audi).
+        if self._brand.name == "audi":
+            try:
+                await resolver.refresh_audi_market_config(self._session)
             except Exception:  # noqa: BLE001 — defense-in-depth
                 pass
         token_url = (

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.5.11"
+  "version": "2.5.12"
 }


### PR DESCRIPTION
## Summary

Follow-up to v2.5.11 — wires up what v2.5.11 promised. Plus documentation of pipeline gaps surfaced during today's deep audit.

### PATCH 1 (real fix): activate v2.5.11's market-config layer

v2.5.11 added \`cariad/auth/_audi_market_config.py\` but **nothing called \`refresh_audi_market_config()\` in any lifecycle path**. The 24h cache stayed permanently empty, so \`oauth_client_id_chain()\` and \`token_url()\` never actually saw market-config values.

v2.5.12 wires the call into:
- \`_exchange_code()\` (initial login, Audi-only) — alongside the existing \`refresh_via_discovery()\` at line 1227
- \`refresh()\` (token-refresh, Audi-only) — ensures long-running HA instances pick up CDN updates over their lifetime

Best-effort with hard fallback. 24h TTL = no extra latency on steady-state polling.

### PATCH 2 (documentation): atlas pipeline broken since 2026-05-25

Daily workflow polls versions correctly (Audi 5.5.0 + CUPRA 2.18.0 + MyVW 2026.5.27 detected today) but APK download silently 403s on APKCombo's Cloudflare for ALL 7 brands. Workflow takes 30s instead of 5-10min. Findings in \`.app-atlas-apk-cache/\` are all manual extractions. Tracking issue #345 opened.

### PATCH 3 (strategy): GIS migration intel posted on #336

Consolidated 3-agent research:
- 2026-05-27 wall = \`client_assertion\` (cryptographic origin-proof from approved app on unmodified device)
- Industry consensus across 10+ projects: nobody migrating to GIS B2B (FOSS-incompatible)
- \`mikrohard/hass-vw-eu-data-act\` = sole HA Data Act portal scraper, ~24h old, coordination target
- 2026-09-12 EU Data Act Art. 3 enforcement = only firm regulatory date

Recommended posture: **HYBRID LEAD** with Plan B (EU Data Act bulk-import mode) prototyped in v2.5.13.

## Test plan

- [x] py_compile syntax verification pass
- [ ] CI green (HA env)
- [ ] HACS install on dev box — Audi user
- [ ] Verify \`_LOGGER.debug\` shows Audi market-config fetch on first login

## Related issues

- #336 — Strategic GIS migration tracker (extensive update posted)
- #345 — Atlas pipeline broken (tracking, fix deferred to v2.5.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)