### PR TITLE
DAG: move URL and user_code into schema fields, add QR code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains daernsinstantfortress as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.0b9] - 2026-05-31
+
+### Changed
+- DAG browser-login Phase 2: URL and user_code now live inside the form schema as pre-filled fields, not just in the description. Description rendering kept failing on real installs (translation-loader miss or HA frontend quirk). Schema fields render reliably.
+- Added a QR code selector showing the verification URL. Scan with phone camera to open the login page in one tap.
+- Field labels chosen so the raw-key fallback ("verification_url", "user_code", "approved_in_browser") stays readable when translations miss.
+- Persistent notification and WARNING log line from b8 kept as belt-and-suspenders.
+
 ## [2.7.0b8] - 2026-05-31
 
 ### Fixed

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -16,6 +16,9 @@ from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
+    QrCodeSelector,
+    QrCodeSelectorConfig,
+    QrErrorCorrectionLevel,
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
@@ -545,14 +548,52 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             # Clicked submit before poll completed — re-render with hint
             errors["base"] = "still_waiting_browser"
 
-        # v2.7.0b8 — Non-empty schema. An empty vol.Schema({}) caused
-        # HA's frontend to render a form with no description on at
-        # least one user's install. A single optional boolean field
-        # gives the renderer something concrete to lay out and forces
-        # the description to render. The field's value is ignored;
-        # clicking Submit is what advances the flow.
+        # v2.7.0b9 — URL and user_code live INSIDE the form schema as
+        # pre-filled selector fields, not just in the description
+        # placeholders. Reason: on at least one real install the form
+        # description rendered empty (translation-loader miss or HA
+        # frontend quirk we still don't fully understand), but the
+        # schema fields rendered fine. Pushing the critical content
+        # into fields makes the URL and code visible no matter what
+        # happens to the description.
+        #
+        # Field shape:
+        #   - qr_code: QrCodeSelector renders the verification URL as
+        #     a scannable QR code. User points their phone camera at
+        #     the screen and gets to the login page in one tap.
+        #   - verification_url: TextSelector pre-filled with the URL.
+        #     User can copy-paste if they don't want to scan.
+        #   - user_code: TextSelector pre-filled with the 8-char code.
+        #     Copy-paste friendly.
+        #   - approved_in_browser: BooleanSelector. The actual submit
+        #     trigger. Defaults to True so the user just clicks Submit.
+        #
+        # Field NAMES are deliberately self-descriptive so the raw-key
+        # fallback ("verification_url", "user_code") is still readable
+        # if the translation lookup misses for any reason.
         confirm_schema = vol.Schema({
-            vol.Optional("approved", default=True): bool,
+            vol.Required(
+                "qr_code",
+                default=self._dag_verification_uri,
+            ): QrCodeSelector(
+                QrCodeSelectorConfig(
+                    data=self._dag_verification_uri,
+                    scale=6,
+                    error_correction_level=QrErrorCorrectionLevel.QUARTILE,
+                )
+            ),
+            vol.Optional(
+                "verification_url",
+                default=self._dag_verification_uri,
+            ): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
+            vol.Optional(
+                "user_code",
+                default=self._dag_user_code,
+            ): TextSelector(TextSelectorConfig()),
+            vol.Required(
+                "approved_in_browser",
+                default=True,
+            ): BooleanSelector(),
         })
 
         return self.async_show_form(

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.0b8"
+  "version": "2.7.0b9"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -81,7 +81,19 @@
       },
       "browser_login_approve": {
         "title": "Approve in your browser",
-        "description": "**1. Open this URL on any device** (phone, laptop, anywhere with a browser):\n\n{verification_uri}\n\n**2. Sign in** to your Brand ID account if asked.\n\n**3. Confirm the code:** `{user_code}`\n\n**4. Once you've approved, click Submit below.**\n\nHome Assistant is polling in the background — clicking Submit confirms you're done. If you click before approval is complete you'll get a 'still waiting' hint and can click again."
+        "description": "Scan the QR code with your phone, or open the URL on any device. Sign in to your Brand ID account if asked, confirm the code, then check the box below and click Submit.",
+        "data": {
+          "qr_code": "Scan with phone camera to open login page",
+          "verification_url": "Or open this URL in any browser",
+          "user_code": "Code to confirm in the browser",
+          "approved_in_browser": "I have approved in the browser"
+        },
+        "data_description": {
+          "qr_code": "Point your phone camera at the QR code. The login page opens in your phone browser pre-filled with the code below.",
+          "verification_url": "If you can't scan: copy this link, open it on any device, sign in to your Brand ID account.",
+          "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
+          "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
+        }
       }
     },
     "error": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -75,7 +75,19 @@
       },
       "browser_login_approve": {
         "title": "Im Browser bestätigen",
-        "description": "**1. Öffne diese URL auf einem beliebigen Gerät** (Handy, Laptop, irgendwas mit Browser):\n\n{verification_uri}\n\n**2. Melde dich** mit deinem Brand-ID-Konto an (falls noch nicht eingeloggt).\n\n**3. Bestätige den Code:** `{user_code}`\n\n**4. Wenn du bestätigt hast, klick unten auf Senden / Submit.**\n\nHome Assistant pollt im Hintergrund — der Klick auf Senden bestätigt dass du fertig bist. Wenn du zu früh klickst kommt ein 'noch warten' Hinweis und du kannst nochmal klicken."
+        "description": "Scanne den QR-Code mit dem Handy, oder öffne die URL auf einem beliebigen Gerät. Mit deinem Brand-ID-Konto anmelden (falls nötig), Code bestätigen, dann unten den Haken setzen und auf Senden klicken.",
+        "data": {
+          "qr_code": "Mit Handy-Kamera scannen um Login-Seite zu öffnen",
+          "verification_url": "Oder diese URL in einem beliebigen Browser öffnen",
+          "user_code": "Code zum Bestätigen im Browser",
+          "approved_in_browser": "Ich habe im Browser bestätigt"
+        },
+        "data_description": {
+          "qr_code": "Handy-Kamera auf den QR-Code halten. Die Login-Seite öffnet sich im Handy-Browser mit dem Code unten vorausgefüllt.",
+          "verification_url": "Falls Scannen nicht klappt: Link kopieren, auf irgendeinem Gerät öffnen, mit Brand-ID-Konto anmelden.",
+          "user_code": "Nach dem Anmelden diesen Code im Browser bestätigen um Home Assistant freizugeben.",
+          "approved_in_browser": "Haken gesetzt lassen. Erst auf Senden klicken nachdem du im Browser angemeldet und den Code bestätigt hast."
+        }
       }
     },
     "error": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -75,7 +75,19 @@
       },
       "browser_login_approve": {
         "title": "Approve in your browser",
-        "description": "**1. Open this URL on any device** (phone, laptop, anywhere with a browser):\n\n{verification_uri}\n\n**2. Sign in** to your Brand ID account if asked.\n\n**3. Confirm the code:** `{user_code}`\n\n**4. Once you've approved, click Submit below.**\n\nHome Assistant is polling in the background — clicking Submit confirms you're done. If you click before approval is complete you'll get a 'still waiting' hint and can click again."
+        "description": "Scan the QR code with your phone, or open the URL on any device. Sign in to your Brand ID account if asked, confirm the code, then check the box below and click Submit.",
+        "data": {
+          "qr_code": "Scan with phone camera to open login page",
+          "verification_url": "Or open this URL in any browser",
+          "user_code": "Code to confirm in the browser",
+          "approved_in_browser": "I have approved in the browser"
+        },
+        "data_description": {
+          "qr_code": "Point your phone camera at the QR code. The login page opens in your phone browser pre-filled with the code below.",
+          "verification_url": "If you can't scan: copy this link, open it on any device, sign in to your Brand ID account.",
+          "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
+          "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
+        }
       }
     },
     "error": {


### PR DESCRIPTION
User on b7 and b8 still saw the dialog body empty after picking a brand. b8's persistent_notification fallback fired correctly (URL surfaced in the HA log), but the dialog itself stayed visually broken and the user couldn't complete the OAuth without hunting through logs.

The schema fields render reliably on that install (the b8 confirm checkbox was visible). The description doesn't. So push the URL and user_code out of `description_placeholders` and into the schema as pre-filled selector fields:

- QrCodeSelector renders the verification URL as a scannable QR. Phone camera plus one tap opens the login page.
- TextSelector pre-filled with the URL for copy-paste fallback.
- TextSelector pre-filled with the 8-char user_code.
- BooleanSelector default True as the actual submit trigger.

Field names chosen for readable raw-key fallback when translations miss: `verification_url`, `user_code`, `approved_in_browser`.

b8 belt-and-suspenders kept: persistent notification on flow entry, WARNING log line with both values.
