### PR TITLE
v2.10.8: CUPRA/SEAT PHEV classification fix when ranges block lacks combustion range (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.10.8] - 2026-06-03
+
+### Fixed
+
+- **CUPRA / SEAT PHEV classification** (#392 heidle78 Formentor diag). Some OLA firmware versions ship `engines.primary.fuelType="gasoline"` but DO NOT populate a combustion range in the `ranges` block on the same response. Pre-v2.10.8 the integration derived `has_combustion` purely from the ranges block, so a Formentor PHEV came out classified as `is_hybrid=False` and `has_combustion=False`, suppressing the fuel-tank / combustion-range sensors downstream. Now also treats any non-electric `primary_engine_type` (gasoline / diesel / cng) as combustion so the PHEV flag flips correctly regardless of which response branch carries the range data on a given poll.
+
 ## [2.10.7] - 2026-06-03
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -1833,6 +1833,19 @@ class SeatCupraClient(CariadBaseClient):
             d.media_exterior_color = img.exterior_color
 
         # ── Drivetrain ───────────────────────────────────────────────────────
+        # v2.10.8 (#392 heidle78 CUPRA Formentor PHEV diag): some firmware
+        # versions ship the engines.primary block with a combustion fuelType
+        # (gasoline / diesel) but DO NOT populate a combustion range in the
+        # `ranges` block. The pre-v2.10.8 logic derived `has_combustion`
+        # purely from the ranges block, so a Formentor PHEV with primary
+        # gasoline + no combustion range came out classified is_hybrid=False,
+        # has_combustion=False, which then suppressed fuel-tank / combustion
+        # sensors downstream. Treat a non-electric primary_engine_type as
+        # combustion regardless of whether the range field happens to
+        # carry data on this particular response.
+        pet = (d.primary_engine_type or "").lower()
+        if pet and pet not in ("electric", "ev", "bev"):
+            d.has_combustion = True
         d.is_electric = d.has_battery and not d.has_combustion
         d.is_hybrid = d.has_battery and d.has_combustion
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.10.7"
+  "version": "2.10.8"
 }


### PR DESCRIPTION
heidle78's CUPRA Formentor diagnostic on #392 showed `engines.primary.fuelType="gasoline"` plus `engines.secondary.fuelType="electric"` (textbook PHEV) but `is_hybrid=false` and `has_combustion=false` in the parsed data. Cause: pre-v2.10.8 the integration derived `has_combustion` purely from the `ranges` block, and on that response the ranges block only carried electric range (19 km) with no `gasolineRange` entry. Downstream fuel-tank and combustion-range sensors then stayed null because the `is_hybrid` gate was false.

Fix: after the ranges block parse, also flip `has_combustion` on whenever `primary_engine_type` is a non-electric fuel (gasoline / diesel / cng). The combustion-range field stays whatever the API actually returned; only the boolean classification flag is hardened against the partial-response case.