### PR TITLE
release: v2.7.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,25 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains upstream as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.0] - 2026-05-31
+
+### Added
+- Browser-Login (OAuth Device Authorization Grant) for Audi, Škoda, SEAT, CUPRA. Open a QR code on your phone, sign in to your Brand ID account, confirm a short code. No password stored in Home Assistant, real refresh_token from the IDP.
+- Trip statistics: `last_trip_*` and `lifetime_*` sensors populate from `/tripstatistics?type=shortTerm|longTerm`.
+- `warning_messages` sensor surfaces every backend warning the manufacturer app would show (Audi STO / towing-bracket alerts etc), not just the hardcoded oil/engine/brake/tyre family.
+- `oilLevel` and `tyrePressure` jobs added to the selectivestatus request. Populates `oil_level_warning` binary_sensor and the existing `tire_pressure_*_bar` sensors.
+
+### Fixed
+- Per-door, per-window, sun-roof, trunk-lock state now populate on locked cars (was only on unlocked).
+- Outside temperature parser tries multiple backend key variants for Audi MY24+ compatibility.
+- Window heating front/back parser tries multiple JSON shape variants.
+- `wake_count_today` defaults to 0 instead of Unknown.
+- TIMESTAMP sensors parse ISO 8601 strings to tz-aware datetime (cures entity-add failure on subscription_expiry_at).
+- Cross-language translation parity. All 8 supported languages now ship the full config_flow translation set (browser_login, browser_login_approve, menu_options, progress, errors).
+
+### Notes
+- If field labels in the config dialog render as raw keys (`brand`, `spin`, etc) after upgrade, do a hard browser refresh (Ctrl+Shift+R). Home Assistant caches translations client-side and may not pick up the new keys until the browser cache clears.
+
 ## [2.7.0b11] - 2026-05-31
 
 ### Added

--- a/README.cs.md
+++ b/README.cs.md
@@ -47,6 +47,19 @@
 
 ---
 
