### PR TITLE
release: v2.8.2 — silence Audi warningLights.error envelope (#384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.8.2] - 2026-06-02
+
+### Fixed
+
+- Scout no longer auto-fires on the 6-key `.error.*` envelope the Cariad BFF returns when the `vehicleHealthWarnings.warningLights` job hits a 5xx upstream. Same shape as the v2.7.4 fix for `oilLevel.error` / `tyrePressure.error` / `auxiliaryHeating.error`, one branch deeper. Closes #384 (moltke69 Audi scout).
+
 ## [2.8.1] - 2026-06-01
 
 Closes 11 SEAT/CUPRA OLA-field parser gaps surfaced via side-by-side comparison with the pycupra reference, after the v2.5.3 OLA v1/v5 fallback chain did not fix DanielBie's offline-Leon entity coverage (issue #306).

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -742,6 +742,13 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             # Older firmwares wrap fields in error objects when the
             # backend can't compute them. Defensive registration.
             "charging.chargeMode.error",
+            # v2.8.2 (#384 moltke69 2026-06-02) — same .error envelope
+            # one level deeper for vehicleHealthWarnings.warningLights.
+            # Cariad BFF wraps the warningLights value in an error
+            # object when the warning-lights subsystem times out
+            # upstream (6-key envelope, mirror of the v2.7.4
+            # oilLevel.error pattern in #371/#373).
+            "vehicleHealthWarnings.warningLights.error",
             # v1.12.1 (#105 + #106, 2026-04-30) — Scout descended one
             # more level past the v1.12.0 wrapper registrations and
             # found the ``.value`` containers below them. Same

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.8.1"
+  "version": "2.8.2"
 }


### PR DESCRIPTION
Same pattern as v2.7.4 (oilLevel/tyrePressure/auxiliaryHeating .error silencers) applied to the warningLights branch the daily Audi scout caught at 06:35 UTC today.

Closes #384.