### PR TITLE
feat(v2.7.0b1 beta): Browser-Login UI via OAuth Device Authorization Grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains daernsinstantfortress as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.0b1] — 2026-05-31 — "Browser-Login UI (beta)"
+
+- New config_flow menu: choose between Browser-Login (recommended) and Email + Password (legacy).
+- Browser-Login wires the v2.6.0 OAuth Device Authorization Grant module into HA's show_progress flow — open a URL, enter a short code, no password stored in HA.
+- Available for Audi, Škoda, SEAT, CUPRA. VW EU + Porsche stay on the email + password path.
+
 ## [2.6.0] — 2026-05-31 — "Multi-Strategy Auth (Hybrid + DAG + Data Act)"
 
 - VW EU now logs in via OIDC hybrid flow (response_type=code id_token token) — bypasses Play Integrity wall.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains daernsinstantfortress as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.0b2] — 2026-05-31 — "Audi token-headers fix (beta)"
+
+- Audi email+password login: dropped the dummy x-assertion / x-platform / x-android-package-name trio from token requests — VW backend now rejects the dummy value and lets through requests that omit the headers entirely. Matches audi_connect_ha v1.19.2+ behaviour.
+
 ## [2.7.0b1] — 2026-05-31 — "Browser-Login UI (beta)"
 
 - New config_flow menu: choose between Browser-Login (recommended) and Email + Password (legacy).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains daernsinstantfortress as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.0b3] — 2026-05-31 — "Hassfest + test contract fixes (beta)"
+
+- Translations: moved progress key from inside step to top-level config.progress per HA schema.
+- Tests aligned with v2.7.0b1 menu split and v2.7.0b2 5-header default.
+
 ## [2.7.0b2] — 2026-05-31 — "Audi token-headers fix (beta)"
 
 - Audi email+password login: dropped the dummy x-assertion / x-platform / x-android-package-name trio from token requests — VW backend now rejects the dummy value and lets through requests that omit the headers entirely. Matches audi_connect_ha v1.19.2+ behaviour.

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -115,49 +115,53 @@ def _cariad_token_headers(
     qmauth_secret: str | None = None,
     qmauth_client_id: str | None = None,
     android_package_name: str = "de.myaudi.mobile.assistant",
+    include_assertion: bool = False,
 ) -> dict[str, str]:
-    """Return the assertion-header set required by the new CARIAD IDK
-    token endpoint (Audi + VW EU).
+    """Return the header set for the CARIAD IDK token endpoint.
 