+
+## Co je nového v2.7.0
+
+**Browser-Login (heslo se neukládá do HA)**: Pro Audi, Škoda, SEAT a CUPRA je nyní k dispozici OAuth Device Authorization Grant. Naskenujte QR kód telefonem, přihlaste se ke svému Brand ID účtu, potvrďte krátký kód. Skutečný refresh_token, žádné dvouhodinové opětovné přihlašování.
+
+**Více dat na vůz**: Trip statistiky, hladina oleje, tlak v každé pneumatice, dveře/okna/střešní okno/kufr po pozicích, venkovní teplota MY24+, Webasto.
+
+**Všechna varování výrobce**: Nový senzor "Vehicle Warning Messages" zobrazuje každé varování z backendu.
+
+Kompletní [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+
+---
+
 ## ✨ v2.0.0 Big-Bang Highlights — also available in English
 
 > The detailed v2.0.0 highlights table + "What makes us unique" USP section

--- a/README.en.md
+++ b/README.en.md
@@ -47,6 +47,19 @@
 
 ---
 
+
+## What is new in v2.7.0
+
+**Browser-Login (no password stored in HA)**: For Audi, Škoda, SEAT and CUPRA, OAuth Device Authorization Grant is now wired. Scan a QR code with your phone, sign in to your Brand ID account, confirm a short code, done. Real refresh_token from the IDP, no two-hour re-login.
+
+**More data per car**: Trip statistics (lifetime distance, last trip), oil level, per-wheel tire pressure, per-position doors / windows / sunroof / trunk lock, outside temperature on MY24+, Webasto auxiliary heating.
+
+**Every manufacturer warning**: New "Vehicle Warning Messages" sensor surfaces every backend warning, including brand-specific ones like Audi STO or towing-bracket alerts.
+
+Full [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+
+---
+
 ## 🚗 What it does
 
 Connects Home Assistant **directly** to your vehicle cloud account (myAudi, We Connect ID, MyŠkoda, MyCupra, MySeat, My Porsche, MyVW). **No middleware, no Docker, no extra service** — log in with your app credentials, done.

--- a/README.es.md
+++ b/README.es.md
@@ -47,6 +47,19 @@
 
 ---
 
+
+## Novedades en v2.7.0
+
+**Inicio de sesión por navegador (sin contraseña en HA)**: Para Audi, Škoda, SEAT y CUPRA, OAuth Device Authorization Grant disponible. Escanea el QR con el móvil, inicia sesión con tu cuenta Brand ID, confirma un código corto. refresh_token real, sin re-login cada dos horas.
+
+**Más datos por coche**: Estadísticas de viaje, nivel de aceite, presión por neumático, puertas/ventanas/techo/maletero por posición, temperatura exterior MY24+, calefacción auxiliar.
+
+**Todas las alertas del fabricante**: Nuevo sensor "Vehicle Warning Messages" muestra cada alerta del backend.
+
+[CHANGELOG completo](CHANGELOG.md#270---2026-05-31).
+
+---
+
 ## ✨ v2.0.0 Big-Bang Highlights — also available in English
 
 > The detailed v2.0.0 highlights table + "What makes us unique" USP section

--- a/README.fr.md
+++ b/README.fr.md
@@ -47,6 +47,19 @@
 
 ---
 
+
+## Nouveautés v2.7.0
+
+**Connexion par navigateur (aucun mot de passe stocké dans HA)**: Pour Audi, Škoda, SEAT et CUPRA, OAuth Device Authorization Grant disponible. Scannez le QR avec le téléphone, connectez-vous à votre compte Brand ID, confirmez un code court. refresh_token réel, plus de re-connexion toutes les deux heures.
+
+**Plus de données par voiture**: Statistiques de trajet, niveau d huile, pression par pneu, portes/vitres/toit/coffre par position, température extérieure MY24+, chauffage auxiliaire.
+
+**Toutes les alertes constructeur**: Nouveau capteur "Vehicle Warning Messages" qui remonte chaque alerte du backend.
+
+[CHANGELOG complet](CHANGELOG.md#270---2026-05-31).
+
+---
+
 ## ✨ v2.0.0 Big-Bang Highlights — also available in English
 
 > The detailed v2.0.0 highlights table + "What makes us unique" USP section

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@
 
 ---
 
+
+## Was ist neu in v2.7.0
+
+**Browser-Login (kein Passwort in HA)**: Für Audi, Škoda, SEAT und CUPRA jetzt OAuth Device Authorization Grant. QR-Code mit dem Handy scannen, mit Brand-ID anmelden, Code bestätigen , fertig. Echtes refresh_token, keine zwei-Stunden-Re-Logins mehr.
+
+**Mehr Daten pro Auto**: Trip-Statistiken (Lebensdauer-Distanz, letzte Fahrt), Ölstand, Reifendruck pro Rad, Türen / Fenster / Sonnendach / Kofferraum pro Position, Außentemperatur auf MY24+, Webasto Standheizung.
+
+**Alle Hersteller-Warnungen**: Neuer "Fahrzeug-Warnungen" Sensor zeigt jedes Backend-Warning, auch markenspezifische wie Audi STO oder Anhängerkupplung-Alarm.
+
+Voll [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+
+---
+
 ## 🚗 Was es kann
 
 Verbindet Home Assistant **direkt** mit deinem Fahrzeug-Cloud-Account (myAudi, We Connect ID, MyŠkoda, MyCupra, MySeat, My Porsche, MyVW). **Keine Middleware, kein Docker, kein extra Dienst** — Anmeldung mit deinen App-Zugangsdaten, fertig.

--- a/README.nl.md
+++ b/README.nl.md
@@ -47,6 +47,19 @@
 
 ---
 
+
+## Wat is nieuw in v2.7.0
+
+**Browser-Login (geen wachtwoord in HA)**: Voor Audi, Škoda, SEAT en CUPRA werkt OAuth Device Authorization Grant. Scan een QR-code met je telefoon, log in bij je Brand ID-account, bevestig een korte code. Echte refresh_token, geen re-login elke twee uur.
+
+**Meer data per auto**: Trip-statistieken, oliepeil, bandenspanning per wiel, deuren/ramen/dak/kofferbak per positie, buitentemperatuur MY24+, hulpverwarming.
+
+**Alle fabrikantswaarschuwingen**: Nieuwe sensor "Vehicle Warning Messages" toont elke waarschuwing van de backend.
+
+Volledige [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+
+---
+
 ## ✨ v2.0.0 Big-Bang Highlights — also available in English
 
 > The detailed v2.0.0 highlights table + "What makes us unique" USP section

--- a/README.pl.md
+++ b/README.pl.md
@@ -47,6 +47,19 @@
 
 ---
 
+
+## Co nowego w v2.7.0
+
+**Logowanie przez przeglądarkę (bez hasła w HA)**: Dla Audi, Škoda, SEAT i CUPRA dostępne OAuth Device Authorization Grant. Zeskanuj kod QR telefonem, zaloguj się do konta Brand ID, potwierdź krótki kod. Prawdziwy refresh_token, brak re-loginu co dwie godziny.
+
+**Więcej danych z samochodu**: Statystyki podróży, poziom oleju, ciśnienie w każdej oponie, drzwi/okna/szyberdach/bagażnik per pozycja, temperatura zewnętrzna MY24+, ogrzewanie postojowe.
+
+**Wszystkie ostrzeżenia producenta**: Nowy sensor "Vehicle Warning Messages" pokazuje każde ostrzeżenie z backendu.
+
+Pełny [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+
+---
+
 ## ✨ v2.0.0 Big-Bang Highlights — also available in English
 
 > The detailed v2.0.0 highlights table + "What makes us unique" USP section

--- a/README.sv.md
+++ b/README.sv.md
@@ -47,6 +47,19 @@
 
 ---
 
+
+## Nytt i v2.7.0
+
+**Browser-inloggning (inget lösenord lagras i HA)**: För Audi, Škoda, SEAT och CUPRA finns OAuth Device Authorization Grant. Skanna en QR-kod med telefonen, logga in med ditt Brand ID-konto, bekräfta en kort kod. Riktig refresh_token, ingen re-inloggning varannan timme.
+
+**Mer data per bil**: Resstatistik, oljenivå, däcktryck per hjul, dörrar/fönster/soltak/baklucka per position, utomhustemperatur MY24+, motorvärmare.
+
+**Alla tillverkarvarningar**: Ny sensor "Vehicle Warning Messages" visar varje varning från backend.
+
+Fullständig [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+
+---
+
 ## ✨ v2.0.0 Big-Bang Highlights — also available in English
 
 > The detailed v2.0.0 highlights table + "What makes us unique" USP section

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.0b11"
+  "version": "2.7.0"
 }

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -19,6 +19,10 @@
           "spin": "Vyžadováno pouze pro zamykání. App → Zabezpečení → S-PIN.",
           "scan_interval": "Jak často se stahují data. Výchozí: 5 min. Minimum: 3 min.",
           "force_enable_access": "Pro starší vozidla, která nesplňují kontrolu schopností."
+        },
+        "menu_options": {
+          "browser_login": "Browser-Login (recommended)",
+          "email_password": "Email + Password (legacy)"
         }
       },
       "reauth_confirm": {
@@ -50,6 +54,56 @@
         "data_description": {
           "mfa_code": "6místný kód — platný několik minut."
         }
+      },
+      "email_password": {
+        "title": "Sign in with email + password (legacy)",
+        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "username": "Email Address",
+          "password": "Password",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
+          "username": "Email address from the manufacturer app.",
+          "password": "Password from the app.",
+          "spin": "Only needed for locking. App → Security → S-PIN.",
+          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
+          "force_enable_access": "For older vehicles that fail the capability check."
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — choose your brand",
+        "description": "Pick the brand of the vehicle you want to connect. On the next screen you will see a short code and a URL to visit on any device with a browser.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        }
+      },
+      "browser_login_pending": {
+        "title": "Requesting login code…",
+        "description": "Asking the IDP for a one-time device code."
+      },
+      "browser_login_approve": {
+        "title": "Approve in your browser",
+        "description": "Scan the QR code with your phone, or open the URL on any device. Sign in to your Brand ID account if asked, confirm the code, then check the box below and click Submit.",
+        "data": {
+          "qr_code": "Scan with phone camera to open login page",
+          "verification_url": "Or open this URL in any browser",
+          "user_code": "Code to confirm in the browser",
+          "approved_in_browser": "I have approved in the browser"
+        },
+        "data_description": {
+          "qr_code": "Point your phone camera at the QR code. The login page opens in your phone browser pre-filled with the code below.",
+          "verification_url": "If you can't scan: copy this link, open it on any device, sign in to your Brand ID account.",
+          "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
+          "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
+        }
       }
     },
     "error": {
@@ -61,12 +115,18 @@
       "email_two_factor_required": "Vyžadováno e-mailové 2FA. Zkontrolujte schránku (i spam), pak se přihlaste ručně v aplikaci.",
       "too_many_requests": "Účet dočasně zablokován. Počkejte 15 minut.",
       "invalid_credentials": "Nesprávná e-mailová adresa nebo heslo.",
-      "upstream_unavailable": "Backend VW dočasně nedostupný. Toto je problém na straně serveru VW, NIKOLI chyba přihlášení. Počkejte 5–15 minut a zkuste to znovu. Integraci znovu NEKONFIGURUJTE."
+      "upstream_unavailable": "Backend VW dočasně nedostupný. Toto je problém na straně serveru VW, NIKOLI chyba přihlášení. Počkejte 5–15 minut a zkuste to znovu. Integraci znovu NEKONFIGURUJTE.",
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
     },
     "abort": {
       "already_configured": "Tento účet je již nastaven.",
       "reauth_successful": "Opětovné ověření bylo úspěšné.",
       "reconfigure_successful": "Konfigurace byla úspěšně aktualizována."
+    },
+    "progress": {
+      "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",
+      "requesting_device_code": "Requesting a one-time login code from the IDP…"
     }
   },
   "options": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -19,6 +19,10 @@
           "spin": "Solo necesario para bloqueo. App → Seguridad → S-PIN.",
           "scan_interval": "Frecuencia de actualización. Por defecto: 5 min. Mínimo: 3 min.",
           "force_enable_access": "Para vehículos antiguos que fallan la verificación de capacidades."
+        },
+        "menu_options": {
+          "browser_login": "Browser-Login (recommended)",
+          "email_password": "Email + Password (legacy)"
         }
       },
       "reauth_confirm": {
@@ -50,6 +54,56 @@
         "data_description": {
           "mfa_code": "Código de 6 dígitos — válido unos minutos."
         }
+      },
+      "email_password": {
+        "title": "Sign in with email + password (legacy)",
+        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "username": "Email Address",
+          "password": "Password",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
+          "username": "Email address from the manufacturer app.",
+          "password": "Password from the app.",
+          "spin": "Only needed for locking. App → Security → S-PIN.",
+          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
+          "force_enable_access": "For older vehicles that fail the capability check."
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — choose your brand",
+        "description": "Pick the brand of the vehicle you want to connect. On the next screen you will see a short code and a URL to visit on any device with a browser.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        }
+      },
+      "browser_login_pending": {
+        "title": "Requesting login code…",
+        "description": "Asking the IDP for a one-time device code."
+      },
+      "browser_login_approve": {
+        "title": "Approve in your browser",
+        "description": "Scan the QR code with your phone, or open the URL on any device. Sign in to your Brand ID account if asked, confirm the code, then check the box below and click Submit.",
+        "data": {
+          "qr_code": "Scan with phone camera to open login page",
+          "verification_url": "Or open this URL in any browser",
+          "user_code": "Code to confirm in the browser",
+          "approved_in_browser": "I have approved in the browser"
+        },
+        "data_description": {
+          "qr_code": "Point your phone camera at the QR code. The login page opens in your phone browser pre-filled with the code below.",
+          "verification_url": "If you can't scan: copy this link, open it on any device, sign in to your Brand ID account.",
+          "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
+          "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
+        }
       }
     },
     "error": {
@@ -61,12 +115,18 @@
       "email_two_factor_required": "Se requiere 2FA por email. Revisa tu bandeja de entrada (y spam) para un código de 6 dígitos, luego inicia sesión manualmente en la app.",
       "too_many_requests": "Cuenta suspendida temporalmente. Espera 15 minutos.",
       "invalid_credentials": "Correo electrónico o contraseña incorrectos.",
-      "upstream_unavailable": "Backend de VW temporalmente no disponible. Es un problema del servidor de VW, NO un problema de credenciales. Espera 5–15 minutos e inténtalo de nuevo. NO reconfigures la integración."
+      "upstream_unavailable": "Backend de VW temporalmente no disponible. Es un problema del servidor de VW, NO un problema de credenciales. Espera 5–15 minutos e inténtalo de nuevo. NO reconfigures la integración.",
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
     },
     "abort": {
       "already_configured": "Esta cuenta ya está configurada.",
       "reauth_successful": "Reautenticación exitosa.",
       "reconfigure_successful": "Configuración actualizada con éxito."
+    },
+    "progress": {
+      "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",
+      "requesting_device_code": "Requesting a one-time login code from the IDP…"
     }
   },
   "options": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -19,6 +19,10 @@
           "spin": "Requis uniquement pour le verrouillage. App → Sécurité → S-PIN.",
           "scan_interval": "Fréquence de mise à jour. Par défaut: 5 min. Minimum: 3 min.",
           "force_enable_access": "Pour les véhicules anciens qui échouent la vérification des capacités."
