### PR TITLE
fix(v2.7.0b5): TIMESTAMP sensors parse ISO strings to tz-aware datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains daernsinstantfortress as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.0b5] — 2026-05-31 — "TIMESTAMP sensors fix (beta)"
+
+- subscription_expiry_at (and any other ISO-string sensors with TIMESTAMP device class) now parse to timezone-aware datetime in native_value. Pre-fix HA rejected the entity at add-time with 'str has no attribute tzinfo'.
+
 ## [2.7.0b4] — 2026-05-31 — "Menu + DAG progress UX fix (beta)"
 
 - Browser-Login / Email+Password menu now passes labels in the code instead of relying on the HA translation lookup — cures empty-chevron rendering when the integration is updated without an HA restart.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.0b4"
+  "version": "2.7.0b5"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1455,6 +1455,31 @@ class VagConnectSensor(VagConnectEntity, SensorEntity):
                 except ValueError:
                     return None
 
+        # v2.7.0b5 — TIMESTAMP sensors: API ships ISO-8601 strings (e.g.
+        # subscription_expiry_at returns "2026-06-16T22:34:00Z"). HA's
+        # SensorDeviceClass.TIMESTAMP requires a timezone-aware datetime
+        # object — feeding a str raises 'str has no attribute tzinfo'
+        # and rejects the entity at add-time. Convert here so brand
+        # parsers can stay loose (just hand through whatever the backend
+        # gives us). Trailing 'Z' is handled by replacing it with +00:00
+        # since datetime.fromisoformat predates RFC 3339 'Z' support on
+        # older Python (3.10 and below).
+        if (
+            self.entity_description.device_class == SensorDeviceClass.TIMESTAMP
+            and val is not None
+        ):
+            if isinstance(val, str):
+                from datetime import datetime, timezone  # noqa: PLC0415
+                try:
+                    parsed = datetime.fromisoformat(val.replace("Z", "+00:00"))
+                except ValueError:
+                    return None
+                # Defensive: ensure tz-aware. ISO strings without
+                # timezone are assumed UTC (the backend convention).
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                return parsed
+
         return val
 
 


### PR DESCRIPTION
## Summary
- Fixes 3 entity-add failures from user HA log: `sensor.*_abonnement_lauft_ab` rejected with `'str' object has no attribute 'tzinfo'`.
- Root cause: `subscription_expiry_at` (and any other ISO-string TIMESTAMP-class sensor) shipped the raw backend string. HA's `SensorDeviceClass.TIMESTAMP` requires a tz-aware `datetime`.
- Fix: `VagConnectSensor.native_value` now parses ISO 8601 strings to tz-aware `datetime` (UTC fallback when naive), mirroring the existing DATE branch.

## Test plan
- [x] `ruff check` clean
- [x] `mypy --strict` clean
- [x] Pre-commit hook (ruff + mypy + CHANGELOG version match) green
- [ ] Hassfest + HACS validate green on CI
- [ ] User confirms 3 errors disappear from HA log after upgrade