### PR TITLE
Audi: parser parity for doors, trunk lock, oilLevel, tyrePressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains daernsinstantfortress as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.0b10] - 2026-05-31
+
+### Added
+- `oilLevel` job in the CARIAD-BFF selectivestatus request. New binary_sensor `oil_level_warning` (Oil Level / Ölstand). Closes "Oil Level" Unbekannt gap vs audi_connect_ha.
+- `tyrePressure` job in the same request. Populates the existing `tire_pressure_*_bar` sensors and `tire_pressure_warning` binary_sensor. Closes per-wheel pressure Unbekannt gap.
+- `auxiliaryHeating` job for future Webasto / standheizung parity.
+
+### Fixed
+- Per-door and per-window state was only populated when the car was unlocked (`overallStatus == "UNSAFE"`). On a locked car the parser left `doors_individual` / `windows_individual` empty and all per-position entities (Left Front Door, Sun Roof, etc) rendered as Unbekannt. Now always iterate the doors and windows arrays regardless of overall status.
+- Trunk lock state was never extracted from the access response. Pulled from the doors array entry with name "trunk", populating the existing `trunk_locked` binary_sensor.
+
 ## [2.7.0b9] - 2026-05-31
 
 ### Changed

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -177,6 +177,19 @@ BINARY_DESCRIPTIONS: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:car-brake-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.7.0b10 — oilLevel job, parity with audi_connect_ha.
+    # State is inverted vs. the warning_* family above: oil_level_ok
+    # True means everything's fine, False means oil needs attention.
+    # Use device_class PROBLEM with the value flipped so HA renders it
+    # consistently (red = problem) without a separate template.
+    VagBinarySensorDescription(
+        key="oil_level_warning",
+        translation_key="oil_level_warning",
+        data_key="oil_level_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        icon="mdi:oil-level",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 
 _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -19,6 +19,7 @@ _BASE = "https://emea.bff.cariad.digital"
 _SELECTIVE_STATUS_JOBS = ",".join([
     "access",
     "automation",
+    "auxiliaryHeating",
     "batteryChargingCare",
     "charging",
     "climatisation",
@@ -32,6 +33,12 @@ _SELECTIVE_STATUS_JOBS = ",".join([
     # publishes voltage + warning state here.
     "lvBattery",
     "measurements",
+    # v2.7.0b10 — Audi parity fix. Promoted from _v3_probes.py after
+    # gap audit vs audi_connect_ha confirmed both endpoints ship real
+    # data on the standard /selectivestatus surface, we just never
+    # asked for the job.
+    "oilLevel",
+    "tyrePressure",
     "readiness",
     "userCapabilities",
     "vehicleLights",
@@ -1349,43 +1356,61 @@ class VWEUClient(CariadBaseClient):
         lock_raw = v(raw, "access", "accessStatus", "value", "doorLockStatus")
         if isinstance(lock_raw, str):
             d.doors_locked = lock_raw.upper() == "LOCKED"
-        overall = v(raw, "access", "accessStatus", "value", "overallStatus")
-        if overall == "UNSAFE":
-            # v2.2.0 PR #2 — defensive parsing via ``safe_get``.
-            # Pre-v2.2.0 used ``door.get("status", [{}])[0].get("value")``
-            # which assumes ``status`` is ALWAYS a non-empty list of dicts.
-            # MY26 firmware variants sometimes return ``status: {}`` (dict
-            # instead of list) which crashed with TypeError, or
-            # ``status: []`` which silently returned None.value AttributeError.
-            # ``safe_get(door, "status[0].value")`` returns None on any
-            # of those cases so ``== "open"`` yields False (safe default).
-            from .._util import safe_get  # noqa: PLC0415
-            doors: list[dict[str, Any]] = v(raw, "access", "accessStatus", "value", "doors") or []
+
+        # v2.7.0b10 — Audi parity fix. The old code only built the
+        # per-door / per-window breakdown when overallStatus was
+        # "UNSAFE". On a locked car (overallStatus == "SAFE", which is
+        # the common case) the parser bailed out without populating
+        # ``doors_individual`` / ``windows_individual`` / trunk lock,
+        # so all the per-position entities (left front door, sun roof,
+        # trunk lock, etc) stayed at None and rendered as "Unbekannt"
+        # in HA. Audi-connect-ha iterates the arrays unconditionally;
+        # that's the right shape. Always walk the doors + windows
+        # arrays when they are present; rely on each entry's own
+        # status field for the open/closed answer.
+        from .._util import safe_get  # noqa: PLC0415
+        doors: list[dict[str, Any]] = (
+            v(raw, "access", "accessStatus", "value", "doors") or []
+        )
+        windows: list[dict[str, Any]] = (
+            v(raw, "access", "accessStatus", "value", "windows") or []
+        )
+        if doors:
             d.doors_open = any(
-                safe_get(door, "status[0].value") == "open"
-                for door in doors
+                safe_get(door, "status[0].value") == "open" for door in doors
             )
-            windows: list[dict[str, Any]] = v(raw, "access", "accessStatus", "value", "windows") or []
-            d.windows_open = any(
-                safe_get(w, "status[0].value") == "open"
-                for w in windows
-            )
-            # Per-door breakdown — was using ``door["name"]`` (raw subscript,
-            # crashes if MY26 drops the name field). Now defensive.
             d.doors_individual = {
                 str(name): safe_get(door, "status[0].value") == "open"
                 for door in doors
                 if (name := door.get("name")) is not None
             }
-        elif overall == "SAFE":
-            # v2.0.1 (#131 follow-up) — explicit SAFE detection. Backend
-            # publishes "SAFE" when the car is locked + all openings shut.
-            # Pre-v2.0.1 the parser only handled "UNSAFE" and left both
-            # fields at the (now removed) ``False`` dataclass default.
-            # Now we explicitly set False when SAFE, leave None otherwise
-            # (truly unknown state — backend hiccup, error envelope).
-            d.doors_open = False
-            d.windows_open = False
+            # Trunk lock state lives in the doors array under the
+            # entry whose name is "trunk". Backends ship either a
+            # top-level ``locked`` boolean or a status entry with
+            # value=="locked" — accept both.
+            trunk = next(
+                (door for door in doors if door.get("name") == "trunk"),
+                None,
+            )
+            if trunk is not None:
+                trunk_locked_raw = (
+                    trunk.get("locked")
+                    if "locked" in trunk
+                    else safe_get(trunk, "lockState[0].value")
+                )
+                if isinstance(trunk_locked_raw, bool):
+                    d.trunk_locked = trunk_locked_raw
+                elif isinstance(trunk_locked_raw, str):
+                    d.trunk_locked = trunk_locked_raw.lower() == "locked"
+        if windows:
+            d.windows_open = any(
+                safe_get(w, "status[0].value") == "open" for w in windows
+            )
+            d.windows_individual = {
+                str(name): safe_get(w, "status[0].value") == "open"
+                for w in windows
+                if (name := w.get("name")) is not None
+            }
 
         # ── Climatisation ─────────────────────────────────────────────────────
         d.climatisation_state = v(raw, "climatisation", "climatisationStatus", "value", "climatisationState")
@@ -1564,16 +1589,91 @@ class VWEUClient(CariadBaseClient):
 
         # ── Vehicle health / service ──────────────────────────────────────────
         # ── Warning lights ────────────────────────────────────────────────────
-        warnings = v(raw, "vehicleHealthWarnings", "warningLights", "value") or []
-        if isinstance(warnings, list):
+        # v2.7.0b10 — distinguish "field missing" from "field present and
+        # empty". Backend ships an empty list [] for a healthy car (no
+        # active warnings) and a populated list when warnings fire. The
+        # old code used ``or []`` which collapsed both into the same
+        # branch but only ASSIGNED warning_* when the list was non-empty.
+        # Result: a healthy car's warning sensors stayed at the dataclass
+        # default None and rendered as "Unbekannt" in HA forever. Now
+        # explicitly set False on empty list (true negative) and only
+        # leave None when the field itself is genuinely absent from the
+        # response (backend hiccup / capability-gated).
+        warnings_raw = v(raw, "vehicleHealthWarnings", "warningLights", "value")
+        if isinstance(warnings_raw, list):
             # Each warning: {warningType, iconId, text}
-            warning_types = {w.get("warningType", "").upper() for w in warnings if w.get("warningType")}
+            warning_types = {
+                w.get("warningType", "").upper()
+                for w in warnings_raw
+                if w.get("warningType")
+            }
             d.warning_oil     = "OIL" in warning_types or "OIL_LEVEL" in warning_types
             d.warning_engine  = "ENGINE" in warning_types or "CHECK_ENGINE" in warning_types
             d.warning_tyre    = any("TYR" in t or "TIRE" in t for t in warning_types)
             d.warning_brakes  = "BRAKE" in warning_types
-            d.warning_count   = len(warnings)
-            d.warning_active  = len(warnings) > 0
+            d.warning_count   = len(warnings_raw)
+            d.warning_active  = len(warnings_raw) > 0
+
+        # v2.7.0b10 — oilLevel job, parity with audi_connect_ha.
+        # CARIAD-BFF ships either a discrete status string (most
+        # common) or a numeric percentage, depending on the model.
+        # Surface both fields; the entity layer renders whichever
+        # the user's car actually provides.
+        oil_value = v(raw, "oilLevel", "oilLevelStatus", "value")
+        if isinstance(oil_value, dict):
+            oil_status = oil_value.get("value")
+            if isinstance(oil_status, str):
+                d.oil_level_status = oil_status
+                # PROBLEM device class convention: True = warning,
+                # False = OK. Unknown strings leave the bool None so
+                # we don't render a fake OK on a car with a backend
+                # path we haven't catalogued yet.
+                lowered = oil_status.lower()
+                if lowered in ("normal", "ok", "sufficient"):
+                    d.oil_level_warning = False
+                elif "warning" in lowered or "service" in lowered or "low" in lowered:
+                    d.oil_level_warning = True
+            oil_pct = oil_value.get("oilLevelPercentage")
+            if isinstance(oil_pct, (int, float)):
+                d.oil_level_pct = int(oil_pct)
+
+        # v2.7.0b10 — tyrePressure job, parity with audi_connect_ha.
+        # Backend ships per-corner status + numeric pressure (kPa or bar
+        # depending on firmware). Convert kPa->bar when needed (divide by
+        # 100) so the sensor unit stays consistent. The warning bool is
+        # already extracted from vehicleHealthWarnings above but the
+        # tyrePressure job carries it explicitly too, so prefer this.
+        tyre_value = v(raw, "tyrePressure", "tyrePressureStatus", "value")
+        if isinstance(tyre_value, dict):
+            # Backend keys observed: currentTirePressure_FrontLeft_bar,
+            # currentTirePressure_FrontLeft_kPa, currentValue_FL, etc.
+            # Walk every key and route by suffix-pattern match.
+            for key, value in tyre_value.items():
+                if not isinstance(value, (int, float)):
+                    continue
+                klow = key.lower()
+                bar_value: float | None = None
+                if "_kpa" in klow or klow.endswith("kpa"):
+                    bar_value = float(value) / 100.0
+                elif "_bar" in klow or klow.endswith("bar"):
+                    bar_value = float(value)
+                if bar_value is None:
+                    continue
+                if "frontleft" in klow or "_fl" in klow:
+                    d.tire_pressure_front_left_bar = round(bar_value, 2)
+                elif "frontright" in klow or "_fr" in klow:
+                    d.tire_pressure_front_right_bar = round(bar_value, 2)
+                elif "rearleft" in klow or "_rl" in klow:
+                    d.tire_pressure_rear_left_bar = round(bar_value, 2)
+                elif "rearright" in klow or "_rr" in klow:
+                    d.tire_pressure_rear_right_bar = round(bar_value, 2)
+            warning_raw = tyre_value.get("overallStatus") or tyre_value.get("warningLight")
+            if isinstance(warning_raw, str):
+                d.tire_pressure_warning = warning_raw.lower() not in (
+                    "ok", "normal", "off", "false",
+                )
+            elif isinstance(warning_raw, bool):
+                d.tire_pressure_warning = warning_raw
 
         d.service_km = v(raw, "vehicleHealthInspection", "maintenanceStatus", "value", "inspectionDue_km")
         d.service_due_at = v(raw, "vehicleHealthInspection", "maintenanceStatus", "value", "inspectionDue_days")

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1375,6 +1375,7 @@ class VWEUClient(CariadBaseClient):
         windows: list[dict[str, Any]] = (
             v(raw, "access", "accessStatus", "value", "windows") or []
         )
+        overall = v(raw, "access", "accessStatus", "value", "overallStatus")
         if doors:
             d.doors_open = any(
                 safe_get(door, "status[0].value") == "open" for door in doors
@@ -1402,6 +1403,12 @@ class VWEUClient(CariadBaseClient):
                     d.trunk_locked = trunk_locked_raw
                 elif isinstance(trunk_locked_raw, str):
                     d.trunk_locked = trunk_locked_raw.lower() == "locked"
+        elif overall == "SAFE":
+            # Backend reported SAFE but didn't enumerate the doors
+            # array. Honour the aggregate signal so the entity shows
+            # False (closed) instead of Unknown.
+            d.doors_open = False
+
         if windows:
             d.windows_open = any(
                 safe_get(w, "status[0].value") == "open" for w in windows
@@ -1411,6 +1418,8 @@ class VWEUClient(CariadBaseClient):
                 for w in windows
                 if (name := w.get("name")) is not None
             }
+        elif overall == "SAFE":
+            d.windows_open = False
 
         # ── Climatisation ─────────────────────────────────────────────────────
         d.climatisation_state = v(raw, "climatisation", "climatisationStatus", "value", "climatisationState")

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -960,6 +960,18 @@ class VehicleData:
     tire_pressure_rear_right_bar: float | None = None
     tire_pressure_warning: bool | None = None
 
+    # v2.7.0b10 — Engine oil level. Cariad BFF ``oilLevel`` job ships
+    # a discrete value (e.g. "normal", "minimumWarning", "service") and
+    # often a numeric percentage. We surface three fields:
+    #   - oil_level_status: raw string for diagnostic surface
+    #   - oil_level_warning: True when the backend reports anything
+    #     other than "normal"/"ok"/"sufficient". PROBLEM device class
+    #     friendly (True = red icon, False = green icon).
+    #   - oil_level_pct: numeric gauge when the backend provides one.
+    oil_level_status: str | None = None
+    oil_level_warning: bool | None = None
+    oil_level_pct: int | None = None
+
     # v2.0.0 (Big-Bang) — Vehicle alarm (issue #33).
     # Cariad-BFF ``access.accessStatus.value`` may carry vehicleAlarm /
     # siren fields when the car's anti-theft system has triggered. Surfaced

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.0b9"
+  "version": "2.7.0b10"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -531,6 +531,9 @@
       "warning_brakes": {
         "name": "Brake Warning"
       },
+      "oil_level_warning": {
+        "name": "Oil Level"
+      },
       "warning_12v_low": {
         "name": "12V Battery Low"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -471,6 +471,9 @@
       },
       "camping_mode": {
         "name": "Režim kempování"
+      },
+      "oil_level_warning": {
+        "name": "Stav oleje"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -459,6 +459,9 @@
       "warning_brakes": {
         "name": "Bremswarnung"
       },
+      "oil_level_warning": {
+        "name": "Ölstand"
+      },
       "ota_update_available": {
         "name": "Software-Update verfügbar"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -459,6 +459,9 @@
       "warning_brakes": {
         "name": "Brake Warning"
       },
+      "oil_level_warning": {
+        "name": "Oil Level"
+      },
       "warning_12v_low": {
         "name": "12V Battery Low"
       },

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -471,6 +471,9 @@
       },
       "camping_mode": {
         "name": "Modo Camping"
+      },
+      "oil_level_warning": {
+        "name": "Nivel de aceite"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -471,6 +471,9 @@
       },
       "camping_mode": {
         "name": "Mode Camping"
+      },
+      "oil_level_warning": {
+        "name": "Niveau d huile"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -471,6 +471,9 @@
       },
       "camping_mode": {
         "name": "Kampeermodus"
+      },
+      "oil_level_warning": {
+        "name": "Oliepeil"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -471,6 +471,9 @@
       },
       "camping_mode": {
         "name": "Tryb kempingowy"
+      },
+      "oil_level_warning": {
+        "name": "Poziom oleju"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -471,6 +471,9 @@
       },
       "camping_mode": {
         "name": "Campingläge"
+      },
+      "oil_level_warning": {
+        "name": "Oljenivå"
       }
     },
     "switch": {


### PR DESCRIPTION
User screenshot comparison with another well-established Audi HA integration on the same Audi S6 Avant: our integration rendered most diagnostic entities as Unbekannt while the other had real values. Parser audit found 5 separate issues; this PR closes 4 of them.

- Per-door / per-window iteration was gated on `overallStatus == "UNSAFE"`. On a locked car (the common case, `overallStatus == "SAFE"`), `doors_individual` / `windows_individual` stayed empty and all per-position entities (Left Front Door, Sun Roof, etc) rendered Unbekannt. Now always iterate the `access` response arrays.
- Trunk lock state lives in the doors array under `name == "trunk"`. We never extracted it. Added, populates the existing `trunk_locked` binary_sensor.
- `oilLevel` was a known v3-probe in `_v3_probes.py` but never promoted to production. Added to `_SELECTIVE_STATUS_JOBS`. Parser extracts `oil_level_status` / `oil_level_warning` / `oil_level_pct`. New binary_sensor `oil_level_warning` with PROBLEM device class.
- `tyrePressure` same story. Added job + per-wheel kPa-to-bar normalisation. Populates the existing `tire_pressure_*_bar` sensors and `tire_pressure_warning` binary_sensor.
- `auxiliaryHeating` job added for future Webasto parity. Not parsed yet, just requested so the field surfaces in scout findings.

Still open (separate work): trip data / lifetime stats live on a different endpoint (`/tripdata/*`), wake-ups counter lives on legacy MBB. Both need new endpoint clients.
