### PR TITLE
v2.10.5: Data Act portal Custom Data Request auto-kickoff (live-trace based)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.10.5] - 2026-06-03
+
+EU Data Act portal: no more manual click-through. When the integration is in read-only portal mode and you opt in via the new toggle, it kicks off the Custom Data Request on its own.
+
+### Added
+
+- **EU Data Act portal Custom Data Request auto-kickoff** (live-trace based). At startup in read-only `data_act_portal` mode, the coordinator checks each VIN for an existing 15-min Custom Request and creates one when none exists. Uses the verified `/proxy_api/euda-apim/` endpoints captured 2026-06-03: GET `metadata/partial` to detect, CSRF + POST `requests/partial` to kick off, GET `datadelivery/{Identifier}/list` to pick up the ZIPs. The portal accepts at most one active custom request per VIN at a time so the check-then-create order is critical; we adopt an existing request if one is already running instead of double-kicking. New toggle `eu_data_act_auto_kickoff` in OptionsFlow defaults to OFF because the kickoff implies a 1-month data subscription on the user's account at the portal.
+- **Repairs issue on portal session expiry**. HTTP 401 on any portal API call now opens a guided `data_act_session_expired` Repairs issue pointing the user at the Reconfigure flow. Portal sessions are cookie-bound and not refreshable, so we surface the prompt instead of silently looping.
+
 ## [2.10.4] - 2026-06-03
 
 Two power-user tools for keeping the auth chain alive when VW rotates client_ids.

--- a/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
@@ -126,6 +126,37 @@ _NEEDS_VERIFICATION_MARKERS = (
     "EU Data Act usership not yet verified",
 )
 
+# v2.10.5 — verified live-trace endpoints captured 2026-06-03.
+# Custom Data Request lives under /proxy_api/euda-apim/ on the portal
+# host. The "Frequency=15mins" + "Duration=1 month" combo is the only
+# one that yields 15-minute polling drops; other combinations return
+# fewer or sparser dumps. See docs/EU_DATA_ACT_PORTAL.md for the
+# full payload schema.
+_EUDA_APIM = "/proxy_api/euda-apim"
+_CUSTOM_REQUEST_POST_PATH = _EUDA_APIM + "/datarequest/vehicles/{vin}/requests/partial"
+_CUSTOM_REQUEST_META_PATH = _EUDA_APIM + "/datarequest/vehicles/{vin}/metadata/partial"
+_ALL_REQUEST_META_PATH = _EUDA_APIM + "/datarequest/vehicles/{vin}/metadata/all"
+_DATASET_LIST_PATH = (
+    _EUDA_APIM + "/datadelivery/vehicles/{vin}/{identifier}/list"
+)
+_CSRF_TOKEN_PATH = "/libs/granite/csrf/token.json"
+
+# Canonical Data Clusters per portal UI as of 2026-06-03. Ordering and
+# spelling matter; the portal's React validator compares against this
+# exact set when the user picks "All Data".
+_DEFAULT_DATA_CLUSTERS = (
+    "All Data",
+    "Charging",
+    "Driving Behaviour",
+    "Maintenance Related Information",
+    "Parking Data",
+    "Vehicle Warning Lights",
+)
+
+
+# DataActSessionExpiredError is defined right after DataActScraperError
+# below; both subclass Exception.
+
 # Route A candidate endpoints. The first entry is the only path that
 # has been verified from public sources and known community Python
 # code: it returns vehicle metadata for the supplied VIN under the
@@ -188,6 +219,14 @@ class DataActScraperError(Exception):
     ``fetch_vehicle_zip`` so the next poll can retry without entity
     flicker. Only structural failures (auth missing, browser toggle
     enabled but ``playwright`` not installed, etc.) raise.
