### PR TITLE
v2.10.4: APK watcher + user client_id override for OAuth chain

### DIFF
--- a/.github/workflows/app-atlas-builder.yml
+++ b/.github/workflows/app-atlas-builder.yml
@@ -73,6 +73,34 @@ jobs:
           fi
           python scripts/app_atlas/build_atlas.py --with-apk-extraction $FORCE_FLAG
 
+      - name: Diff client_ids vs source (v2.10.4 watcher)
+        id: client_id_diff
+        run: |
+          python scripts/app_atlas/diff_known_client_ids.py
+          if [ -f .app-atlas-apk-cache/new-client-ids-found.md ]; then
+            echo "new_ids=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "new_ids=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open issue for new client_ids
+        if: steps.client_id_diff.outputs.new_ids == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          # De-dupe against an already-open issue from a previous run.
+          EXISTING=$(gh issue list --state open --label apk-watcher --search 'in:title "new OAuth client_id"' --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "Issue #$EXISTING already tracks new client_ids - adding comment."
+            gh issue comment "$EXISTING" --body-file .app-atlas-apk-cache/new-client-ids-found.md
+          else
+            gh issue create \
+              --title "apk-watcher: new OAuth client_id detected (${DATE})" \
+              --label apk-watcher \
+              --body-file .app-atlas-apk-cache/new-client-ids-found.md
+          fi
+
       - name: Detect changes
         id: changes
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.10.4] - 2026-06-03
+
+Two power-user tools for keeping the auth chain alive when VW rotates client_ids.
+
+### Added
+
+- **APK watcher: auto-issue on new OAuth client_id**. The daily atlas builder already polled VW Group APKs and extracted client_ids; now there is a diff step that compares the latest extraction against everything wired into source. When a brand-new id appears, a labeled issue gets opened so the maintainer (or anyone) can promote it into the alternates list without waiting for someone to notice manually.
+- **OAuth client_id override in OptionsFlow** (power-user). When the community spots a fresh client_id in a new APK before the daily watcher catches it, paste the full `UUID@apps_vw-dilab_com` into the new field and the resolver tries it first. All existing fallbacks stay in the chain. Empty / malformed values are silently ignored.
+
 ## [2.10.3] - 2026-06-03
 
 VW EU users finally get a working read-only path again.

--- a/custom_components/vag_connect/cariad/auth/_auth_config_resolver.py
+++ b/custom_components/vag_connect/cariad/auth/_auth_config_resolver.py
@@ -172,6 +172,7 @@ class AuthConfigResolver:
         hardcoded_token_url: str,
         prior_qmauth_secret: str | None = None,
         prior_qmauth_client_id: str | None = None,
+        user_client_id_override: str | None = None,
     ) -> None:
         self._brand = brand_name
         self._apk = _load_apk_auth_secrets(brand_name)
@@ -182,6 +183,27 @@ class AuthConfigResolver:
         # v2.5.7 R2 — optional prior qmauth pair as last-resort fallback.
         self._prior_qmauth_secret = prior_qmauth_secret
         self._prior_qmauth_client_id = prior_qmauth_client_id
+        # v2.10.4 — power-user OAuth client_id override pasted via the
+        # OptionsFlow. Prepended to the top of oauth_client_id_chain
+        # when present. Silently dropped when malformed so a typo in
+        # the config field never breaks the auth chain.
+        self._user_client_id_override: str | None = None
+        if isinstance(user_client_id_override, str):
+            cand = user_client_id_override.strip()
+            if "@apps_vw-dilab_com" in cand and len(cand) > 36:
+                self._user_client_id_override = cand
+                _LOGGER.info(
+                    "AuthConfigResolver(%s): user-supplied client_id "
+                    "override active (prepended to chain).",
+                    brand_name,
+                )
+            elif cand:
+                _LOGGER.warning(
+                    "AuthConfigResolver(%s): client_id override "
+                    "ignored - expected UUID@apps_vw-dilab_com, got "
+                    "%d-char string starting %r.",
+                    brand_name, len(cand), cand[:8],
+                )
         if self._apk:
             _LOGGER.debug(
                 "AuthConfigResolver(%s): loaded auth_secrets from APK cache: keys=%s",
@@ -457,6 +479,12 @@ class AuthConfigResolver:
             if cid and cid not in seen:
                 ordered.append(cid)
                 seen.add(cid)
+
+        # v2.10.4 — 0. User-supplied override from the OptionsFlow.
+        # Tried first when present so power users can paste a freshly
+        # extracted client_id and unblock themselves immediately.
+        if self._user_client_id_override:
+            _add(self._user_client_id_override)
 
         # v2.5.11 — 1. Audi market-config (only for Audi brand).
         if self._brand == "audi":

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -320,6 +320,21 @@ class IDKAuth:
             else _SIGNIN_BASE
         )
         self._signin_client_id = signin_client_id_override or self._brand.client_id
