### PR TITLE
v2.10.2: Data Act portal flow rebuilt against verified live trace (#388, #393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,20 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.10.2] - 2026-06-03
+
+EU Data Act portal flow rebuilt against a verified live trace.
+
+### Fixed
+
+- **Data Act portal OAuth flow** (#388, #393). The portal client uses plain authorization-code flow with `prompt=login`, not the hybrid response_type we were sending. That mismatch was the source of the "unexpected landing URL - IDP may have rejected client_id" error several users hit when the live BFF strategies all failed and the integration tried the read-only fallback. Now switched to standard code flow plus PKCE-S256 plus a token exchange against `identity.vwgroup.io/oidc/v1/token`. Hybrid fragment delivery is kept as a defensive fallback so accounts that happened to work on the old path are not regressed.
+- **Data Act portal state-string order**. Was `{country}__{language}__{BRAND}`, now `{language}__{country}__{BRAND}` per the live trace. DE/DE users worked by coincidence; non-matching country/language combinations were routed to the wrong portal locale.
+
+### Added
+
+- **EU Data Act portal usership-verification scaffolding**. New `check_verification_state()` and `submit_usership_verification()` on the scraper detect whether the one-time EU Data Act declaration is on file per VIN and can submit it on behalf of the user when an opt-in config flag is set. The Repairs / OptionsFlow wire-up lands in v2.10.3; the methods are usable from external code today.
+- **Data request submission scaffolding**. New `submit_data_request()` and `poll_for_dataset_url()` for the async ZIP delivery flow. Endpoint shapes are best-effort against the documented form fields; verified shapes ship in v2.10.3 once a live trace captures the AJAX call that populates "Ihre Dateien".
+
 ## [2.10.1] - 2026-06-03
 
 VW EU login hotfix. The v2.10.0 SPA fix unblocked one path, but several users still hit HTTP 403 on the authorize endpoint itself - the Azure WAF in front of `identity.vwgroup.io` started rejecting the Android user-agent some time on 2026-05-31. Same finding the wider HA-VAG community converged on this week.

--- a/custom_components/vag_connect/cariad/auth/_data_act_portal.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_portal.py
@@ -60,6 +60,8 @@ When this strategy returns a TokenSet, the strategy field is set to
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import logging
 import secrets
 import time
@@ -84,6 +86,7 @@ _PORTAL_OIDC_CLIENT_ID = "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com
 _PORTAL_OIDC_SCOPE = "openid cars profile"
 _PORTAL_OIDC_REDIRECT_URI = f"{_PORTAL_BASE}/login"
 _IDP_AUTHORIZE_URL = "https://identity.vwgroup.io/oidc/v1/authorize"
+_IDP_TOKEN_URL = "https://identity.vwgroup.io/oidc/v1/token"
 _PORTAL_LOGIN_CALLBACK_PATH = "/services/callbacklogin"
 
 # Per-brand state-string suffix expected by the portal so it routes
@@ -107,15 +110,35 @@ _PORTAL_REQUEST_TIMEOUT_S = 30
 def _build_state(brand_name: str, country: str, language: str) -> str:
     """Return the state-string expected by the portal router.
 
-    Format: ``{country}__{language}__{brand_suffix}`` where the
-    brand_suffix matches the portal's internal brand-routing enum.
-    Falls back to VOLKSWAGEN_PASSENGER_CARS for unknown brand names
-    so the login at least lands somewhere instead of erroring out.
+    Format: ``{language}__{country}__{brand_suffix}`` (e.g.
+    ``de__de__VOLKSWAGEN_PASSENGER_CARS``). The portal's state-string
+    routing decodes the language first, then the country, then the
+    brand-suffix that matches its internal brand-routing enum.
+
+    Pre-v2.10.2 we shipped the wrong order ``{country}__{language}``
+    which works for de_DE users (both halves identical) but routes the
+    wrong locale for any non-matching country/language pair. Verified
+    against a live portal trace 2026-06-03.
+
+    Falls back to VOLKSWAGEN_PASSENGER_CARS for unknown brand names so
+    the login at least lands somewhere instead of erroring out.
     """
     brand_suffix = _BRAND_STATE_FRAGMENTS.get(
         brand_name.lower(), _BRAND_STATE_FRAGMENTS["volkswagen"],
     )
-    return f"{country.lower()}__{language.lower()}__{brand_suffix}"
+    return f"{language.lower()}__{country.lower()}__{brand_suffix}"
+
+
+def _make_pkce() -> tuple[str, str]:
+    """Return a (verifier, challenge) pair for PKCE-S256.
+
+    verifier: 43-128 byte URL-safe random string
+    challenge: BASE64URL(SHA256(verifier)) with padding stripped
+    """
+    verifier = secrets.token_urlsafe(64)[:96]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
 
 
 class DataActPortalAuth:
@@ -157,8 +180,12 @@ class DataActPortalAuth:
         """
         from aiohttp import ClientTimeout  # noqa: PLC0415
 
-        nonce = secrets.token_urlsafe(16)
         state = _build_state(self._brand_name, self._country, self._language)
+        # v2.10.2 — Portal uses plain authorization-code flow (not
+        # hybrid). Add PKCE-S256 defensively even though we don't yet
+        # know the IDP enforces it; modern OIDC public-clients usually
+        # require it and the verifier is cheap to carry.
+        pkce_verifier, pkce_challenge = _make_pkce()
 
         # Step 1 — prime the AEM load-balancer cookies. The portal
         # router rejects /services/callbacklogin requests that lack a
@@ -182,13 +209,20 @@ class DataActPortalAuth:
         # portal's OAuth client. Auth0 returns a 302 to the brand-id
         # signin form; we follow the redirect chain and parse the
         # login HTML.
+        # v2.10.2 — verified against live portal trace 2026-06-03.
+        # The portal client uses plain authorization-code flow with
+        # prompt=login. Hybrid (code id_token token) was rejected by
+        # the IDP for this specific client_id and caused the
+        # "unexpected landing URL" symptom users reported on #388/#393.
         authorize_params = {
             "client_id": _PORTAL_OIDC_CLIENT_ID,
             "redirect_uri": _PORTAL_OIDC_REDIRECT_URI,
-            "response_type": "code id_token token",
+            "response_type": "code",
             "scope": _PORTAL_OIDC_SCOPE,
             "state": state,
-            "nonce": nonce,
+            "prompt": "login",
+            "code_challenge": pkce_challenge,
+            "code_challenge_method": "S256",
         }
         try:
             async with self._session.get(
@@ -422,10 +456,11 @@ class DataActPortalAuth:
                 f"Data Act portal: password POST failed ({exc})"
             ) from exc
 
-        # Step 4 — verify we landed on the portal host and not on an
-        # error page. Extract the access_token + id_token from the
-        # callback URL fragment (hybrid flow delivery), as Auth0 does
-        # for the portal client.
+        # Step 4 — verify we landed on the portal host and extract the
+        # authorization code from the callback URL. v2.10.2: portal
+        # uses plain code flow, so the callback ends on
+        # ``.../login?code=...&state=...`` instead of returning tokens
+        # in the fragment. The token exchange happens in step 5.
         parsed = urlparse(callback_url)
         host_ok = parsed.netloc.endswith("drivesomethinggreater.com")
         if not host_ok or "signin-service" in callback_url or "/error" in callback_url:
@@ -435,13 +470,78 @@ class DataActPortalAuth:
             )
 
         all_params = {**parse_qs(parsed.query), **parse_qs(parsed.fragment)}
-        access_token = (all_params.get("access_token") or [""])[0]
-        id_token = (all_params.get("id_token") or [""])[0]
+        auth_code = (all_params.get("code") or [""])[0]
+        if not auth_code:
+            # Belt-and-braces: some IDP variants still deliver in the
+            # fragment with hybrid; keep the legacy path as a fallback
+            # so we don't regress accounts that happened to work before.
+            legacy_access = (all_params.get("access_token") or [""])[0]
+            legacy_id = (all_params.get("id_token") or [""])[0]
+            if legacy_access and legacy_id:
+                _LOGGER.warning(
+                    "Data Act portal: callback delivered tokens in the "
+                    "fragment (legacy hybrid path) instead of a code. "
+                    "Using them directly. IDP behaviour may have changed."
+                )
+                return TokenSet(
+                    access_token=legacy_access,
+                    refresh_token="",
+                    id_token=legacy_id,
+                    expires_at=time.time() + 3300,
+                    strategy="data_act_portal",
+                )
+            raise AuthenticationError(
+                "Data Act portal: callback URL missing the authorization "
+                "code — IDP may have changed the redirect parameters"
+            )
+
+        # Step 5 — exchange the code for tokens at the IDP token endpoint.
+        token_body = {
+            "grant_type": "authorization_code",
+            "code": auth_code,
+            "redirect_uri": _PORTAL_OIDC_REDIRECT_URI,
+            "client_id": _PORTAL_OIDC_CLIENT_ID,
+            "code_verifier": pkce_verifier,
+        }
+        try:
+            async with self._session.post(
+                _IDP_TOKEN_URL,
+                data=token_body,
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Accept": "application/json",
+                },
+                timeout=ClientTimeout(total=_PORTAL_REQUEST_TIMEOUT_S),
+                allow_redirects=False,
+            ) as resp:
+                token_status = resp.status
+                token_json: dict[str, str] = {}
+                try:
+                    token_json = await resp.json(content_type=None)
+                except Exception:  # noqa: BLE001
+                    token_json = {}
+                if token_status != 200:
+                    err = token_json.get("error", "")
+                    err_desc = token_json.get("error_description", "")
+                    raise AuthenticationError(
+                        f"Data Act portal: token exchange HTTP {token_status} "
+                        f"(error={err!r} desc={err_desc[:120]!r})"
+                    )
+        except AuthenticationError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise AuthenticationError(
+                f"Data Act portal: token exchange failed ({exc})"
+            ) from exc
+
+        access_token = token_json.get("access_token", "")
+        id_token = token_json.get("id_token", "")
+        refresh_token = token_json.get("refresh_token", "")
+        expires_in = int(token_json.get("expires_in", 3600))
         if not access_token or not id_token:
             raise AuthenticationError(
-                "Data Act portal: callback URL missing access_token or "
-                "id_token — IDP may have stripped hybrid response_type "
-                "for the portal client"
+                "Data Act portal: token endpoint returned an empty "
+                "access_token or id_token"
             )
 
         _LOGGER.info(
@@ -452,11 +552,9 @@ class DataActPortalAuth:
         )
         return TokenSet(
             access_token=access_token,
-            refresh_token="",
+            refresh_token=refresh_token,
             id_token=id_token,
-            # Portal access_tokens are typically valid ~1 h; mark
-            # explicitly so the coordinator schedules re-login before
-            # silent 401s.
-            expires_at=time.time() + 3300,
+            # Subtract 5min safety margin so we re-auth before silent 401s.
+            expires_at=time.time() + max(expires_in - 300, 60),
             strategy="data_act_portal",
         )

--- a/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
@@ -95,6 +95,37 @@ _LOGGER = logging.getLogger(__name__)
 # in tests without spinning up the auth strategy).
 _PORTAL_BASE = "https://eu-data-act.drivesomethinggreater.com"
 
+# v2.10.2 — Usership Verification endpoints. The EU Data Act portal
+# requires every signed-in user to declare once per VIN that they
+# are the owner / legitimate user of the vehicle AND that they are
+# an EU resident. Without this declaration the portal refuses to
+# accept data requests for that VIN. See docs/EU_DATA_ACT_PORTAL.md
+# for the full live trace that backs these paths.
+_PORTAL_VEHICLE_DETAILS_PATH = "/{lang}/{country}/user/details.html"
+_PORTAL_VERIFICATION_FORM_PATH = (
+    "/{lang}/{country}/user/details/usership-verification-form.html"
+)
+_PORTAL_DATA_REQUEST_PATH = (
+    "/{lang}/{country}/user/details/request-eu-data-act-data.html"
+)
+
+# Verification-state machine values returned by check_verification_state.
+VERIFICATION_VERIFIED = "verified"            # user has already declared
+VERIFICATION_NEEDS_DECLARATION = "needs_declaration"  # banner present
+VERIFICATION_UNKNOWN = "unknown"              # could not determine
+
+# Marker strings observed on the portal HTML. Captured 2026-06-03.
+_VERIFIED_MARKERS = (
+    "Sie haben Ihre EU Data Act Berechtigung erfolgreich nachgewiesen",
+    "EU Data Act usership verified",
+    "Rolle gemäß EU Data Act nachgewiesen",
+)
+_NEEDS_VERIFICATION_MARKERS = (
+    "EU Data Act Berechtigung nicht nachgewiesen",
+    "Berechtigung nachweisen",
+    "EU Data Act usership not yet verified",
+)
+
 # Route A candidate endpoints. The first entry is the only path that
 # has been verified from public sources and known community Python
 # code: it returns vehicle metadata for the supplied VIN under the
@@ -189,6 +220,8 @@ class DataActScraper:
         *,
         brand_name: str,
         enable_browser_fallback: bool = False,
+        language: str = "de",
+        country: str = "de",
     ) -> None:
         """Set up a scraper.
 
@@ -209,6 +242,8 @@ class DataActScraper:
         self._session = session
         self._brand_name = brand_name
         self._enable_browser_fallback = enable_browser_fallback
+        self._language = language.lower()
+        self._country = country.lower()
         self._empty_streak: int = 0
         # Hash of the last successfully fetched zip, used to detect
         # "the portal handed us the exact same data as last time"
@@ -649,6 +684,216 @@ class DataActScraper:
         # source fields above carried a timestamp.
         out.last_updated_at = time.time()
         return out
+
+    # ── v2.10.2 Phase B: usership verification ───────────────────────────────
+
+    async def check_verification_state(self, vin: str) -> str:
+        """Probe the portal for whether ``vin`` has the EU Data Act
+        usership declaration on file.
+
+        Returns one of ``VERIFICATION_VERIFIED`` /
+        ``VERIFICATION_NEEDS_DECLARATION`` / ``VERIFICATION_UNKNOWN``.
+        Network failures or unexpected HTML always degrade to
+        ``UNKNOWN`` so the caller never blocks on a transient error.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
+        url = _PORTAL_BASE + _PORTAL_VEHICLE_DETAILS_PATH.format(
+            lang=self._language, country=self._country
+        )
+        try:
+            async with self._session.get(
+                url, params={"vin": vin},
+                timeout=ClientTimeout(total=20),
+                allow_redirects=True,
+            ) as resp:
+                if resp.status != 200:
+                    return VERIFICATION_UNKNOWN
+                html = await resp.text(errors="replace")
+        except Exception:  # noqa: BLE001
+            return VERIFICATION_UNKNOWN
+
+        # Verified markers win over needs-verification because the
+        # success banner sometimes ships alongside historical CTA
+        # strings still in the DOM.
+        if any(m in html for m in _VERIFIED_MARKERS):
+            return VERIFICATION_VERIFIED
+        if any(m in html for m in _NEEDS_VERIFICATION_MARKERS):
+            return VERIFICATION_NEEDS_DECLARATION
+        return VERIFICATION_UNKNOWN
+
+    async def submit_usership_verification(
+        self,
+        vin: str,
+        *,
+        role: str = "owner",
+    ) -> bool:
+        """Submit the one-time EU Data Act usership-declaration form.
+
+        DOES NOT call itself unless the OptionsFlow toggle
+        ``CONF_DATA_ACT_AUTO_VERIFY`` is True AND the user has
+        affirmed ownership + EU residency for ALL VINs in the config
+        flow. The caller is responsible for that gating; this method
+        is the mechanical form-submitter only.
+
+        Args:
+            vin: vehicle identification number to declare on.
+            role: ``owner`` (default) submits the
+                "Ich bin der Eigentümer des Fahrzeugs" radio. Other
+                accepted values map to the portal's enum:
+                ``owner`` / ``user`` (übertragenes Nutzungsrecht) /
+                ``service`` (Dienstleistung) / ``none``.
+
+        Returns True when the portal acknowledges the declaration,
+        False on any error. The live trace 2026-06-03 captured a
+        quirk where the first POST is silently dropped and a second
+        identical POST goes through; we handle that by retrying once
+        on a non-success response.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
+        url = _PORTAL_BASE + _PORTAL_VERIFICATION_FORM_PATH.format(
+            lang=self._language, country=self._country
+        )
+        # Step 1: GET the form so we can pick up any CSRF / form-state
+        # hidden fields the portal may set per-VIN. We do not parse
+        # the HTML in detail because the form field names live in the
+        # remote React component bundle; instead we send the canonical
+        # field set from the live trace and let the portal-side
+        # JavaScript-equivalent handler resolve it.
+        try:
+            async with self._session.get(
+                url, params={"vin": vin},
+                timeout=ClientTimeout(total=20),
+                allow_redirects=True,
+            ) as resp:
+                if resp.status != 200:
+                    _LOGGER.debug(
+                        "Verification form GET HTTP %s for VIN %s",
+                        resp.status, _mask_vin(vin),
+                    )
+                    return False
+                # Discard the body - cookies are already set on the
+                # session by aiohttp.
+                await resp.read()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("Verification GET failed: %s", exc)
+            return False
+
+        form_body = {
+            "vin": vin,
+            "role": role,
+            "confirmation": "yes",  # the "Ja" radio - default is "no"
+        }
+        for attempt in (1, 2):
+            try:
+                async with self._session.post(
+                    url, params={"vin": vin},
+                    data=form_body,
+                    timeout=ClientTimeout(total=30),
+                    allow_redirects=True,
+                ) as resp:
+                    body = await resp.text(errors="replace")
+                    if resp.status == 200 and any(
+                        m in body for m in _VERIFIED_MARKERS
+                    ):
+                        _LOGGER.info(
+                            "EU Data Act usership declared for VIN %s "
+                            "(attempt %d, role=%s)",
+                            _mask_vin(vin), attempt, role,
+                        )
+                        return True
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Verification POST attempt %d failed: %s", attempt, exc
+                )
+        return False
+
+    # ── v2.10.2 Phase C: data request submission + ZIP polling ───────────────
+
+    async def submit_data_request(self, vin: str) -> bool:
+        """Submit the "Verfügbare Daten anfragen" form for ``vin``.
+
+        Requires the Article 4 EU Data Act checkbox to be ticked on
+        the live form. The portal's React bundle owns the exact field
+        names so this is a best-effort POST of the canonical pair and
+        a verification GET of the details page to see whether the
+        spinner appeared. Returns True if the request looks accepted.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
+        url = _PORTAL_BASE + _PORTAL_DATA_REQUEST_PATH.format(
+            lang=self._language, country=self._country
+        )
+        try:
+            async with self._session.post(
+                url, params={"vin": vin},
+                data={
+                    "vin": vin,
+                    "article4Accepted": "true",
+                    "requestType": "available",
+                },
+                timeout=ClientTimeout(total=30),
+                allow_redirects=True,
+            ) as resp:
+                if resp.status not in (200, 201, 202):
+                    _LOGGER.debug(
+                        "Data request POST HTTP %s for VIN %s",
+                        resp.status, _mask_vin(vin),
+                    )
+                    return False
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("Data request POST failed: %s", exc)
+            return False
+        _LOGGER.info(
+            "EU Data Act data request submitted for VIN %s (async "
+            "delivery, may take up to 24h)",
+            _mask_vin(vin),
+        )
+        return True
+
+    async def poll_for_dataset_url(self, vin: str) -> str | None:
+        """Return a download URL for the latest dataset on ``vin``, or
+        None if no file is ready yet.
+
+        Status endpoint not captured in the live trace 2026-06-03;
+        this method scrapes the rendered vehicle-details page and
+        looks for an anchor href that links to a ZIP under the portal
+        domain. The remote React component bundle owns the exact API,
+        so this is a best-effort scrape. Replace with the verified
+        endpoint once the next live trace captures the AJAX call that
+        populates the "Ihre Dateien" section.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
+        url = _PORTAL_BASE + _PORTAL_VEHICLE_DETAILS_PATH.format(
+            lang=self._language, country=self._country
+        )
+        try:
+            async with self._session.get(
+                url, params={"vin": vin},
+                timeout=ClientTimeout(total=20),
+                allow_redirects=True,
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                html = await resp.text(errors="replace")
+        except Exception:  # noqa: BLE001
+            return None
+
+        # Cheap regex-free scan: look for href candidates ending in .zip
+        # under the portal host. The proper fix uses the React bundle's
+        # AJAX response shape once captured.
+        for token in html.split('href="')[1:]:
+            href = token.split('"', 1)[0]
+            if (
+                href.endswith(".zip")
+                and "drivesomethinggreater.com" in (href + _PORTAL_BASE)
+            ):
+                if href.startswith("/"):
+                    href = _PORTAL_BASE + href
+                return href
+        return None
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.10.1"
+  "version": "2.10.2"
 }


### PR DESCRIPTION
Live capture of the EU Data Act portal on 2026-06-03 surfaced three concrete OAuth bugs we shipped in v2.10.1, plus the structure of two follow-up flows we did not have at all.

## Fixed (Phase A - immediate user impact)

The portal client uses plain authorization-code flow with `prompt=login`, not the hybrid response_type our v2.10.1 fallback sent. That mismatch was the source of the `unexpected landing URL - IDP may have rejected client_id` error several users hit when the live BFF strategies all failed and the integration tried the read-only fallback. Plus state-string order was reversed (`{country}__{lang}` instead of `{lang}__{country}` per the trace), plus no token exchange against `/oidc/v1/token` after the code-flow callback.

- response_type switched from `code id_token token` -> `code`
- PKCE-S256 added defensively
- state reformatted to `{lang}__{country}__{BRAND}`
- prompt=login added
- POST grant_type=authorization_code with code_verifier to the IDP token endpoint
- Hybrid fragment delivery kept as defensive fallback so accounts that happened to work on the old path are not regressed

## Added (Phase B + C - scaffolding, not yet wired into coordinator)

- `check_verification_state(vin)` and `submit_usership_verification(vin)` for the one-time "Ich bin der Eigentumer + EU-Resident" declaration the portal requires before any data request can be submitted. Used by the next-version Repairs flow + opt-in auto-verify config toggle.
- `submit_data_request(vin)` and `poll_for_dataset_url(vin)` for the async ZIP delivery flow (up to 24h). Endpoint shapes are best-effort against the documented form fields; verified shapes ship in v2.10.3 once a live AJAX trace captures the exact call that populates "Ihre Dateien".

Coordinator wire-up + Repairs flow + OptionsFlow auto-verify toggle land in v2.10.3.