### PR TITLE
auth: catch non-AuthenticationError in resolver + redact coordinator log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains upstream as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.2] - 2026-05-31
+
+### Security
+- Coordinator setup-failure log no longer prints the raw exception message at ERROR level. An aiohttp `InvalidURL` raised on the OAuth callback path could surface the full redirect URL including `access_token`, `id_token`, and `code` JWTs, all of which base64-decode to the user's email and a working access token. Log type only at ERROR; message at DEBUG.
+
+### Fixed
+- Multi-strategy auth resolver in `base.py` now also catches non-`AuthenticationError` exceptions (e.g. `aiohttp.InvalidURL`), converts them to a clean `AuthenticationError`, and falls through to the next strategy. Prevents the raw URL from leaking up to the coordinator's catch-all.
+
 ## [2.7.1] - 2026-05-31
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -300,6 +300,26 @@ class CariadBaseClient:
                     "trying next strategy",
                     idx, kind, opts, self._brand.name, err,
                 )
+            except Exception as err:  # noqa: BLE001
+                # v2.7.2 — aiohttp.InvalidURL and similar low-level
+                # errors can carry tokens or full OAuth callback URLs
+                # in their __str__. Catch any non-AuthenticationError
+                # here, log the exception TYPE only (no PII), and
+                # convert to an AuthenticationError so downstream
+                # handlers see a clean error without the raw URL.
+                # Re-raise on the last strategy; otherwise fall through
+                # to the next one like AuthenticationError above.
+                last_err = err
+                _LOGGER.warning(
+                    "Auth strategy #%d (kind=%s opts=%s) raised %s for %s "
+                    "(message redacted to protect tokens)",
+                    idx, kind, opts, type(err).__name__, self._brand.name,
+                )
+                if idx == len(strategies) - 1:
+                    raise AuthenticationError(
+                        f"Auth failed with {type(err).__name__} "
+                        f"(no usable strategy left)"
+                    ) from err
 
     def set_persisted_tokens(self, tokens: TokenSet | None) -> None:
         """v1.19.2 (#118) — inject tokens loaded from HA storage at

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -662,7 +662,19 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         except AuthenticationError as err:
             raise ValueError("invalid_credentials") from err
         except Exception as err:  # noqa: BLE001
-            _LOGGER.error("VAG Connect setup failed: %s", err)
+            # v2.7.2 — never log the raw exception message at ERROR
+            # level. aiohttp.InvalidURL and similar carry the full
+            # request URL in __str__, which on the OAuth callback path
+            # is `weconnect://authenticated#access_token=<JWT>&id_token=
+            # <JWT>&code=<JWT>...`. Those JWTs base64-decode to the
+            # user's email and a working access token. Log type only at
+            # ERROR; route the message to DEBUG for triage.
+            _LOGGER.error(
+                "VAG Connect setup failed: %s "
+                "(message redacted, see DEBUG for details)",
+                type(err).__name__,
+            )
+            _LOGGER.debug("VAG Connect setup failed details: %s", err)
             return False
 
     def _trigger_reauth(self, reason: str) -> None:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.1"
+  "version": "2.7.2"
 }


### PR DESCRIPTION
A community report on #319 surfaced a coordinator log line that printed the full OAuth callback URL including the `access_token`, `id_token`, and `code` JWTs. The `id_token` base64-decodes to the user's email; the `access_token` is live for two hours. Posting it in a GitHub issue is a real PII / credential leak.

Root cause: `aiohttp.InvalidURL` propagated up from the redirect chain in `idk.py` when something tried to GET a non-http scheme URL (the `weconnect://` callback). `InvalidURL.__str__` returns the URL verbatim. The coordinator's catch-all logged it as `%s`.

Two-layer fix:

1. `base.py` authenticate() multi-strategy resolver: add a generic `Exception` catch alongside the `AuthenticationError` catch. Log the type only (no message) and convert to `AuthenticationError` before letting it escape. Same fallback semantics as before for `AuthenticationError`, just sanitised.
2. `coordinator.py:665` catch-all: log exception type at ERROR, route the full message to DEBUG. Even if a future exception carries PII in `__str__`, the public log shows only the type.
