### PR TITLE
fix(v2.7.0b7): DAG Phase 2 — form-based URL display, drop show_progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,21 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains daernsinstantfortress as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.0b7] — 2026-05-31 — "DAG spinner-forever fix #3 — form-based URL display (beta)"
+
+- After b4 and b6 both failed to reliably surface the verification URL + user_code in the show_progress dialog (HA frontend cached the progress description per flow id and didn't always pick up `description_placeholders` even when the show_progress task and step_id changed), Phase 2 is now rendered as a normal config_flow form. Forms substitute placeholders via the standard text-rendering pipeline which works reliably.
+- New UX:
+  - URL + 6-digit code shown as plain markdown text — fully visible and copyable
+  - Submit button visible from the start
+  - User opens URL in their browser (any device), signs in, approves
+  - When done, clicks Submit
+  - Background poll task validates with VW backend
+  - If poll done + tokens → advance to entry creation
+  - If poll done + error → drop back to brand picker (retry)
+  - If user clicked Submit before approval was complete → re-renders form with a "still waiting for browser approval" hint
+- Trade-off vs show_progress: lost auto-advance (user has to click Submit once they've approved), but gained guaranteed visibility of the URL + code. Worth it.
+- Translation key added: `still_waiting_browser` (DE + EN).
+
 ## [2.7.0b6] — 2026-05-31 — "DAG spinner-forever fix #2 — split phases into distinct step_ids (beta)"
 
 - Browser-login progress dialog now reliably shows the verification URL + user_code after the device_code is acquired. The b4 attempt at a single-step two-phase flow ran into HA's frontend caching the progress description per step_id — when the same step_id returned a second `show_progress` with a different `progress_action` and new `description_placeholders`, the dialog often kept showing the first (empty) description and the spinner appeared to spin forever.

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -473,44 +473,71 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
     async def async_step_browser_login_approve(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
-        """v2.7.0b6 — Browser-login Phase 2: wait for user approval.
+        """v2.7.0b7 — Browser-login Phase 2: form-based URL display.
 
-        Polls /token while the user opens the verification URL in their
-        own browser, signs in to their Brand ID account, and approves
-        the device. HA shows the URL + user_code in the progress dialog
-        the whole time. When polling completes:
-          - success → advance to ``browser_login_finish``
-          - failure → drop back to brand picker so user can retry
+        Why a form instead of show_progress:
 
-        Reached only after Phase 1 (``browser_login_pending``) populated
-        ``_dag_verification_uri`` and ``_dag_user_code``.
+        Earlier betas (b4, b6) tried two-phase show_progress with
+        description_placeholders to surface the verification URL +
+        user_code. In practice the HA frontend kept showing a spinner
+        without the placeholder text on multiple installs — even
+        after a full HA restart. Root cause traced to HA's
+        progress-dialog rendering pipeline caching the description by
+        flow id and not always picking up placeholders from a
+        show_progress call that wasn't the first one in the flow.
+
+        Forms render the step description via the standard config_flow
+        text pipeline which substitutes ``description_placeholders``
+        reliably. Trading the auto-advance UX of show_progress for
+        bulletproof URL/code visibility is the right trade-off — the
+        user can see exactly what to do and gets immediate feedback
+        when they click submit.
+
+        Behaviour:
+          - First entry: kick off background poll task, show form with
+            URL + code as plain text, submit button visible.
+          - User opens URL in their browser, signs in, approves.
+          - User clicks submit:
+            - poll task done + tokens → advance to finish step
+            - poll task done + error → drop to brand picker (retry)
+            - poll task still running → re-show form with
+              ``still_waiting_browser`` error (user clicked too early).
         """
         # Defensive — should only be reached with Phase 1 state populated.
         if not self._dag_device_code:
-            return self.async_show_progress_done(next_step_id="browser_login")
+            return await self.async_step_browser_login()
 
-        # Kick off poll_for_tokens() on first entry
+        # Kick off poll_for_tokens() on first entry (idempotent)
         if self._dag_poll_task is None:
             self._dag_poll_task = self.hass.async_create_task(
                 self._do_poll_tokens()
             )
 
-        if not self._dag_poll_task.done():
-            return self.async_show_progress(
-                step_id="browser_login_approve",
-                progress_action="awaiting_browser_login",
-                progress_task=self._dag_poll_task,
-                description_placeholders={
-                    "verification_uri": self._dag_verification_uri,
-                    "user_code": self._dag_user_code,
-                },
-            )
+        errors: dict[str, str] = {}
 
-        # Poll done — advance to finish (success) or restart (failure)
-        next_step = (
-            "browser_login_finish" if self._dag_tokens else "browser_login"
+        if user_input is not None:
+            # User clicked "I've approved" — check poll state
+            if self._dag_poll_task.done():
+                if self._dag_tokens:
+                    return await self.async_step_browser_login_finish()
+                # Poll completed with error — reset state and route
+                # back to brand picker so user can retry.
+                self._dag_poll_task = None
+                self._dag_device_code = ""
+                return await self.async_step_browser_login()
+            # Clicked submit before poll completed — re-render with hint
+            errors["base"] = "still_waiting_browser"
+
+        return self.async_show_form(
+            step_id="browser_login_approve",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "verification_uri": self._dag_verification_uri,
+                "user_code": self._dag_user_code,
+            },
+            errors=errors,
+            last_step=False,
         )
-        return self.async_show_progress_done(next_step_id=next_step)
 
     async def _do_request_device_code(self) -> None:
         """v2.7.0b4 — Phase 1 of the DAG flow: get device_code.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.0b6"
+  "version": "2.7.0b7"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -80,8 +80,8 @@
         "description": "Asking the IDP for a one-time device code."
       },
       "browser_login_approve": {
-        "title": "Waiting for your browser approval",
-        "description": "1. Open **{verification_uri}** on any device.\n2. Sign in to your Brand ID account if asked.\n3. Confirm the code **{user_code}**.\n\nHome Assistant is polling — this page will advance automatically once you approve."
+        "title": "Approve in your browser",
+        "description": "**1. Open this URL on any device** (phone, laptop, anywhere with a browser):\n\n{verification_uri}\n\n**2. Sign in** to your Brand ID account if asked.\n\n**3. Confirm the code:** `{user_code}`\n\n**4. Once you've approved, click Submit below.**\n\nHome Assistant is polling in the background — clicking Submit confirms you're done. If you click before approval is complete you'll get a 'still waiting' hint and can click again."
       }
     },
     "error": {
@@ -94,7 +94,8 @@
       "too_many_requests": "Account temporarily suspended (too many login attempts). Please wait 15 minutes.",
       "invalid_credentials": "Email address or password incorrect.",
       "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, not a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration.",
-      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead."
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
     },
     "abort": {
       "already_configured": "This account is already configured.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -74,8 +74,8 @@
         "description": "Fordere einen Einmal-Code vom IDP an."
       },
       "browser_login_approve": {
-        "title": "Warte auf deine Browser-Bestätigung",
-        "description": "1. Öffne **{verification_uri}** auf einem beliebigen Gerät.\n2. Melde dich mit deinem Brand-ID-Konto an (falls noch nicht eingeloggt).\n3. Bestätige den Code **{user_code}**.\n\nHome Assistant pollt im Hintergrund — die Seite wechselt automatisch sobald du bestätigt hast."
+        "title": "Im Browser bestätigen",
+        "description": "**1. Öffne diese URL auf einem beliebigen Gerät** (Handy, Laptop, irgendwas mit Browser):\n\n{verification_uri}\n\n**2. Melde dich** mit deinem Brand-ID-Konto an (falls noch nicht eingeloggt).\n\n**3. Bestätige den Code:** `{user_code}`\n\n**4. Wenn du bestätigt hast, klick unten auf Senden / Submit.**\n\nHome Assistant pollt im Hintergrund — der Klick auf Senden bestätigt dass du fertig bist. Wenn du zu früh klickst kommt ein 'noch warten' Hinweis und du kannst nochmal klicken."
       }
     },
     "error": {
@@ -88,7 +88,8 @@
       "too_many_requests": "Account vorübergehend gesperrt (zu viele Anmeldeversuche). Bitte 15 Minuten warten.",
       "invalid_credentials": "E-Mail-Adresse oder Passwort falsch.",
       "upstream_unavailable": "VW-Backend vorübergehend nicht erreichbar. Das ist ein Server-Problem bei VW, KEIN Anmeldefehler. Bitte 5–15 Minuten warten und nochmal versuchen. Die Integration NICHT neu konfigurieren.",
-      "brand_not_dag_eligible": "Diese Marke unterstützt kein Browser-Login. Nutze stattdessen E-Mail + Passwort."
+      "brand_not_dag_eligible": "Diese Marke unterstützt kein Browser-Login. Nutze stattdessen E-Mail + Passwort.",
+      "still_waiting_browser": "Warte noch auf die Browser-Bestätigung. Öffne die URL oben, melde dich an, bestätige den Code und klick dann nochmal auf Senden."
     },
     "abort": {
       "already_configured": "Dieses Konto ist bereits eingerichtet.",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -74,8 +74,8 @@
         "description": "Asking the IDP for a one-time device code."
       },
       "browser_login_approve": {
-        "title": "Waiting for your browser approval",
-        "description": "1. Open **{verification_uri}** on any device.\n2. Sign in to your Brand ID account if asked.\n3. Confirm the code **{user_code}**.\n\nHome Assistant is polling — this page will advance automatically once you approve."
+        "title": "Approve in your browser",
+        "description": "**1. Open this URL on any device** (phone, laptop, anywhere with a browser):\n\n{verification_uri}\n\n**2. Sign in** to your Brand ID account if asked.\n\n**3. Confirm the code:** `{user_code}`\n\n**4. Once you've approved, click Submit below.**\n\nHome Assistant is polling in the background — clicking Submit confirms you're done. If you click before approval is complete you'll get a 'still waiting' hint and can click again."
       }
     },
     "error": {
@@ -88,7 +88,8 @@
       "too_many_requests": "Account temporarily suspended (too many login attempts). Please wait 15 minutes.",
       "invalid_credentials": "Email address or password incorrect.",
       "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, NOT a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration.",
-      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead."
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
     },
     "abort": {
       "already_configured": "This account is already configured.",


### PR DESCRIPTION
## Summary
- After b4 and b6 both failed to surface the verification URL + user_code reliably (HA frontend cached the progress-dialog description per flow id, ignored placeholders on later `show_progress` calls in the same flow), Phase 2 is now a normal config_flow form.
- Forms render `description_placeholders` deterministically via the standard text pipeline. URL + 6-digit code are shown as plain markdown text, fully visible and copyable.
- User opens URL, signs in, approves, clicks Submit. Background poll task validates with VW. If user clicks before approval is complete, the form re-renders with a "still waiting" hint.
- Trade-off: lost auto-advance. Gained guaranteed visibility. Worth it after 2 failed beta iterations.

## Test plan
- [x] Pre-commit hook (ruff + mypy strict + CHANGELOG version match) green
- [ ] CI green (Lint, Hassfest, HACS, Unit Tests)
- [ ] User confirms URL + code now visible in browser-login Phase 2 (no more spinner-only screen)