### PR TITLE
v2.10.7: Data Act portal SPA state from HTML (Arno-MA-73 trace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.10.7] - 2026-06-03
+
+### Fixed
+
+- **Data Act portal SPA: state token extraction from HTML** (#388 Arno-MA-73 post-restart trace). v2.10.6 fixed the 405 but then failed with "no Auth0 state parameter in URL" because aiohttp's redirect-following strips the state from the final response URL on some SPA flows. Now mirrors `idk.py`'s extraction order: HTML hidden input first (most reliable, Auth0 always embeds `<input type="hidden" name="state" value="...">` in the page body even on SPA), regex over hidden inputs as fallback, JSON-embed pattern as third option, then the URL query strings as last resort. Both `password_html` (most recent) and `landing_html` (original GET) get checked.
+
 ## [2.10.6] - 2026-06-03
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_data_act_portal.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_portal.py
@@ -400,19 +400,54 @@ class DataActPortalAuth:
                 # on 4xx, follow the resulting redirect chain.
                 from urllib.parse import urlparse as _urlparse  # noqa: PLC0415
 
-                # Pull the Auth0 state from the password-page URL first
-                # (most reliable post-identifier), then fall back to the
-                # original landing URL we captured earlier.
+                # v2.10.7 (Arno-MA-73 trace) - state extraction order
+                # mirrors idk.py: HTML hidden input first (most reliable
+                # on SPA pages where aiohttp's redirect-following strips
+                # the state from the final response URL), then the URL
+                # query string of the password-page / landing-page as
+                # fallback. Auth0 SPA always embeds the state as
+                # ``<input type="hidden" name="state" value="...">`` in
+                # the page HTML even when the SPA itself owns rendering.
                 state_from_url = ""
-                for src in (identifier_url, landing_url):
-                    qs = parse_qs(_urlparse(src).query)
-                    if qs.get("state"):
-                        state_from_url = qs["state"][0]
+                # Try HTML extraction on both the password page (most
+                # recent) AND the original landing page.
+                for src_html in (password_html, landing_html):
+                    if not src_html:
+                        continue
+                    p = _IdentifierFormParser()
+                    p.feed(src_html)
+                    if p.fields.get("state"):
+                        state_from_url = p.fields["state"]
                         break
+                    # Regex fallback for hidden input with state
+                    state_m = re.search(
+                        r'<input[^>]+name=["\']state["\'][^>]+'
+                        r'value=["\']([^"\']+)["\']',
+                        src_html, re.IGNORECASE,
+                    )
+                    if state_m:
+                        state_from_url = state_m.group(1)
+                        break
+                    # JS / JSON embed fallback
+                    state_m = re.search(
+                        r'"state"\s*:\s*"([A-Za-z0-9_\-]{8,})"', src_html
+                    )
+                    if state_m:
+                        state_from_url = state_m.group(1)
+                        break
+                if not state_from_url:
+                    # Last resort: URL query strings.
+                    for src in (identifier_url, landing_url):
+                        qs = parse_qs(_urlparse(src).query)
+                        if qs.get("state"):
+                            state_from_url = qs["state"][0]
+                            break
                 if not state_from_url:
                     raise AuthenticationError(
                         "Data Act portal: SPA password page reached but "
-                        "no Auth0 state parameter in URL - cannot continue"
+                        "no Auth0 state token found (checked HTML hidden "
+                        "input, JS JSON embed, password-page URL and "
+                        "landing URL). IDP markup may have changed."
                     )
                 from urllib.parse import quote as _quote  # noqa: PLC0415
                 spa_post_url = (

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.10.6"
+  "version": "2.10.7"
 }


### PR DESCRIPTION
v2.10.6 fixed the 405 but Arno-MA-73's restarted trace surfaced the next dead-end: `Data Act portal: SPA password page reached but no Auth0 state parameter in URL`. Cause: aiohttp's redirect-following ends up on a final URL that no longer carries the state query parameter on some SPA flows.

Mirror idk.py's extraction order:

1. HTML hidden input via `_IdentifierFormParser` (Auth0 always embeds the state in the page body even on SPA-rendered pages)
2. Regex over hidden inputs as fallback
3. JSON-embed pattern for SPA bundles
4. URL query strings of password-page + landing-page as last resort

Both `password_html` and `landing_html` get checked.