+        },
+        "menu_options": {
+          "browser_login": "Browser-Login (recommended)",
+          "email_password": "Email + Password (legacy)"
         }
       },
       "reauth_confirm": {
@@ -50,6 +54,56 @@
         "data_description": {
           "mfa_code": "Code à 6 chiffres — valide quelques minutes."
         }
+      },
+      "email_password": {
+        "title": "Sign in with email + password (legacy)",
+        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "username": "Email Address",
+          "password": "Password",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
+          "username": "Email address from the manufacturer app.",
+          "password": "Password from the app.",
+          "spin": "Only needed for locking. App → Security → S-PIN.",
+          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
+          "force_enable_access": "For older vehicles that fail the capability check."
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — choose your brand",
+        "description": "Pick the brand of the vehicle you want to connect. On the next screen you will see a short code and a URL to visit on any device with a browser.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        }
+      },
+      "browser_login_pending": {
+        "title": "Requesting login code…",
+        "description": "Asking the IDP for a one-time device code."
+      },
+      "browser_login_approve": {
+        "title": "Approve in your browser",
+        "description": "Scan the QR code with your phone, or open the URL on any device. Sign in to your Brand ID account if asked, confirm the code, then check the box below and click Submit.",
+        "data": {
+          "qr_code": "Scan with phone camera to open login page",
+          "verification_url": "Or open this URL in any browser",
+          "user_code": "Code to confirm in the browser",
+          "approved_in_browser": "I have approved in the browser"
+        },
+        "data_description": {
+          "qr_code": "Point your phone camera at the QR code. The login page opens in your phone browser pre-filled with the code below.",
+          "verification_url": "If you can't scan: copy this link, open it on any device, sign in to your Brand ID account.",
+          "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
+          "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
+        }
       }
     },
     "error": {
@@ -61,12 +115,18 @@
       "email_two_factor_required": "Authentification 2FA par e-mail requise. Vérifiez votre boîte de réception (et spam) pour un code à 6 chiffres, puis connectez-vous manuellement dans l'application.",
       "too_many_requests": "Compte suspendu temporairement. Attendez 15 minutes.",
       "invalid_credentials": "Adresse e-mail ou mot de passe incorrect.",
-      "upstream_unavailable": "Backend VW temporairement indisponible. C'est un problème côté serveur chez VW, PAS un problème d'identifiants. Veuillez patienter 5 à 15 minutes puis réessayer. NE reconfigurez PAS l'intégration."
+      "upstream_unavailable": "Backend VW temporairement indisponible. C'est un problème côté serveur chez VW, PAS un problème d'identifiants. Veuillez patienter 5 à 15 minutes puis réessayer. NE reconfigurez PAS l'intégration.",
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
     },
     "abort": {
       "already_configured": "Ce compte est déjà configuré.",
       "reauth_successful": "Ré-authentification réussie.",
       "reconfigure_successful": "Configuration mise à jour avec succès."
+    },
+    "progress": {
+      "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",
+      "requesting_device_code": "Requesting a one-time login code from the IDP…"
     }
   },
   "options": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -19,6 +19,10 @@
           "spin": "Alleen nodig voor vergrendeling. App → Beveiliging → S-PIN.",
           "scan_interval": "Hoe vaak gegevens worden opgehaald. Standaard: 5 min. Minimum: 3 min.",
           "force_enable_access": "Voor oudere voertuigen die de capabiliteitscheck niet doorstaan."
