### PR TITLE
Scout: silence oilLevel + tyrePressure + auxiliaryHeating branches (v2.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains upstream as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.1] - 2026-05-31
+
+### Fixed
+- Vehicle Data Scout no longer auto-fires on `oilLevel` / `tyrePressure` / `auxiliaryHeating` branches we just promoted in v2.7.0. Closes scout-report issues #366 and #367.
+
 ## [2.7.0] - 2026-05-31
 
 ### Added

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -855,6 +855,28 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "vehicleHealthInspection.maintenanceStatus.value.*",
             "departureProfiles.departureProfilesStatus.value.*",
             "userCapabilities.capabilitiesStatus.value.*",
+            # v2.7.0 — oilLevel + tyrePressure + auxiliaryHeating jobs
+            # promoted to production in v2.7.0b10. Scout was firing on
+            # these freshly-arrived top-level branches (issues #366,
+            # #367) the moment the new job ran for the first time even
+            # though our parser already reads them. Silence the entire
+            # branch family.
+            "oilLevel",
+            "oilLevel.*",
+            "oilLevel.oilLevelStatus",
+            "oilLevel.oilLevelStatus.*",
+            "oilLevel.oilLevelStatus.value",
+            "oilLevel.oilLevelStatus.value.*",
+            "tyrePressure",
+            "tyrePressure.*",
+            "tyrePressure.tyrePressureStatus",
+            "tyrePressure.tyrePressureStatus.*",
+            "tyrePressure.tyrePressureStatus.value",
+            "tyrePressure.tyrePressureStatus.value.*",
+            "auxiliaryHeating",
+            "auxiliaryHeating.*",
+            "auxiliaryHeating.*.value",
+            "auxiliaryHeating.*.value.*",
             # batteryChargingCare + climatisationTimers .value children
             # (proactive — these top-level wrappers may have own .value
             # blocks on newer firmwares per #103/#104 pattern).

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.0"
+  "version": "2.7.1"
 }


### PR DESCRIPTION
closes #366
closes #367

v2.7.0 promoted `oilLevel`, `tyrePressure`, and `auxiliaryHeating` jobs to production but forgot the matching `EXPECTED_KEYS` silencer entries. First poll after upgrade trips the scout on these freshly-arrived branches even though the parser already reads them, generating an auto-issue per integration.

Adds wildcard silencers for the three top-level branches and their `.value` containers. No parser change.
