### PR TITLE
release: 2.8.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.8.0rc2] - 2026-06-01
+
+Two-way VW EU re-auth recovery + hotfix for the 2026-05-31 IDP markup migration that broke the Data Act portal fallback. Same feature set as 2.8.0rc1 plus the two fixes below.
+
 ### Fixed
 
 - VW EU re-auth after the 2h token expiry was crashing in the Data Act portal fallback because the IDP migrated the `hmac` and `_csrf` fields out of plain `<input type="hidden">` markup into a SPA-rendered JSON block. The portal-side form parser now mirrors the multi-fallback strategy already in `idk.py:_parse_csrf_robust` (HTMLParser, regex over hidden inputs, form-action regex, and JSON/script-block extraction), so a markup migration on either side fails loudly in the regression tests instead of in production. Reported in #378.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.8.0rc1"
+  "version": "2.8.0rc2"
 }


### PR DESCRIPTION
Hotfix RC for the 2026-05-31 IDP markup migration.

- Path A: Data Act portal form parser hardened against SPA shape (#378).
- Path B: hybrid_full opportunistically picks up refresh_token after the standard token endpoint loosened.

Bumps manifest 2.8.0rc1 -> 2.8.0rc2 and seals the CHANGELOG section. All CI checks already green on the underlying fix PR #380.

Tag flow: merge -> tag v2.8.0rc2 -> prerelease workflow.