+        },
+        "menu_options": {
+          "browser_login": "Browser-Login (recommended)",
+          "email_password": "Email + Password (legacy)"
         }
       },
       "reauth_confirm": {
@@ -50,6 +54,56 @@
         "data_description": {
           "mfa_code": "6-cijferige code — geldig een paar minuten."
         }
+      },
+      "email_password": {
+        "title": "Sign in with email + password (legacy)",
+        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "username": "Email Address",
+          "password": "Password",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
+          "username": "Email address from the manufacturer app.",
+          "password": "Password from the app.",
+          "spin": "Only needed for locking. App → Security → S-PIN.",
+          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
+          "force_enable_access": "For older vehicles that fail the capability check."
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — choose your brand",
+        "description": "Pick the brand of the vehicle you want to connect. On the next screen you will see a short code and a URL to visit on any device with a browser.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        }
+      },
+      "browser_login_pending": {
+        "title": "Requesting login code…",
+        "description": "Asking the IDP for a one-time device code."
+      },
+      "browser_login_approve": {
+        "title": "Approve in your browser",
+        "description": "Scan the QR code with your phone, or open the URL on any device. Sign in to your Brand ID account if asked, confirm the code, then check the box below and click Submit.",
+        "data": {
+          "qr_code": "Scan with phone camera to open login page",
+          "verification_url": "Or open this URL in any browser",
+          "user_code": "Code to confirm in the browser",
+          "approved_in_browser": "I have approved in the browser"
+        },
+        "data_description": {
+          "qr_code": "Point your phone camera at the QR code. The login page opens in your phone browser pre-filled with the code below.",
+          "verification_url": "If you can't scan: copy this link, open it on any device, sign in to your Brand ID account.",
+          "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
+          "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
+        }
       }
     },
     "error": {
@@ -61,12 +115,18 @@
       "email_two_factor_required": "E-mail 2FA vereist. Controleer je inbox (en spam) op een 6-cijferige code, log dan handmatig in via de app.",
       "too_many_requests": "Account tijdelijk geblokkeerd. Wacht 15 minuten.",
       "invalid_credentials": "E-mailadres of wachtwoord onjuist.",
-      "upstream_unavailable": "VW backend tijdelijk onbereikbaar. Dit is een serverprobleem bij VW, GEEN inlogfout. Wacht 5–15 minuten en probeer opnieuw. Configureer de integratie NIET opnieuw."
+      "upstream_unavailable": "VW backend tijdelijk onbereikbaar. Dit is een serverprobleem bij VW, GEEN inlogfout. Wacht 5–15 minuten en probeer opnieuw. Configureer de integratie NIET opnieuw.",
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
     },
     "abort": {
       "already_configured": "Dit account is al geconfigureerd.",
       "reauth_successful": "Herauthenticatie geslaagd.",
       "reconfigure_successful": "Configuratie succesvol bijgewerkt."
+    },
+    "progress": {
+      "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",
+      "requesting_device_code": "Requesting a one-time login code from the IDP…"
     }
   },
   "options": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -19,6 +19,10 @@
           "spin": "Wymagany tylko do blokowania. App → Bezpieczeństwo → S-PIN.",
           "scan_interval": "Jak często pobierane są dane. Domyślnie: 5 min. Minimum: 3 min.",
           "force_enable_access": "Dla starszych pojazdów, które nie przechodzą sprawdzania możliwości."
