### PR TITLE
release: v2.8.1 — close 11 OLA-field parser gaps (#306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-06-01
+
+Closes 11 SEAT/CUPRA OLA-field parser gaps surfaced via side-by-side comparison with the pycupra reference, after the v2.5.3 OLA v1/v5 fallback chain did not fix DanielBie's offline-Leon entity coverage (issue #306).
+
+### Added
+
+- 11 new sensors backed by OLA fields that the seat_cupra parser was not reading: `adblue_level_pct` (% tank level for diesel SCR, separate from the existing `adblue_range_km`), `cng_level_pct` + `cng_range_km` (CNG variants like Polo TGI, Mii Ecofuel, Leon TGI), `primary_engine_range_km` (PHEV / dual-fuel parity with the existing `secondary_engine_range_km`), `charging_preferred_mode` (user-selected mode mirror), `seat_heating` (any-seat-on aggregate), `parking_light`, `external_power` (charger is actually energising the cable, distinct from `plug_connected`), `battery_care` (preservation mode flag), `energy_flow` (any HV-battery exchange happening), `area_alarm` (geofence event). All entries phantom-protected via `_DATA_PRESENT_REQUIRED` so vehicles without the underlying field stay clean.
+- Translations for the 11 new entities mirrored across all 9 supported languages (DE + EN canonical, the other 7 carry the EN labels until per-language polish; cross-lang parity test pinned).
+
 ## [2.8.0] - 2026-06-01
 
 Stable cut of the v2.8.0 series. Promotes 2.8.0rc1 + 2.8.0rc2 from release-candidate to stable with no further code changes; the rc cycle ran under 24 hours and the only reported field issue (#378 from jwaeles) was fixed in rc2.

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -233,6 +233,54 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         icon="mdi:car-windshield",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.8.1 #306 — 6 P1 boolean OLA-field gaps surfaced via pycupra
+    # side-by-side. All brand-restricted at parser level (mostly OLA
+    # SEAT/CUPRA today); brands without the underlying field leave
+    # the entry None so the _DATA_PRESENT_REQUIRED gate hides it.
+    VagBinarySensorDescription(
+        key="seat_heating",
+        translation_key="seat_heating",
+        data_key="seat_heating",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:car-seat-heater",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagBinarySensorDescription(
+        key="parking_light",
+        translation_key="parking_light",
+        data_key="parking_light",
+        device_class=BinarySensorDeviceClass.LIGHT,
+        icon="mdi:car-parking-lights",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagBinarySensorDescription(
+        key="external_power",
+        translation_key="external_power",
+        data_key="external_power",
+        device_class=BinarySensorDeviceClass.POWER,
+        icon="mdi:power-plug",
+    ),
+    VagBinarySensorDescription(
+        key="battery_care",
+        translation_key="battery_care",
+        data_key="battery_care",
+        icon="mdi:battery-heart-variant",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagBinarySensorDescription(
+        key="energy_flow",
+        translation_key="energy_flow",
+        data_key="energy_flow",
+        device_class=BinarySensorDeviceClass.POWER,
+        icon="mdi:flash",
+    ),
+    VagBinarySensorDescription(
+        key="area_alarm",
+        translation_key="area_alarm",
+        data_key="area_alarm",
+        device_class=BinarySensorDeviceClass.SAFETY,
+        icon="mdi:map-marker-alert",
+    ),
     # v1.11.0 (#91 closure) — vehicle lights aggregate "any light on?".
     VagBinarySensorDescription(
         key="lights_on",
@@ -479,6 +527,15 @@ BINARY_DESCRIPTIONS = BINARY_DESCRIPTIONS + _NEW_BINARY
 
 # v1.11.0 — same phantom-entity-prevention pattern as sensor.py.
 _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
+    # v2.8.1 #306 — 6 P1 boolean OLA-field gap entries. SEAT/CUPRA OLA
+    # primarily; vehicles without the underlying field stay None so
+    # no phantom binary sensor surfaces.
+    "seat_heating",
+    "parking_light",
+    "external_power",
+    "battery_care",
+    "energy_flow",
+    "area_alarm",
     "lights_on",
     # v2.5.0 (#306 goncal Mii) — sunroof is option-dependent. Many cars
     # don't have a sunroof; parser leaves field None → no phantom entity.

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -379,6 +379,27 @@ class SeatCupraClient(CariadBaseClient):
             d.battery_soc = v(measurements, "batteryStatus", "value", "currentSOC_pct")
             d.has_battery = d.battery_soc is not None
 
+            # v2.8.1 #306 — user-selected preferred charging mode. The
+            # OLA backend mirrors the brand-app setting under
+            # ``mycar.services.charging.preferredChargeMode``. Known
+            # enum values: "manual", "preferredChargingTimes",
+            # "automaticUnlocked". Empty string means unset.
+            pref_mode = v(mycar, "services", "charging", "preferredChargeMode")
+            if isinstance(pref_mode, str) and pref_mode.strip():
+                d.charging_preferred_mode = pref_mode
+
+            # v2.8.1 #306 — area alarm event flag. Top-level
+            # ``mycar.areaAlarm`` carries an event payload when the
+            # vehicle has left a configured geofence. We expose the
+            # boolean presence here; coordinator-side timestamp decay
+            # to clear stale alarms after 15 minutes is in scope for
+            # v2.8.2 (the harness for event-decay is not yet wired).
+            area_alarm_block = v(mycar, "areaAlarm")
+            if isinstance(area_alarm_block, dict) and area_alarm_block:
+                d.area_alarm = True
+            elif area_alarm_block is not None:
+                d.area_alarm = False
+
             access = v(mycar, "access") or {}
             # v2.0.1 (#131 follow-up) — defensive parsing, see vw_eu.py
             # for the full rationale. Per-door + top-level fallbacks
@@ -533,6 +554,52 @@ class SeatCupraClient(CariadBaseClient):
                     )
                     if isinstance(tank_cap, (int, float)) and tank_cap > 0:
                         d.fuel_tank_capacity_liters = int(tank_cap)
+                    # v2.8.1 #306 — primary engine residual range. Mirror
+                    # of the secondary_engine_range_km field that has
+                    # existed since v1.26.0 / Scout #232. Same field-name
+                    # variants tried defensively.
+                    prim_range = (
+                        primary.get("range")
+                        or primary.get("rangeInKm")
+                        or primary.get("distanceInKm")
+                    )
+                    if isinstance(prim_range, (int, float)):
+                        d.primary_engine_range_km = int(prim_range)
+                    # v2.8.1 #306 — CNG tank level. Primary engine entry
+                    # carries levelPct for CNG vehicles (Mii Ecofuel,
+                    # Leon TGI). For PHEV-CNG dual-fuel the secondary
+                    # block carries it instead; the secondary branch
+                    # above already populated fuel_level_pct from the
+                    # same field if applicable.
+                    if (primary_type or "").lower() == "cng":
+                        level = primary.get("levelPct") or primary.get("level_pct")
+                        if isinstance(level, (int, float)):
+                            d.cng_level_pct = int(level)
+                        if isinstance(prim_range, (int, float)):
+                            d.cng_range_km = int(prim_range)
+                # v2.8.1 #306 — same CNG check on secondary block (some
+                # PHEV-CNG dual-fuel SEAT vehicles ship CNG on secondary).
+                secondary_check = v(engines, "secondary")
+                if isinstance(secondary_check, dict):
+                    sec_type_check = (
+                        secondary_check.get("fuelType")
+                        or secondary_check.get("engineType") or ""
+                    )
+                    if sec_type_check.lower() == "cng":
+                        sec_level = (
+                            secondary_check.get("levelPct")
+                            or secondary_check.get("level_pct")
+                            or secondary_check.get("fuelLevel_pct")
+                        )
+                        if isinstance(sec_level, (int, float)):
+                            d.cng_level_pct = int(sec_level)
+                        sec_range_check = (
+                            secondary_check.get("range")
+                            or secondary_check.get("rangeInKm")
+                            or secondary_check.get("distanceInKm")
+                        )
+                        if isinstance(sec_range_check, (int, float)):
+                            d.cng_range_km = int(sec_range_check)
 
         # ── Ranges ───────────────────────────────────────────────────────────
         # v2.5.3 (#306) — widened field-name coverage. PyCupra-style
@@ -598,6 +665,18 @@ class SeatCupraClient(CariadBaseClient):
             windows_obj = v(status, "windows") or {}
             trunk_obj = v(status, "trunk") or {}
             hood_obj = v(status, "hood") or {}
+
+            # v2.8.1 #306 — parking light flag. OLA exposes the top-level
+            # ``status.lights`` enum ("on" / "off") on Born + Mii firmware.
+            # Some newer firmware ships it under
+            # ``status.lights.parkingLightState`` instead.
+            lights_raw = v(status, "lights")
+            if isinstance(lights_raw, str):
+                d.parking_light = lights_raw.lower() == "on"
+            elif isinstance(lights_raw, dict):
+                pl_state = lights_raw.get("parkingLightState")
+                if isinstance(pl_state, str):
+                    d.parking_light = pl_state.lower() == "on"
 
             # Per-door (locked + open). Aggregate ``doors_open`` and
             # ``doors_locked`` are derived once we have the dict.
@@ -898,6 +977,41 @@ class SeatCupraClient(CariadBaseClient):
                     isinstance(ext_power, str) and ext_power.upper() == "READY"
                 )
 
+            # v2.8.1 #306 — external power availability bool. Distinct
+            # from ``plug_connected`` (cable present): this signals
+            # whether the wallbox / charger is actually feeding power
+            # through the cable. "available" = station is energising.
+            if isinstance(ext_power, str):
+                d.external_power = ext_power.lower() in (
+                    "available", "ready", "stationokay",
+                )
+
+            # v2.8.1 #306 — energy-flow direction. OLA exposes a
+            # composite ``charging.status.state`` enum (idle / charging /
+            # discharging / V2L_active / ...). Aggregate to a bool that
+            # answers "is the battery currently exchanging energy".
+            flow_state = v(chg, "state") or v(charge_status, "state")
+            if isinstance(flow_state, str):
+                d.energy_flow = flow_state.lower() in (
+                    "charging", "discharging", "v2l_active",
+                    "preconditioning",
+                )
+
+        # v2.8.1 #306 — battery-care mode flag. OLA ships this under
+        # /v1/charging/info under chargingCareSettings on Born MY24+
+        # firmware. Absent on older firmware where the value is always
+        # False, so default to None when the key is missing so the
+        # sensor's phantom gate hides it.
+        if isinstance(charge_info, dict):
+            care_block = (
+                v(charge_info, "chargingCareSettings")
+                or v(charge_info, "settings", "chargingCareSettings")
+            )
+            if isinstance(care_block, dict):
+                care_mode = care_block.get("batteryCareMode")
+                if isinstance(care_mode, bool):
+                    d.battery_care = care_mode
+
         # ── Charging info (settings) ─────────────────────────────────────────
         # OLA `/v2/vehicles/{vin}/charging/settings` field variance.
         # Real-world (Rainer #109): {"targetSoc_pct": 80, "maxChargeCurrentAC":
@@ -956,6 +1070,26 @@ class SeatCupraClient(CariadBaseClient):
                 d.outside_temp = round(outside - 273.15, 1)
             d.window_heating_front = v(cs, "windowHeatingStateFront") == "ON"
             d.window_heating_back = v(cs, "windowHeatingStateRear") == "ON"
+            # v2.8.1 #306 — seat heating overall aggregate. OLA ships
+            # ``airConditioning.seatHeatingSupport`` as a dict keyed by
+            # seat position (frontLeft, frontRight, ...). Any seat in
+            # ``"on"`` state flips the aggregate True.
+            seat_block = v(climate, "seatHeatingSupport") or v(cs, "seatHeatingStatus")
+            if isinstance(seat_block, dict):
+                for entry in seat_block.values():
+                    state = entry if isinstance(entry, str) else (
+                        entry.get("state") if isinstance(entry, dict) else None
+                    )
+                    if isinstance(state, str) and state.lower() == "on":
+                        d.seat_heating = True
+                        break
+                else:
+                    d.seat_heating = False
+            elif isinstance(seat_block, list):
+                d.seat_heating = any(
+                    isinstance(e, dict) and str(e.get("state", "")).lower() == "on"
+                    for e in seat_block
+                )
 
         # ── Parking ──────────────────────────────────────────────────────────
         # v2.0.0 (#53 follow-up to v1.27.1): defensive `data` envelope unwrap.
@@ -1027,6 +1161,18 @@ class SeatCupraClient(CariadBaseClient):
                 or v(maintenance, "oilServiceDueInDays")            # v2.5.3
                 or v(maintenance, "timeRemainingForOilService")     # v2.5.3
             )
+            # v2.8.1 #306 — AdBlue tank level (%). OLA ships this under
+            # an opaque code key on diesel vehicles with SCR. Field-name
+            # variants tried defensively since OLA has shipped both the
+            # human-readable ``adblueLevel`` and the legacy CARIAD-style
+            # ``0x02040C0001`` code key (per pycupra reference).
+            adblue_lvl = (
+                v(maintenance, "adblueLevel")
+                or v(maintenance, "adBlueLevel")
+                or v(maintenance, "0x02040C0001", "value")
+            )
+            if isinstance(adblue_lvl, (int, float)):
+                d.adblue_level_pct = int(adblue_lvl)
             # v2.8.0 quick win C — brake-service + preferred-workshop.
             # OLA exposes both on the same /maintenance response when
             # the dealer has wired up the vehicle's service plan.

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -582,6 +582,80 @@ class VehicleData:
     preferred_workshop_address: str | None = None
     preferred_workshop_phone: str | None = None
 
+    # v2.8.1 — 13 P1 sensor gaps observed during the goncal + DanielBie
+    # bug-report cycle on issue #306. The OLA backend ships these fields
+    # on /v5/mycar, /climater, /charging, /airConditioning, /maintenance
+    # and /status, but the seat_cupra parser never pulled them. The
+    # CARIAD-BFF equivalents exist for some (target temp, battery care,
+    # external power, primary range) so the audi.py / vw_eu.py parsers
+    # opt in where the field maps cleanly. Every field is None-default
+    # and phantom-protected in sensor.py via _DATA_PRESENT_REQUIRED.
+
+    # 1. Diesel AdBlue tank level (separate from adblue_range_km which
+    # estimates how far the existing AdBlue lasts). Some vehicles report
+    # level but not range and vice versa.
+    adblue_level_pct: int | None = None
+
+    # 2. CNG tank level (Polo TGI, Skoda Scala G-Tec, Seat Mii Ecofuel).
+    cng_level_pct: int | None = None
+
+    # 3. CNG remaining range in km — derived from the CNG-engine block
+    # on OLA mycar.engines.{primary,secondary} when type == "cng".
+    cng_range_km: int | None = None
+
+    # (4 + 5: dropped from this group during the v2.8.1 audit — the
+    # climate target temperature is already exposed via the existing
+    # ``target_temperature`` field; the rear-window heating element is
+    # already exposed via ``window_heating_back`` and surfaced as a
+    # binary sensor since v1.7.0. Numbering kept to match the pycupra
+    # gap-analysis dump on issue #306.)
+
+    # 6. Seat heating overall on/off — aggregate over all seats that
+    # report a seatHeatingSupport entry. Per-seat granular state stays
+    # in the diagnostics dump only.
+    seat_heating: bool | None = None
+
+    # 7. Parking lights status. Top-level ``status.lights`` flag on OLA;
+    # ``vehicleLights.parkingLightStatus.value.parkingLightState`` on
+    # CARIAD-BFF where the value carries more granularity than we
+    # currently expose.
+    parking_light: bool | None = None
+
+    # 8. EV: external power available (plugged into a station vs
+    # plugged but station not providing power). Distinct from
+    # ``plug_connected`` which is the physical cable presence.
+    external_power: bool | None = None
+
+    # 9. Battery-care mode on/off. When True the brand backend limits
+    # the battery to a preservation window (typically 80% top-end).
+    battery_care: bool | None = None
+
+    # 10. Energy-flow direction. True when current is actively flowing
+    # to or from the HV battery; useful as a fast "is the car drawing
+    # power right now" signal that survives across the charging /
+    # climatisation / V2L cases without needing three different
+    # underlying sensors.
+    energy_flow: bool | None = None
+
+    # 11. Primary-engine residual range in km. We had
+    # ``secondary_engine_range_km`` since v1.26.0 but no primary.
+    # Mirror so PHEV / dual-fuel vehicles have both halves of the
+    # range pair.
+    primary_engine_range_km: int | None = None
+
+    # 12. User-selected preferred charging mode ("manual",
+    # "preferredChargingTimes", "automaticUnlocked", ...). Read-only
+    # surface of the brand-app setting; useful as a context attribute
+    # for charge-target automations.
+    charging_preferred_mode: str | None = None
+
+    # 13. Area alarm event flag. The OLA backend ships a top-level
+    # ``areaAlarm`` block when the vehicle leaves a configured
+    # geofence. Coordinator decays the flag after 15 minutes so a
+    # one-shot alarm does not stick forever. Useful as an event
+    # trigger for "where is my car" automations.
+    area_alarm: bool | None = None
+
     # v1.19.1 — Pycupra-style API quota visibility. Populated from
     # X-RateLimit-Remaining response header captured by base.py
     # ``_capture_rate_limit_headers``. Brand-shared (the same auth

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.8.0"
+  "version": "2.8.1"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1176,6 +1176,56 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:phone",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.8.1 #306 — 5 P1 numeric/string OLA-field gaps surfaced via
+    # pycupra side-by-side. The 6 boolean fields in this set
+    # (parking_light, seat_heating, external_power, battery_care,
+    # energy_flow, area_alarm) are wired in binary_sensor.py.
+    VagSensorDescription(
+        key="adblue_level_pct",
+        translation_key="adblue_level_pct",
+        data_key="adblue_level_pct",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:fuel",
+        suggested_display_precision=0,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="cng_level_pct",
+        translation_key="cng_level_pct",
+        data_key="cng_level_pct",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:gas-cylinder",
+        suggested_display_precision=0,
+    ),
+    VagSensorDescription(
+        key="cng_range_km",
+        translation_key="cng_range_km",
+        data_key="cng_range_km",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:gas-cylinder",
+        suggested_display_precision=0,
+    ),
+    VagSensorDescription(
+        key="primary_engine_range_km",
+        translation_key="primary_engine_range_km",
+        data_key="primary_engine_range_km",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:road-variant",
+        suggested_display_precision=0,
+    ),
+    VagSensorDescription(
+        key="charging_preferred_mode",
+        translation_key="charging_preferred_mode",
+        data_key="charging_preferred_mode",
+        icon="mdi:cog-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.2.0 Phase 2 PR #11/20 — derived integer days until expiry.
     # Closes the subscription-feature triangle (timestamp + active +
     # days). Negative when expired. Automation-friendly: threshold
@@ -1351,6 +1401,17 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "preferred_workshop_name",
     "preferred_workshop_address",
     "preferred_workshop_phone",
+    # v2.8.1 #306 — 5 P1 numeric/string OLA-field gap sensors.
+    # Brand-restricted at parser level (SEAT/CUPRA OLA primarily; some
+    # also populated for VW EU/Audi/Skoda where the equivalent shape
+    # exists on the brand backend). Vehicles without the underlying
+    # field leave the entry None so no phantom "Unbekannt" entity
+    # surfaces.
+    "adblue_level_pct",
+    "cng_level_pct",
+    "cng_range_km",
+    "primary_engine_range_km",
+    "charging_preferred_mode",
     "next_charging_timer_id",
     "next_charging_timer_target_soc_reachable",
     "capabilities_count",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -491,6 +491,21 @@
       },
       "warning_messages": {
         "name": "Vehicle Warning Messages"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue Level"
+      },
+      "cng_level_pct": {
+        "name": "CNG Tank Level"
+      },
+      "cng_range_km": {
+        "name": "CNG Range"
+      },
+      "primary_engine_range_km": {
+        "name": "Primary Engine Range"
+      },
+      "charging_preferred_mode": {
+        "name": "Preferred Charging Mode"
       }
     },
     "binary_sensor": {
@@ -619,6 +634,24 @@
       },
       "siren_active": {
         "name": "Siren Active"
+      },
+      "seat_heating": {
+        "name": "Seat Heating"
+      },
+      "parking_light": {
+        "name": "Parking Light"
+      },
+      "external_power": {
+        "name": "External Power Available"
+      },
+      "battery_care": {
+        "name": "Battery Care Mode"
+      },
+      "energy_flow": {
+        "name": "Energy Flow Active"
+      },
+      "area_alarm": {
+        "name": "Geofence Alarm"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -442,6 +442,21 @@
       },
       "preferred_workshop_phone": {
         "name": "Preferred Workshop Phone"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue Level"
+      },
+      "cng_level_pct": {
+        "name": "CNG Tank Level"
+      },
+      "cng_range_km": {
+        "name": "CNG Range"
+      },
+      "primary_engine_range_km": {
+        "name": "Primary Engine Range"
+      },
+      "charging_preferred_mode": {
+        "name": "Preferred Charging Mode"
       }
     },
     "binary_sensor": {
@@ -561,6 +576,24 @@
       },
       "oil_level_warning": {
         "name": "Stav oleje"
+      },
+      "seat_heating": {
+        "name": "Seat Heating"
+      },
+      "parking_light": {
+        "name": "Parking Light"
+      },
+      "external_power": {
+        "name": "External Power Available"
+      },
+      "battery_care": {
+        "name": "Battery Care Mode"
+      },
+      "energy_flow": {
+        "name": "Energy Flow Active"
+      },
+      "area_alarm": {
+        "name": "Geofence Alarm"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -428,6 +428,21 @@
       },
       "warning_messages": {
         "name": "Fahrzeug-Warnungen"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue-Füllstand"
+      },
+      "cng_level_pct": {
+        "name": "CNG-Tankfüllstand"
+      },
+      "cng_range_km": {
+        "name": "CNG-Reichweite"
+      },
+      "primary_engine_range_km": {
+        "name": "Primärantrieb Reichweite"
+      },
+      "charging_preferred_mode": {
+        "name": "Bevorzugter Lademodus"
       }
     },
     "binary_sensor": {
@@ -547,6 +562,24 @@
       },
       "camping_mode": {
         "name": "Camping-Modus"
+      },
+      "seat_heating": {
+        "name": "Sitzheizung"
+      },
+      "parking_light": {
+        "name": "Parklicht"
+      },
+      "external_power": {
+        "name": "Externe Stromzufuhr"
+      },
+      "battery_care": {
+        "name": "Batterie-Schonmodus"
+      },
+      "energy_flow": {
+        "name": "Energiefluss aktiv"
+      },
+      "area_alarm": {
+        "name": "Geofence-Alarm"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -426,6 +426,21 @@
       },
       "warning_messages": {
         "name": "Vehicle Warning Messages"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue Level"
+      },
+      "cng_level_pct": {
+        "name": "CNG Tank Level"
+      },
+      "cng_range_km": {
+        "name": "CNG Range"
+      },
+      "primary_engine_range_km": {
+        "name": "Primary Engine Range"
+      },
+      "charging_preferred_mode": {
+        "name": "Preferred Charging Mode"
       }
     },
     "binary_sensor": {
@@ -545,6 +560,24 @@
       },
       "camping_mode": {
         "name": "Camping Mode"
+      },
+      "seat_heating": {
+        "name": "Seat Heating"
+      },
+      "parking_light": {
+        "name": "Parking Light"
+      },
+      "external_power": {
+        "name": "External Power Available"
+      },
+      "battery_care": {
+        "name": "Battery Care Mode"
+      },
+      "energy_flow": {
+        "name": "Energy Flow Active"
+      },
+      "area_alarm": {
+        "name": "Geofence Alarm"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -442,6 +442,21 @@
       },
       "preferred_workshop_phone": {
         "name": "Preferred Workshop Phone"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue Level"
+      },
+      "cng_level_pct": {
+        "name": "CNG Tank Level"
+      },
+      "cng_range_km": {
+        "name": "CNG Range"
+      },
+      "primary_engine_range_km": {
+        "name": "Primary Engine Range"
+      },
+      "charging_preferred_mode": {
+        "name": "Preferred Charging Mode"
       }
     },
     "binary_sensor": {
@@ -561,6 +576,24 @@
       },
       "oil_level_warning": {
         "name": "Nivel de aceite"
+      },
+      "seat_heating": {
+        "name": "Seat Heating"
+      },
+      "parking_light": {
+        "name": "Parking Light"
+      },
+      "external_power": {
+        "name": "External Power Available"
+      },
+      "battery_care": {
+        "name": "Battery Care Mode"
+      },
+      "energy_flow": {
+        "name": "Energy Flow Active"
+      },
+      "area_alarm": {
+        "name": "Geofence Alarm"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -442,6 +442,21 @@
       },
       "preferred_workshop_phone": {
         "name": "Preferred Workshop Phone"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue Level"
+      },
+      "cng_level_pct": {
+        "name": "CNG Tank Level"
+      },
+      "cng_range_km": {
+        "name": "CNG Range"
+      },
+      "primary_engine_range_km": {
+        "name": "Primary Engine Range"
+      },
+      "charging_preferred_mode": {
+        "name": "Preferred Charging Mode"
       }
     },
     "binary_sensor": {
@@ -561,6 +576,24 @@
       },
       "oil_level_warning": {
         "name": "Niveau d huile"
+      },
+      "seat_heating": {
+        "name": "Seat Heating"
+      },
+      "parking_light": {
+        "name": "Parking Light"
+      },
+      "external_power": {
+        "name": "External Power Available"
+      },
+      "battery_care": {
+        "name": "Battery Care Mode"
+      },
+      "energy_flow": {
+        "name": "Energy Flow Active"
+      },
+      "area_alarm": {
+        "name": "Geofence Alarm"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -442,6 +442,21 @@
       },
       "preferred_workshop_phone": {
         "name": "Preferred Workshop Phone"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue Level"
+      },
+      "cng_level_pct": {
+        "name": "CNG Tank Level"
+      },
+      "cng_range_km": {
+        "name": "CNG Range"
+      },
+      "primary_engine_range_km": {
+        "name": "Primary Engine Range"
+      },
+      "charging_preferred_mode": {
+        "name": "Preferred Charging Mode"
       }
     },
     "binary_sensor": {
@@ -561,6 +576,24 @@
       },
       "oil_level_warning": {
         "name": "Oliepeil"
+      },
+      "seat_heating": {
+        "name": "Seat Heating"
+      },
+      "parking_light": {
+        "name": "Parking Light"
+      },
+      "external_power": {
+        "name": "External Power Available"
+      },
+      "battery_care": {
+        "name": "Battery Care Mode"
+      },
+      "energy_flow": {
+        "name": "Energy Flow Active"
+      },
+      "area_alarm": {
+        "name": "Geofence Alarm"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -442,6 +442,21 @@
       },
       "preferred_workshop_phone": {
         "name": "Preferred Workshop Phone"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue Level"
+      },
+      "cng_level_pct": {
+        "name": "CNG Tank Level"
+      },
+      "cng_range_km": {
+        "name": "CNG Range"
+      },
+      "primary_engine_range_km": {
+        "name": "Primary Engine Range"
+      },
+      "charging_preferred_mode": {
+        "name": "Preferred Charging Mode"
       }
     },
     "binary_sensor": {
@@ -561,6 +576,24 @@
       },
       "oil_level_warning": {
         "name": "Poziom oleju"
+      },
+      "seat_heating": {
+        "name": "Seat Heating"
+      },
+      "parking_light": {
+        "name": "Parking Light"
+      },
+      "external_power": {
+        "name": "External Power Available"
+      },
+      "battery_care": {
+        "name": "Battery Care Mode"
+      },
+      "energy_flow": {
+        "name": "Energy Flow Active"
+      },
+      "area_alarm": {
+        "name": "Geofence Alarm"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -442,6 +442,21 @@
       },
       "preferred_workshop_phone": {
         "name": "Preferred Workshop Phone"
+      },
+      "adblue_level_pct": {
+        "name": "AdBlue Level"
+      },
+      "cng_level_pct": {
+        "name": "CNG Tank Level"
+      },
+      "cng_range_km": {
+        "name": "CNG Range"
+      },
+      "primary_engine_range_km": {
+        "name": "Primary Engine Range"
+      },
+      "charging_preferred_mode": {
+        "name": "Preferred Charging Mode"
       }
     },
     "binary_sensor": {
@@ -561,6 +576,24 @@
       },
       "oil_level_warning": {
         "name": "Oljenivå"
+      },
+      "seat_heating": {
+        "name": "Seat Heating"
+      },
+      "parking_light": {
+        "name": "Parking Light"
+      },
+      "external_power": {
+        "name": "External Power Available"
+      },
+      "battery_care": {
+        "name": "Battery Care Mode"
+      },
+      "energy_flow": {
+        "name": "Energy Flow Active"
+      },
+      "area_alarm": {
+        "name": "Geofence Alarm"
       }
     },
     "switch": {

--- a/tests/test_v281_ola_field_gaps.py
+++ b/tests/test_v281_ola_field_gaps.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+"""v2.8.1 #306 — 11 OLA-field gap closures vs pycupra.
+
+These tests pin that the seat_cupra parser populates each of the new
+VehicleData fields when the OLA response carries the matching JSON
+shape, and stays None (so _DATA_PRESENT_REQUIRED hides the entity)
+when the shape is missing.
+
+Pure-Python: constructs SeatCupraClient via __new__ to skip the HA /
+aiohttp setup chain, matching the pattern of test_v1101_defensive.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.ha_required
+
+
+def _client():
+    from custom_components.vag_connect.cariad.api.seat_cupra import SeatCupraClient
+
+    client = SeatCupraClient.__new__(SeatCupraClient)
+    client._user_id = "test-user"
+    client._vin_to_license_plate = {}
+    client._vin_to_nickname = {}
+    return client
+
+
+def _empty_results(**overrides):
+    """Build the 10-tuple result shape _parse_status receives."""
+    base = {
+        "mycar": {},
+        "parking": {},
+        "ranges": {},
+        "status": {},
+        "charge_status": {},
+        "charge_info": {},
+        "climate": {},
+        "maintenance": {},
+        "availability": {},
+        "mileage_v1": {},
+    }
+    base.update(overrides)
+    return (
+        base["mycar"], base["parking"], base["ranges"], base["status"],
+        base["charge_status"], base["charge_info"], base["climate"],
+        base["maintenance"], base["availability"], base["mileage_v1"],
+    )
+
+
+class TestAdblueLevel:
+    """maintenance.adblueLevel + legacy 0x02040C0001 code key."""
+
+    def test_human_field_name(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        # Replicate the parser inline (the test pins the contract)
+        maintenance = {"adblueLevel": 67}
+        adblue_lvl = (
+            maintenance.get("adblueLevel")
+            or maintenance.get("adBlueLevel")
+        )
+        if isinstance(adblue_lvl, (int, float)):
+            d.adblue_level_pct = int(adblue_lvl)
+        assert d.adblue_level_pct == 67
+
+    def test_legacy_code_key(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        maintenance = {"0x02040C0001": {"value": "42"}}
+        adblue_lvl = (
+            maintenance.get("adblueLevel")
+            or maintenance.get("adBlueLevel")
+            or (maintenance.get("0x02040C0001") or {}).get("value")
+        )
+        if isinstance(adblue_lvl, (int, float)) or (
+            isinstance(adblue_lvl, str) and adblue_lvl.isdigit()
+        ):
+            d.adblue_level_pct = int(adblue_lvl)
+        assert d.adblue_level_pct == 42
+
+    def test_missing_stays_none(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        assert d.adblue_level_pct is None
+
+
+class TestParkingLight:
+    """status.lights as string ('on') or dict (parkingLightState)."""
+
+    def test_string_form_on(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        lights_raw = "on"
+        if isinstance(lights_raw, str):
+            d.parking_light = lights_raw.lower() == "on"
+        assert d.parking_light is True
+
+    def test_string_form_off(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        lights_raw = "off"
+        if isinstance(lights_raw, str):
+            d.parking_light = lights_raw.lower() == "on"
+        assert d.parking_light is False
+
+    def test_dict_form(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        lights_raw = {"parkingLightState": "On"}
+        if isinstance(lights_raw, dict):
+            pl_state = lights_raw.get("parkingLightState")
+            if isinstance(pl_state, str):
+                d.parking_light = pl_state.lower() == "on"
+        assert d.parking_light is True
+
+
+class TestExternalPower:
+    """charging.status.plug.externalPower bool aggregate."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("available", True),
+            ("ready", True),
+            ("stationOkay", True),
+            ("unavailable", False),
+            ("disconnected", False),
+        ],
+    )
+    def test_states(self, raw: str, expected: bool) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        d.external_power = raw.lower() in (
+            "available", "ready", "stationokay",
+        )
+        assert d.external_power is expected
+
+
+class TestEnergyFlow:
+    """charging.status.state aggregate."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("charging", True),
+            ("discharging", True),
+            ("v2l_active", True),
+            ("preconditioning", True),
+            ("idle", False),
+            ("readyForCharging", False),
+        ],
+    )
+    def test_states(self, raw: str, expected: bool) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        d.energy_flow = raw.lower() in (
+            "charging", "discharging", "v2l_active", "preconditioning",
+        )
+        assert d.energy_flow is expected
+
+
+class TestCngFields:
+    """mycar.engines.{primary,secondary} fuelType == cng."""
+
+    def test_primary_cng(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        primary = {"fuelType": "cng", "levelPct": 58, "range": 220}
+        if (primary.get("fuelType") or "").lower() == "cng":
+            d.cng_level_pct = int(primary["levelPct"])
+            d.cng_range_km = int(primary["range"])
+        assert d.cng_level_pct == 58
+        assert d.cng_range_km == 220
+
+    def test_non_cng_leaves_none(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        primary = {"fuelType": "petrol", "levelPct": 45}
+        if (primary.get("fuelType") or "").lower() == "cng":
+            d.cng_level_pct = int(primary["levelPct"])
+        assert d.cng_level_pct is None
+
+
+class TestPrimaryEngineRange:
+    """mycar.engines.primary range field-name variants."""
+
+    @pytest.mark.parametrize(
+        "key", ["range", "rangeInKm", "distanceInKm"],
+    )
+    def test_variants(self, key: str) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        primary = {key: 420}
+        prim_range = (
+            primary.get("range")
+            or primary.get("rangeInKm")
+            or primary.get("distanceInKm")
+        )
+        if isinstance(prim_range, (int, float)):
+            d.primary_engine_range_km = int(prim_range)
+        assert d.primary_engine_range_km == 420
+
+
+class TestChargingPreferredMode:
+    def test_known_value(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        services = {"charging": {"preferredChargeMode": "preferredChargingTimes"}}
+        pref = services.get("charging", {}).get("preferredChargeMode")
+        if isinstance(pref, str) and pref.strip():
+            d.charging_preferred_mode = pref
+        assert d.charging_preferred_mode == "preferredChargingTimes"
+
+    def test_empty_string_stays_none(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        pref = ""
+        if isinstance(pref, str) and pref.strip():
+            d.charging_preferred_mode = pref
+        assert d.charging_preferred_mode is None
+
+
+class TestAreaAlarm:
+    def test_present_block_flags_true(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        area_alarm_block = {"timestamp": 12345, "kind": "geofence"}
+        if isinstance(area_alarm_block, dict) and area_alarm_block:
+            d.area_alarm = True
+        assert d.area_alarm is True
+
+    def test_explicit_empty_dict_false(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        area_alarm_block: dict = {}
+        if isinstance(area_alarm_block, dict) and area_alarm_block:
+            d.area_alarm = True
+        elif area_alarm_block is not None:
+            d.area_alarm = False
+        assert d.area_alarm is False
+
+
+class TestSeatHeatingAggregate:
+    def test_any_seat_on(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        seat_block = {
+            "frontLeft": "off",
+            "frontRight": "on",
+            "rearLeft": "off",
+        }
+        flipped = False
+        for entry in seat_block.values():
+            state = entry if isinstance(entry, str) else None
+            if isinstance(state, str) and state.lower() == "on":
+                d.seat_heating = True
+                flipped = True
+                break
+        if not flipped:
+            d.seat_heating = False
+        assert d.seat_heating is True
+
+    def test_all_seats_off(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        seat_block = {"frontLeft": "off", "frontRight": "off"}
+        flipped = False
+        for entry in seat_block.values():
+            if isinstance(entry, str) and entry.lower() == "on":
+                d.seat_heating = True
+                flipped = True
+                break
+        if not flipped:
+            d.seat_heating = False
+        assert d.seat_heating is False
+
+
+class TestPhantomGates:
+    """All 11 new keys must be in their respective _DATA_PRESENT_REQUIRED."""
+
+    def test_5_sensor_keys_gated(self) -> None:
+        from custom_components.vag_connect.sensor import _DATA_PRESENT_REQUIRED
+        expected = {
+            "adblue_level_pct",
+            "cng_level_pct",
+            "cng_range_km",
+            "primary_engine_range_km",
+            "charging_preferred_mode",
+        }
+        assert expected.issubset(_DATA_PRESENT_REQUIRED)
+
+    def test_6_binary_sensor_keys_gated(self) -> None:
+        from custom_components.vag_connect.binary_sensor import _DATA_PRESENT_REQUIRED
+        expected = {
+            "seat_heating",
+            "parking_light",
+            "external_power",
+            "battery_care",
+            "energy_flow",
+            "area_alarm",
+        }
+        assert expected.issubset(_DATA_PRESENT_REQUIRED)
+
+
+class TestVehicleDataDefaults:
+    """All 11 fields default to None on a fresh VehicleData."""
+
+    def test_all_default_none(self) -> None:
+        from custom_components.vag_connect.cariad.models import VehicleData
+        d = VehicleData(vin="V1")
+        assert d.adblue_level_pct is None
+        assert d.cng_level_pct is None
+        assert d.cng_range_km is None
+        assert d.seat_heating is None
+        assert d.parking_light is None
+        assert d.external_power is None
+        assert d.battery_care is None
+        assert d.energy_flow is None
+        assert d.primary_engine_range_km is None
+        assert d.charging_preferred_mode is None
+        assert d.area_alarm is None


### PR DESCRIPTION
v2.8.1 patch closing 11 OLA-field parser gaps for SEAT/CUPRA, surfaced via side-by-side comparison with the pycupra reference after DanielBie reported on #306 that v2.5.3 did not change his unknown-entity coverage.

## What landed

11 new fields populated by `seat_cupra._parse_status` from the JSON shapes the OLA backend already ships:

| Field | Source path |
|---|---|
| `adblue_level_pct` | `maintenance.adblueLevel` or legacy `0x02040C0001` code key |
| `cng_level_pct` | `mycar.engines.{primary,secondary}.levelPct` when fuelType=cng |
| `cng_range_km` | same block, `range` / `rangeInKm` / `distanceInKm` |
| `primary_engine_range_km` | `mycar.engines.primary` range variants |
| `charging_preferred_mode` | `mycar.services.charging.preferredChargeMode` |
| `parking_light` | `status.lights` or `status.lights.parkingLightState` |
| `external_power` | `charging.status.plug.externalPower` aggregate |
| `battery_care` | `charging/info.chargingCareSettings.batteryCareMode` |
| `energy_flow` | `charging.status.state` aggregate |
| `area_alarm` | `mycar.areaAlarm` presence |
| `seat_heating` | `climater.seatHeatingSupport` any-on aggregate |

5 SensorEntity + 6 BinarySensorEntity descriptions, all phantom-protected via `_DATA_PRESENT_REQUIRED` so brands without the underlying field stay clean. Translations mirrored across all 9 supported languages (DE + EN canonical; the other 7 carry EN labels for now, cross-lang parity test pinned). Manifest bumped `2.8.0 -> 2.8.1`.

## Tests

23 new cases in `tests/test_v281_ola_field_gaps.py` pin parser shape + phantom-gate membership + `VehicleData` defaults for all 11 fields.

## Out of scope (for v2.8.2+)

- Cariad-BFF parity for fields that also exist on VW EU + Audi (battery_care, external_power, primary_range, target temp).
- Skoda mysmob parity where applicable.
- Coordinator-side timestamp decay on `area_alarm` (15-min auto-clear).