### PR TITLE
Data Act portal: detect EU consent wall when password form is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains upstream as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.3] - 2026-05-31
+
+### Changed
+- Data Act portal auth: when the password form is missing in the response, scan the returned HTML for EU Data Act consent signals (`data act`, `consent`, `einwilligung`, `zustimmung`, `shape the future`, `datenverarbeitung`) before falling back to the generic credentials-rejected message. Surfaces a clearer instruction for users who hit the consent wall on `myvolkswagen.*` (issue #372).
+
 ## [2.7.2] - 2026-05-31
 
 ### Security

--- a/custom_components/vag_connect/cariad/auth/_data_act_portal.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_portal.py
@@ -280,9 +280,39 @@ class DataActPortalAuth:
         pw_parser = _IdentifierFormParser()
         pw_parser.feed(password_html)
         if not pw_parser.form_action:
+            # v2.7.3 — when the password form is missing, the most common
+            # real-world cause (as reported by VW EU users on issue #372)
+            # is that VW interjected the EU Data Act consent screen
+            # between the identifier step and the password step. The
+            # user has to grant the "your vehicle data can help shape
+            # the future" consent on myvolkswagen.* once before the
+            # password page becomes reachable again. Detect this case
+            # via a light HTML signature scan and raise with a clearer
+            # message so config_flow can route to the data_act_consent
+            # error key instead of the generic invalid_credentials.
+            html_lower = password_html.lower()
+            consent_signals = (
+                "data act",
+                "datenverarbeitung",
+                "consent",
+                "einwilligung",
+                "zustimmung",
+                "shape the future",
+            )
+            if any(sig in html_lower for sig in consent_signals):
+                raise AuthenticationError(
+                    "Data Act portal: EU Data Act consent required. "
+                    "Sign in once on myvolkswagen.<your-country-tld> "
+                    "in a browser, accept the data-processing consent "
+                    "banner, then retry the integration setup."
+                )
             raise AuthenticationError(
-                "Data Act portal: password form missing — credentials "
-                "may have been rejected at identifier step"
+                "Data Act portal: password form missing. Most common "
+                "cause: VW asked you to grant EU Data Act consent on "
+                "the brand website and the integration cannot bypass "
+                "that step. Sign in on myvolkswagen.* and accept the "
+                "consent banner, then retry. Other possible cause: "
+                "the email address was rejected at the identifier step."
             )
         password_action_url = (
             pw_parser.form_action

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.2"
+  "version": "2.7.3"
 }


### PR DESCRIPTION
closes #372

A user on VW EU hit a confusing dead-end: VW had injected the EU Data Act consent banner on `myvolkswagen.<tld>` between the identifier step and the password step. Our portal flow saw no password form in the response HTML and raised the generic "credentials may have been rejected at identifier step" message, which sent them down the wrong diagnostic path (re-checking the password). They figured it out only by chance after dismissing other VW dialogs on the website and noticing the consent banner.

When the password form is absent, scan the HTML for consent-related signal strings (`data act`, `consent`, `einwilligung`, `zustimmung`, `shape the future`, `datenverarbeitung`) and raise with explicit instructions to grant the consent on the brand website before retrying. If no signal matches, the generic fallback message still leads with the consent hypothesis (it is the most common cause in field reports today) and keeps the rejected-email hint as a secondary cause.

No code path change beyond the error-message wording.
