### PR TITLE
v2.10.1: VW EU 403 hotfix - browser-UA retry + UA bump 3.61.0 (#388, #393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-06-03
+
+VW EU login hotfix. The v2.10.0 SPA fix unblocked one path, but several users still hit HTTP 403 on the authorize endpoint itself - the Azure WAF in front of `identity.vwgroup.io` started rejecting the Android user-agent some time on 2026-05-31. Same finding the wider HA-VAG community converged on this week.
+
+### Fixed
+
+- **VW EU 403 on authorize endpoint** (#388, #393). When the initial GET to `/oidc/v1/authorize` comes back 401 or 403, retry once with a plain mobile-browser user-agent. Picks up users blocked at the WAF without affecting accounts that already work on the Android UA.
+- **VW user-agent bumped** to `Volkswagen/3.61.0-android/14` to match the current shipping APK. The old `3.51.1` string is what the WAF presumably flagged.
+
 ## [2.10.0] - 2026-06-02
 
 The biggest single release so far. VW EU login is unblocked again after the 2026-05-31 backend change, parked cars no longer show all-Unknown, and SEAT/CUPRA gets its Energy-Dashboard story plus settable battery-care.

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -494,10 +494,50 @@ class IDKAuth:
                 "IDK step1: status=%s url=%s html_len=%d",
                 resp.status, login_url[:80], len(html),
             )
-            if resp.status != 200:
-                raise AuthenticationError(
-                    f"Authorization page HTTP {resp.status} at {login_url}"
+            initial_status = resp.status
+        # v2.10.1 (#388 / #393) — when the Auth0 Universal Login front-end
+        # rejects an Android UA at the WAF layer (observed 2026-05-31+),
+        # retry once with a plain mobile-browser UA. Multiple users have
+        # reported a 403 at this step even though the credentials are
+        # correct. The retry leaves all other path semantics unchanged.
+        if initial_status in (401, 403):
+            browser_headers = {
+                "Accept": (
+                    "text/html,application/xhtml+xml,application/xml;q=0.9,"
+                    "image/avif,image/webp,*/*;q=0.8"
+                ),
+                "Accept-Language": "de-DE,de;q=0.9,en;q=0.8",
+                "User-Agent": (
+                    "Mozilla/5.0 (Linux; Android 14; SM-S908B) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/126.0.0.0 Mobile Safari/537.36"
+                ),
+                "Sec-Fetch-Dest": "document",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Site": "none",
+                "Upgrade-Insecure-Requests": "1",
+            }
+            async with self._session.get(
+                self._authorize_url,
+                timeout=_AUTH_TIMEOUT, params=params, headers=browser_headers,
+                allow_redirects=True,
+            ) as retry_resp:
+                login_url = str(retry_resp.url)
+                html = await retry_resp.text(errors="replace")
+                _LOGGER.debug(
+                    "IDK step1 browser-UA retry: status=%s url=%s html_len=%d",
+                    retry_resp.status, login_url[:80], len(html),
                 )
+                if retry_resp.status != 200:
+                    raise AuthenticationError(
+                        f"Authorization page HTTP {retry_resp.status} at "
+                        f"{login_url} (after browser-UA retry; first "
+                        f"attempt was HTTP {initial_status})"
+                    )
+        elif initial_status != 200:
+            raise AuthenticationError(
+                f"Authorization page HTTP {initial_status} at {login_url}"
+            )
 
         # Determine which login variant we landed on
         if "/u/login" in login_url:

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -52,7 +52,7 @@ BRAND_VW_EU = BrandConfig(
     name="volkswagen",
     client_id="a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com",
     redirect_uri="weconnect://authenticated",
-    user_agent="Volkswagen/3.51.1-android/14",
+    user_agent="Volkswagen/3.61.0-android/14",
     api_base="https://emea.bff.cariad.digital",
     # scope from volkswagencarnet (upstream/volkswagencarnet, MIT) — confirmed working
     scope="openid profile badge cars dealers vin",

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.10.0"
+  "version": "2.10.1"
 }


### PR DESCRIPTION
Fixes the residual VW EU login failures still hitting users on v2.10.0.

The v2.10.0 SPA fix unblocked one path (Auth0 form-encoded vs JSON body). Two other users (BalooDK on #388, wgumaa, SniperWCW on #393) still hit HTTP 403 earlier in the chain - on the GET to `/oidc/v1/authorize` itself. Their DEBUG logs show:

```
IDK step1: status=403 url=https://identity.vwgroup.io/oidc/v1/authorize?...
```

That 403 is the Azure WAF in front of `identity.vwgroup.io` flagging the Android user-agent. The wider HA-VAG-integration community independently converged on the same finding this week.

Two changes:

1. Bump VW EU user-agent `3.51.1` -> `3.61.0` to match the shipping VW APK. The old string is what the WAF presumably started flagging on the 2026-05-31 backend change.
2. When the initial authorize GET returns 401 or 403, retry once with a plain mobile-browser UA + standard `Sec-Fetch-*` navigation headers. All other path semantics stay the same. Accounts that already work on the Android UA see no change because the retry only fires on auth failure.