+        # v2.10.4 — user-supplied OAuth client_id override from the
+        # OptionsFlow. Set via ``set_user_client_id_override`` after
+        # construction (we do not add a constructor param here to
+        # avoid touching every IDKAuth call-site). Passed into the
+        # AuthConfigResolver so the resolver prepends it to the chain.
+        self._user_client_id_override: str | None = None
+
+    def set_user_client_id_override(self, value: str | None) -> None:
+        """v2.10.4 — set the OAuth client_id paste-in from OptionsFlow.
+
+        Called by the brand client after reading the config-entry
+        options. Empty / whitespace-only / malformed values are
+        silently ignored by the resolver downstream.
+        """
+        self._user_client_id_override = value if value else None
 
     def hydrate_session_cookies(self, cookies: list[dict[str, Any]]) -> None:
         """v2.8.0 — pre-load persisted IDP cookies into the session jar.
@@ -1548,6 +1563,7 @@ class IDKAuth:
             hardcoded_token_url=_CARIAD_TOKEN_URL,
             prior_qmauth_secret=_QM_PRIOR_SECRET,
             prior_qmauth_client_id=_QM_PRIOR_CLIENT_ID,
+            user_client_id_override=self._user_client_id_override,
         )
         # v2.5.7 R3 — try OIDC discovery for the token URL before
         # falling back to APK / hardcoded values. Best-effort: a

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -32,6 +32,7 @@ from homeassistant.helpers.selector import (
 from .const import (
     BRANDS,
     CONF_BRAND,
+    CONF_CLIENT_ID_OVERRIDE,
     CONF_ENABLE_DATA_ACT_BROWSER,
     CONF_WAKE_BEFORE_POLL,
     CONF_WAKE_DELAY_SECONDS,
@@ -1075,5 +1076,20 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                         mode=NumberSelectorMode.SLIDER,
                     )
                 ),
+                # v2.10.4 - OAuth client_id override. Power-user escape
+                # hatch for when the community spots a fresh client_id
+                # in a new APK before our daily atlas builder catches
+                # it. Pasted value is prepended to the resolver chain
+                # so it gets tried first; the existing fallbacks stay
+                # in place. Empty string = no override. Format must
+                # match "UUID@apps_vw-dilab_com" or the resolver
+                # silently drops it.
+                vol.Optional(
+                    CONF_CLIENT_ID_OVERRIDE,
+                    default=current_options.get(
+                        CONF_CLIENT_ID_OVERRIDE,
+                        current_data.get(CONF_CLIENT_ID_OVERRIDE, ""),
+                    ),
+                ): str,
             }),
         )

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -112,6 +112,18 @@ CONF_WAKE_BEFORE_POLL         = "wake_before_poll"
 CONF_WAKE_DELAY_SECONDS       = "wake_delay_seconds"
 DEFAULT_WAKE_DELAY_SECONDS    = 15
 
+# v2.10.4 - User-supplied OAuth client_id override. Lets a user paste
+# a freshly extracted client_id (e.g. from a new APK the community
+# captured before our daily atlas builder picked it up, or a beta
+# build) without waiting for a release. When set, the AuthConfigResolver
+# prepends this value to the top of the oauth_client_id_chain so it
+# is tried FIRST. The existing chain (APK-discovered + hardcoded
+# alternates + hardcoded canonical) stays in place as fallback. Empty
+# string / unset = no override, resolver behaves as before. Format
+# must match the canonical "UUID@apps_vw-dilab_com" shape; resolver
+# validates and silently drops anything malformed.
+CONF_CLIENT_ID_OVERRIDE       = "client_id_override"
+
 # Supported brands — must match CariadClientFactory.create() keys
 BRANDS = {
     "audi":           "Audi (myAudi)",

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -526,12 +526,31 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         ola_app_v = self.entry.data.get(CONF_OLA_APP_VERSION_OVERRIDE) or None
         ola_ua    = self.entry.data.get(CONF_OLA_USER_AGENT_OVERRIDE) or None
 
+        # v2.10.4 — read OAuth client_id override from entry options
+        # (preferred, set via OptionsFlow) with fallback to entry.data
+        # (legacy / config-flow-time override).
+        from .const import CONF_CLIENT_ID_OVERRIDE  # noqa: PLC0415
+        client_id_override = (
+            self.entry.options.get(CONF_CLIENT_ID_OVERRIDE)
+            or self.entry.data.get(CONF_CLIENT_ID_OVERRIDE)
+            or ""
+        ).strip() or None
+
         session = async_get_clientsession(self.hass)
         self._cariad_client = CariadClientFactory.create(
             brand, session, username, password, spin,
             ola_app_version_override=ola_app_v,
             ola_user_agent_override=ola_ua,
         )
+        # v2.10.4 — push the user-supplied OAuth client_id override
+        # onto the underlying IDKAuth instance so the AuthConfigResolver
+        # prepends it to the chain. No-op when override is None.
+        if client_id_override and hasattr(self._cariad_client, "_auth"):
+            inner_auth = getattr(self._cariad_client, "_auth", None)
+            if inner_auth is not None and hasattr(
+                inner_auth, "set_user_client_id_override"
+            ):
+                inner_auth.set_user_client_id_override(client_id_override)
 
         # v1.19.2 (#118 eismarkt) — token persistence wire-up.
         # Load any persisted IDK tokens from HA storage BEFORE the

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.10.3"
+  "version": "2.10.4"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -134,7 +134,8 @@
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, Live (beta))",
           "enable_data_act_browser": "EU Data Act portal: headless-browser fallback (EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
-          "wake_delay_seconds": "Wake delay (seconds)"
+          "wake_delay_seconds": "Wake delay (seconds)",
+          "client_id_override": "OAuth client_id override (power users)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -147,7 +148,8 @@
           "enable_push_audi_vw": "Live (beta): Audi/VW only. Enables real-time push notifications from the Cariad FCM channel (same one myAudi/WeConnect mobile apps use, covers lock/unlock results, charging-state, climate, alarm). Decoded events are fired onto the Home Assistant event bus as ``vag_connect_push_event`` and trigger a coordinator refresh. Requires firebase-messaging Python package (same lazy-import as Skoda MQTT + CUPRA/SEAT FCM). Live activation since v2.8.0 (Action #4); the credential resolver is still tester-gated until task #40 follow-up lands the Cariad Firebase sender_id. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_data_act_browser": "EXPERIMENTAL: only meaningful when the integration has fallen back to the EU Data Act portal (read-only). Drives a headless Chromium via the optional 'playwright' Python package to click the portal's data-export button automatically. The package is NOT preinstalled (it pulls roughly 100 MB of Chromium). When enabled but missing, a Repair issue tells you how to install it from inside the Home Assistant container. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
-          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit."
+          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
         }
       }
     }

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -143,7 +143,8 @@
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
-          "wake_delay_seconds": "Wake delay (seconds)"
+          "wake_delay_seconds": "Wake delay (seconds)",
+          "client_id_override": "OAuth client_id override (power users)"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",
@@ -155,7 +156,8 @@
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
-          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit."
+          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
         }
       }
     }

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -128,7 +128,8 @@
           "enable_data_act_browser": "EU Data Act Portal: Headless-Browser-Fallback (EXPERIMENTELL)",
           "read_only_mode": "Nur-Lesen-Modus",
           "wake_before_poll": "Fahrzeug aktiv aufwecken vor Status-Abfrage",
-          "wake_delay_seconds": "Wartezeit nach Wake-up (Sekunden)"
+          "wake_delay_seconds": "Wartezeit nach Wake-up (Sekunden)",
+          "client_id_override": "OAuth client_id Override (Power-User)"
         },
         "data_description": {
           "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",
@@ -141,7 +142,8 @@
           "read_only_mode": "Wenn aktiv: nur Status-Sensoren werden erstellt, keine Schalter/Buttons/Schlösser/Climate die Befehle senden würden. Schützt vor versehentlicher Auslösung und Subscription-zählenden Kommandos.",
           "enable_data_act_browser": "EXPERIMENTELL: Nur relevant wenn die Integration auf das EU Data Act Portal (read-only) zurückgefallen ist. Steuert einen Headless-Chromium über das optionale 'playwright' Python-Paket, um den Daten-Export-Button automatisch zu klicken. Das Paket ist NICHT vorinstalliert (zieht ca. 100 MB Chromium nach). Wenn aktiv aber nicht installiert: ein Repair-Issue zeigt dir wie du es im HA-Container nachinstallierst. Integration nach Aktivierung neu laden.",
           "wake_before_poll": "Wenn aktiviert, sendet die Integration einen Wake-POST an Fahrzeuge die beim letzten Poll OFFLINE waren, bevor sie den Status abruft. Das Auto bekommt einen serverseitigen Wake-up und pusht frische Daten, dann wartet die Integration die Wake-Verzögerung ab und liest erst dann. Schließt die 'alle Sensoren unbekannt bei geparktem Auto'-Lücke, kostet aber pro Offline-VIN pro Poll-Zyklus einen zusätzlichen API-Call. Standard: aus. Integration nach dem Umschalten neu laden.",
-          "wake_delay_seconds": "Sekunden Wartezeit zwischen dem Wake-up-POST und dem Status-Abruf. Die Standardeinstellung von 15 Sekunden ist das, was die meisten Brand-Backends brauchen um den Wake-induzierten Daten-Push zu verarbeiten. Niedrigere Werte riskieren veraltete Daten; höhere strecken den Poll-Zyklus ohne weiteren Nutzen."
+          "wake_delay_seconds": "Sekunden Wartezeit zwischen dem Wake-up-POST und dem Status-Abruf. Die Standardeinstellung von 15 Sekunden ist das, was die meisten Brand-Backends brauchen um den Wake-induzierten Daten-Push zu verarbeiten. Niedrigere Werte riskieren veraltete Daten; höhere strecken den Poll-Zyklus ohne weiteren Nutzen.",
+          "client_id_override": "Power-User Eskapeluke wenn die Community einen frischen OAuth client_id in einer neuen VW Group APK entdeckt bevor unser täglicher Atlas-Builder ihn findet. Paste den vollen UUID@apps_vw-dilab_com String hier rein, dann probiert der Resolver ihn ZUERST bei jedem authenticate, mit allen bestehenden client_ids weiter als Fallback in der Chain. Leer lassen für Default-Verhalten. Format: 8-4-4-4-12 hex Zeichen gefolgt von @apps_vw-dilab_com. Ungültige Werte werden stillschweigend ignoriert."
         }
       }
     }

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -127,7 +127,8 @@
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, Live (beta))",
           "wake_before_poll": "Active vehicle wake-up before status poll",
-          "wake_delay_seconds": "Wake delay (seconds)"
+          "wake_delay_seconds": "Wake delay (seconds)",
+          "client_id_override": "OAuth client_id override (power users)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -139,7 +140,8 @@
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_audi_vw": "Live (beta): Audi/VW only. Enables real-time push notifications from the Cariad FCM channel (same one myAudi/WeConnect mobile apps use, covers lock/unlock results, charging-state, climate, alarm). Decoded events are fired onto the Home Assistant event bus as ``vag_connect_push_event`` and trigger a coordinator refresh. Requires firebase-messaging Python package (same lazy-import as Skoda MQTT + CUPRA/SEAT FCM). Live activation since v2.8.0 (Action #4); the credential resolver is still tester-gated until task #40 follow-up lands the Cariad Firebase sender_id. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
-          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit."
+          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
         }
       }
     }

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -143,7 +143,8 @@
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
-          "wake_delay_seconds": "Wake delay (seconds)"
+          "wake_delay_seconds": "Wake delay (seconds)",
+          "client_id_override": "OAuth client_id override (power users)"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",
@@ -155,7 +156,8 @@
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
-          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit."
+          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
         }
       }
     }

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -143,7 +143,8 @@
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
-          "wake_delay_seconds": "Wake delay (seconds)"
+          "wake_delay_seconds": "Wake delay (seconds)",
+          "client_id_override": "OAuth client_id override (power users)"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",
@@ -155,7 +156,8 @@
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
-          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit."
+          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
         }
       }
     }

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -143,7 +143,8 @@
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
-          "wake_delay_seconds": "Wake delay (seconds)"
+          "wake_delay_seconds": "Wake delay (seconds)",
+          "client_id_override": "OAuth client_id override (power users)"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",
@@ -155,7 +156,8 @@
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
-          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit."
+          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
         }
       }
     }

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -143,7 +143,8 @@
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
-          "wake_delay_seconds": "Wake delay (seconds)"
+          "wake_delay_seconds": "Wake delay (seconds)",
+          "client_id_override": "OAuth client_id override (power users)"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",
@@ -155,7 +156,8 @@
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
-          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit."
+          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
         }
       }
     }

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -143,7 +143,8 @@
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
-          "wake_delay_seconds": "Wake delay (seconds)"
+          "wake_delay_seconds": "Wake delay (seconds)",
+          "client_id_override": "OAuth client_id override (power users)"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",
@@ -155,7 +156,8 @@
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
-          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit."
+          "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
         }
       }
     }

--- a/scripts/app_atlas/diff_known_client_ids.py
+++ b/scripts/app_atlas/diff_known_client_ids.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""Diff client_ids found in the latest APK extraction against the
+client_ids we already know about in source.
+
+Output:
+- Exit 0 always (advisory; never fails the workflow).
+- When a brand-new client_id is detected, writes a markdown summary
+  to `.app-atlas-apk-cache/new-client-ids-found.md` and prints it to
+  stdout. The app-atlas-builder workflow reads that file and creates
+  a GitHub issue tagged `apk-watcher` so we can react quickly when
+  VW (or any other brand) ships a fresh OAuth client.
+- When no new ids are found, the marker file is removed (so the
+  follow-up workflow step can `if: hashFiles(marker) != ''` reliably).
+
+This is intentionally a small, dependency-free script. It runs
+inside the existing `app-atlas-builder.yml` workflow as a step
+after `build_atlas.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_APK_CACHE = _REPO_ROOT / ".app-atlas-apk-cache"
+_MODELS_PY = _REPO_ROOT / "custom_components" / "vag_connect" / "cariad" / "models.py"
+_RESOLVER_PY = (
+    _REPO_ROOT
+    / "custom_components"
+    / "vag_connect"
+    / "cariad"
+    / "auth"
+    / "_auth_config_resolver.py"
+)
+_MARKER_FILE = _APK_CACHE / "new-client-ids-found.md"
+
+# Matches the canonical VAG OAuth client_id shape (UUID@apps_vw-dilab_com).
+_CID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    r"@apps_vw-dilab_com",
+    re.IGNORECASE,
+)
+
+
+def _known_from_source() -> set[str]:
+    """Collect every client_id string already wired into source.
+
+    Walks models.py + _auth_config_resolver.py. Cheap regex grep,
+    deliberately not importing the modules so this can run during
+    CI without setting up the HA path.
+    """
+    known: set[str] = set()
+    for path in (_MODELS_PY, _RESOLVER_PY):
+        if not path.is_file():
+            continue
+        for match in _CID_RE.findall(path.read_text(encoding="utf-8")):
+            known.add(match.lower())
+    return known
+
+
+def _candidates_from_cache() -> dict[str, set[str]]:
+    """Return brand -> set of client_ids found in the latest APK
+    extraction for that brand.
+    """
+    out: dict[str, set[str]] = {}
+    if not _APK_CACHE.is_dir():
+        return out
+    for json_path in sorted(_APK_CACHE.glob("*.json")):
+        try:
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        brand = data.get("brand") or json_path.stem
+        # Cache shape varies across atlas builder iterations. Handle
+        # both single-version and multi-version layouts.
+        candidates: list[str] = []
+        if isinstance(data.get("findings"), dict):
+            auth = (data["findings"].get("auth_secrets") or {})
+            candidates = list(auth.get("client_id_candidates") or [])
+        elif isinstance(data.get("versions"), dict):
+            versions = data["versions"]
+            if versions:
+                latest = max(versions.keys())
+                auth = (
+                    (versions[latest].get("findings") or {})
+                    .get("auth_secrets") or {}
+                )
+                candidates = list(auth.get("client_id_candidates") or [])
+        for cand in candidates:
+            if isinstance(cand, str) and _CID_RE.fullmatch(cand):
+                out.setdefault(brand, set()).add(cand.lower())
+    return out
+
+
+def main() -> int:
+    """Run the diff. Always exit 0 - this is advisory only."""
+    known = _known_from_source()
+    per_brand = _candidates_from_cache()
+
+    new_per_brand: dict[str, list[str]] = {}
+    for brand, cids in per_brand.items():
+        new = sorted(cids - known)
+        if new:
+            new_per_brand[brand] = new
+
+    # Clean up any stale marker from a previous run.
+    if _MARKER_FILE.exists():
+        try:
+            _MARKER_FILE.unlink()
+        except OSError:
+            pass
+
+    if not new_per_brand:
+        print(
+            f"No new client_ids found. ({sum(len(v) for v in per_brand.values())} "
+            f"candidates checked across {len(per_brand)} brand(s), "
+            f"all already wired into source.)"
+        )
+        return 0
+
+    lines = [
+        "## New OAuth client_id(s) detected in latest APK extraction",
+        "",
+        "The daily app-atlas builder found one or more OAuth client_ids "
+        "in a fresh APK that are not yet wired into our source.",
+        "",
+        "When a brand rotates or adds a client_id, the WAF may pass it "
+        "while the old ones get blocked. Worth promoting these into "
+        "`_ALTERNATE_CLIENT_IDS` in `_auth_config_resolver.py` so the "
+        "chain can fall back to them.",
+        "",
+        "### Findings",
+        "",
+    ]
+    for brand in sorted(new_per_brand):
+        lines.append(f"**{brand}**")
+        for cid in new_per_brand[brand]:
+            lines.append(f"- `{cid}`")
+        lines.append("")
+    lines.append("### Next steps")
+    lines.append("")
+    lines.append(
+        "1. Manually verify the candidate is genuinely a new auth "
+        "client_id and not a different kind of UUID that happens to "
+        "match the pattern."
+    )
+    lines.append(
+        "2. Add it to `_ALTERNATE_CLIENT_IDS[<brand>]` in "
+        "`custom_components/vag_connect/cariad/auth/_auth_config_resolver.py`."
+    )
+    lines.append(
+        "3. Bump the manifest version + add a CHANGELOG entry under Fixed."
+    )
+
+    marker_body = "\n".join(lines) + "\n"
+    _MARKER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _MARKER_FILE.write_text(marker_body, encoding="utf-8")
+    print(marker_body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two power-user tools for keeping the auth chain alive when VW rotates client_ids.

## Part 1 - APK watcher auto-issue on new client_id

Daily `app-atlas-builder.yml` already polls VW Group APKs and extracts client_ids into `.app-atlas-apk-cache/{brand}.json`. The new `scripts/app_atlas/diff_known_client_ids.py` runs as an extra step and compares those candidates against everything currently wired into `models.py` + `_auth_config_resolver.py`. When a brand-new client_id appears in the cache, the workflow opens (or comments on) a labelled `apk-watcher` issue listing the new id(s) + next steps. De-duped per day so a stuck cache doesn't spam the tracker.

## Part 2 - Power-user OAuth client_id override (CONF_CLIENT_ID_OVERRIDE)

New text field in OptionsFlow. When the community spots a fresh client_id in a new APK before the daily watcher catches it, paste the full `UUID@apps_vw-dilab_com` into the field. The AuthConfigResolver prepends it to position 0 of the chain so it gets tried first; all existing fallbacks (APK-discovered + hardcoded alternates + canonical) stay in place. Empty / malformed values are silently dropped.

Plumbed end-to-end: `OptionsFlow` -> `entry.options[CONF_CLIENT_ID_OVERRIDE]` -> coordinator reads it -> calls `IDKAuth.set_user_client_id_override` -> resolver picks it up on next authenticate. Translations added in DE + EN, mirrored to the other 7 langs (English text for non-DE/EN until volunteer translators land).