+    """
+
+
+class DataActSessionExpiredError(DataActScraperError):
+    """v2.10.5 - raised when the portal returns 401 on an endpoint we
+    depend on. The coordinator catches this and opens a Repairs issue
+    prompting the user to reauthenticate; portal sessions are cookie-
+    bound and not refreshable from the integration side.
     """
 
 
@@ -809,91 +848,230 @@ class DataActScraper:
                 )
         return False
 
-    # ── v2.10.2 Phase C: data request submission + ZIP polling ───────────────
+    # ── v2.10.5 Phase C: Custom Data Request (live-trace based) ──────────────
 
-    async def submit_data_request(self, vin: str) -> bool:
-        """Submit the "Verfügbare Daten anfragen" form for ``vin``.
-
-        Requires the Article 4 EU Data Act checkbox to be ticked on
-        the live form. The portal's React bundle owns the exact field
-        names so this is a best-effort POST of the canonical pair and
-        a verification GET of the details page to see whether the
-        spinner appeared. Returns True if the request looks accepted.
+    async def _fetch_csrf_token(self) -> str | None:
+        """Return a fresh CSRF token, or None if the portal did not
+        deliver one. CSRF expires per-session so callers re-fetch
+        before every POST that needs it.
         """
         from aiohttp import ClientTimeout  # noqa: PLC0415
 
-        url = _PORTAL_BASE + _PORTAL_DATA_REQUEST_PATH.format(
-            lang=self._language, country=self._country
-        )
-        try:
-            async with self._session.post(
-                url, params={"vin": vin},
-                data={
-                    "vin": vin,
-                    "article4Accepted": "true",
-                    "requestType": "available",
-                },
-                timeout=ClientTimeout(total=30),
-                allow_redirects=True,
-            ) as resp:
-                if resp.status not in (200, 201, 202):
-                    _LOGGER.debug(
-                        "Data request POST HTTP %s for VIN %s",
-                        resp.status, _mask_vin(vin),
-                    )
-                    return False
-        except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("Data request POST failed: %s", exc)
-            return False
-        _LOGGER.info(
-            "EU Data Act data request submitted for VIN %s (async "
-            "delivery, may take up to 24h)",
-            _mask_vin(vin),
-        )
-        return True
-
-    async def poll_for_dataset_url(self, vin: str) -> str | None:
-        """Return a download URL for the latest dataset on ``vin``, or
-        None if no file is ready yet.
-
-        Status endpoint not captured in the live trace 2026-06-03;
-        this method scrapes the rendered vehicle-details page and
-        looks for an anchor href that links to a ZIP under the portal
-        domain. The remote React component bundle owns the exact API,
-        so this is a best-effort scrape. Replace with the verified
-        endpoint once the next live trace captures the AJAX call that
-        populates the "Ihre Dateien" section.
-        """
-        from aiohttp import ClientTimeout  # noqa: PLC0415
-
-        url = _PORTAL_BASE + _PORTAL_VEHICLE_DETAILS_PATH.format(
-            lang=self._language, country=self._country
-        )
         try:
             async with self._session.get(
-                url, params={"vin": vin},
-                timeout=ClientTimeout(total=20),
-                allow_redirects=True,
+                _PORTAL_BASE + _CSRF_TOKEN_PATH,
+                timeout=ClientTimeout(total=10),
+                headers={"Accept": "application/json"},
             ) as resp:
                 if resp.status != 200:
                     return None
-                html = await resp.text(errors="replace")
+                data = await resp.json(content_type=None)
         except Exception:  # noqa: BLE001
             return None
-
-        # Cheap regex-free scan: look for href candidates ending in .zip
-        # under the portal host. The proper fix uses the React bundle's
-        # AJAX response shape once captured.
-        for token in html.split('href="')[1:]:
-            href = token.split('"', 1)[0]
-            if (
-                href.endswith(".zip")
-                and "drivesomethinggreater.com" in (href + _PORTAL_BASE)
-            ):
-                if href.startswith("/"):
-                    href = _PORTAL_BASE + href
-                return href
+        if isinstance(data, dict):
+            token = data.get("token") or data.get("csrfToken")
+            if isinstance(token, str) and token:
+                return token
         return None