+        },
+        "menu_options": {
+          "browser_login": "Browser-Login (recommended)",
+          "email_password": "Email + Password (legacy)"
         }
       },
       "reauth_confirm": {
@@ -50,6 +54,56 @@
         "data_description": {
           "mfa_code": "6-cyfrowy kod — ważny przez kilka minut."
         }
+      },
+      "email_password": {
+        "title": "Sign in with email + password (legacy)",
+        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "username": "Email Address",
+          "password": "Password",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
+          "username": "Email address from the manufacturer app.",
+          "password": "Password from the app.",
+          "spin": "Only needed for locking. App → Security → S-PIN.",
+          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
+          "force_enable_access": "For older vehicles that fail the capability check."
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — choose your brand",
+        "description": "Pick the brand of the vehicle you want to connect. On the next screen you will see a short code and a URL to visit on any device with a browser.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        }
+      },
+      "browser_login_pending": {
+        "title": "Requesting login code…",
+        "description": "Asking the IDP for a one-time device code."
+      },
+      "browser_login_approve": {
+        "title": "Approve in your browser",
+        "description": "Scan the QR code with your phone, or open the URL on any device. Sign in to your Brand ID account if asked, confirm the code, then check the box below and click Submit.",
+        "data": {
+          "qr_code": "Scan with phone camera to open login page",
+          "verification_url": "Or open this URL in any browser",
+          "user_code": "Code to confirm in the browser",
+          "approved_in_browser": "I have approved in the browser"
+        },
+        "data_description": {
+          "qr_code": "Point your phone camera at the QR code. The login page opens in your phone browser pre-filled with the code below.",
+          "verification_url": "If you can't scan: copy this link, open it on any device, sign in to your Brand ID account.",
+          "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
+          "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
+        }
       }
     },
     "error": {
@@ -61,12 +115,18 @@
       "email_two_factor_required": "Wymagane 2FA przez e-mail. Sprawdź skrzynkę (i spam) w poszukiwaniu 6-cyfrowego kodu, następnie zaloguj się ręcznie w aplikacji.",
       "too_many_requests": "Konto tymczasowo zablokowane. Poczekaj 15 minut.",
       "invalid_credentials": "Nieprawidłowy e-mail lub hasło.",
-      "upstream_unavailable": "Backend VW chwilowo niedostępny. To problem po stronie serwera VW, a NIE błąd uwierzytelniania. Poczekaj 5–15 minut i spróbuj ponownie. NIE konfiguruj integracji ponownie."
+      "upstream_unavailable": "Backend VW chwilowo niedostępny. To problem po stronie serwera VW, a NIE błąd uwierzytelniania. Poczekaj 5–15 minut i spróbuj ponownie. NIE konfiguruj integracji ponownie.",
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
     },
     "abort": {
       "already_configured": "To konto jest już skonfigurowane.",
       "reauth_successful": "Ponowne uwierzytelnianie zakończone sukcesem.",
       "reconfigure_successful": "Konfiguracja zaktualizowana pomyślnie."
+    },
+    "progress": {
+      "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",
+      "requesting_device_code": "Requesting a one-time login code from the IDP…"
     }
   },
   "options": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -19,6 +19,10 @@
           "spin": "Krävs endast för låsning. App → Säkerhet → S-PIN.",
           "scan_interval": "Hur ofta data hämtas. Standard: 5 min. Minimum: 3 min.",
           "force_enable_access": "För äldre fordon som inte klarar kapabilitetskontrollen."
