### PR TITLE
v2.10.3: Data Act portal completes SPA-rendered password page (#388 caraar12345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.10.3] - 2026-06-03
+
+VW EU users finally get a working read-only path again.
+
+### Fixed
+
+- **Data Act portal SPA password completion** (#388 caraar12345's trace). When the portal's password page is SPA-rendered, v2.10.2 detected it but bailed out telling the user the fallback in idk.py was the route - except that route is for the BFF client, not the portal client, so users on VW EU had nowhere to land. The Data Act portal flow now finishes the SPA-rendered password page itself with a form-encoded POST that includes `action=default` and the state lifted out of the page URL, then runs the standard token exchange. The portal client_id passes the Azure WAF where the main VW Android client_id is blocked, so this is the one path most affected VW EU users can actually use for read-only data.
+
 ## [2.10.2] - 2026-06-03
 
 EU Data Act portal flow rebuilt against a verified live trace.

--- a/custom_components/vag_connect/cariad/auth/_data_act_portal.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_portal.py
@@ -390,11 +390,61 @@ class DataActPortalAuth:
                 and "<form" not in html_lower
             )
             if is_spa_password_page:
-                raise AuthenticationError(
-                    "Data Act portal: password page is SPA-rendered (no "
-                    "static form). The static-form-scraping path cannot "
-                    "complete; the JSON SPA fallback in idk.py is the "
-                    "supported route. See issue #388."
+                # v2.10.3 (#388 caraar12345) — actually complete the SPA-
+                # rendered password page on the portal flow. The portal
+                # client_id passes the Azure WAF where the standard VW
+                # Android client_id is blocked, so this is the one path
+                # we can actually walk for read-only fallback. Mirror
+                # the SPA POST shape from idk.py: form-encoded body to
+                # the same /u/login?state=... URL with action=default,
+                # follow the redirect chain to the portal callback.
+                from urllib.parse import urlparse as _urlparse  # noqa: PLC0415
+                state_from_url = ""
+                identifier_qs = parse_qs(_urlparse(identifier_url).query)
+                if identifier_qs.get("state"):
+                    state_from_url = identifier_qs["state"][0]
+                spa_form = {
+                    "username": email,
+                    "password": password,
+                    "action": "default",
+                }
+                if state_from_url:
+                    spa_form["state"] = state_from_url
+                try:
+                    async with self._session.post(
+                        identifier_url,
+                        data=spa_form,
+                        timeout=ClientTimeout(
+                            total=_PORTAL_REQUEST_TIMEOUT_S
+                        ),
+                        allow_redirects=True,
+                        headers={
+                            "Accept": (
+                                "text/html,application/xhtml+xml,"
+                                "application/xml;q=0.9,*/*;q=0.8"
+                            ),
+                        },
+                    ) as resp:
+                        callback_url = str(resp.url)
+                        if resp.status not in (200, 302):
+                            raise AuthenticationError(
+                                "Data Act portal: SPA password POST "
+                                f"HTTP {resp.status}"
+                            )
+                except AuthenticationError:
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    raise AuthenticationError(
+                        f"Data Act portal: SPA password POST failed ({exc})"
+                    ) from exc
+                # Jump ahead to step 4 (callback validation + token
+                # exchange). Reuse the existing logic by returning a
+                # synthetic password-action URL; the caller below
+                # already runs the callback parsing + token POST chain.
+                # Skip the static-form password POST by branching here.
+                return await self._complete_after_callback(
+                    callback_url=callback_url,
+                    pkce_verifier=pkce_verifier,
                 )
 
             # v2.7.3 — when the password form is missing, the most common
@@ -456,20 +506,48 @@ class DataActPortalAuth:
                 f"Data Act portal: password POST failed ({exc})"
             ) from exc
 
-        # Step 4 — verify we landed on the portal host and extract the
-        # authorization code from the callback URL. v2.10.2: portal
-        # uses plain code flow, so the callback ends on
-        # ``.../login?code=...&state=...`` instead of returning tokens
-        # in the fragment. The token exchange happens in step 5.
+        # Step 4 + 5 — callback parsing + token exchange. Factored into
+        # a helper so the v2.10.3 SPA-password path can short-circuit
+        # to the same completion logic without duplicating code.
+        return await self._complete_after_callback(
+            callback_url=callback_url,
+            pkce_verifier=pkce_verifier,
+        )
+
+    async def _complete_after_callback(
+        self,
+        *,
+        callback_url: str,
+        pkce_verifier: str,
+    ) -> TokenSet:
+        """Validate callback URL, extract code, exchange for tokens.
+
+        Shared between the static-form password-POST path and the
+        v2.10.3 SPA-password-POST path. Both land on the same
+        ``{portal}/login?code=...&state=...`` callback shape so the
+        downstream work is identical.
+
+        Raises:
+            AuthenticationError on any validation or HTTP failure.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
         parsed = urlparse(callback_url)
         host_ok = parsed.netloc.endswith("drivesomethinggreater.com")
-        if not host_ok or "signin-service" in callback_url or "/error" in callback_url:
+        if (
+            not host_ok
+            or "signin-service" in callback_url
+            or "/error" in callback_url
+        ):
             raise AuthenticationError(
                 f"Data Act portal: login did not land on portal host "
                 f"(final URL: {callback_url[:120]})"
             )
 
-        all_params = {**parse_qs(parsed.query), **parse_qs(parsed.fragment)}
+        all_params = {
+            **parse_qs(parsed.query),
+            **parse_qs(parsed.fragment),
+        }
         auth_code = (all_params.get("code") or [""])[0]
         if not auth_code:
             # Belt-and-braces: some IDP variants still deliver in the
@@ -495,7 +573,6 @@ class DataActPortalAuth:
                 "code — IDP may have changed the redirect parameters"
             )
 
-        # Step 5 — exchange the code for tokens at the IDP token endpoint.
         token_body = {
             "grant_type": "authorization_code",
             "code": auth_code,
@@ -524,8 +601,9 @@ class DataActPortalAuth:
                     err = token_json.get("error", "")
                     err_desc = token_json.get("error_description", "")
                     raise AuthenticationError(
-                        f"Data Act portal: token exchange HTTP {token_status} "
-                        f"(error={err!r} desc={err_desc[:120]!r})"
+                        f"Data Act portal: token exchange HTTP "
+                        f"{token_status} (error={err!r} "
+                        f"desc={err_desc[:120]!r})"
                     )
         except AuthenticationError:
             raise

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.10.2"
+  "version": "2.10.3"
 }


### PR DESCRIPTION
caraar12345 posted a full v2.10.2 trace on #388 showing the residual break for VW EU users:

- **Strategy #0 hybrid_full**: HTTP 403 at the authorize endpoint with both the Android UA and the v2.10.1 browser-UA retry. The Azure WAF is fingerprinting the Android client_id, not just the user-agent.
- **Strategy #1 classic auth-code**: login succeeds and returns a code, but the BFF token exchange returns HTTP 400 `invalid assertion headers` - the Play Integrity wall we cannot get past from Python.
- **Strategy #2 data_act_portal**: lands on the SPA-rendered password page. v2.10.2 detected it but raised with `JSON SPA fallback in idk.py is the supported route` - except idk.py runs the BFF client, not the portal client, so this path was a dead-end.

The portal client_id `9b58543e-` **does** pass the WAF (caraar12345's strategy #2 reached the password page with status 200). So the portal is the one path most affected users can actually walk.

## Fixed

The Data Act portal flow now finishes the SPA-rendered password page itself: form-encoded POST with `action=default` plus the state pulled from the URL query string, then the standard v2.10.2 token exchange. The callback validation + token POST is factored out into a helper so both the static-form and SPA-password paths share it without duplicating code.