### PR TITLE
Scout: silence .error.* envelope on promoted v2.7.0 jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - OLA watcher gains upstream as 3rd consensus source
 - App Atlas covers all 7 brands
 
+## [2.7.4] - 2026-05-31
+
+### Fixed
+- Scout no longer auto-fires on the 6-key `.error.*` envelope the Cariad BFF returns when `oilLevel` / `tyrePressure` / `auxiliaryHeating` jobs hit a 5xx upstream. v2.7.1 silenced the parent path but the single-level `.*` wildcard did not cover the 4-component child paths. Closes #371 and #373.
+
 ## [2.7.3] - 2026-05-31
 
 ### Changed

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -877,6 +877,23 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "auxiliaryHeating.*",
             "auxiliaryHeating.*.value",
             "auxiliaryHeating.*.value.*",
+            # v2.7.4 — when these jobs return 5xx the Cariad BFF wraps
+            # the response in a ``.error`` envelope with 6 sub-keys
+            # (message, errorTimeStamp, info, code, group, retry).
+            # The single-level ``.*`` wildcard above does not match
+            # the 4-component child paths, so Scout auto-opened issues
+            # #371 + #373 with the same six error sub-keys on a Bad
+            # Gateway response. Add 4-component wildcards explicitly.
+            "oilLevel.oilLevelStatus.error",
+            "oilLevel.oilLevelStatus.error.*",
+            "tyrePressure.tyrePressureStatus.error",
+            "tyrePressure.tyrePressureStatus.error.*",
+            "auxiliaryHeating.auxiliaryHeatingStatus",
+            "auxiliaryHeating.auxiliaryHeatingStatus.*",
+            "auxiliaryHeating.auxiliaryHeatingStatus.error",
+            "auxiliaryHeating.auxiliaryHeatingStatus.error.*",
+            "auxiliaryHeating.auxiliaryHeatingStatus.value",
+            "auxiliaryHeating.auxiliaryHeatingStatus.value.*",
             # batteryChargingCare + climatisationTimers .value children
             # (proactive — these top-level wrappers may have own .value
             # blocks on newer firmwares per #103/#104 pattern).

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.3"
+  "version": "2.7.4"
 }


### PR DESCRIPTION
closes #371
closes #373

v2.7.1 added `oilLevel.oilLevelStatus.*` to the EXPECTED_KEYS silencer. That is a single-level wildcard. When the Cariad BFF wraps the response in a `.error` envelope with six sub-keys (`message`, `errorTimeStamp`, `info`, `code`, `group`, `retry`) on a 5xx, the 4-component child paths (`oilLevel.oilLevelStatus.error.message`, etc) are NOT covered by the 3-component `.*` silencer and Scout auto-opens an issue every time a poll hits a Bad Gateway.

Adds 4-component `.error` + `.error.*` silencers for the three branches we promoted in v2.7.0b10 (oilLevel, tyrePressure, auxiliaryHeating). Also adds the inferred `auxiliaryHeating.auxiliaryHeatingStatus.{*,error,error.*,value,value.*}` paths preemptively since that response shape has not been field-tested yet.