+        },
+        "menu_options": {
+          "browser_login": "Browser-Login (recommended)",
+          "email_password": "Email + Password (legacy)"
         }
       },
       "reauth_confirm": {
@@ -50,6 +54,56 @@
         "data_description": {
           "mfa_code": "6-siffrig kod — giltig i några minuter."
         }
+      },
+      "email_password": {
+        "title": "Sign in with email + password (legacy)",
+        "description": "Connect your vehicle to Home Assistant.\n\nChoose your brand and enter the credentials from your manufacturer's app.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "username": "Email Address",
+          "password": "Password",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Choose your brand — myAudi, WeConnect ID, MyŠkoda, SEAT, CUPRA, VW US/CA or Porsche.",
+          "username": "Email address from the manufacturer app.",
+          "password": "Password from the app.",
+          "spin": "Only needed for locking. App → Security → S-PIN.",
+          "scan_interval": "How often data is fetched. Default: 5 min. Minimum: 3 min.",
+          "force_enable_access": "For older vehicles that fail the capability check."
+        }
+      },
+      "browser_login": {
+        "title": "Browser-Login — choose your brand",
+        "description": "Pick the brand of the vehicle you want to connect. On the next screen you will see a short code and a URL to visit on any device with a browser.",
+        "data": {
+          "brand": "Vehicle Brand",
+          "spin": "S-PIN",
+          "scan_interval": "Update Interval",
+          "force_enable_access": "Force Door Status"
+        }
+      },
+      "browser_login_pending": {
+        "title": "Requesting login code…",
+        "description": "Asking the IDP for a one-time device code."
+      },
+      "browser_login_approve": {
+        "title": "Approve in your browser",
+        "description": "Scan the QR code with your phone, or open the URL on any device. Sign in to your Brand ID account if asked, confirm the code, then check the box below and click Submit.",
+        "data": {
+          "qr_code": "Scan with phone camera to open login page",
+          "verification_url": "Or open this URL in any browser",
+          "user_code": "Code to confirm in the browser",
+          "approved_in_browser": "I have approved in the browser"
+        },
+        "data_description": {
+          "qr_code": "Point your phone camera at the QR code. The login page opens in your phone browser pre-filled with the code below.",
+          "verification_url": "If you can't scan: copy this link, open it on any device, sign in to your Brand ID account.",
+          "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
+          "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
+        }
       }
     },
     "error": {
@@ -61,12 +115,18 @@
       "email_two_factor_required": "E-post 2FA krävs. Kolla inkorgen (och skräp) efter en 6-siffrig kod, logga sedan in manuellt i appen.",
       "too_many_requests": "Kontot är tillfälligt spärrat. Vänta 15 minuter.",
       "invalid_credentials": "Felaktig e-postadress eller lösenord.",
-      "upstream_unavailable": "VW backend tillfälligt otillgänglig. Detta är ett serverproblem hos VW, INTE ett autentiseringsfel. Vänta 5–15 minuter och försök igen. Konfigurera INTE om integrationen."
+      "upstream_unavailable": "VW backend tillfälligt otillgänglig. Detta är ett serverproblem hos VW, INTE ett autentiseringsfel. Vänta 5–15 minuter och försök igen. Konfigurera INTE om integrationen.",
+      "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
     },
     "abort": {
       "already_configured": "Det här kontot är redan konfigurerat.",
       "reauth_successful": "Omautentisering lyckades.",
       "reconfigure_successful": "Konfigurationen uppdaterades."
+    },
+    "progress": {
+      "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",
+      "requesting_device_code": "Requesting a one-time login code from the IDP…"
     }
   },
   "options": {


### PR DESCRIPTION
Cuts v2.7.0 stable after eleven beta iterations. Headline features:

- Browser-Login (OAuth Device Authorization Grant) for Audi, Škoda, SEAT, CUPRA. QR-code scan plus short user_code, no password stored, real refresh_token from the IDP.
- Trip statistics endpoint wired. `last_trip_*` and `lifetime_*` sensors populate from `/tripstatistics?type=shortTerm|longTerm`.
- New `warning_messages` sensor surfaces every backend warning the manufacturer app would show, not just the hardcoded oil/engine/brake/tyre family.
- `oilLevel` and `tyrePressure` jobs added to selectivestatus. Populates `oil_level_warning` binary_sensor and the existing `tire_pressure_*_bar` sensors.
- Per-door, per-window, sun-roof, trunk-lock state now populates on locked cars.
- All 8 languages ship the full config_flow translation set (browser_login + browser_login_approve + menu_options + progress block + errors). The cs/es/fr/nl/pl/sv files previously missed the entire browser_login step which would surface as raw keys on those locales.
- READMEs updated in all 9 languages with a v2.7 news block at the top.

Known caveat: if field labels in the config dialog render as raw keys after upgrade, do a hard browser refresh (Ctrl+Shift+R). HA caches translations client-side.