-    v2.5.4 (#313) — Sent for BOTH authorization_code exchange AND
-    refresh_token. Missing any one of these results in either an HTTP
-    403 (Azure WAF) or an ``{"error":"invalid assertion headers"}``
-    response body once past the gateway.
+    v2.7.0b2 — DEFAULT FLIPPED to the 5-header set that
+    audi_connect_ha has used in production since 2026-05-28.
+    Background: the v2.5.4 introduction of the 3-header assertion
+    trio (``x-platform``, ``x-android-package-name``,
+    ``x-assertion``) was a defensive "mimic the official app"
+    measure based on early reverse engineering. We kept it as a
+    superset on the theory that more headers = more
+    anomaly-score-resilient.
 
-    v2.5.6 (#313 follow-on) — qmauth values are now caller-supplied so
-    the resolver can swap in APK-mined values. Caller omits = defaults
-    apply (v2.5.4 hardcoded constants, cross-verified against
-    audi_connect_ha + evcc + volkswagencarnet + ioBroker.vw-connect).
+    Reality (observed 2026-05-31): VW backend now validates the
+    ``x-assertion`` value at the BFF layer. The dummy ``"0"``
+    placeholder we (and iobroker.vw-connect 0.8.8 briefly) sent is
+    rejected — the only valid value is a Google Play Integrity JWT
+    signed by Google with VW's registered app fingerprint, which a
+    Python integration cannot produce. So sending ``x-assertion: "0"``
+    triggers the assertion check and fails; OMITTING the header
+    entirely skips the check and the request passes.
 
-    v2.5.11 — brand-impersonation bugfix. Pre-v2.5.11 the
-    ``x-android-package-name`` was hardcoded to
-    ``de.myaudi.mobile.assistant`` for ALL brands including VW EU,
-    silently impersonating the Audi app on VW token requests. Our own
-    atlas profile (vw_group_auth_profile.json) documented this as
-    wrong since 2026-05-29 but the code didn't match. Caller now
-    passes per-brand value via ``android_package_name`` kwarg
-    (resolved from ``BrandConfig.android_package_name``). Default
-    remains the Audi value for backward-compat with any unparameterised
-    callers, but the production paths in IDKAuth always pass through
-    the brand-specific value as of v2.5.11.
+    The 5-header set matches audi_connect_ha v1.19.2+ which is
+    confirmed working for many Audi users. v2.7.0b2 adopts it as
+    default. Callers that need the 8-header superset (e.g. for
+    future debugging) can pass ``include_assertion=True``.
 
-    Note: audi_connect_ha v1.19.2 (PR #736 / 2026-05-28) reportedly
-    works with only 5 headers (no x-platform / x-android-package-name /
-    x-assertion). Our 8-header set is a superset that mimics the
-    official app more closely — still functional, more
-    anomaly-score-resilient if VW tightens WAF rules. Documented for
-    future minimisation if WAF stays permissive.
+    Per-brand details:
+      - ``android_package_name`` is only relevant if
+        ``include_assertion=True``. With the assertion trio absent,
+        the package name is no longer transmitted to the backend.
+      - ``user_agent`` + ``x-qmauth`` stay per-call.
     """
-    return {
-        "Content-Type":            "application/x-www-form-urlencoded",
-        "Accept":                  "application/json",
-        "Accept-Charset":          "utf-8",
-        "User-Agent":              user_agent,
-        "x-qmauth":                _calculate_x_qmauth(qmauth_secret, qmauth_client_id),
-        "x-platform":              "android",
-        "x-android-package-name":  android_package_name,
-        "x-assertion":             "0",
+    headers = {
+        "Content-Type":   "application/x-www-form-urlencoded",
+        "Accept":         "application/json",
+        "Accept-Charset": "utf-8",
+        "User-Agent":     user_agent,
+        "x-qmauth":       _calculate_x_qmauth(qmauth_secret, qmauth_client_id),
     }
+    if include_assertion:
+        headers.update({
+            "x-platform":             "android",
+            "x-android-package-name": android_package_name,
+            "x-assertion":            "0",
+        })
+    return headers
 
 
 class _CSRFParser(HTMLParser):

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -167,7 +167,41 @@ def _map_error(err_code: str) -> str:
         "terms_and_conditions", "marketing_consent", "two_factor_required",
         "too_many_requests", "invalid_credentials", "missing_library",
         "upstream_unavailable",  # v2.5.7 — 5xx from VW backend
+        "brand_not_dag_eligible",  # v2.7.0 — user picked non-DAG brand for browser login
     } else "cannot_connect"
+
+
+def _extract_user_id_from_id_token(id_token: str, fallback: str) -> str:
+    """v2.7.0 — Decode the ``sub`` claim from an OIDC id_token.
+
+    Used by the browser-login (DAG) flow to derive a stable per-user
+    identifier without ever asking the user for their email. The
+    id_token is signed by VW's IDP — we do NOT verify the signature
+    here (the IDP verified it when minting it; tampering doesn't
+    affect us because we only consume our own freshly-acquired token).
+
+    Returns the ``sub`` claim if extractable, else ``fallback``.
+    Never raises — id_token formats vary across brands and we never
+    want a parse failure to block setup.
+    """
+    import base64  # noqa: PLC0415
+    import json  # noqa: PLC0415
+
+    try:
+        parts = id_token.split(".")
+        if len(parts) < 2:
+            return fallback
+        payload_b64 = parts[1]
+        # Base64-url padding: JWT strips '=', so add it back.
+        padding = (-len(payload_b64)) % 4
+        payload_bytes = base64.urlsafe_b64decode(payload_b64 + ("=" * padding))
+        payload = json.loads(payload_bytes.decode("utf-8"))
+        sub = payload.get("sub")
+        if isinstance(sub, str) and sub:
+            return sub
+    except Exception:  # noqa: BLE001 — defensive, never block setup
+        pass
+    return fallback
 
 
 # ── Schema builders ───────────────────────────────────────────────────────────
@@ -203,11 +237,43 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         self._pending_username: str = ""
         self._pending_password: str = ""
         self._pending_entry_data: dict[str, Any] = {}
+        # v2.7.0 — Device Authorization Grant (browser-login) state.
+        # Populated in async_step_browser_login + read by the polling
+        # background task. Reset at the start of every new browser flow.
+        self._dag_brand: str = ""
+        self._dag_user_input: dict[str, Any] = {}
+        self._dag_task: Any = None
+        self._dag_user_code: str = ""
+        self._dag_verification_uri: str = ""
+        self._dag_tokens: Any = None
+        self._dag_user_id: str = ""
+        self._dag_error: str = ""
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
-        """Step 1: brand + credentials."""
+        """Step 1 (v2.7.0): menu — browser login vs email + password.
+
+        Browser login (Device Authorization Grant) is recommended for
+        Audi/Skoda/SEAT/CUPRA — no password storage in HA, real
+        refresh_token, password-less. VW EU and Porsche stay on the
+        email + password path because VW has not whitelisted those
+        client_ids for the device grant flow.
+        """
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["browser_login", "email_password"],
+        )
+
+    async def async_step_email_password(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """v2.7.0 — original credentials flow (was async_step_user).
+
+        Browser-login users skip this step entirely. Legacy email +
+        password path stays for backwards compatibility and for brands
+        without device-grant whitelisting (VW EU, Porsche).
+        """
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -247,7 +313,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         # client even via schema-default).
         suggested = user_input or {}
         return self.async_show_form(
-            step_id="user",
+            step_id="email_password",
             data_schema=_credentials_schema(
                 brand=suggested.get(CONF_BRAND, ""),
                 username=suggested.get(CONF_USERNAME, ""),
@@ -258,6 +324,199 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 force_access=bool(suggested.get(CONF_FORCE_ACCESS, False)),
             ),
             errors=errors,
+        )
+
+    async def async_step_browser_login(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """v2.7.0 — Browser-login (Device Authorization Grant) step 1.
+
+        User picks a DAG-eligible brand and optional advanced settings.
+        Submits → we start the background DAG task and transition to the
+        pending step (which shows progress + verification URL).
+        """
+        from .cariad.auth._device_grant import DAG_ENABLED_BRANDS  # noqa: PLC0415
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            brand = user_input[CONF_BRAND]
+            if brand not in DAG_ENABLED_BRANDS:
+                # Defence in depth — the form should have filtered these
+                # out already, but the user could send a crafted payload.
+                errors["base"] = "brand_not_dag_eligible"
+            else:
+                # Reset state for this attempt.
+                self._dag_brand = brand
+                self._dag_user_input = dict(user_input)
+                self._dag_task = None
+                self._dag_user_code = ""
+                self._dag_verification_uri = ""
+                self._dag_tokens = None
+                self._dag_user_id = ""
+                self._dag_error = ""
+                return await self.async_step_browser_login_pending()
+
+        # DAG-eligible brand options only (subset of the standard list).
+        dag_brand_options: list[SelectOptionDict] = [
+            opt for opt in _BRAND_OPTIONS
+            if opt["value"] in DAG_ENABLED_BRANDS
+        ]
+        dag_brand_selector = SelectSelector(
+            SelectSelectorConfig(
+                options=dag_brand_options,
+                mode=SelectSelectorMode.LIST,
+                translation_key="brand",
+            )
+        )
+
+        suggested = user_input or {}
+        return self.async_show_form(
+            step_id="browser_login",
+            data_schema=vol.Schema({
+                vol.Required(
+                    CONF_BRAND, default=suggested.get(CONF_BRAND, vol.UNDEFINED),
+                ): dag_brand_selector,
+                vol.Optional(
+                    CONF_SPIN, default=suggested.get(CONF_SPIN, ""),
+                ): _SPIN_SELECTOR,
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=int(suggested.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)),
+                ): _INTERVAL_SELECTOR,
+                vol.Optional(
+                    CONF_FORCE_ACCESS,
+                    default=bool(suggested.get(CONF_FORCE_ACCESS, False)),
+                ): _BOOL_SELECTOR,
+            }),
+            errors=errors,
+        )
+
+    async def async_step_browser_login_pending(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """v2.7.0 — Browser-login step 2: poll while the user approves.
+
+        HA's show_progress pattern: the first call starts a background
+        task; subsequent calls (HA polls this step every ~2s) check if
+        the task is done. When done, we advance to the finish step.
+        """
+        if self._dag_task is None:
+            self._dag_task = self.hass.async_create_task(self._run_dag_flow())
+
+        if not self._dag_task.done():
+            return self.async_show_progress(
+                step_id="browser_login_pending",
+                progress_action="awaiting_browser_login",
+                progress_task=self._dag_task,
+                description_placeholders={
+                    "verification_uri": (
+                        self._dag_verification_uri or "(requesting...)"
+                    ),
+                    "user_code": self._dag_user_code or "(requesting...)",
+                },
+            )
+
+        # Task finished — advance to either finish (success) or
+        # back to the brand-pick form with an error (failure).
+        next_step = (
+            "browser_login_finish" if self._dag_tokens else "browser_login"
+        )
+        return self.async_show_progress_done(next_step_id=next_step)
+
+    async def _run_dag_flow(self) -> None:
+        """v2.7.0 — Background task that drives the DAG flow.
+
+        Sequence:
+          1. Request device_code (populates _dag_user_code/_uri for the
+             show_progress description_placeholders).
+          2. Poll /token until the user approves in the browser.
+          3. Decode id_token's `sub` claim → use as user identifier for
+             the config_entry unique_id and title.
+
+        Errors are stashed on ``self._dag_error`` so the pending step
+        can surface them; raising here would crash the HA flow handler.
+        """
+        import aiohttp  # noqa: PLC0415
+        from .cariad.auth._device_grant import DeviceAuthorizationGrant  # noqa: PLC0415
+        from .const import BRANDS as _CONST_BRANDS  # noqa: PLC0415
+
+        # Reuse the existing CariadClientFactory's session pattern.
+        connector = aiohttp.TCPConnector(ssl=True)
+        try:
+            async with aiohttp.ClientSession(
+                connector=connector,
+                cookie_jar=aiohttp.CookieJar(unsafe=True),
+            ) as session:
+                # Brand → client_id mapping via the BRANDS registry.
+                from .cariad.models import BRANDS as BRAND_CONFIGS  # noqa: PLC0415
+
+                brand_cfg = BRAND_CONFIGS[self._dag_brand]
+                dag = DeviceAuthorizationGrant(
+                    session,
+                    brand_cfg.client_id,
+                    scope=brand_cfg.scope,
+                )
+                code = await dag.request_device_code()
+                self._dag_user_code = code.user_code
+                self._dag_verification_uri = code.verification_uri_complete
+                self._dag_tokens = await dag.poll_for_tokens(
+                    code.device_code,
+                    interval=code.interval,
+                    expires_in=code.expires_in,
+                )
+                self._dag_user_id = _extract_user_id_from_id_token(
+                    self._dag_tokens.id_token, fallback=f"{self._dag_brand}_dag",
+                )
+                _LOGGER.info(
+                    "Browser login succeeded for %s — sub=%s",
+                    _CONST_BRANDS.get(self._dag_brand, self._dag_brand),
+                    self._dag_user_id[:8] if self._dag_user_id else "(none)",
+                )
+        except Exception as err:  # noqa: BLE001 — flow-level catch
+            self._dag_error = str(err)
+            _LOGGER.warning(
+                "Browser login failed for %s: %s", self._dag_brand, err,
+            )
+
+    async def async_step_browser_login_finish(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """v2.7.0 — Browser-login step 3: create the config entry.
+
+        Reached only after _run_dag_flow set _dag_tokens. Stores the
+        tokens in the entry's data dict; the coordinator's existing
+        token-persistence machinery picks them up on first run.
+        """
+        if self._dag_tokens is None:
+            # Shouldn't happen if step routing is correct, but defensive.
+            return self.async_abort(reason="dag_no_tokens")
+
+        unique = f"{self._dag_brand}_{self._dag_user_id}"
+        await self.async_set_unique_id(unique)
+        self._abort_if_unique_id_configured()
+
+        # Reuse _build_entry_data but with synthetic email-substitute
+        # (BrandID `sub`). Password is empty — the refresh-token path
+        # handles renewal without it.
+        entry_data = self._build_entry_data(
+            self._dag_brand,
+            self._dag_user_id,
+            "",  # no password stored
+            self._dag_user_input,
+        )
+        # Stash the DAG-acquired tokens so the coordinator's token
+        # persistence loader picks them up before the first poll cycle.
+        entry_data["dag_initial_tokens"] = {
+            "access_token": self._dag_tokens.access_token,
+            "refresh_token": self._dag_tokens.refresh_token,
+            "id_token": self._dag_tokens.id_token,
+            "expires_at": self._dag_tokens.expires_at,
+            "strategy": "device_grant",
+        }
+        return self.async_create_entry(
+            title=f"{BRANDS[self._dag_brand]} — {self._dag_user_id[:8]}…",
+            data=entry_data,
         )
 
     async def async_step_mfa(

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -553,6 +553,31 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         )
         self._token_storage = TokenStorage(store)
         persisted = await self._token_storage.load()
+
+        # v2.7.0 — config_flow's browser-login (DAG) flow stashes the
+        # initial tokens in entry.data["dag_initial_tokens"] because
+        # the persistent storage hadn't been set up yet at that point.
+        # Promote those into the persistent store on the first run, then
+        # behave like a normal restart from cached tokens.
+        if persisted is None:
+            dag_initial = self.entry.data.get("dag_initial_tokens")
+            if dag_initial:
+                from .cariad.models import TokenSet  # noqa: PLC0415
+                persisted = TokenSet(
+                    access_token=str(dag_initial.get("access_token", "")),
+                    refresh_token=str(dag_initial.get("refresh_token", "")),
+                    id_token=str(dag_initial.get("id_token", "")),
+                    expires_at=float(dag_initial.get("expires_at", 0.0)),
+                    strategy=str(dag_initial.get("strategy", "")),
+                )
+                _LOGGER.debug(
+                    "VAG Connect: bootstrapping with DAG initial tokens "
+                    "for %s (strategy=%s)", brand, persisted.strategy,
+                )
+                # Save immediately so the entry.data copy can be cleaned
+                # up on a subsequent config_flow update.
+                await self._token_storage.save(persisted)
+
         if persisted is not None:
             self._cariad_client.set_persisted_tokens(persisted)
         # Fire-and-forget save callback — never blocks API path.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.0b1"
+  "version": "2.7.0b2"
 }

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.6.0"
+  "version": "2.7.0b1"
 }

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.0b2"
+  "version": "2.7.0b3"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1,26 +1,6 @@
 {
   "config": {
     "step": {
-      "user": {
-        "title": "Set up VW Group Connect",
-        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
-        "data": {
-          "brand": "Vehicle Brand",
-          "username": "Email Address",
-          "password": "Password",
-          "spin": "S-PIN",
-          "scan_interval": "Update Interval",
-          "force_enable_access": "Force Door Status"
-        },
-        "data_description": {
-          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
-          "username": "Email address from the manufacturer app.",
-          "password": "Password from the app.",
-          "spin": "Only needed for locking. App → Security → S-PIN.",
-          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
-          "force_enable_access": "For older vehicles that fail the capability check."
-        }
-      },
       "reauth_confirm": {
         "title": "Re-authenticate — {brand}",
         "description": "The session for **{username}** has expired.\n\nPlease re-enter your password.",
@@ -50,6 +30,57 @@
         "data_description": {
           "mfa_code": "6-digit code — valid for a few minutes."
         }
+      },
+      "email_password": {
+        "title": "Sign in with email + password (legacy)",
+        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "username": "Email Address",
+          "password": "Password",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
+          "username": "Email address from the manufacturer app.",
+          "password": "Password from the app.",
+          "spin": "Only needed for locking. App → Security → S-PIN.",
+          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
+          "force_enable_access": "For older vehicles that fail the capability check."
+        }
+      },
+      "user": {
+        "title": "Set up VW Group Connect",
+        "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU and Porsche.",
+        "menu_options": {
+          "browser_login": "Browser-Login (recommended)",
+          "email_password": "Email + Password (legacy)"
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — choose your brand",
+        "description": "Pick the brand of the vehicle you want to connect. On the next screen you will see a short code and a URL to visit on any device with a browser.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Only brands with browser-login support are listed. Use 'Email + Password' for Volkswagen EU and Porsche.",
+          "spin": "Optional 4-digit Security-PIN for remote actions (lock, unlock, climate).",
+          "scan_interval": "Minutes between vehicle data polls.",
+          "force_enable_access": "Force door-status entities even when the vehicle reports the data missing."
+        }
+      },
+      "browser_login_pending": {
+        "title": "Waiting for your browser approval",
+        "description": "1. Open **{verification_uri}** on any device.\n2. Sign in to your Brand ID account if asked.\n3. Confirm the code **{user_code}**.\n\nHome Assistant is polling — this page will advance automatically once you approve.",
+        "progress": {
+          "awaiting_browser_login": "Waiting for browser approval…"
+        }
       }
     },
     "error": {
@@ -61,7 +92,8 @@
       "email_two_factor_required": "Email 2FA required. Check your inbox (and spam) for a 6-digit code from VAG IDP, then sign in manually in the brand app once.",
       "too_many_requests": "Account temporarily suspended (too many login attempts). Please wait 15 minutes.",
       "invalid_credentials": "Email address or password incorrect.",
-      "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, not a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration."
+      "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, not a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration.",
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead."
     },
     "abort": {
       "already_configured": "This account is already configured.",
@@ -256,9 +288,6 @@
       },
       "requests_remaining_today": {
         "name": "API Requests Remaining"
-      },
-      "license_plate": {
-        "name": "License Plate"
       },
       "equipment_count": {
         "name": "Equipment Count"

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -77,10 +77,7 @@
       },
       "browser_login_pending": {
         "title": "Waiting for your browser approval",
-        "description": "1. Open **{verification_uri}** on any device.\n2. Sign in to your Brand ID account if asked.\n3. Confirm the code **{user_code}**.\n\nHome Assistant is polling — this page will advance automatically once you approve.",
-        "progress": {
-          "awaiting_browser_login": "Waiting for browser approval…"
-        }
+        "description": "1. Open **{verification_uri}** on any device.\n2. Sign in to your Brand ID account if asked.\n3. Confirm the code **{user_code}**.\n\nHome Assistant is polling — this page will advance automatically once you approve."
       }
     },
     "error": {
@@ -99,6 +96,9 @@
       "already_configured": "This account is already configured.",
       "reauth_successful": "Re-authentication successful.",
       "reconfigure_successful": "Configuration updated successfully."
+    },
+    "progress": {
+      "awaiting_browser_login": "Waiting for browser approval…"
     }
   },
   "options": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1,26 +1,6 @@
 {
   "config": {
     "step": {
-      "user": {
-        "title": "VW Group Connect einrichten",
-        "description": "Verbinde dein Fahrzeug mit Home Assistant. Wähle deine Marke und gib die Zugangsdaten aus der jeweiligen App ein.",
-        "data": {
-          "brand": "Fahrzeugmarke",
-          "username": "E-Mail-Adresse",
-          "password": "Passwort",
-          "spin": "S-PIN (optional, für Türverriegelung)",
-          "scan_interval": "Aktualisierungsintervall (Minuten)",
-          "force_enable_access": "Türzustand erzwingen (für ältere Modelle)"
-        },
-        "data_description": {
-          "spin": "Wird für Türverriegelung und einige andere Aktionen benötigt. Kann leer gelassen werden.",
-          "scan_interval": "Wie oft die API abgefragt wird (Minuten). Standard: 5. Minimum: 3.",
-          "force_enable_access": "Aktivieren, wenn Tür- und Fensterstatus nicht angezeigt werden, obwohl sie in der App sichtbar sind.",
-          "brand": "Wähle deine Marke — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA oder Porsche.",
-          "username": "Deine VAG-Konto E-Mail (myAudi, myŠkoda, We Connect, MyCupra, MySEAT, etc.)",
-          "password": "Dein VAG-Konto Passwort"
-        }
-      },
       "reauth_confirm": {
         "title": "Erneut anmelden — {brand}",
         "description": "Die Anmeldung für **{username}** ist abgelaufen.\n\nBitte Passwort erneut eingeben.",
@@ -50,6 +30,51 @@
         "data_description": {
           "mfa_code": "6-stelliger Code aus E-Mail oder Authenticator-App"
         }
+      },
+      "email_password": {
+        "title": "Mit E-Mail + Passwort anmelden (Legacy)",
+        "description": "Verbinde dein Fahrzeug mit Home Assistant. Wähle deine Marke und gib die Zugangsdaten aus der jeweiligen App ein.",
+        "data": {
+          "brand": "Fahrzeugmarke",
+          "username": "E-Mail-Adresse",
+          "password": "Passwort",
+          "spin": "S-PIN (optional, für Türverriegelung)",
+          "scan_interval": "Aktualisierungsintervall (Minuten)",
+          "force_enable_access": "Türzustand erzwingen (für ältere Modelle)"
+        },
+        "data_description": {
+          "spin": "Wird für Türverriegelung und einige andere Aktionen benötigt. Kann leer gelassen werden.",
+          "scan_interval": "Wie oft die API abgefragt wird (Minuten). Standard: 5. Minimum: 3.",
+          "force_enable_access": "Aktivieren, wenn Tür- und Fensterstatus nicht angezeigt werden, obwohl sie in der App sichtbar sind.",
+          "brand": "Wähle deine Marke — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA oder Porsche.",
+          "username": "Deine VAG-Konto E-Mail (myAudi, myŠkoda, We Connect, MyCupra, MySEAT, etc.)",
+          "password": "Dein VAG-Konto Passwort"
+        }
+      },
+      "user": {
+        "title": "VW Group Connect einrichten",
+        "description": "Wie möchtest du dich anmelden?\n\n**Browser-Login (empfohlen)** — öffne eine URL auf Handy oder Laptop, melde dich mit deinem Brand-ID-Konto an, bestätige das Gerät. Kein Passwort wird in Home Assistant gespeichert. Verfügbar für Audi, Škoda, SEAT und CUPRA.\n\n**E-Mail + Passwort (Legacy)** — gib deine Brand-ID-Zugangsdaten direkt ein. Erforderlich für Volkswagen EU und Porsche.",
+        "menu_options": {
+          "browser_login": "Browser-Login (empfohlen)",
+          "email_password": "E-Mail + Passwort (Legacy)"
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — Marke wählen",
+        "description": "Wähle die Marke deines Fahrzeugs. Auf dem nächsten Bildschirm bekommst du einen Kurz-Code und eine URL die du auf jedem Gerät mit Browser aufrufen kannst.",
+        "data": {
+          "brand": "Marke",
+          "spin": "S-PIN",
+          "scan_interval": "Aktualisierungsintervall",
+          "force_enable_access": "Tür-Status erzwingen"
+        }
+      },
+      "browser_login_pending": {
+        "title": "Warte auf deine Browser-Bestätigung",
+        "description": "1. Öffne **{verification_uri}** auf einem beliebigen Gerät.\n2. Melde dich mit deinem Brand-ID-Konto an (falls noch nicht eingeloggt).\n3. Bestätige den Code **{user_code}**.\n\nHome Assistant pollt im Hintergrund — die Seite wechselt automatisch sobald du bestätigt hast.",
+        "progress": {
+          "awaiting_browser_login": "Warte auf Browser-Bestätigung…"
+        }
       }
     },
     "error": {
@@ -61,7 +86,8 @@
       "email_two_factor_required": "E-Mail-2FA nötig. Postfach (und Spam) auf 6-stelligen Code von VAG IDP prüfen, dann einmal manuell in der Marken-App anmelden.",
       "too_many_requests": "Account vorübergehend gesperrt (zu viele Anmeldeversuche). Bitte 15 Minuten warten.",
       "invalid_credentials": "E-Mail-Adresse oder Passwort falsch.",
-      "upstream_unavailable": "VW-Backend vorübergehend nicht erreichbar. Das ist ein Server-Problem bei VW, KEIN Anmeldefehler. Bitte 5–15 Minuten warten und nochmal versuchen. Die Integration NICHT neu konfigurieren."
+      "upstream_unavailable": "VW-Backend vorübergehend nicht erreichbar. Das ist ein Server-Problem bei VW, KEIN Anmeldefehler. Bitte 5–15 Minuten warten und nochmal versuchen. Die Integration NICHT neu konfigurieren.",
+      "brand_not_dag_eligible": "Diese Marke unterstützt kein Browser-Login. Nutze stattdessen E-Mail + Passwort."
     },
     "abort": {
       "already_configured": "Dieses Konto ist bereits eingerichtet.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -71,10 +71,7 @@
       },
       "browser_login_pending": {
         "title": "Warte auf deine Browser-Bestätigung",
-        "description": "1. Öffne **{verification_uri}** auf einem beliebigen Gerät.\n2. Melde dich mit deinem Brand-ID-Konto an (falls noch nicht eingeloggt).\n3. Bestätige den Code **{user_code}**.\n\nHome Assistant pollt im Hintergrund — die Seite wechselt automatisch sobald du bestätigt hast.",
-        "progress": {
-          "awaiting_browser_login": "Warte auf Browser-Bestätigung…"
-        }
+        "description": "1. Öffne **{verification_uri}** auf einem beliebigen Gerät.\n2. Melde dich mit deinem Brand-ID-Konto an (falls noch nicht eingeloggt).\n3. Bestätige den Code **{user_code}**.\n\nHome Assistant pollt im Hintergrund — die Seite wechselt automatisch sobald du bestätigt hast."
       }
     },
     "error": {
@@ -93,6 +90,9 @@
       "already_configured": "Dieses Konto ist bereits eingerichtet.",
       "reauth_successful": "Erneute Anmeldung erfolgreich.",
       "reconfigure_successful": "Konfiguration erfolgreich aktualisiert."
+    },
+    "progress": {
+      "awaiting_browser_login": "Warte auf Browser-Bestätigung…"
     }
   },
   "options": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1,26 +1,6 @@
 {
   "config": {
     "step": {
-      "user": {
-        "title": "Set up VW Group Connect",
-        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
-        "data": {
-          "brand": "Vehicle Brand",
-          "username": "Email Address",
-          "password": "Password",
-          "spin": "S-PIN",
-          "scan_interval": "Update Interval",
-          "force_enable_access": "Force Door Status"
-        },
-        "data_description": {
-          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
-          "username": "Email address from the manufacturer app.",
-          "password": "Password from the app.",
-          "spin": "Only needed for locking. App → Security → S-PIN.",
-          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
-          "force_enable_access": "For older vehicles that fail the capability check."
-        }
-      },
       "reauth_confirm": {
         "title": "Re-authenticate — {brand}",
         "description": "The session for **{username}** has expired.\n\nPlease re-enter your password.",
@@ -50,6 +30,51 @@
         "data_description": {
           "mfa_code": "6-digit code — valid for a few minutes."
         }
+      },
+      "email_password": {
+        "title": "Sign in with email + password (legacy)",
+        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "username": "Email Address",
+          "password": "Password",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
+          "username": "Email address from the manufacturer app.",
+          "password": "Password from the app.",
+          "spin": "Only needed for locking. App → Security → S-PIN.",
+          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
+          "force_enable_access": "For older vehicles that fail the capability check."
+        }
+      },
+      "user": {
+        "title": "Set up VW Group Connect",
+        "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU and Porsche.",
+        "menu_options": {
+          "browser_login": "Browser-Login (recommended)",
+          "email_password": "Email + Password (legacy)"
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — choose your brand",
+        "description": "Pick the brand of the vehicle you want to connect. On the next screen you will see a short code and a URL to visit on any device with a browser.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        }
+      },
+      "browser_login_pending": {
+        "title": "Waiting for your browser approval",
+        "description": "1. Open **{verification_uri}** on any device.\n2. Sign in to your Brand ID account if asked.\n3. Confirm the code **{user_code}**.\n\nHome Assistant is polling — this page will advance automatically once you approve.",
+        "progress": {
+          "awaiting_browser_login": "Waiting for browser approval…"
+        }
       }
     },
     "error": {
@@ -61,7 +86,8 @@
       "email_two_factor_required": "Email 2FA required. Check your inbox (and spam) for a 6-digit code from VAG IDP, then sign in manually in the brand app once.",
       "too_many_requests": "Account temporarily suspended (too many login attempts). Please wait 15 minutes.",
       "invalid_credentials": "Email address or password incorrect.",
-      "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, NOT a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration."
+      "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, NOT a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration.",
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead."
     },
     "abort": {
       "already_configured": "This account is already configured.",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -71,10 +71,7 @@
       },
       "browser_login_pending": {
         "title": "Waiting for your browser approval",
-        "description": "1. Open **{verification_uri}** on any device.\n2. Sign in to your Brand ID account if asked.\n3. Confirm the code **{user_code}**.\n\nHome Assistant is polling — this page will advance automatically once you approve.",
-        "progress": {
-          "awaiting_browser_login": "Waiting for browser approval…"
-        }
+        "description": "1. Open **{verification_uri}** on any device.\n2. Sign in to your Brand ID account if asked.\n3. Confirm the code **{user_code}**.\n\nHome Assistant is polling — this page will advance automatically once you approve."
       }
     },
     "error": {
@@ -93,6 +90,9 @@
       "already_configured": "This account is already configured.",
       "reauth_successful": "Re-authentication successful.",
       "reconfigure_successful": "Configuration updated successfully."
+    },
+    "progress": {
+      "awaiting_browser_login": "Waiting for browser approval…"
     }
   },
   "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -31,12 +31,30 @@ class TestConfigFlowUser:
         from custom_components.vag_connect.config_flow import VagConnectConfigFlow
         return VagConnectConfigFlow
 
-    def test_flow_shows_form_when_no_input(self):
-        """Step user without input returns a form."""
+    def test_flow_user_step_shows_menu(self):
+        """v2.7.0b1 — async_step_user is now a menu (Browser-Login vs Email + Password)."""
         import asyncio
 
         hass = MagicMock()
-        hass.async_add_executor_job = AsyncMock()
+        flow = self._get_flow_class()()
+        flow.hass = hass
+        flow.context = {}
+        flow.handler = DOMAIN
+        flow.flow_id = "test"
+
+        result = asyncio.get_event_loop().run_until_complete(
+            flow.async_step_user(None)
+        )
+        assert result["type"] == "menu"
+        assert result["step_id"] == "user"
+        assert "browser_login" in result["menu_options"]
+        assert "email_password" in result["menu_options"]
+
+    def test_email_password_step_shows_form_when_no_input(self):
+        """The legacy credentials flow lives under async_step_email_password."""
+        import asyncio
+
+        hass = MagicMock()
         flow = self._get_flow_class()()
         flow.hass = hass
         flow.context = {}
@@ -46,31 +64,29 @@ class TestConfigFlowUser:
         flow._abort_if_unique_id_configured = MagicMock()
 
         result = asyncio.get_event_loop().run_until_complete(
-            flow.async_step_user(None)
+            flow.async_step_email_password(None)
         )
         assert result["type"] == "form"
-        assert result["step_id"] == "user"
+        assert result["step_id"] == "email_password"
 
     def test_duplicate_entry_aborts(self):
         """Entering same brand+username twice aborts with already_configured."""
         import asyncio
 
         hass = MagicMock()
-        hass.async_add_executor_job = AsyncMock()
         flow = self._get_flow_class()()
         flow.hass = hass
         flow.context = {}
         flow.handler = DOMAIN
         flow.flow_id = "test"
         flow.async_set_unique_id = AsyncMock()
-        # Simulate abort
         flow._abort_if_unique_id_configured = MagicMock(
             side_effect=Exception("already_configured")
         )
 
         with pytest.raises(Exception, match="already_configured"):
             asyncio.get_event_loop().run_until_complete(
-                flow.async_step_user({
+                flow.async_step_email_password({
                     CONF_BRAND: "audi",
                     "username": "test@test.de",
                     "password": "pw",
@@ -78,11 +94,10 @@ class TestConfigFlowUser:
             )
 
     def test_invalid_credentials_shows_error(self):
-        """Wrong credentials → form with error base:invalid_credentials."""
+        """Wrong credentials → email_password form with error base:invalid_credentials."""
         import asyncio
 
         hass = MagicMock()
-        hass.async_add_executor_job = AsyncMock(side_effect=ValueError("invalid_credentials"))
         flow = self._get_flow_class()()
         flow.hass = hass
         flow.context = {}
@@ -96,7 +111,7 @@ class TestConfigFlowUser:
             side_effect=ValueError("invalid_credentials"),
         ):
             result = asyncio.get_event_loop().run_until_complete(
-                flow.async_step_user({
+                flow.async_step_email_password({
                     CONF_BRAND: "audi",
                     "username": "test@test.de",
                     "password": "wrong",
@@ -106,10 +121,11 @@ class TestConfigFlowUser:
                 })
             )
         assert result["type"] == "form"
+        assert result["step_id"] == "email_password"
         assert result["errors"]["base"] == "invalid_credentials"
 
     def test_cannot_connect_shows_error(self):
-        """Connection failure → cannot_connect error."""
+        """Connection failure → cannot_connect error in email_password step."""
         import asyncio
 
         hass = MagicMock()
@@ -126,7 +142,7 @@ class TestConfigFlowUser:
             side_effect=ValueError("cannot_connect"),
         ):
             result = asyncio.get_event_loop().run_until_complete(
-                flow.async_step_user({
+                flow.async_step_email_password({
                     CONF_BRAND: "volkswagen",
                     "username": "t@t.de",
                     "password": "pw",
@@ -139,7 +155,7 @@ class TestConfigFlowUser:
         assert result["errors"]["base"] == "cannot_connect"
 
     def test_successful_setup_creates_entry(self):
-        """Valid credentials → creates config entry with correct data."""
+        """Valid credentials → creates config entry with correct data via email_password step."""
         import asyncio
 
         hass = MagicMock()
@@ -157,7 +173,7 @@ class TestConfigFlowUser:
         ):
             with patch.object(flow, "async_create_entry", return_value={"type": "create_entry", "data": {}}) as mock_create:
                 asyncio.get_event_loop().run_until_complete(
-                    flow.async_step_user({
+                    flow.async_step_email_password({
                         CONF_BRAND: "audi",
                         "username": "user@audi.de",
                         "password": "secret",

--- a/tests/test_v2511_auth_hardening.py
+++ b/tests/test_v2511_auth_hardening.py
@@ -67,22 +67,31 @@ class TestCariadTokenHeaders:
     """``_cariad_token_headers()`` accepts ``android_package_name``."""
 
     def test_header_uses_param(self) -> None:
+        """v2.7.0b2: android_package_name only transmitted when
+        include_assertion=True. Default 5-header set omits the assertion
+        trio entirely."""
         from custom_components.vag_connect.cariad.auth.idk import (
             _cariad_token_headers,
         )
         headers = _cariad_token_headers(
             "test-ua",
             android_package_name="com.example.testbrand",
+            include_assertion=True,
         )
         assert headers["x-android-package-name"] == "com.example.testbrand"
 
     def test_default_remains_audi_for_back_compat(self) -> None:
-        """Unparameterised callers (none in prod after v2.5.11) keep working."""
+        """v2.7.0b2 — default flipped to 5-header set (audi_connect_ha
+        parity). x-android-package-name is no longer in the default
+        output. Opt-in via include_assertion=True."""
         from custom_components.vag_connect.cariad.auth.idk import (
             _cariad_token_headers,
         )
         headers = _cariad_token_headers("test-ua")
-        assert headers["x-android-package-name"] == "de.myaudi.mobile.assistant"
+        assert "x-android-package-name" not in headers
+        # When opted-in, the Audi-default value still applies
+        headers_opt = _cariad_token_headers("test-ua", include_assertion=True)
+        assert headers_opt["x-android-package-name"] == "de.myaudi.mobile.assistant"
 
 
 # ── PATCH 2 — Audi market-config dynamic discovery ─────────────────────────

--- a/tests/test_v254_vw_azure_waf_migration.py
+++ b/tests/test_v254_vw_azure_waf_migration.py
@@ -102,15 +102,31 @@ class TestQMAuthSigning:
 
 
 class TestCariadTokenHeaders:
-    """v2.5.4 (#313) — The CARIAD BFF token endpoint validates the
-    8-header set on every request. All 8 must be present, otherwise
-    the Azure WAF returns 403 or the gateway returns invalid-assertion."""
+    """v2.5.4 introduced the 8-header set as defensive 'mimic the
+    official app' superset. v2.7.0b2 flipped the default to the
+    5-header set (audi_connect_ha parity) after VW backend started
+    validating the dummy x-assertion='0' value. The assertion trio
+    is still accessible via include_assertion=True for debugging."""
 
-    def test_all_eight_headers_present(self) -> None:
+    def test_default_is_five_header_set(self) -> None:
+        """v2.7.0b2 — default omits assertion trio."""
         from custom_components.vag_connect.cariad.auth.idk import (
             _cariad_token_headers,
         )
         h = _cariad_token_headers(user_agent="ua/test")
+        expected = {
+            "Content-Type", "Accept", "Accept-Charset", "User-Agent", "x-qmauth",
+        }
+        assert set(h.keys()) == expected
+
+    def test_all_eight_headers_present_when_opted_in(self) -> None:
+        """When the caller passes include_assertion=True the full
+        v2.5.4 8-header superset is still produced — useful for
+        debugging if VW ever flips the assertion validation back off."""
+        from custom_components.vag_connect.cariad.auth.idk import (
+            _cariad_token_headers,
+        )
+        h = _cariad_token_headers(user_agent="ua/test", include_assertion=True)
         expected = {
             "Content-Type", "Accept", "Accept-Charset", "User-Agent",
             "x-qmauth", "x-platform", "x-android-package-name", "x-assertion",
@@ -121,13 +137,16 @@ class TestCariadTokenHeaders:
         from custom_components.vag_connect.cariad.auth.idk import (
             _cariad_token_headers,
         )
+        # Default 5-header set
         h = _cariad_token_headers(user_agent="ua/test")
         assert h["Content-Type"] == "application/x-www-form-urlencoded"
         assert h["Accept"] == "application/json"
         assert h["Accept-Charset"] == "utf-8"
-        assert h["x-platform"] == "android"
-        assert h["x-android-package-name"] == "de.myaudi.mobile.assistant"
-        assert h["x-assertion"] == "0"
+        # Opted-in 8-header superset
+        h_opt = _cariad_token_headers(user_agent="ua/test", include_assertion=True)
+        assert h_opt["x-platform"] == "android"
+        assert h_opt["x-android-package-name"] == "de.myaudi.mobile.assistant"
+        assert h_opt["x-assertion"] == "0"
 
     def test_user_agent_threaded_from_brand(self) -> None:
         from custom_components.vag_connect.cariad.auth.idk import (


### PR DESCRIPTION
## Summary

First beta of v2.7.0 — the UI integration of the OAuth Device Authorization Grant (RFC 8628) module shipped in v2.6.0. Browser-based, password-less, refresh-token-friendly login as a user-facing option in the config_flow.

## New flow

`async_step_user` is now a menu:

- **Browser-Login (recommended)** — for Audi/Škoda/SEAT/CUPRA. User picks brand → HA requests device_code → shows verification URL + 8-char code → user visits URL, signs in, approves → HA polls in background via `show_progress` → tokens land in the config_entry. No password stored in HA.
- **Email + Password (legacy)** — unchanged behaviour, just moved to its own step. Required for Volkswagen EU and Porsche (DAG client_ids not whitelisted by VW for those brands).

Brand routing per the live-probed `DAG_ENABLED_BRANDS = {audi, skoda, seat, cupra}` set.

## Architectural notes

- `_extract_user_id_from_id_token` decodes the OIDC `sub` claim (no signature verify — IDP-minted, we never trust a forged one) and uses it as the config_entry unique_id since DAG never sees the user's email.
- Coordinator bootstrap promotes `entry.data['dag_initial_tokens']` into the persistent TokenStorage on first run so the existing 401-refresh + persistence machinery picks them up unchanged.
- Translations: canonical `strings.json` + `de.json` + `en.json` updated. Other locales fall back until contributed.

## Beta — what to test

- [ ] Audi browser login end-to-end (open URL, sign in, approve, verify entry created)
- [ ] Same for Škoda, SEAT, CUPRA
- [ ] Existing email-password installs continue to work (no migration needed)
- [ ] VW EU + Porsche only see Email + Password option (menu hides Browser-Login for them via brand-filter on submit)
- [ ] HACS shows v2.7.0b1 as a prerelease (PEP 440 `b1` marker)
- [ ] After ~6 h, token-refresh path still works (DAG refresh_tokens should outlive hybrid_full's 2 h ceiling)

## Manifest

Bumped to `2.7.0b1` — HACS interprets PEP 440 `b1` as beta/prerelease.

## Test plan local

- [x] ruff + mypy strict pass on all changed files (pre-commit hook enforces)
- [x] strings.json + de/en JSON are valid
- [ ] CI green
- [ ] Manual install on a dev HA instance + Audi account smoke test