### PR TITLE
docs(v2.5.13): Play Integrity wall decoded via Audi 5.5.0 APK forensics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,69 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ### Fixed
 - **App Atlas Builder workflow PR creation** — repo setting `Allow GitHub Actions to create and approve pull requests` was disabled. The daily atlas builder runs detected version changes correctly (creating `auto/atlas-*` branches) but failed at the final `gh pr create` step with `GitHub Actions is not permitted to create or approve pull requests`. Setting now enabled via API. Next daily run (08:00 UTC) will properly open the auto-PR.
 
+## [2.5.13] — 2026-05-30 — "Play Integrity Wall Decoded"
+
+Documentation-only release. No code changes to runtime behaviour. Captures the **architectural decoding** of VW's 2026-05-27 `client_assertion` enforcement after local APK forensics on three freshly-released app versions.
+
+### Investigated
+
+- Downloaded Audi 5.5.0 + MyVW US 2026.5.27-9076 APKs locally via APKMirror direct CDN (manual workaround for the broken atlas pipeline tracked in #345)
+- apktool-decoded the Audi base.apk into 82,797 smali files across 16 DEX classes
+- Smali-grep'd for VAG-related hosts → **151 unique URLs** extracted, atlas profile updated
+- Located the smoking-gun smali class for VW's `client_assertion` wall
+
+### Discovered: Play Integrity attestation
+
+The endpoint `/auth/v1/android/challenge` exists in exactly ONE smali file:
+
+```
+audi_550_decoded/smali_classes5/technology/cariad/cat/playintegrity/NonceGenerator.smali
+```
+
+Sibling files reveal the complete flow:
+
+| Smali class | Purpose |
+|---|---|
+| `Nonce` | Data class `{ challenge: String }` returned by the challenge endpoint |
+| `NonceGenerator` | Issues POST to `/auth/v1/android/challenge` to obtain a nonce |
+| `PlayIntegrityTokenProvider` | Wraps Google `StandardIntegrityManager` — produces signed JWT bound to nonce + request hash |
+| `AssertionTokenProvider$Error$Integrity` | "JWT signature invalid (server rejected)" |
+| `AssertionTokenProvider$Error$QueryNonce` | "Challenge endpoint failed" |
+| `AssertionTokenProvider$Error$RequestHash` | "Request-body hash mismatch" |
+
+Full architectural breakdown in [issue #347](https://github.com/its-me-prash/vwgroup-connect-ha/issues/347).
+
+### Why this is the END for OSS integrations
+
+Python-based HA integration cannot produce a valid Google Play Integrity JWT. Requires (a) Google-signed APK, (b) Play Store install, (c) real device with Play Services, (d) app package fingerprint matching VW's registered Audi/VW app. **No static APK extraction path bypasses this.**
+
+### Why we still work today
+
+Enforcement is soft. iobroker observed `x-assertion: "0"` dummy works for 12-24h before backend rejects. Our v2.5.7+ users see 502 = endpoint REACHES backend = `x-assertion` not yet strictly verified for all paths. Audi APK has `anna_attestation_enabled` remote-config flag — VW is dialling strictness up gradually.
+
+### What's NEW in atlas profile
+
+- Added top-level `play_integrity_attestation` section with all 14 Play Integrity classes + 8 assertion-interface error types
+- Annotated `assertion_headers` section with the v2.5.13 update
+- Confirmed `/auth/v1/android/challenge` as the Play Integrity nonce endpoint
+- Documented Google dependency `com.google.android.play.core.integrity.StandardIntegrityManager`
+
+### Strategic posture (no change from v2.5.12 strategy doc on #336)
+
+- **Plan A (BFF integration)**: on a countdown — works today, will fail when VW flips `anna_attestation_enabled` to strict
+- **Plan B (EU Data Act portal scraper)**: survives Play Integrity (uses `identity.vwgroup.io` + portal session, no `/auth/v1/android/challenge` involved). Coordinate with [mikrohard/hass-vw-eu-data-act](https://github.com/mikrohard/hass-vw-eu-data-act) — Option B (side-by-side recommendation) per the v2.5.12 research agent
+- **Plan C (Cariad GIS B2B partner)**: paid, contract, VAT-ID required — not FOSS-viable
+- **Plan D (OBD-II hardware)**: WICAN, OVMS — community recommendation in iobroker thread
+
+### Local-only forensic artifacts (gitignored)
+
+- `.app-atlas-apk-cache/_manual/audi_5.5.0.apkm` (123 MB original .apkm bundle)
+- `.app-atlas-apk-cache/_manual/audi_550_decoded/` (full smali decode)
+- `.app-atlas-apk-cache/_manual/myvw_2026527.apkm` (111 MB)
+- `.app-atlas-apk-cache/_manual/myvw_decoded/` (30,670 smali files)
+
+Cross-references: #336 (strategic tracker), #345 (atlas pipeline broken), #347 (Play Integrity decoded), [audi_connect_ha PR #736](https://github.com/audiconnect/audi_connect_ha/pull/736), [iobroker thread page 3349](https://forum.iobroker.net/topic/26438/test-adapter-vw-connect-f%C3%BCr-vw-id-audi-seat-skoda/3349)
+
 ## [2.5.12] — 2026-05-30 — "Market-Config Activation + Atlas Pipeline Audit"
 
 Follow-up to v2.5.11 — wires the Audi market-config helper that was added (but inert) in v2.5.11, plus opens tracking issues for the atlas-builder pipeline gaps surfaced during today's deep audit. Also a major strategic update on #336 (VW GIS migration) capturing 3-agent industry-wide intel.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.5.12"
+  "version": "2.5.13"
 }

--- a/docs/research/app-atlas/vw_group_auth_profile.json
+++ b/docs/research/app-atlas/vw_group_auth_profile.json
@@ -62,7 +62,42 @@
       "x-android-package-name": "(per brand — de.myaudi.mobile.assistant for Audi, de.volkswagen.weconnect for VW EU)",
       "x-assertion": "0",
       "x_assertion_validation": "Currently presence-only check; value '0' (dummy) accepted per ioBroker observation. WARNING: anna_attestation_enabled remote-config flag in VW APK could flip server-side to require real Play Integrity attestation — when that happens, dummy '0' stops working and we need real attestation values. Watch-item for daily atlas.",
-      "_source": "evcc PR #30292 + ioBroker commit 884269b1 + verified against AttestationEnabledUseCase smali in VW 3.61.0 APK (research agent finding)"
+      "_source": "evcc PR #30292 + ioBroker commit 884269b1 + verified against AttestationEnabledUseCase smali in VW 3.61.0 APK (research agent finding)",
+      "_v2513_update_2026_05_30": "Audi 5.5.0 APK forensics (manual local extraction) revealed the full architecture: x-assertion is the slot that will eventually carry a Google Play Integrity JWT, not the current dummy '0'. See #347 for class-level breakdown."
+    },
+    "play_integrity_attestation": {
+      "_status": "DISCOVERED_2026_05_30 — Audi 5.5.0 APK forensics",
+      "_source_ref_issue": "https://github.com/its-me-prash/vwgroup-connect-ha/issues/347",
+      "_overview": "VW's 2026-05-27 'client_assertion' wall is implemented as Google Play Integrity attestation. App requests nonce, calls Google's StandardIntegrityManager, sends signed JWT as x-assertion. Soft-enforced today (anna_attestation_enabled remote-config), expected to harden over weeks-to-months.",
+      "challenge_endpoint": "https://emea.bff.cariad.digital/auth/v1/android/challenge",
+      "_challenge_endpoint_source": "Audi 5.5.0 smali_classes5/technology/cariad/cat/playintegrity/NonceGenerator.smali — only smali reference in entire 82,797-file decode",
+      "smali_classes_observed": [
+        "technology.cariad.cat.playintegrity.Nonce (data class with 'challenge' field)",
+        "technology.cariad.cat.playintegrity.Nonce$Companion",
+        "technology.cariad.cat.playintegrity.Nonce$$serializer (kotlinx.serialization)",
+        "technology.cariad.cat.playintegrity.NonceGenerator (issues POST to challenge endpoint)",
+        "technology.cariad.cat.playintegrity.NonceGenerator$queryNonce$1 (coroutine continuation)",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProvider (uses Google StandardIntegrityManager)",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProvider$initIntegrityTokenProvider$1",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProvider$requestIntegrityToken$1",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProvider$requestIntegrityToken$3",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProvider$requestIntegrityTokenBoundToNonce$1 (the nonce-bound JWT request)",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProvider$retryOrFail$1",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProvider$tokenProviderResult$2",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProvider$tryRequestIntegrityToken$1",
+        "technology.cariad.cat.playintegrity.PlayIntegrityTokenProviderKt"
+      ],
+      "assertion_interface_errors": [
+        "Initialization — Google Play Integrity API init failed",
+        "Integrity — JWT signature invalid (server rejected)",
+        "QueryNonce — /auth/v1/android/challenge failed",
+        "RequestHash — request-body hash mismatch"
+      ],
+      "_assertion_interface_source": "Audi 5.5.0 smali_classes9/technology/cariad/cat/assertioninterface/*.smali",
+      "_constructor_signature": "PlayIntegrityTokenProvider(Context, Uri, HttpClient, Function) — requires Android Context = cannot be invoked from Python HA server",
+      "google_dependency": "com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenProvider",
+      "_blocked_for_oss": "Python HA integration cannot produce a Play Integrity JWT. Requires (a) Google-signed APK + (b) Play Store install + (c) real device with Play Services + (d) app package fingerprint matching VW's registered Audi/VW app. NO static-extraction bypass exists.",
+      "_observed_enforcement_state": "Soft — dummy x-assertion='0' still accepted on most paths as of 2026-05-30 evening, hourly tightening pattern reported in iobroker thread."
     }
   },
   "brands": {


### PR DESCRIPTION
## Summary

**Documentation-only release.** Captures the architectural decoding of VW's 2026-05-27 `client_assertion` enforcement after local APK forensics on Audi 5.5.0 + MyVW US 2026.5.27.

## What was done

1. **Workaround the broken atlas pipeline** (issue #345): downloaded Audi 5.5.0 (123MB .apkm) + MyVW US 2026.5.27 (111MB) via APKMirror direct CDN with mobile-UA + 3-step chain navigation
2. apktool decoded → 82,797 smali files across 16 DEX classes for Audi
3. Smali-grep'd for VAG hosts → 151 unique URLs extracted, atlas profile updated
4. Located smoking-gun smali class for `client_assertion`: `technology.cariad.cat.playintegrity.NonceGenerator`

## The wall, fully decoded

`/auth/v1/android/challenge` is referenced in exactly ONE smali file. Sibling classes (14 in `playintegrity` package + 8 in `assertioninterface` package) reveal the complete flow: app requests nonce → Google StandardIntegrityManager produces signed JWT bound to nonce + request-hash → JWT sent as `client_assertion` to `/auth/v1/idk/oidc/token`.

Constructor signature `PlayIntegrityTokenProvider(Context, Uri, HttpClient, Function)` requires Android Context = **cannot be invoked from Python HA server**.

Full architectural breakdown in [issue #347](https://github.com/its-me-prash/vwgroup-connect-ha/issues/347).

## Why we still work today

Enforcement is SOFT. iobroker observed `x-assertion: "0"` dummy works for 12-24h windows. Our v2.5.7+ users see 502 errors → endpoint REACHES backend → `x-assertion` not yet strictly verified for all paths. `anna_attestation_enabled` remote-config flag is the kill-switch.

## No code changes

This is pure documentation. Steady-state runtime behaviour unchanged. Sets the stage for v2.6 Plan B (EU Data Act portal scraper, coordinate with mikrohard).

## Test plan

- [x] Atlas profile JSON validates
- [x] CHANGELOG syntax check
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)