+
+    async def get_active_custom_request_identifier(
+        self, vin: str
+    ) -> str | None:
+        """Return the Identifier of the active 15-min Custom Request,
+        or None if no active request exists yet.
+
+        GET metadata/partial returns 200 with either an empty list or
+        a list of request descriptors. We pick the first descriptor
+        whose Frequency is "15mins" - that is the one we kick off
+        from the integration. The portal enforces at most one active
+        custom request per VIN, so this is unambiguous.
+
+        Raises ``DataActSessionExpiredError`` on 401 so the coordinator
+        can open a Repairs issue.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
+        url = _PORTAL_BASE + _CUSTOM_REQUEST_META_PATH.format(vin=vin)
+        try:
+            async with self._session.get(
+                url,
+                timeout=ClientTimeout(total=20),
+                headers={"Accept": "application/json"},
+            ) as resp:
+                if resp.status == 401:
+                    raise DataActSessionExpiredError(
+                        "metadata/partial returned 401 - portal session expired"
+                    )
+                if resp.status != 200:
+                    _LOGGER.debug(
+                        "metadata/partial HTTP %s for VIN %s",
+                        resp.status, _mask_vin(vin),
+                    )
+                    return None
+                payload = await resp.json(content_type=None)
+        except DataActSessionExpiredError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("metadata/partial fetch failed: %s", exc)
+            return None
+
+        # Payload shape captured 2026-06-03: either a list of request
+        # descriptors directly OR a dict with a key like "items" /
+        # "requests" wrapping them. Walk both shapes defensively.
+        candidates: list[dict[str, Any]] = []
+        if isinstance(payload, list):
+            candidates = [p for p in payload if isinstance(p, dict)]
+        elif isinstance(payload, dict):
+            for key in ("items", "requests", "data"):
+                inner = payload.get(key)
+                if isinstance(inner, list):
+                    candidates = [p for p in inner if isinstance(p, dict)]
+                    break
+            if not candidates:
+                # Single-dict response variant - treat the top-level
+                # dict itself as a candidate if it carries Identifier.
+                if payload.get("Identifier"):
+                    candidates = [payload]
+        for c in candidates:
+            if str(c.get("Frequency", "")).lower() == "15mins":
+                identifier = c.get("Identifier")
+                if isinstance(identifier, str) and len(identifier) >= 16:
+                    return identifier
+        return None
+
+    async def kickoff_custom_data_request(
+        self,
+        vin: str,
+        *,
+        name: str = "VAG Connect HA Integration",
+        duration_days: int = 31,
+        data_clusters: tuple[str, ...] | None = None,
+    ) -> str | None:
+        """Create the active 15-min Custom Data Request for ``vin``.
+
+        Should ONLY be called when ``get_active_custom_request_identifier``
+        returns None for this VIN (the portal allows AT MOST ONE active
+        custom request and rejects a second concurrent kickoff with 4xx).
+
+        Returns the new Identifier on success, None on failure. Raises
+        ``DataActSessionExpiredError`` on 401.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+        import secrets as _secrets  # noqa: PLC0415
+        from datetime import datetime, timedelta, timezone  # noqa: PLC0415
+
+        csrf = await self._fetch_csrf_token()
+        if not csrf:
+            _LOGGER.debug(
+                "kickoff_custom_data_request: no CSRF token - aborting"
+            )
+            return None
+
+        identifier = _secrets.token_hex(16)  # 32 chars
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        end = (now + timedelta(days=duration_days)).replace(
+            hour=23, minute=59, second=59
+        )
+        clusters = list(data_clusters or _DEFAULT_DATA_CLUSTERS)
+        body = {
+            "Name": name,
+            "Identifier": identifier,
+            "Frequency": "15mins",
+            "StartDate": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "EndDate": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "DataClusters": clusters,
+            "EmailFrequency": "No notification",
+            "LastNotificationDate": None,
+        }
+        url = _PORTAL_BASE + _CUSTOM_REQUEST_POST_PATH.format(vin=vin)
+        try:
+            async with self._session.post(
+                url,
+                json=body,
+                timeout=ClientTimeout(total=30),
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "CSRF-Token": csrf,
+                    "X-CSRF-Token": csrf,  # belt and braces
+                },
+            ) as resp:
+                if resp.status == 401:
+                    raise DataActSessionExpiredError(
+                        "requests/partial returned 401 - portal session expired"
+                    )
+                if resp.status not in (200, 201, 202):
+                    body_text = await resp.text(errors="replace")
+                    _LOGGER.info(
+                        "kickoff_custom_data_request HTTP %s for VIN %s: %s",
+                        resp.status, _mask_vin(vin), body_text[:200],
+                    )
+                    return None
+        except DataActSessionExpiredError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("kickoff_custom_data_request failed: %s", exc)
+            return None
+
+        _LOGGER.info(
+            "EU Data Act Custom Request kicked off for VIN %s "
+            "(Identifier=%s..., duration=%dd, frequency=15min)",
+            _mask_vin(vin), identifier[:8], duration_days,
+        )
+        return identifier
+
+    async def check_dataset_ready(
+        self,
+        vin: str,
+        identifier: str,
+    ) -> list[str] | None:
+        """Return list of ZIP download URLs for the given Identifier,
+        or None when the dataset is not yet ready.
+
+        Per live trace: 404 or 500 means "still being collected"
+        (can take up to 24h). 200 means ready and the response body
+        carries the file list + download URLs.
+
+        Raises ``DataActSessionExpiredError`` on 401.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
+        url = _PORTAL_BASE + _DATASET_LIST_PATH.format(
+            vin=vin, identifier=identifier
+        )
+        try:
+            async with self._session.get(
+                url,
+                timeout=ClientTimeout(total=30),
+                headers={"Accept": "application/json"},
+            ) as resp:
+                if resp.status == 401:
+                    raise DataActSessionExpiredError(
+                        "datadelivery/list returned 401 - portal session expired"
+                    )
+                if resp.status in (404, 500):
+                    return None  # not ready yet, keep polling
+                if resp.status != 200:
+                    _LOGGER.debug(
+                        "datadelivery/list HTTP %s for VIN %s",
+                        resp.status, _mask_vin(vin),
+                    )
+                    return None
+                payload = await resp.json(content_type=None)
+        except DataActSessionExpiredError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("datadelivery/list fetch failed: %s", exc)
+            return None
+
+        urls = _extract_download_urls(payload)
+        if urls:
+            _LOGGER.info(
+                "EU Data Act dataset READY for VIN %s (Identifier=%s..., "
+                "%d file(s) available for 24h)",
+                _mask_vin(vin), identifier[:8], len(urls),
+            )
+        return urls or None
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -909,6 +1087,38 @@ def _mask_vin(vin: str) -> str:
     if not vin:
         return "?"
     return f"...{vin[-6:]}" if len(vin) > 6 else vin
+
+
+def _extract_download_urls(payload: Any) -> list[str]:
+    """Walk the datadelivery/list response and return all plausible
+    download URLs (ZIP or otherwise) the portal points at.
+
+    The exact shape captured per live trace is a file list with one
+    URL per entry; we accept either a flat list of dicts or a wrapped
+    ``{"files": [...]}`` envelope. URLs must be https:// to count.
+    """
+    out: list[str] = []
+    entries: list[Any] = []
+    if isinstance(payload, list):
+        entries = payload
+    elif isinstance(payload, dict):
+        for key in ("files", "items", "data", "downloads"):
+            inner = payload.get(key)
+            if isinstance(inner, list):
+                entries = inner
+                break
+        if not entries and payload.get("downloadUrl"):
+            entries = [payload]
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        for key in ("downloadUrl", "download_url", "url", "href", "link"):
+            val = entry.get(key)
+            if isinstance(val, str) and val.startswith("https://"):
+                if val not in out:
+                    out.append(val)
+                break
+    return out
 
 
 def _extract_download_url(payload: Any) -> str | None:

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_BRAND,
     CONF_CLIENT_ID_OVERRIDE,
     CONF_ENABLE_DATA_ACT_BROWSER,
+    CONF_EU_DATA_ACT_AUTO_KICKOFF,
     CONF_WAKE_BEFORE_POLL,
     CONF_WAKE_DELAY_SECONDS,
     DEFAULT_WAKE_DELAY_SECONDS,
@@ -1091,5 +1092,23 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                         current_data.get(CONF_CLIENT_ID_OVERRIDE, ""),
                     ),
                 ): str,
+                # v2.10.5 - EU Data Act portal Custom Data Request
+                # auto-kickoff. Only meaningful when the integration
+                # is operating in read-only data_act_portal mode (live
+                # BFF strategies exhausted). When True, the coordinator
+                # checks at startup whether an active 15-min Custom
+                # Request exists for each VIN and creates one when
+                # none does. The portal kickoff implies a 1-month
+                # subscription on the user's account, so this is
+                # opt-in - the user has to flip it explicitly.
+                vol.Optional(
+                    CONF_EU_DATA_ACT_AUTO_KICKOFF,
+                    default=current_options.get(
+                        CONF_EU_DATA_ACT_AUTO_KICKOFF,
+                        current_data.get(
+                            CONF_EU_DATA_ACT_AUTO_KICKOFF, False,
+                        ),
+                    ),
+                ): _BOOL_SELECTOR,
             }),
         )

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -124,6 +124,17 @@ DEFAULT_WAKE_DELAY_SECONDS    = 15
 # validates and silently drops anything malformed.
 CONF_CLIENT_ID_OVERRIDE       = "client_id_override"
 
+# v2.10.5 - EU Data Act portal Custom Data Request auto-kickoff.
+# When ON and the integration is operating in read-only data_act_portal
+# mode, the coordinator checks for an active 15-min Custom Data Request
+# at startup and kicks one off when none exists. The portal accepts
+# exactly one custom request per VIN at a time and the kickoff implies
+# a 1-month subscription on the user's account, so this stays OFF by
+# default; the user has to flip it explicitly. Persisted Identifier
+# per VIN lives under CONF_DATA_ACT_IDENTIFIERS in entry.options.
+CONF_EU_DATA_ACT_AUTO_KICKOFF = "eu_data_act_auto_kickoff"
+CONF_DATA_ACT_IDENTIFIERS     = "data_act_identifiers"
+
 # Supported brands — must match CariadClientFactory.create() keys
 BRANDS = {
     "audi":           "Audi (myAudi)",

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -662,6 +662,20 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             found = len(self.vehicles)
             _LOGGER.info("VAG Connect: setup complete — %d vehicle(s)", found)
 
+            # v2.10.5 — EU Data Act portal Custom Data Request first-time
+            # kickoff. Only fires when (a) the user opted in via the
+            # OptionsFlow toggle CONF_EU_DATA_ACT_AUTO_KICKOFF and (b) we
+            # actually authenticated via the data_act_portal strategy.
+            # Best-effort: any failure is debug-logged and never blocks
+            # setup. Session-expiry surfaces a Repairs issue.
+            try:
+                await self._ensure_data_act_custom_request_kickoff()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Data Act kickoff helper raised - non-fatal, continuing",
+                    exc_info=True,
+                )
+
             # Start background polling — use background task so HA bootstrap doesn't wait
             self.hass.async_create_background_task(self._poll_loop(), f"{DOMAIN}_poll")
             return found > 0
@@ -804,6 +818,121 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         _LOGGER.info(
             "VAG Connect: watchdog silent re-auth succeeded, "
             "failure counts cleared. Next poll should recover."
+        )
+
+    async def _ensure_data_act_custom_request_kickoff(self) -> None:
+        """v2.10.5 - check + first-time kickoff for the EU Data Act
+        portal's 15-min Custom Data Request per VIN.
+
+        No-op unless ALL three conditions hold:
+
+        1. ``CONF_EU_DATA_ACT_AUTO_KICKOFF`` is True in entry.options
+           (default False - the user has to opt in because the kickoff
+           starts a 1-month data subscription on their account).
+        2. The active auth strategy is ``"data_act_portal"`` (the
+           coordinator only knows how to consume the portal's ZIP
+           dumps in that mode; for the live BFF strategies there is
+           no need to ever go through the portal).
+        3. The DataActScraper is available (always true since
+           v2.10.0; defensive check kept for future refactors).
+
+        For each VIN: try ``get_active_custom_request_identifier``,
+        and if it returns None, call ``kickoff_custom_data_request``.
+        Resulting Identifiers are persisted to
+        ``entry.options[CONF_DATA_ACT_IDENTIFIERS]`` keyed by VIN so
+        subsequent polls can match without another metadata round-trip.
+
+        Session expiry (HTTP 401) opens a Repairs issue
+        ``data_act_session_expired`` and the kickoff is skipped this
+        cycle.
+        """
+        from .const import (  # noqa: PLC0415
+            CONF_DATA_ACT_IDENTIFIERS,
+            CONF_EU_DATA_ACT_AUTO_KICKOFF,
+        )
+
+        if not self.entry.options.get(CONF_EU_DATA_ACT_AUTO_KICKOFF, False):
+            return
+
+        tokens = getattr(self._cariad_client, "_tokens", None)
+        active_strategy = getattr(tokens, "strategy", "") if tokens else ""
+        if active_strategy != "data_act_portal":
+            _LOGGER.debug(
+                "Data Act kickoff: skipped (active strategy is %r, not "
+                "data_act_portal)", active_strategy,
+            )
+            return
+
+        from .cariad.auth._data_act_scraper import (  # noqa: PLC0415
+            DataActScraper,
+            DataActSessionExpiredError,
+        )
+        from homeassistant.helpers.aiohttp_client import (  # noqa: PLC0415
+            async_get_clientsession,
+        )
+
+        session = async_get_clientsession(self.hass)
+        brand = self.entry.data[CONF_BRAND]
+        scraper = DataActScraper(session, brand_name=brand)
+
+        existing_map = dict(
+            self.entry.options.get(CONF_DATA_ACT_IDENTIFIERS) or {}
+        )
+        new_map = dict(existing_map)
+        changed = False
+
+        for vin in list(self.vehicles):
+            try:
+                active = await scraper.get_active_custom_request_identifier(vin)
+                if active:
+                    if new_map.get(vin) != active:
+                        new_map[vin] = active
+                        changed = True
+                        _LOGGER.info(
+                            "Data Act kickoff: VIN %s already has active "
+                            "15min Custom Request (Identifier=%s...), "
+                            "adopting it.",
+                            mask_vin(vin), active[:8],
+                        )
+                    continue
+                # No active request - kick one off.
+                new_id = await scraper.kickoff_custom_data_request(vin)
+                if new_id:
+                    new_map[vin] = new_id
+                    changed = True
+            except DataActSessionExpiredError:
+                self._raise_data_act_session_expired_repair()
+                return  # stop processing further VINs this cycle
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Data Act kickoff: VIN %s probe failed (%s) - skipping",
+                    mask_vin(vin), exc,
+                )
+
+        if changed:
+            self.hass.config_entries.async_update_entry(
+                self.entry,
+                options={**self.entry.options, CONF_DATA_ACT_IDENTIFIERS: new_map},
+            )
+
+    def _raise_data_act_session_expired_repair(self) -> None:
+        """v2.10.5 - open a Repairs issue when the portal session
+        cookies expired and the integration needs the user to
+        reauthenticate via the OptionsFlow re-login button.
+        """
+        from homeassistant.helpers import issue_registry as ir  # noqa: PLC0415
+
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"data_act_session_expired_{self.entry.entry_id}",
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="data_act_session_expired",
+            translation_placeholders={
+                "brand": self.entry.data[CONF_BRAND],
+            },
         )
 
     async def _poll_loop(self) -> None:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.10.4"
+  "version": "2.10.5"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -135,7 +135,8 @@
           "enable_data_act_browser": "EU Data Act portal: headless-browser fallback (EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
-          "client_id_override": "OAuth client_id override (power users)"
+          "client_id_override": "OAuth client_id override (power users)",
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -149,7 +150,8 @@
           "enable_data_act_browser": "EXPERIMENTAL: only meaningful when the integration has fallen back to the EU Data Act portal (read-only). Drives a headless Chromium via the optional 'playwright' Python package to click the portal's data-export button automatically. The package is NOT preinstalled (it pulls roughly 100 MB of Chromium). When enabled but missing, a Repair issue tells you how to install it from inside the Home Assistant container. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
-          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
         }
       }
     }
@@ -951,6 +953,10 @@
     "data_act_browser_missing": {
       "title": "EU Data Act portal: optional 'playwright' package missing",
       "description": "You enabled the headless-browser fallback for the EU Data Act portal but the `playwright` Python package is not installed in your Home Assistant container.\n\n**To install:** open the HA container shell (Add-ons → Terminal & SSH, or `docker exec` for a manual install) and run:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nThe chromium download is large (around 100 MB), which is why this dependency is opt-in instead of bundled with the integration. After installing, restart Home Assistant.\n\nAlternatively, disable the toggle under Settings → Devices & Services → VW Group Connect → Configure → 'EU Data Act portal: headless-browser fallback'."
+    },
+    "data_act_session_expired": {
+      "title": "EU Data Act portal session expired - reauthenticate",
+      "description": "The {brand} portal at `eu-data-act.drivesomethinggreater.com` returned HTTP 401 to a Custom Data Request API call, which means the session cookies have expired. The portal does not support background token refresh, so Home Assistant cannot recover this automatically.\n\n**What to do:** Settings → Devices & Services → VW Group Connect → 3-dot menu → Reconfigure → re-enter your credentials. The next setup cycle will reopen the portal session and the integration will resume polling the active Custom Data Request.\n\nThis warning auto-clears as soon as the next portal API call succeeds."
     }
   },
   "selector": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -144,7 +144,8 @@
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
-          "client_id_override": "OAuth client_id override (power users)"
+          "client_id_override": "OAuth client_id override (power users)",
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",
@@ -157,7 +158,8 @@
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
-          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
         }
       }
     }

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -129,7 +129,8 @@
           "read_only_mode": "Nur-Lesen-Modus",
           "wake_before_poll": "Fahrzeug aktiv aufwecken vor Status-Abfrage",
           "wake_delay_seconds": "Wartezeit nach Wake-up (Sekunden)",
-          "client_id_override": "OAuth client_id Override (Power-User)"
+          "client_id_override": "OAuth client_id Override (Power-User)",
+          "eu_data_act_auto_kickoff": "EU Data Act: Custom Data Request automatisch anlegen"
         },
         "data_description": {
           "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",
@@ -143,7 +144,8 @@
           "enable_data_act_browser": "EXPERIMENTELL: Nur relevant wenn die Integration auf das EU Data Act Portal (read-only) zurückgefallen ist. Steuert einen Headless-Chromium über das optionale 'playwright' Python-Paket, um den Daten-Export-Button automatisch zu klicken. Das Paket ist NICHT vorinstalliert (zieht ca. 100 MB Chromium nach). Wenn aktiv aber nicht installiert: ein Repair-Issue zeigt dir wie du es im HA-Container nachinstallierst. Integration nach Aktivierung neu laden.",
           "wake_before_poll": "Wenn aktiviert, sendet die Integration einen Wake-POST an Fahrzeuge die beim letzten Poll OFFLINE waren, bevor sie den Status abruft. Das Auto bekommt einen serverseitigen Wake-up und pusht frische Daten, dann wartet die Integration die Wake-Verzögerung ab und liest erst dann. Schließt die 'alle Sensoren unbekannt bei geparktem Auto'-Lücke, kostet aber pro Offline-VIN pro Poll-Zyklus einen zusätzlichen API-Call. Standard: aus. Integration nach dem Umschalten neu laden.",
           "wake_delay_seconds": "Sekunden Wartezeit zwischen dem Wake-up-POST und dem Status-Abruf. Die Standardeinstellung von 15 Sekunden ist das, was die meisten Brand-Backends brauchen um den Wake-induzierten Daten-Push zu verarbeiten. Niedrigere Werte riskieren veraltete Daten; höhere strecken den Poll-Zyklus ohne weiteren Nutzen.",
-          "client_id_override": "Power-User Eskapeluke wenn die Community einen frischen OAuth client_id in einer neuen VW Group APK entdeckt bevor unser täglicher Atlas-Builder ihn findet. Paste den vollen UUID@apps_vw-dilab_com String hier rein, dann probiert der Resolver ihn ZUERST bei jedem authenticate, mit allen bestehenden client_ids weiter als Fallback in der Chain. Leer lassen für Default-Verhalten. Format: 8-4-4-4-12 hex Zeichen gefolgt von @apps_vw-dilab_com. Ungültige Werte werden stillschweigend ignoriert."
+          "client_id_override": "Power-User Eskapeluke wenn die Community einen frischen OAuth client_id in einer neuen VW Group APK entdeckt bevor unser täglicher Atlas-Builder ihn findet. Paste den vollen UUID@apps_vw-dilab_com String hier rein, dann probiert der Resolver ihn ZUERST bei jedem authenticate, mit allen bestehenden client_ids weiter als Fallback in der Chain. Leer lassen für Default-Verhalten. Format: 8-4-4-4-12 hex Zeichen gefolgt von @apps_vw-dilab_com. Ungültige Werte werden stillschweigend ignoriert.",
+          "eu_data_act_auto_kickoff": "Nur relevant wenn die Integration im Read-only EU Data Act Portal-Modus läuft (die Live BFF Strategien sind gescheitert). Wenn AN, prüft der Coordinator beim Start ob pro VIN ein aktiver 15-min Custom Data Request existiert und legt einen an wenn nicht. Der Kickoff impliziert ein 1-Monats Daten-Abo auf deinem Account beim Portal, deshalb opt-in. Das Portal akzeptiert HÖCHSTENS EINEN aktiven Custom Request pro VIN gleichzeitig. Standard: aus."
         }
       }
     }

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -128,7 +128,8 @@
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, Live (beta))",
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
-          "client_id_override": "OAuth client_id override (power users)"
+          "client_id_override": "OAuth client_id override (power users)",
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -141,7 +142,8 @@
           "enable_push_audi_vw": "Live (beta): Audi/VW only. Enables real-time push notifications from the Cariad FCM channel (same one myAudi/WeConnect mobile apps use, covers lock/unlock results, charging-state, climate, alarm). Decoded events are fired onto the Home Assistant event bus as ``vag_connect_push_event`` and trigger a coordinator refresh. Requires firebase-messaging Python package (same lazy-import as Skoda MQTT + CUPRA/SEAT FCM). Live activation since v2.8.0 (Action #4); the credential resolver is still tester-gated until task #40 follow-up lands the Cariad Firebase sender_id. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
-          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
         }
       }
     }

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -144,7 +144,8 @@
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
-          "client_id_override": "OAuth client_id override (power users)"
+          "client_id_override": "OAuth client_id override (power users)",
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",
@@ -157,7 +158,8 @@
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
-          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
         }
       }
     }

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -144,7 +144,8 @@
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
-          "client_id_override": "OAuth client_id override (power users)"
+          "client_id_override": "OAuth client_id override (power users)",
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",
@@ -157,7 +158,8 @@
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
-          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
         }
       }
     }

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -144,7 +144,8 @@
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
-          "client_id_override": "OAuth client_id override (power users)"
+          "client_id_override": "OAuth client_id override (power users)",
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",
@@ -157,7 +158,8 @@
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
-          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
         }
       }
     }

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -144,7 +144,8 @@
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
-          "client_id_override": "OAuth client_id override (power users)"
+          "client_id_override": "OAuth client_id override (power users)",
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",
@@ -157,7 +158,8 @@
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
-          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
         }
       }
     }

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -144,7 +144,8 @@
           "enable_push_audi_vw": "Audi/VW push updates (Cariad FCM, EXPERIMENTAL)",
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
-          "client_id_override": "OAuth client_id override (power users)"
+          "client_id_override": "OAuth client_id override (power users)",
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",
@@ -157,7 +158,8 @@
           "enable_push_audi_vw": "EXPERIMENTAL: Audi/VW only. Enables real-time push notifications from Cariad FCM channel (same one myAudi/WeConnect mobile apps use — covers lock/unlock results, charging-state, climate, alarm). Requires firebase-messaging Python package (same as Skoda MQTT + CUPRA/SEAT FCM). Foundation phase in v1.23.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
-          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored."
+          "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
         }
       }
     }


### PR DESCRIPTION
Implements the live-trace endpoints captured 2026-06-03 for the EU Data Act portal Custom Data Request flow so users in read-only portal mode no longer have to click through the portal manually.

## Verified endpoints (under `/proxy_api/euda-apim/`)

1. `POST /datarequest/vehicles/{VIN}/requests/partial` -> 201, kickoff (requires CSRF from `/libs/granite/csrf/token.json`)
2. `GET /datarequest/vehicles/{VIN}/metadata/partial` -> 200, active 15-min Custom Request descriptor (or empty)
3. `GET /datadelivery/vehicles/{VIN}/{Identifier}/list` -> 200 file list or 404/500 if still collecting

## First-time logic

On coordinator setup, when (a) opt-in `CONF_EU_DATA_ACT_AUTO_KICKOFF` is ON and (b) active strategy is `data_act_portal`:

- For each VIN: GET metadata/partial
- If an active 15-min request exists -> adopt its Identifier (no double-kick)
- If none exists -> CSRF fetch -> POST requests/partial with canonical payload (Frequency=15mins, 31-day duration, all 6 DataClusters, EmailFrequency=No notification) -> persist Identifier per VIN to `entry.options[CONF_DATA_ACT_IDENTIFIERS]`

The portal allows AT MOST ONE active custom request per VIN at a time, so the check-then-create order is critical.

## Edge cases

- 401 from any portal API -> raises `DataActSessionExpiredError` -> Repairs issue `data_act_session_expired` with reconfigure-flow CTA. Portal sessions are cookie-bound and not refreshable.
- 404 or 500 on /list -> dataset not yet ready (up to 24h). Returns None, polling continues.
- CSRF token is fetched fresh before every POST.
- ZIP downloads available 24h after fileset ready; max 30 files per package; regular files retained 7 days.

## Why opt-in

The kickoff implies a 1-month data subscription on the user's account at the portal. We don't want to silently take that action for users who happen to fall back into portal mode - they have to flip the OptionsFlow toggle explicitly.