### PR TITLE
v2.11.0: cross-brand parser audit vs upstream lib source code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Cross-brand parser audit against upstream lib source code. Five parallel deep di
 
 ### Added (cont. - post-audit upstream sync)
 
+- **Skoda charging statistics endpoint** (myskoda PR #586 source-verified). POSTs to `prod.emea.mobile.charging.cariad.digital/charging_statistics` with a VIN-filtered date range and Skoda-brand headers (`X-Brand: skoda`, `X-Device-Timezone: Europe/Berlin`, `X-Api-Version: 1`). The legacy `/v1/charging/{vin}/history` endpoint started returning HTTP 500 for many users after the Skoda app update on 2026-05-15 (upstream issue #585). The replacement uses `monthSections[].entries[].{primaryValue.value, secondaryValue.value, sessionDetails.startedAt, sessionDetails.currentType}` to populate `total_charged_energy_kwh` (sum across all entries), `last_charging_session_kwh`, `last_charging_session_duration_min`, `last_charging_session_start`, `last_charging_session_current_type`, and a compact `recent_charging_sessions` list. Adopted preemptively because PR #586 has not yet landed upstream but the broken state affects every Skoda user on current firmware.
 - **VW EU / Audi `chargeMode` selectivestatus sub-job** (volkswagencarnet PR #328 source-verified, merged 2026-06-01). CARIAD-BFF now exposes a dedicated `charging.chargeMode.value` block carrying `preferredChargeMode` + `availableChargeModes`. Independent of the auth crisis - this is a real additive backend change. Now populates `charging_preferred_mode` and `available_charge_modes` for VW EU / Audi vehicles (CUPRA / SEAT have already shipped these from OLA endpoints since v2.10.0).
 
 ### Verified aligned with upstream (no action required)
@@ -86,7 +87,7 @@ Cross-brand parser audit against upstream lib source code. Five parallel deep di
 - **`tokentype: IDK_TECHNICAL` header** is not set anywhere in our codebase. Aligned with volkswagencarnet v5.4.7 removal.
 - **VW NA OAuth scope** confirmed `openid profile cars vin` against zackcornelius HEAD source — both repo source and live API behavior verified.
 - **VW EU auth situation**: refresh tokens dead, Play Integrity X-Assertion required, Python cannot bypass. Confirmed wide community consensus (volkswagencarnet pinned #989, o11e's APK Frida writeup, evcc-io). Our Data Act portal fallback is the realistic ceiling.
-- **Skoda mysmob charging-history /v1/charging/{vin}/history**: upstream broken with HTTP 500 since 2026-05-15 (myskoda issue #585). myskoda PR #586 (rsa-wusel, open) is the in-progress reverse-engineering fix. We will adopt once that lands.
+- **Skoda mysmob charging-history /v1/charging/{vin}/history**: upstream broken with HTTP 500 since 2026-05-15 (myskoda issue #585). We adopt the in-progress fix from myskoda PR #586 (rsa-wusel APK reverse-engineered) preemptively because the upstream-broken state hits every Skoda user on 2026-05-15+ firmware.
 
 ### Still pending (separate PRs scheduled)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,35 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-06-04
+
+Cross-brand parser audit against upstream lib source code. Five parallel deep diffs (pycupra, myskoda, volkswagencarnet, audi_connect_ha + CarConnectivity-VW, CarConnectivity-connector-volkswagen-na) surfaced field-name and parsing bugs that have been silently returning null on every car for some time. Bundled into one PR rather than the per-brand hotfix chain pattern.
+
+### Fixed (cross-brand)
+
+- **Skoda driving range fields** (myskoda source-verified). `electricRange.distanceInKm` / `combustionRange.distanceInKm` / `secondaryEngineRange.distanceInKm` are scout-derived paths that myskoda's DrivingRange model does NOT include. Canonical keys are `primaryEngineRange.remainingRangeInKm` + `secondaryEngineRange.remainingRangeInKm` plus an `engineType` enum to decide which is electric vs combustion. Old paths kept as fallback for any firmware that genuinely ships them. `adBlueRange` is a flat int upstream, not a dict.
+- **Skoda doors_open / windows_open** were reading from `access.doorsOpenedCount` / `windowsOpenedCount` which do not exist on Skoda mysmob vehicle-status (no `access` subobject). For years these sensors silently reported false. Now reads `overall.doors == "OPEN"` / `overall.windows == "OPEN"` per myskoda Status.Overall model.
+- **Skoda driving_score** was reading non-existent top-level `score` / `drivingScoreClass`. Upstream DrivingScore model is per-period (`daily/weekly/monthly/quarterlyScore.main`). Now prefers `weeklyScore.main` then falls back through the other periods.
+- **SEAT / CUPRA charging path-prefix** (pycupra source-verified). The canonical path is `charging.status.charging.*` and `charging.status.battery.chargeEnergyInKwh` on Born MY24+. Pre-v2.11.0 we only tried `charging.charging.*` (direct) so `charging_power_kw`, `charging_rate_kmh`, `charging_type`, `total_charged_energy_kwh` were silently null on newer firmwares. Now adds the `.status.` segment as the canonical primary, keeps direct as fallback.
+- **SEAT / CUPRA `battery_care_target_soc_pct`** field name. pycupra reads `targetSocPercentage` (no underscores); we previously tried `targetSOC_pct` and other variants only.
+- **VW EU / Audi `plug_led_color` double-write bug**. A second unconditional assignment at the end of the charging block overwrote a valid PPE-firmware value (`plugLedColor` on access or chargingStatus) with `None` from `plugStatus.value.ledColor`. Now consolidated into a single defensive chain ordered upstream-canonical-first.
+- **VW EU / Audi `battery_care` parent block order**. Volkswagencarnet's `vw_const` puts the canonical path under `batteryChargingCare.chargingCareSettings.*`; we previously tried `charging.chargingCareSettings.*` FIRST and the dedicated batteryChargingCare block was a fallback. Flipped so the canonical wins.
+
+### Added
+
+- **SEAT / CUPRA min_soc** read at `settings.minBatteryStateOfChargeInPercent` on `/v1/charging/info` (pycupra `get_min_charge_level`). Sensor previously stayed null.
+- **SEAT / CUPRA climate_remaining_time_min + climate_ready_at** wired. The OLA climate payload already shipped `status.remainingClimatisationTime_min`; we just never read it. Derived `climate_ready_at` ISO timestamp lets HA show a "ready by" clock.
+- **VW EU missing selectivestatus jobs**: `activeVentilation`, `batterySupport`, `chargingProfiles`, `chargingTimers`. Without these requested, parsers that read from those blocks (active ventilation state at v2.10.0 Group A, next-charging-timer at #173) returned null on any car whose data didn't happen to ship inside a sibling block.
+- **VW EU `measurements.rangeStatus.value.electricRange`** added as a third fallback in the electric range chain. Some pure-EV ID.x firmware ships only this leaf.
+- **VW EU / Audi aux-heating legacy fallback** at `climatisation.auxiliaryHeatingStatus.value.*`. Older Audi A4 B9 / MIB3 cars ship aux-heating state under the climatisation parent, NOT under top-level auxiliaryHeating. audi_connect_ha references this legacy path; we missed it pre-v2.11.0.
+
+### Known divergences not yet addressed (separate PRs)
+
+- **VW NA**: substantial divergences from upstream (zackcornelius/CarConnectivity-connector-volkswagen-na). SPIN flow uses wrong hash algorithm (SHA1 vs SHA512) + wrong concat order + wrong endpoint URL + wrong body keys + wrong token transport. Lock / unlock + set-target-SOC + climate-settings + departure-timer commands all use wrong HTTP verbs + body shapes. Subscription parser shape is fictional. Field reads on RVS endpoint use wrong keys for `location`, `secure`, `readiness.readinessStatus.value.connectionState.isOnline`, `battery_soc` is on the wrong endpoint, `cruiseRange` units (KM/MI) are ignored, `vehicleType.engine` does not exist (use `data.platform == "MEB"`). Full rewrite scheduled for v2.11.1 with proper unit-test fixtures.
+- **Trip statistics** for SEAT / CUPRA (`/v1/vehicles/{vin}/trips/{shortTerm,longTerm,lastrefuel}`) and Skoda (`/v1/trip-statistics/{vin}`) are not yet fetched. Cross-brand lifetime / avg-consumption sensors stay null until v2.11.x adds the parsers.
+- **Skoda health endpoint** (`/v1/vehicle-health-report/warning-lights/{vin}`) is the canonical source for dashboard warning lamps but we don't poll it - relies on warning-lights data piggybacking onto other responses.
+- **SEAT / CUPRA aux-heating status** via `/api/auxiliary-heating/v1/{vin}/status` - we use the host for commands but never read the status. Pycupra has it.
+
 ## [2.10.12] - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,12 +62,24 @@ Cross-brand parser audit against upstream lib source code. Five parallel deep di
 - **VW EU `measurements.rangeStatus.value.electricRange`** added as a third fallback in the electric range chain. Some pure-EV ID.x firmware ships only this leaf.
 - **VW EU / Audi aux-heating legacy fallback** at `climatisation.auxiliaryHeatingStatus.value.*`. Older Audi A4 B9 / MIB3 cars ship aux-heating state under the climatisation parent, NOT under top-level auxiliaryHeating. audi_connect_ha references this legacy path; we missed it pre-v2.11.0.
 
-### Known divergences not yet addressed (separate PRs)
+### Added (cont. - new endpoint integrations)
 
-- **VW NA**: substantial divergences from upstream (zackcornelius/CarConnectivity-connector-volkswagen-na). SPIN flow uses wrong hash algorithm (SHA1 vs SHA512) + wrong concat order + wrong endpoint URL + wrong body keys + wrong token transport. Lock / unlock + set-target-SOC + climate-settings + departure-timer commands all use wrong HTTP verbs + body shapes. Subscription parser shape is fictional. Field reads on RVS endpoint use wrong keys for `location`, `secure`, `readiness.readinessStatus.value.connectionState.isOnline`, `battery_soc` is on the wrong endpoint, `cruiseRange` units (KM/MI) are ignored, `vehicleType.engine` does not exist (use `data.platform == "MEB"`). Full rewrite scheduled for v2.11.1 with proper unit-test fixtures.
-- **Trip statistics** for SEAT / CUPRA (`/v1/vehicles/{vin}/trips/{shortTerm,longTerm,lastrefuel}`) and Skoda (`/v1/trip-statistics/{vin}`) are not yet fetched. Cross-brand lifetime / avg-consumption sensors stay null until v2.11.x adds the parsers.
-- **Skoda health endpoint** (`/v1/vehicle-health-report/warning-lights/{vin}`) is the canonical source for dashboard warning lamps but we don't poll it - relies on warning-lights data piggybacking onto other responses.
-- **SEAT / CUPRA aux-heating status** via `/api/auxiliary-heating/v1/{vin}/status` - we use the host for commands but never read the status. Pycupra has it.
+- **Skoda dedicated warning-lights health endpoint** (`/api/v1/vehicle-health-report/warning-lights/{vin}`, myskoda Health model). Canonical source for dashboard warning lamps with per-category breakdown (engine / brakes / tyre / oil / fluid) and human-readable defect text. Previously the warning_* fields relied on data piggybacking inside other responses.
+- **Skoda trip statistics endpoint** (`/api/v1/trip-statistics/{vin}`, myskoda TripStatistics model). Populates `lifetime_distance_km`, `lifetime_avg_fuel_consumption_l_100km`, `lifetime_avg_electric_consumption_kwh_100km` from the overview block plus `last_trip_*` fields from `detailedStatistics[0]`.
+- **SEAT / CUPRA aux-heating status read** (`/api/auxiliary-heating/v1/{vin}/status`). We have used this host for start/stop commands since v1.x; the status read now fills in `auxiliary_heating_status`, `aux_heating_active`, `auxiliary_heating_remaining_min`, and `heater_source` which were null on every car before.
+- **SEAT / CUPRA trip statistics** via three OLA endpoints (`/v1/vehicles/{vin}/trips/{shortTerm,longTerm,lastrefuel}`, pycupra references). Populates `last_trip_*`, `lifetime_*`, and `refuel_trip_*` with defensive field-name variants for both legacy MBB-suffixed and CARIAD-suffixed shapes.
+
+### Fixed (VW NA - in-place corrections, full rewrite still scheduled)
+
+- **VW NA SPIN flow algorithm + token field** (zackcornelius source-verified). The canonical hash is `SHA-512("{challenge}.{spin}")` (challenge first, period, then spin); pre-v2.11.0 used `SHA-1(spin + nonce)` which fails on modern Cox firmware. SHA-512 is now the primary attempt; the legacy SHA-1 stays as fallback on 4xx so users on older firmware are not regressed. The session token field is `carnetVehicleToken` (NOT `sessionToken`); both are tried.
+- **VW NA Canada client_id** at `69eb3c39-d2be-4006-8197-37cc4971e8fe_MYVW_ANDROID`. CA accounts that authenticated with the shared US client_id were rejected on newer firmware.
+- **VW NA OAuth scope** now `openid profile cars vin` (was bare `openid`). The NA IDP returns reduced consent + missing claims when only `openid` is requested.
+- **VW NA field-name corrections**: `data.location` (not `vehicleLocation`), `data.readiness.readinessStatus.value.connectionState.isOnline` (boolean) as primary online signal, `chargingStatus.currentChargeState` (not `chargingState`), `chargingStatus.chargePower` (not `chargePower_kW`), `chargeSettings.targetSOCPercentage` (not `chargingSettings.targetSOC_pct`), `chargingStatus.currentSOCPct` for battery_soc (was on wrong endpoint), `climateStatusReport.climateStatusInd` (not `climateState`), `data.timestamp` (epoch-ms) as canonical last-seen. `cruiseRangeUnits == "MI"` now converts to km (was silently treated as km, miles users had ~38% underreported range).
+
+### Still pending (separate PRs scheduled)
+
+- **VW NA write-side full rewrite** (lock/unlock HTTP verbs, set-target-SOC method + body shape, climate-settings PUT shape, departure-timer shape) - too risky to bundle without live test fixtures; scheduled v2.11.1.
+- **VW NA subscription/privileges** parser shape (zackcornelius reads `data.services[*].operations[*].capabilityStatus`, not a top-level `subscription` block) - scheduled v2.11.1.
 
 ## [2.10.12] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,10 +76,25 @@ Cross-brand parser audit against upstream lib source code. Five parallel deep di
 - **VW NA OAuth scope** now `openid profile cars vin` (was bare `openid`). The NA IDP returns reduced consent + missing claims when only `openid` is requested.
 - **VW NA field-name corrections**: `data.location` (not `vehicleLocation`), `data.readiness.readinessStatus.value.connectionState.isOnline` (boolean) as primary online signal, `chargingStatus.currentChargeState` (not `chargingState`), `chargingStatus.chargePower` (not `chargePower_kW`), `chargeSettings.targetSOCPercentage` (not `chargingSettings.targetSOC_pct`), `chargingStatus.currentSOCPct` for battery_soc (was on wrong endpoint), `climateStatusReport.climateStatusInd` (not `climateState`), `data.timestamp` (epoch-ms) as canonical last-seen. `cruiseRangeUnits == "MI"` now converts to km (was silently treated as km, miles users had ~38% underreported range).
 
+### Added (cont. - post-audit upstream sync)
+
+- **VW EU / Audi `chargeMode` selectivestatus sub-job** (volkswagencarnet PR #328 source-verified, merged 2026-06-01). CARIAD-BFF now exposes a dedicated `charging.chargeMode.value` block carrying `preferredChargeMode` + `availableChargeModes`. Independent of the auth crisis - this is a real additive backend change. Now populates `charging_preferred_mode` and `available_charge_modes` for VW EU / Audi vehicles (CUPRA / SEAT have already shipped these from OLA endpoints since v2.10.0).
+
+### Verified aligned with upstream (no action required)
+
+- **SEAT / CUPRA `app-market: android` header** already set in `_ola_headers.py` for both brands since v2.1.x. Aligned with pycupra v0.2.30 403 fix.
+- **`tokentype: IDK_TECHNICAL` header** is not set anywhere in our codebase. Aligned with volkswagencarnet v5.4.7 removal.
+- **VW NA OAuth scope** confirmed `openid profile cars vin` against zackcornelius HEAD source — both repo source and live API behavior verified.
+- **VW EU auth situation**: refresh tokens dead, Play Integrity X-Assertion required, Python cannot bypass. Confirmed wide community consensus (volkswagencarnet pinned #989, o11e's APK Frida writeup, evcc-io). Our Data Act portal fallback is the realistic ceiling.
+- **Skoda mysmob charging-history /v1/charging/{vin}/history**: upstream broken with HTTP 500 since 2026-05-15 (myskoda issue #585). myskoda PR #586 (rsa-wusel, open) is the in-progress reverse-engineering fix. We will adopt once that lands.
+
 ### Still pending (separate PRs scheduled)
 
-- **VW NA write-side full rewrite** (lock/unlock HTTP verbs, set-target-SOC method + body shape, climate-settings PUT shape, departure-timer shape) - too risky to bundle without live test fixtures; scheduled v2.11.1.
-- **VW NA subscription/privileges** parser shape (zackcornelius reads `data.services[*].operations[*].capabilityStatus`, not a top-level `subscription` block) - scheduled v2.11.1.
+- **VW NA write-side full rewrite** (lock/unlock HTTP verbs, set-target-SOC method + body shape, climate-settings PUT shape, departure-timer shape). zackcornelius HEAD now has the APK-decompiled reference: `GET /ss/v1/user/{userId}/challenge` → `POST /ss/v1/user/{userId}/vehicle/{uuid}/session` body `{idToken, spinHash, tsp:"WCT"}` → carnetVehicleToken as Bearer (not X-Spin-Session). Lock = PUT body `{"lock":bool}`. Verbatim port scheduled v2.11.1.
+- **VW NA subscription/privileges** parser shape (zackcornelius reads `data.services[*].operations[*].capabilityStatus`, not a top-level `subscription` block) - v2.11.1.
+- **Audi refresh_token KeyError defense** (audi_connect_ha PR #749 source-verified) - backend now intermittently omits refresh_token. Our refresh path needs same `if "refresh_token" in resp` guard - v2.11.1.
+- **Audi IDK discovery URL preference** (audi_connect_ha PR #738) - verify `_audi_market_config.py` reads `idkLoginServiceConfigurationURLProduction` with fallback to `/auth/v1/idk/oidc/openid-configuration` - v2.11.1.
+- **Skoda TripStatistics OverallCost/FuelCost fields** (myskoda v2.11.1 additive). Needs new VehicleData attributes + sensor.py registrations + 9-lang translations + currency-aware unit handling - v2.11.1.
 
 ## [2.10.12] - 2026-06-04
 

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -469,6 +469,20 @@ class SeatCupraClient(CariadBaseClient):
             ),
             self._get(f"{_BASE}/v1/vehicles/{vin}/charging/profiles"),
             self._get(f"{_BASE}/v1/vehicles/{vin}/charging/modes"),
+            # v2.11.0 (pycupra source-verified): aux-heating status
+            # read. We already use this host for start/stop commands;
+            # the status read fills in `auxiliary_heating_status`,
+            # `aux_heating_active`, `auxiliary_heating_remaining_min`,
+            # and `heater_source` which were null before.
+            self._get(f"{_BASE}/api/auxiliary-heating/v1/{vin}/status"),
+            # v2.11.0 (pycupra source-verified): trip statistics. pycupra
+            # has 25+ trip_last_*/trip_last_cycle_* properties reading
+            # these three endpoints; we never polled any of them. shortTerm
+            # is the last trip, longTerm is the lifetime aggregate,
+            # lastrefuel is the cyclic per-tank/per-charge totals.
+            self._get(f"{_BASE}/v1/vehicles/{vin}/trips/shortTerm"),
+            self._get(f"{_BASE}/v1/vehicles/{vin}/trips/longTerm"),
+            self._get(f"{_BASE}/v1/vehicles/{vin}/trips/lastrefuel"),
             return_exceptions=True,
         )
         (
@@ -484,6 +498,10 @@ class SeatCupraClient(CariadBaseClient):
             engine_measurements,  # v2.10.0 Group B
             charging_profiles_resp,  # v2.10.0 Group B
             charging_modes_resp,  # v2.10.0 Group B
+            aux_heating_status_resp,  # v2.11.0
+            trip_short_term,  # v2.11.0
+            trip_long_term,  # v2.11.0
+            trip_lastrefuel,  # v2.11.0
         ) = results
 
         # v1.9.0 — Vehicle Data Scout opt-in. Endpoint names match
@@ -1914,6 +1932,110 @@ class SeatCupraClient(CariadBaseClient):
                         modes_list.append(mode_name)
         if modes_list:
             d.available_charge_modes = modes_list
+
+        # v2.11.0 (pycupra source-verified) - trip statistics. Three
+        # endpoints feeding distinct fields:
+        # - shortTerm -> last_trip_*
+        # - longTerm -> lifetime_*
+        # - lastrefuel -> refuel_trip_*
+        # Field names defensive (camelCase vs snake_case variants
+        # observed across firmwares).
+        def _safe_int(val: Any) -> int | None:
+            return int(val) if isinstance(val, (int, float)) else None
+
+        def _safe_float(val: Any) -> float | None:
+            return float(val) if isinstance(val, (int, float)) else None
+
+        if isinstance(trip_short_term, dict):
+            st = trip_short_term.get("data") or trip_short_term
+            if isinstance(st, dict):
+                d.last_trip_distance_km = _safe_int(
+                    st.get("mileage_km") or st.get("mileage")
+                )
+                d.last_trip_duration_min = _safe_int(
+                    st.get("travelTime") or st.get("traveltime")
+                )
+                d.last_trip_avg_speed_kmh = _safe_int(
+                    st.get("averageSpeed_kmph") or st.get("averageSpeed")
+                )
+                d.last_trip_avg_fuel_consumption_l_100km = _safe_float(
+                    st.get("averageFuelConsumption")
+                )
+                d.last_trip_avg_electric_consumption_kwh_100km = _safe_float(
+                    st.get("averageElectricEngineConsumption")
+                )
+                ts = st.get("tripEndTimestamp") or st.get("timestamp")
+                if isinstance(ts, str) and ts:
+                    d.last_trip_timestamp = ts
+        if isinstance(trip_long_term, dict):
+            lt = trip_long_term.get("data") or trip_long_term
+            if isinstance(lt, dict):
+                d.lifetime_distance_km = _safe_int(
+                    lt.get("overallMileage_km")
+                    or lt.get("overallMileage")
+                    or lt.get("mileage_km")
+                )
+                d.lifetime_avg_fuel_consumption_l_100km = _safe_float(
+                    lt.get("averageFuelConsumption")
+                )
+                d.lifetime_avg_electric_consumption_kwh_100km = _safe_float(
+                    lt.get("averageElectricEngineConsumption")
+                )
+        if isinstance(trip_lastrefuel, dict):
+            rt = trip_lastrefuel.get("data") or trip_lastrefuel
+            if isinstance(rt, dict):
+                d.refuel_trip_distance_km = _safe_int(
+                    rt.get("mileage_km") or rt.get("mileage")
+                )
+                d.refuel_trip_duration_min = _safe_int(
+                    rt.get("travelTime") or rt.get("traveltime")
+                )
+                d.refuel_trip_avg_speed_kmh = _safe_int(
+                    rt.get("averageSpeed_kmph") or rt.get("averageSpeed")
+                )
+                d.refuel_trip_avg_fuel_consumption_l_100km = _safe_float(
+                    rt.get("averageFuelConsumption")
+                )
+                d.refuel_trip_avg_electric_consumption_kwh_100km = _safe_float(
+                    rt.get("averageElectricEngineConsumption")
+                )
+                d.refuel_trip_total_fuel_consumption_l = _safe_float(
+                    rt.get("totalFuelConsumption_l")
+                    or rt.get("totalFuelConsumption")
+                )
+                d.refuel_trip_total_electric_consumption_kwh = _safe_float(
+                    rt.get("totalElectricConsumption_kwh")
+                    or rt.get("totalElectricConsumption")
+                )
+                rts = rt.get("tripEndTimestamp") or rt.get("timestamp")
+                if isinstance(rts, str) and rts:
+                    d.refuel_trip_timestamp = rts
+
+        # v2.11.0 (pycupra source-verified) - aux-heating status.
+        # Shape per pycupra get_pheater_status:
+        # {"status": {"climatisationState": "off"|"heating"|"finished",
+        #             "remainingTime_min": int, "operationMode": "..."},
+        #  "settings": {"heaterSource": "automatic|fuel|electric", ...}}
+        if isinstance(aux_heating_status_resp, dict):
+            aux_status = v(aux_heating_status_resp, "status") or {}
+            if isinstance(aux_status, dict):
+                aux_state = (
+                    aux_status.get("climatisationState")
+                    or aux_status.get("operationMode")
+                )
+                if isinstance(aux_state, str) and aux_state:
+                    d.auxiliary_heating_status = aux_state
+                    d.aux_heating_active = aux_state.lower() in (
+                        "heating", "on", "heatingon", "active",
+                    )
+                aux_rem = aux_status.get("remainingTime_min")
+                if isinstance(aux_rem, (int, float)):
+                    d.auxiliary_heating_remaining_min = int(aux_rem)
+            aux_settings = v(aux_heating_status_resp, "settings") or {}
+            if isinstance(aux_settings, dict):
+                heater_src = aux_settings.get("heaterSource")
+                if isinstance(heater_src, str) and heater_src:
+                    d.heater_source = heater_src
 
         # ── v2.5.3 — /v1/mileage fallback (#306 Mii/Tavascan/Leon FR-KL) ────
         # PyCupra dedicates an entire endpoint to the cached odometer

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -1047,7 +1047,18 @@ class SeatCupraClient(CariadBaseClient):
             # a non-None numeric value, so vehicles without this field
             # show no entity at all (HACS / SoC-pessimist owners stay
             # clean).
-            charge_energy = v(bat, "chargeEnergyInKwh")
+            # v2.11.0 (pycupra source-verified): chargeEnergyInKwh lives
+            # at `charging.status.battery.chargeEnergyInKwh` on Born MY24+
+            # (pycupra reads `charging.status.battery.chargeEnergyInKwh`
+            # canonical). Pre-v2.11.0 we read `charging.battery.*` direct
+            # and missed it on newer firmwares.
+            status_bat = (
+                v(charge_status, "status", "battery") or {}
+            )
+            charge_energy = (
+                v(bat, "chargeEnergyInKwh")
+                or v(status_bat, "chargeEnergyInKwh")
+            )
             if isinstance(charge_energy, (int, float)) and charge_energy >= 0:
                 d.total_charged_energy_kwh = float(charge_energy)
 
@@ -1063,7 +1074,17 @@ class SeatCupraClient(CariadBaseClient):
                     if d.electric_range_km is None:
                         d.electric_range_km = est_int
 
-            chg = v(charge_status, "charging") or charge_status
+            # v2.11.0 (#392 pycupra source-verified): the canonical
+            # path is `charging.status.charging.*` on Born MY24+. Our
+            # pre-v2.11.0 code only tried `charging.charging.*` (direct
+            # nest) or top-level - silently returning None on firmwares
+            # that wrap the block under `.status.` (which pycupra
+            # confirms is current shape).
+            chg = (
+                v(charge_status, "status", "charging")
+                or v(charge_status, "charging")
+                or charge_status
+            )
             d.charging_state = (
                 v(chg, "state")             # Rainer #109 shape B — verified
                 or v(chg, "status")         # Rainer #109 shape A — verified
@@ -1211,6 +1232,13 @@ class SeatCupraClient(CariadBaseClient):
                 or v(charge_info, "maxChargeCurrentAC")
                 or v(charge_info, "maxChargeCurrent")
             )
+            # v2.11.0 (pycupra source-verified): min_soc lives at
+            # `settings.minBatteryStateOfChargeInPercent` on /v1/charging/info.
+            # Pre-v2.11.0 we never read it - sensor stayed null on every car.
+            if isinstance(settings, dict):
+                min_soc_raw = settings.get("minBatteryStateOfChargeInPercent")
+                if isinstance(min_soc_raw, (int, float)):
+                    d.min_soc = int(min_soc_raw)
             auto_raw = (
                 (settings.get("autoUnlockPlugWhenCharged")
                  if isinstance(settings, dict) else None)
@@ -1252,6 +1280,19 @@ class SeatCupraClient(CariadBaseClient):
                     v(climate, "settings", "targetTemperatureInCelsius")
                     or v(cs, "targetTemperatureCelsius")  # Rainer #109
                 )
+            # v2.11.0 (pycupra source-verified): climate_remaining_time_min
+            # is in the climate payload at `.status.remainingClimatisationTime_min`,
+            # we just never read it. Pycupra's `climatisation_time_left`
+            # property reads this same key.
+            rem_climate = v(cs, "remainingClimatisationTime_min")
+            rem_climate_int = safe_int(rem_climate)
+            if rem_climate_int is not None:
+                d.climate_remaining_time_min = rem_climate_int
+                # Derived `climate_ready_at` so HA can show a clock.
+                from datetime import datetime as _dt, timedelta as _td  # noqa: PLC0415
+                d.climate_ready_at = (
+                    _dt.now(tz=timezone.utc) + _td(minutes=rem_climate_int)
+                ).isoformat()
             d.outside_temp = v(cs, "outsideTemperature")
             # v1.24.2 (audit): safe_float defensive coerce for Kelvin → Celsius.
             # > 100 heuristic distinguishes Kelvin (Skoda/CUPRA returns ~280-310 K)
@@ -1455,8 +1496,12 @@ class SeatCupraClient(CariadBaseClient):
                 # value derived from /v1/charging/info above in
                 # _DATA_PRESENT_REQUIRED protected sensor.
                 d.battery_care = care_enabled
+            # v2.11.0 (pycupra source-verified): `targetSocPercentage`
+            # is the canonical key (no _ between Soc and Percentage,
+            # matches pycupra's get_battery_care_target reader).
             care_target = (
-                battery_care_settings.get("targetSOC_pct")
+                battery_care_settings.get("targetSocPercentage")
+                or battery_care_settings.get("targetSOC_pct")
                 or battery_care_settings.get("targetSocPct")
                 or battery_care_settings.get("targetStateOfChargeInPercent")
             )

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -285,13 +285,25 @@ class SeatCupraClient(CariadBaseClient):
             fm = spec.get("factoryModel") or {} if isinstance(spec, dict) else {}
             # model: pycupra concatenates factoryModel.vehicleModel +
             # optional " " + specifications.carBody for the display name.
+            # v2.11.0 follow-up (heidle78 #392 v2.10.12 trace): the
+            # OLA API returns the literal string "default" as carBody
+            # for many MJ22-23 Formentor PHEVs, which then surfaced
+            # as the ugly model name "formentor default" in HA. Skip
+            # the suffix when it is a generic placeholder. Also title-
+            # case so "formentor" -> "Formentor" matches the official
+            # CUPRA app's display style.
             base_model = fm.get("vehicleModel") if isinstance(fm, dict) else None
             if isinstance(base_model, str) and base_model:
                 car_body = spec.get("carBody") if isinstance(spec, dict) else None
-                if isinstance(car_body, str) and car_body and car_body not in base_model:
-                    info["model"] = f"{base_model} {car_body}"
+                _GENERIC_BODIES = {"default", "unknown", "n/a", "none", ""}
+                if (
+                    isinstance(car_body, str)
+                    and car_body.strip().lower() not in _GENERIC_BODIES
+                    and car_body.strip().lower() not in base_model.lower()
+                ):
+                    info["model"] = f"{base_model} {car_body}".title()
                 else:
-                    info["model"] = base_model
+                    info["model"] = base_model.title()
             # Fallback to top-level for older firmware that may flatten.
             if not info.get("model"):
                 top_model = vehicle.get("model") or vehicle.get("modelName")

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -429,8 +429,23 @@ class SkodaClient(CariadBaseClient):
             # the block below reads authoritatively. Leave
             # ``doors_locked`` as ``None`` if neither is present —
             # better "unknown" than "wrong".
-            d.doors_open = v(access, "doorsOpenedCount", default=0) > 0
-            d.windows_open = v(access, "windowsOpenedCount", default=0) > 0
+            # v2.11.0 (myskoda source-verified): there is no `access`
+            # subobject on Skoda mysmob vehicle-status — those
+            # `doorsOpenedCount` / `windowsOpenedCount` reads have
+            # been returning 0 (= False) for every Skoda since v1.0.
+            # The canonical source is `overall.doors` / `overall.windows`
+            # which is a literal "OPEN" / "CLOSED" string.
+            overall_doors_status = v(status, "overall", "doors")
+            overall_windows_status = v(status, "overall", "windows")
+            if isinstance(overall_doors_status, str):
+                d.doors_open = overall_doors_status.upper() == "OPEN"
+            elif "access" in status:
+                # Legacy fallback in case any firmware ever ships it.
+                d.doors_open = v(access, "doorsOpenedCount", default=0) > 0
+            if isinstance(overall_windows_status, str):
+                d.windows_open = overall_windows_status.upper() == "OPEN"
+            elif "access" in status:
+                d.windows_open = v(access, "windowsOpenedCount", default=0) > 0
 
             # v1.8.11 (Session 3S) — `vehicle-status` real shape verified
             # against upstream/cc-skoda issue #50
@@ -747,9 +762,54 @@ class SkodaClient(CariadBaseClient):
             #   totalRangeInKm
             # Each is its own entity now; ``range_km`` keeps its old
             # "headline" semantics (electric for EV/PHEV, total for ICE).
-            electric = v(driving_range, "electricRange", "distanceInKm")
+            # v2.11.0 (#392 myskoda source-verified): the canonical key is
+            # ``primaryEngineRange.remainingRangeInKm`` for the primary
+            # propulsion (electric on BEV, combustion on ICE) and
+            # ``secondaryEngineRange.remainingRangeInKm`` for the
+            # secondary on PHEVs. ``electricRange.distanceInKm`` and
+            # ``combustionRange.distanceInKm`` were our scout-derived
+            # guesses that myskoda's DrivingRange model does NOT
+            # include — for years they have returned None on every
+            # Skoda. Keep the old paths as last-resort fallbacks for
+            # any firmware that genuinely ships them.
+            primary_remaining = v(
+                driving_range, "primaryEngineRange", "remainingRangeInKm"
+            )
+            secondary_remaining = v(
+                driving_range, "secondaryEngineRange", "remainingRangeInKm"
+            )
+            primary_eng_type = (
+                v(driving_range, "primaryEngineRange", "engineType") or ""
+            ).upper()
+            # Derive electric / combustion from primary+secondary +
+            # engineType. EV / PHEV electric: primary if primary is
+            # ELECTRIC, else secondary. Combustion: primary if non-
+            # electric, else secondary.
+            if "ELECTRIC" in primary_eng_type or primary_eng_type in ("BEV",):
+                electric = primary_remaining or v(
+                    driving_range, "electricRange", "distanceInKm"
+                )
+                combustion = secondary_remaining or v(
+                    driving_range, "combustionRange", "distanceInKm"
+                )
+            elif primary_eng_type:
+                combustion = primary_remaining or v(
+                    driving_range, "combustionRange", "distanceInKm"
+                )
+                electric = secondary_remaining or v(
+                    driving_range, "electricRange", "distanceInKm"
+                )
+            else:
+                # No engineType - try both, prefer remainingRangeInKm.
+                electric = (
+                    v(driving_range, "primaryEngineRange", "remainingRangeInKm")
+                    or v(driving_range, "electricRange", "distanceInKm")
+                )
+                combustion = (
+                    v(driving_range, "secondaryEngineRange", "remainingRangeInKm")
+                    or v(driving_range, "combustionRange", "distanceInKm")
+                )
             total = v(driving_range, "totalRangeInKm")
-            combustion = v(driving_range, "combustionRange", "distanceInKm")
             if combustion is None:
                 # Older firmwares published a flat scalar without the
                 # ``distanceInKm`` wrapper — keep that path as a fallback.
@@ -773,13 +833,25 @@ class SkodaClient(CariadBaseClient):
                 d.range_km = d.combustion_range_km
             else:
                 d.range_km = electric or total
-            adblue = v(driving_range, "adBlueRange", "distanceInKm")
-            d.adblue_range_km = safe_int(adblue)
+            # v2.11.0 (myskoda source-verified): adBlueRange is a FLAT
+            # int on the Skoda payload, NOT a dict with distanceInKm.
+            # The pre-v2.11.0 dict lookup returned None on every car.
+            adblue_flat = v(driving_range, "adBlueRange")
+            if isinstance(adblue_flat, (int, float)):
+                d.adblue_range_km = safe_int(adblue_flat)
+            else:
+                # Fallback if some firmware genuinely ships the dict.
+                d.adblue_range_km = safe_int(
+                    v(driving_range, "adBlueRange", "distanceInKm")
+                )
             # v1.26.0 Welle-6 (#173, scout #165 christianmhz) — Skoda PHEV
             # secondary engine range (Kodiaq iV, Octavia iV, Superb iV).
-            # Distinct from combustion_range_km because Skoda PHEVs report
-            # both via separate API blocks since 2024 firmware.
-            sec_eng = v(driving_range, "secondaryEngineRange", "distanceInKm")
+            # v2.11.0: prefer remainingRangeInKm (myskoda canonical)
+            # over the scout-derived distanceInKm.
+            sec_eng = (
+                v(driving_range, "secondaryEngineRange", "remainingRangeInKm")
+                or v(driving_range, "secondaryEngineRange", "distanceInKm")
+            )
             d.secondary_engine_range_km = safe_int(sec_eng)
             # v2.2.0 (Skoda Scout #220 — Daniel Walter 2026-05-16):
             # ``secondaryEngineRange`` expanded from 1-key (distanceInKm)
@@ -995,9 +1067,26 @@ class SkodaClient(CariadBaseClient):
         # /api/v2/vehicle-status/{vin}/driving-score — 0-100 efficiency metric.
         # Newer Skoda Connect MY24+ surface this; older 404. Defensive parse.
         if isinstance(driving_score, dict):
-            score = driving_score.get("score")
-            if isinstance(score, (int, float)):
-                d.driving_score = int(score)
+            # v2.11.0 (myskoda source-verified): the top-level `score`
+            # and `drivingScoreClass` keys were a scout-derived guess
+            # that DrivingScore model does not include. The canonical
+            # shape is per-period objects (daily/weekly/monthly/quarterly)
+            # each with a `main` score and breakdown metrics. Prefer
+            # weeklyScore.main as the "headline" value, then monthlyScore
+            # as fallback. Class field doesn't exist upstream - drop.
+            for period_key in ("weeklyScore", "monthlyScore",
+                               "quarterlyScore", "dailyScore"):
+                period = driving_score.get(period_key)
+                if isinstance(period, dict):
+                    main = period.get("main")
+                    if isinstance(main, (int, float)):
+                        d.driving_score = int(main)
+                        break
+            # Legacy fallback if any firmware actually ships top-level.
+            if d.driving_score is None:
+                score = driving_score.get("score")
+                if isinstance(score, (int, float)):
+                    d.driving_score = int(score)
             cls = driving_score.get("drivingScoreClass")
             if isinstance(cls, str) and cls:
                 d.driving_score_class = cls

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -98,6 +98,14 @@ class SkodaClient(CariadBaseClient):
         """v1.15.0 (#35) — Skoda charging history (myskoda PR shipped 2026).
 
         Endpoint: ``GET /api/v1/charging/{vin}/history?userTimezone=UTC&limit={N}``
+
+        v2.11.0 (myskoda issue #585): the Skoda app update on 2026-05-15
+        broke this endpoint with HTTP 500 for many users. The replacement
+        path is now ``get_charging_statistics`` which lives on a different
+        host (charging.cariad.digital, the same vhost SEAT/CUPRA already
+        use) and is wired via myskoda PR #586. We keep the legacy
+        endpoint as a fallback for accounts where it still works.
+
         Response shape (verified via myskoda/models/charging_history.py):
             {
               "nextCursor": "<ISO datetime>" | null,
@@ -119,6 +127,90 @@ class SkodaClient(CariadBaseClient):
             url, params={"userTimezone": "UTC", "limit": limit}
         )
         return data if isinstance(data, dict) else {}
+
+    async def get_charging_statistics(
+        self, vin: str, days_back: int = 90
+    ) -> dict[str, Any]:
+        """v2.11.0 (myskoda PR #586 source-verified, rsa-wusel
+        reverse-engineered). Skoda charging-statistics replacement for
+        the legacy /v1/charging/{vin}/history endpoint that started
+        returning HTTP 500 after the Skoda app update on 2026-05-15.
+
+        Endpoint: ``POST prod.emea.mobile.charging.cariad.digital/charging_statistics``
+        Same vhost we already use for SEAT/CUPRA charging stats but
+        with Skoda-specific X-Brand header + a structured POST body
+        carrying VIN-filtered date range.
+
+        Body shape:
+            {
+              "started_after": "YYYY-MM-DD",
+              "started_before": "YYYY-MM-DD",
+              "selected_filter_options": [
+                {"filter_type": "VEHICLE", "vin": "<VIN>"}
+              ],
+              "fetch_filter_options": true
+            }
+
+        Response shape (verified via myskoda PR #586):
+            {
+              "applicableFilterOptions": [...],
+              "missingElliConsent": false,
+              "monthSections": [
+                {
+                  "entries": [
+                    {
+                      "id": "...", "title": "...",
+                      "primaryValue": {"value": 12.5, "unit": "kWh"},
+                      "secondaryValue": {"value": 45, "unit": "min"},
+                      "sessionDetails": {
+                        "startedAt": "...", "isCurveAvailable": true,
+                        ...
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+
+        Best-effort: 401/403/404 soft-fail to ``{}`` so older accounts
+        without the cap stay clean. Returns the raw parsed dict for the
+        coordinator to consume.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+        from datetime import date, timedelta  # noqa: PLC0415
+
+        today = date.today()
+        started_before = today.isoformat()
+        started_after = (today - timedelta(days=days_back)).isoformat()
+        url = (
+            "https://prod.emea.mobile.charging.cariad.digital/charging_statistics"
+        )
+        headers = {
+            "Accept": "application/json",
+            "Accept-Language": "en-US",
+            "Content-Type": "application/json",
+            "X-Brand": "skoda",
+            "X-Device-Timezone": "Europe/Berlin",
+            "X-Api-Version": "1",
+        }
+        body = {
+            "started_after": started_after,
+            "started_before": started_before,
+            "selected_filter_options": [
+                {"filter_type": "VEHICLE", "vin": vin},
+            ],
+            "fetch_filter_options": True,
+        }
+        try:
+            # We use the parent client's _request with explicit JSON
+            # body. The auth Bearer header is injected by base.
+            resp = await self._request(
+                "POST", url, json=body, headers=headers,
+                timeout=ClientTimeout(total=30),
+            )
+        except Exception:  # noqa: BLE001
+            return {}
+        return resp if isinstance(resp, dict) else {}
 
     async def get_capabilities(self, vin: str) -> dict[str, Any]:
         """Return mysmob capabilities document for *vin*.
@@ -357,12 +449,18 @@ class SkodaClient(CariadBaseClient):
             self._get(
                 f"{_BASE}/api/v1/trip-statistics/{vin}?offsetType=week&offset=0"
             ),
+            # v2.11.0 (myskoda PR #586 source-verified) - charging
+            # statistics replacement after the legacy /v1/charging/
+            # {vin}/history returned HTTP 500 since the 2026-05-15
+            # Skoda app update. POST body w/ VIN-filter on the
+            # charging.cariad.digital host.
+            self.get_charging_statistics(vin),
             return_exceptions=True,
         )
         (
             status, charging, ac, parking, driving_range,
             maintenance, readiness, sw_update, widget, driving_score,
-            health_v1, trip_stats,
+            health_v1, trip_stats, charging_stats_v2,
         ) = results
 
         # v1.9.0 — Vehicle Data Scout opt-in. Stash raw responses keyed by
@@ -1130,6 +1228,73 @@ class SkodaClient(CariadBaseClient):
                     )
                     if isinstance(last_ts, str) and last_ts:
                         d.last_trip_timestamp = last_ts
+
+        # v2.11.0 (myskoda PR #586 source-verified): charging stats
+        # from the replacement endpoint. monthSections[].entries[] each
+        # carry an aggregated charging session with primaryValue (kWh)
+        # + secondaryValue (duration) + sessionDetails.
+        if isinstance(charging_stats_v2, dict):
+            month_sections = charging_stats_v2.get("monthSections") or []
+            all_entries: list[dict[str, Any]] = []
+            for section in month_sections:
+                if isinstance(section, dict):
+                    entries = section.get("entries") or []
+                    for entry in entries:
+                        if isinstance(entry, dict):
+                            all_entries.append(entry)
+            # Lifetime aggregate: sum primaryValue.value (kWh) across
+            # all entries when the value type is kWh.
+            total_kwh = 0.0
+            for entry in all_entries:
+                pv = entry.get("primaryValue") or {}
+                if isinstance(pv, dict):
+                    unit = str(pv.get("unit", "")).lower()
+                    val = pv.get("value")
+                    if unit in ("kwh", "kw_h") and isinstance(val, (int, float)):
+                        total_kwh += float(val)
+            if total_kwh > 0:
+                d.total_charged_energy_kwh = round(total_kwh, 2)
+            # Last session = first entry (newest first per myskoda model).
+            if all_entries:
+                last = all_entries[0]
+                pv_last = last.get("primaryValue") or {}
+                sv_last = last.get("secondaryValue") or {}
+                details = last.get("sessionDetails") or {}
+                if isinstance(pv_last, dict):
+                    last_kwh = pv_last.get("value")
+                    if isinstance(last_kwh, (int, float)):
+                        d.last_charging_session_kwh = float(last_kwh)
+                if isinstance(sv_last, dict):
+                    last_min = sv_last.get("value")
+                    if isinstance(last_min, (int, float)):
+                        d.last_charging_session_duration_min = int(last_min)
+                started_at = details.get("startedAt") if isinstance(details, dict) else None
+                if isinstance(started_at, str) and started_at:
+                    d.last_charging_session_start = started_at
+                current_type = details.get("currentType") if isinstance(details, dict) else None
+                if isinstance(current_type, str) and current_type:
+                    d.last_charging_session_current_type = current_type.upper()
+                # recent_charging_sessions = compact list of last 10
+                recent: list[dict[str, Any]] = []
+                for e in all_entries[:10]:
+                    e_pv = e.get("primaryValue") or {}
+                    e_sv = e.get("secondaryValue") or {}
+                    e_det = e.get("sessionDetails") or {}
+                    recent.append({
+                        "started_at": (
+                            e_det.get("startedAt")
+                            if isinstance(e_det, dict) else None
+                        ),
+                        "kwh": (
+                            e_pv.get("value")
+                            if isinstance(e_pv, dict) else None
+                        ),
+                        "duration_min": (
+                            e_sv.get("value")
+                            if isinstance(e_sv, dict) else None
+                        ),
+                    })
+                d.recent_charging_sessions = recent
 
         # v2.11.0 (myskoda Health model source-verified): per-category
         # warning lights from the dedicated health endpoint. Shape:

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -343,11 +343,26 @@ class SkodaClient(CariadBaseClient):
             # v2.0.0 — driving score (efficiency metric 0-100). Skoda-only,
             # not all MY expose it; 404 → None handled below.
             self._get(f"{_BASE}/api/v2/vehicle-status/{vin}/driving-score"),
+            # v2.11.0 (myskoda source-verified) - canonical warning-lights
+            # endpoint. Previously we relied on the embedded
+            # vehicleHealthWarnings block inside other responses; this
+            # is the dedicated source that ships per-category +
+            # per-defect data with priorities.
+            self._get(
+                f"{_BASE}/api/v1/vehicle-health-report/warning-lights/{vin}"
+            ),
+            # v2.11.0 (myskoda source-verified) - trip statistics
+            # endpoint. Lifetime + avg consumption + travel time per
+            # myskoda TripStatistics model.
+            self._get(
+                f"{_BASE}/api/v1/trip-statistics/{vin}?offsetType=week&offset=0"
+            ),
             return_exceptions=True,
         )
         (
             status, charging, ac, parking, driving_range,
             maintenance, readiness, sw_update, widget, driving_score,
+            health_v1, trip_stats,
         ) = results
 
         # v1.9.0 — Vehicle Data Scout opt-in. Stash raw responses keyed by
@@ -1066,6 +1081,88 @@ class SkodaClient(CariadBaseClient):
         # ── Driving Score (v2.0.0, Skoda-only) ────────────────────────────────
         # /api/v2/vehicle-status/{vin}/driving-score — 0-100 efficiency metric.
         # Newer Skoda Connect MY24+ surface this; older 404. Defensive parse.
+        # v2.11.0 (myskoda TripStatistics model source-verified): the
+        # /v1/trip-statistics/{vin} endpoint returns an OverviewTrip
+        # with overall_average_fuel_consumption / overall_average_mileage /
+        # overall_travel_time_in_min / overall_mileage_in_km + a
+        # detailedStatistics list of per-period TripStatistics entries.
+        if isinstance(trip_stats, dict):
+            overview = trip_stats.get("overview") or trip_stats
+            if isinstance(overview, dict):
+                lifetime_km = (
+                    overview.get("overallMileageInKm")
+                    or overview.get("mileageInKm")
+                )
+                if isinstance(lifetime_km, (int, float)):
+                    d.lifetime_distance_km = int(lifetime_km)
+                avg_fuel = overview.get("overallAverageFuelConsumption")
+                if isinstance(avg_fuel, (int, float)):
+                    d.lifetime_avg_fuel_consumption_l_100km = float(avg_fuel)
+                avg_electric = (
+                    overview.get("overallAverageElectricConsumption")
+                    or overview.get("overallAverageElectricEngineConsumption")
+                )
+                if isinstance(avg_electric, (int, float)):
+                    d.lifetime_avg_electric_consumption_kwh_100km = float(avg_electric)
+            # last-trip from detailedStatistics[0]
+            detailed = trip_stats.get("detailedStatistics")
+            if isinstance(detailed, list) and detailed:
+                last = detailed[0]
+                if isinstance(last, dict):
+                    last_km = last.get("mileageInKm") or last.get("mileage")
+                    if isinstance(last_km, (int, float)):
+                        d.last_trip_distance_km = int(last_km)
+                    last_time = (
+                        last.get("travelTimeInMin")
+                        or last.get("travelTime")
+                    )
+                    if isinstance(last_time, (int, float)):
+                        d.last_trip_duration_min = int(last_time)
+                    last_fuel = last.get("averageFuelConsumption")
+                    if isinstance(last_fuel, (int, float)):
+                        d.last_trip_avg_fuel_consumption_l_100km = float(last_fuel)
+                    last_speed = last.get("averageSpeedInKmph")
+                    if isinstance(last_speed, (int, float)):
+                        d.last_trip_avg_speed_kmh = int(last_speed)
+                    last_ts = (
+                        last.get("tripEndTimestamp")
+                        or last.get("timestamp")
+                    )
+                    if isinstance(last_ts, str) and last_ts:
+                        d.last_trip_timestamp = last_ts
+
+        # v2.11.0 (myskoda Health model source-verified): per-category
+        # warning lights from the dedicated health endpoint. Shape:
+        # {"capturedAt":"...","mileageInKm":12345,
+        #  "warningLights":[{"category":"ENGINE","defects":[{"text":...,
+        #    "priority":"HIGH","icon":"..."}]}, ...]}
+        # Each defect lifts to a per-category boolean; concatenated
+        # defect text feeds the cross-brand warning_messages field.
+        if isinstance(health_v1, dict):
+            lights = health_v1.get("warningLights")
+            if isinstance(lights, list) and lights:
+                warning_messages: list[str] = []
+                categories_seen: set[str] = set()
+                for light in lights:
+                    if not isinstance(light, dict):
+                        continue
+                    cat = str(light.get("category", "")).upper()
+                    if cat:
+                        categories_seen.add(cat)
+                    for defect in (light.get("defects") or []):
+                        if isinstance(defect, dict):
+                            text = defect.get("text") or ""
+                            if isinstance(text, str) and text:
+                                warning_messages.append(text)
+                d.warning_active = bool(lights)
+                d.warning_count = len(lights)
+                d.warning_engine = "ENGINE" in categories_seen
+                d.warning_brakes = "BRAKES" in categories_seen or "BRAKE" in categories_seen
+                d.warning_tyre = "TYRE" in categories_seen or "TIRE" in categories_seen
+                d.warning_oil = "OIL" in categories_seen or "FLUID" in categories_seen
+                if warning_messages:
+                    d.warning_messages = " | ".join(warning_messages[:5])
+
         if isinstance(driving_score, dict):
             # v2.11.0 (myskoda source-verified): the top-level `score`
             # and `drivingScoreClass` keys were a scout-derived guess

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -19,10 +19,21 @@ _BASE = "https://emea.bff.cariad.digital"
 
 _SELECTIVE_STATUS_JOBS = ",".join([
     "access",
+    # v2.11.0 (cross-brand upstream audit): activeVentilation job was
+    # not requested but the parser at _parse_status reads from this
+    # block - pre-v2.11.0 the field would have been None for any car
+    # whose firmware doesn't ship ventilation data inside another sibling
+    # block. audi_services.JOBS2QUERY lists it explicitly.
+    "activeVentilation",
     "automation",
     "auxiliaryHeating",
     "batteryChargingCare",
+    # v2.11.0: also missing - batterySupport, chargingProfiles,
+    # chargingTimers per audi_services.JOBS2QUERY + CC-VW connector jobs.
+    "batterySupport",
     "charging",
+    "chargingProfiles",
+    "chargingTimers",
     "climatisation",
     "climatisationTimers",
     "departureProfiles",
@@ -1364,8 +1375,15 @@ class VWEUClient(CariadBaseClient):
         # current colour string under several paths; defensive lookup
         # since not all Audi models report it (PPE Q6/A6 e-tron yes,
         # older B9 A4 no).
+        # v2.11.0 (audi audit): consolidated with the post-block
+        # ``ledColor`` write below into a single defensive chain so
+        # the second assignment doesn't clobber a valid value with
+        # None on PPE firmware. ``ledColor`` is the canonical upstream
+        # key (audi_connect_ha); the three plugLedColor variants are
+        # our scout-derived fallbacks for older / PPE shape variance.
         led_color = (
-            v(raw, "access", "accessStatus", "value", "plugLedColor")
+            v(raw, "charging", "plugStatus", "value", "ledColor")
+            or v(raw, "access", "accessStatus", "value", "plugLedColor")
             or v(raw, "charging", "plugStatus", "value", "plugLedColor")
             or v(raw, "charging", "chargingStatus", "value", "plugLedColor")
         )
@@ -1409,11 +1427,9 @@ class VWEUClient(CariadBaseClient):
         if isinstance(nav_eta, (int, float)):
             d.remaining_charge_time_nav_min = int(nav_eta)
 
-        # v1.27.2 — Plug visual feedback (LED color on the charge port) +
-        # external-power availability. Both come straight from plugStatus.
-        # Helpful for "is the wallbox actually delivering power right now?"
-        # diagnostics, especially for users with intermittent EVSE issues.
-        d.plug_led_color = v(raw, "charging", "plugStatus", "value", "ledColor")
+        # v2.11.0: ``ledColor`` extraction consolidated into the
+        # defensive chain at the top of this section so a second
+        # unconditional write doesn't clobber a valid PPE plugLedColor.
         ext_power = v(raw, "charging", "plugStatus", "value", "externalPower")
         if isinstance(ext_power, str):
             d.external_power_available = ext_power.lower() == "available"
@@ -1422,16 +1438,26 @@ class VWEUClient(CariadBaseClient):
         # Skoda + CUPRA/SEAT have these via own paths since v1.17.5; VW EU/Audi
         # finally exposed via Cariad-BFF (paths from scout reports
         # #144/#145/#146/#147 — were silenced in v1.19.3, now wired as features).
-        care_mode = v(raw, "charging", "chargingCareSettings", "value", "batteryCareMode")
+        # v2.11.0 (volkswagencarnet vw_const source-verified): the
+        # canonical parent block is `batteryChargingCare`, not
+        # `charging`. Pre-v2.11.0 we read `charging.chargingCareSettings`
+        # FIRST and the dedicated batteryChargingCare job (already in
+        # _SELECTIVE_STATUS_JOBS) was a fallback - flipped the order
+        # so the canonical source wins.
+        care_mode = (
+            v(raw, "batteryChargingCare", "chargingCareSettings", "value", "batteryCareMode")
+            or v(raw, "charging", "chargingCareSettings", "value", "batteryCareMode")
+        )
         if isinstance(care_mode, str):
             up = care_mode.upper()
             if up in ("ACTIVATED", "ACTIVE", "ON", "TRUE"):
                 d.battery_care_enabled = True
             elif up in ("DEACTIVATED", "INACTIVE", "OFF", "FALSE"):
                 d.battery_care_enabled = False
-        care_target = v(raw, "batteryChargingCare", "chargingCareSettings", "value", "batteryCareTargetSoc")
-        if care_target is None:
-            care_target = v(raw, "charging", "chargingCareSettings", "value", "batteryCareTargetSoc")
+        care_target = (
+            v(raw, "batteryChargingCare", "chargingCareSettings", "value", "batteryCareTargetSoc")
+            or v(raw, "charging", "chargingCareSettings", "value", "batteryCareTargetSoc")
+        )
         d.battery_care_target_soc_pct = safe_int(care_target)
 
         # v1.26.0 — Auto-Unlock plug when charged. From scout #144 VW ID.4 Pro.
@@ -1714,7 +1740,14 @@ class VWEUClient(CariadBaseClient):
         # Back-compat ``range_km`` headline. Preference order matches
         # users' intuitive expectation — EVs/PHEVs see battery range as
         # primary, ICE see combustion or total.
-        battery_range = v(raw, "charging", "batteryStatus", "value", "cruisingRangeElectric_km")
+        # v2.11.0 (volkswagencarnet source-verified): also try
+        # `measurements.rangeStatus.value.electricRange` - some pure-EV
+        # ID.x firmware ships only this leaf and our pre-v2.11.0 code
+        # missed it.
+        battery_range = (
+            v(raw, "charging", "batteryStatus", "value", "cruisingRangeElectric_km")
+            or v(raw, "measurements", "rangeStatus", "value", "electricRange")
+        )
         if d.electric_range_km is None and battery_range is not None:
             # v1.24.2 (audit): safe_int — handles None/string/float defensively
             d.electric_range_km = safe_int(battery_range)
@@ -2275,18 +2308,27 @@ class VWEUClient(CariadBaseClient):
         # Different firmwares ship one key or the other (some both); take
         # whichever is a non-empty string so older Audi MIB3 and newer
         # PPE/PPC both light up.
+        # v2.11.0 (audi_connect_ha source-verified): older Audi A4 B9 /
+        # MIB3 cars ship aux heating under `climatisation.auxiliary
+        # HeatingStatus.value.climatisationState` (parent = climatisation,
+        # NOT auxiliaryHeating). audi_connect_ha references this legacy
+        # path; we missed it pre-v2.11.0.
         aux_state = (
             v(raw, "auxiliaryHeating", "auxiliaryHeatingStatus", "value", "operationMode")
             or v(raw, "auxiliaryHeating", "auxiliaryHeatingStatus", "value", "climatisationState")
+            or v(raw, "climatisation", "auxiliaryHeatingStatus", "value", "climatisationState")
+            or v(raw, "climatisation", "auxiliaryHeatingStatus", "value", "operationMode")
         )
         if isinstance(aux_state, str) and aux_state:
             d.auxiliary_heating_status = aux_state
             d.aux_heating_active = aux_state.lower() in {
                 "heating", "on", "heatingon", "active",
             }
-        aux_rem = v(
-            raw, "auxiliaryHeating", "auxiliaryHeatingStatus", "value",
-            "remainingTime_min",
+        aux_rem = (
+            v(raw, "auxiliaryHeating", "auxiliaryHeatingStatus", "value",
+              "remainingTime_min")
+            or v(raw, "climatisation", "auxiliaryHeatingStatus", "value",
+                 "remainingTime_min")
         )
         if isinstance(aux_rem, (int, float)):
             d.auxiliary_heating_remaining_min = int(aux_rem)

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1513,7 +1513,24 @@ class VWEUClient(CariadBaseClient):
             d.connector_locked = plug_lock.upper() == "LOCKED"
 
         d.target_soc = v(raw, "charging", "chargingSettings", "value", "targetSOC_pct")
-        d.charge_mode = v(raw, "charging", "chargingStatus", "value", "chargeMode")
+        # v2.11.0 (volkswagencarnet PR #328, merged 2026-06-01) - CARIAD-BFF
+        # now exposes a dedicated chargeMode sub-job under selectivestatus
+        # charging block. preferredChargeMode + availableChargeModes are
+        # real backend additions (independent of the auth crisis). Values
+        # observed: "manual", "timer", "preferredChargingTimes",
+        # "timerChargingWithClimatisation".
+        preferred = v(raw, "charging", "chargeMode", "value", "preferredChargeMode")
+        if isinstance(preferred, str) and preferred:
+            d.charging_preferred_mode = preferred
+        available = v(raw, "charging", "chargeMode", "value", "availableChargeModes")
+        if isinstance(available, list):
+            d.available_charge_modes = [
+                m for m in available if isinstance(m, str) and m
+            ]
+        d.charge_mode = (
+            v(raw, "charging", "chargingStatus", "value", "chargeMode")
+            or v(raw, "charging", "chargeMode", "value")
+        )
         d.min_soc = v(raw, "charging", "chargingSettings", "value", "minChargeLimit_pct")
         # v1.10.1 (#58) — safe_float for max charge current too. The
         # ``_A`` field is a clean integer in #90's Live-Dump (16) but the

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -38,13 +38,18 @@ BRAND_VW_NA = BrandConfig(
     redirect_uri="kombi:///login",
     user_agent="MyVW/1.0 Android",
     api_base="https://b-h-s.spr.us00.p.con-veh.net",
-    # v2.3.0 (#269 roberttco, 2026-05-21) — single ``openid`` scope per
-    # matpoulin/CarConnectivity-connector-volkswagen-na (Apache-2.0).
-    # Previously we sent the wider VW EU-style scope chain
-    # (``openid profile email offline_access mbb vin cars dealers``)
-    # which the NA IDP rejected as part of its HTTP 400 response.
-    scope="openid",
+    # v2.11.0 (zackcornelius source-verified) - scope must be
+    # "openid profile cars vin", not bare "openid". The NA IDP
+    # returns reduced consent + missing claims when only "openid"
+    # is requested.
+    scope="openid profile cars vin",
 )
+
+# v2.11.0 (zackcornelius source-verified) - Canada needs its own
+# OAuth client_id. matpoulin's old shared client_id worked for some
+# accounts but the NA IDP rejects CA accounts that authenticate with
+# the US client_id on newer firmware revisions.
+_CA_CLIENT_ID = "69eb3c39-d2be-4006-8197-37cc4971e8fe_MYVW_ANDROID"
 
 # v2.3.0 (#269) — VW NA-specific IDP host: identity.na.vwgroup.io
 # (NOT identity.vwgroup.io). When the authorize-redirect lands on the
@@ -76,10 +81,14 @@ class VWNAClient:
         self._country  = country.lower()
         self._base     = _COUNTRY_BASES.get(self._country, _COUNTRY_BASES["us"])
         self._tokens: TokenSet | None = None
-        # VW NA uses IDK auth but against a country-specific endpoint
+        # VW NA uses IDK auth but against a country-specific endpoint.
+        # v2.11.0 - CA gets the dedicated CA client_id per zackcornelius.
+        client_id = (
+            _CA_CLIENT_ID if self._country == "ca" else BRAND_VW_NA.client_id
+        )
         brand = BrandConfig(
             name=f"volkswagen_{self._country}",
-            client_id=BRAND_VW_NA.client_id,
+            client_id=client_id,
             redirect_uri=BRAND_VW_NA.redirect_uri,
             user_agent=BRAND_VW_NA.user_agent,
             api_base=self._base,
@@ -372,7 +381,17 @@ class VWNAClient:
                 or v(power, "odometer")
             )
             d.fuel_level  = v(power, "fuelPercentRemaining")
-            d.range_km    = v(power, "cruiseRange")
+            # v2.11.0 (zackcornelius source-verified) - cruiseRangeUnits
+            # is "KM" or "MI"; pre-v2.11.0 we unconditionally treated
+            # the value as km, miles users got their range under-
+            # reported by ~38%.
+            range_raw = v(power, "cruiseRange")
+            range_unit = (v(power, "cruiseRangeUnits") or "KM").upper()
+            if isinstance(range_raw, (int, float)):
+                if range_unit == "MI":
+                    d.range_km = int(range_raw * 1.609344)
+                else:
+                    d.range_km = int(range_raw)
 
             # Battery
             bat = v(vehicle_raw, "batteryStatus") or {}
@@ -460,8 +479,12 @@ class VWNAClient:
             # offline cars. Modern VW NA backend caches the last known
             # parking GPS under ``data.lastParkedLocation`` even when
             # the car is OFFLINE and ``vehicleLocation`` is null.
+            # v2.11.0 (zackcornelius source-verified) - canonical key
+            # is ``location`` (without "vehicle" prefix); kept old key
+            # as fallback for any firmware that does ship it.
             pos = (
-                v(vehicle_raw, "vehicleLocation")
+                v(vehicle_raw, "location")
+                or v(vehicle_raw, "vehicleLocation")
                 or v(vehicle_raw, "lastParkedLocation")
                 or {}
             )
@@ -469,9 +492,21 @@ class VWNAClient:
             d.longitude = v(pos, "longitude")
 
             # Connection — v2.0.1 (#131 follow-up): defensive parsing.
-            conn_state = v(vehicle_raw, "connectionStatus", "connectionState")
-            if isinstance(conn_state, str):
-                d.is_online = conn_state.upper() == "CONNECTED"
+            # v2.11.0 (zackcornelius source-verified) - canonical online
+            # signal is `readiness.readinessStatus.value.connectionState.isOnline`
+            # (boolean). Pre-v2.11.0 we read `connectionStatus.connectionState`
+            # as a string ("CONNECTED" check) which is a scout-derived
+            # guess; the legacy path stays as fallback.
+            ready_online = v(
+                vehicle_raw, "readiness", "readinessStatus", "value",
+                "connectionState", "isOnline",
+            )
+            if isinstance(ready_online, bool):
+                d.is_online = ready_online
+            else:
+                conn_state = v(vehicle_raw, "connectionStatus", "connectionState")
+                if isinstance(conn_state, str):
+                    d.is_online = conn_state.upper() == "CONNECTED"
 
             # Drivetrain type
             engine = v(vehicle_raw, "vehicleType", "engine") or ""
@@ -491,32 +526,77 @@ class VWNAClient:
             # least 4 different timestamp field-name conventions across
             # firmware generations — try them in priority order, first
             # ISO-8601-looking string wins.
-            for path in (
-                ("vehicleStatusTime",),                  # myVW 2024+
-                ("connectionStatus", "lastConnectionTime"),  # legacy myVW
-                ("connectionStatus", "timestamp"),
-                ("carCapturedTimestamp",),               # CARIAD-aligned newer firmware
-                ("powerStatus", "carCapturedTimestamp"), # sub-block timestamp
-                ("lastUpdated",),
-                ("dataTimestamp",),
-            ):
-                ts = v(vehicle_raw, *path)
-                if isinstance(ts, str) and len(ts) >= 10 and "T" in ts:
-                    d.last_seen_at = ts
-                    break
+            # v2.11.0 (zackcornelius source-verified) - canonical
+            # last-seen field on RVS is `data.timestamp` as epoch-ms.
+            # Try epoch-ms first then fall back to ISO strings.
+            ts_ms = v(vehicle_raw, "timestamp")
+            if isinstance(ts_ms, (int, float)) and ts_ms > 1e12:
+                from datetime import datetime as _dt2  # noqa: PLC0415
+                try:
+                    d.last_seen_at = _dt2.fromtimestamp(
+                        ts_ms / 1000, tz=timezone.utc
+                    ).isoformat()
+                except (ValueError, OSError):
+                    pass
+            ts_clamp = v(vehicle_raw, "clampStateTimestamp")
+            if not d.last_seen_at and isinstance(ts_clamp, (int, float)) and ts_clamp > 1e12:
+                from datetime import datetime as _dt2  # noqa: PLC0415
+                try:
+                    d.last_seen_at = _dt2.fromtimestamp(
+                        ts_clamp / 1000, tz=timezone.utc
+                    ).isoformat()
+                except (ValueError, OSError):
+                    pass
+            if not d.last_seen_at:
+                # Note: upstream zackcornelius uses the field name
+                # `instrumentCluserTime` (with the typo - missing 't').
+                for path in (
+                    ("instrumentCluserTime",),
+                    ("vehicleStatusTime",),
+                    ("connectionStatus", "lastConnectionTime"),
+                    ("connectionStatus", "timestamp"),
+                    ("carCapturedTimestamp",),
+                    ("powerStatus", "carCapturedTimestamp"),
+                    ("lastUpdated",),
+                    ("dataTimestamp",),
+                ):
+                    ts = v(vehicle_raw, *path)
+                    if isinstance(ts, str) and len(ts) >= 10 and "T" in ts:
+                        d.last_seen_at = ts
+                        break
 
         # ── Charging ──────────────────────────────────────────────────────────
         if isinstance(charge, dict):
-            d.charging_state    = v(charge, "chargingStatus", "chargingState")
+            # v2.11.0 (zackcornelius source-verified):
+            #   currentChargeState (NOT chargingState)
+            #   chargePower (NOT chargePower_kW)
+            #   chargeSettings.targetSOCPercentage (NOT chargingSettings.targetSOC_pct)
+            d.charging_state    = (
+                v(charge, "chargingStatus", "currentChargeState")
+                or v(charge, "chargingStatus", "chargingState")
+            )
             # v2.0.1 (#131 follow-up) — defensive parsing.
             if isinstance(d.charging_state, str):
                 d.is_charging = d.charging_state.upper() == "CHARGING"
-            d.charging_power_kw = v(charge, "chargingStatus", "chargePower_kW")
+            d.charging_power_kw = (
+                v(charge, "chargingStatus", "chargePower")
+                or v(charge, "chargingStatus", "chargePower_kW")
+            )
             plug = v(charge, "plugStatus", "plugConnectionState")
             if isinstance(plug, str):
                 d.plug_connected = plug.upper() == "CONNECTED"
                 d.plug_state = plug
-            d.target_soc        = v(charge, "chargingSettings", "targetSOC_pct")
+            d.target_soc = (
+                v(charge, "chargeSettings", "targetSOCPercentage")
+                or v(charge, "chargingSettings", "targetSOC_pct")
+            )
+            # v2.11.0 (zackcornelius source-verified): battery_soc lives
+            # on the charging endpoint at chargingStatus.currentSOCPct,
+            # NOT on the RVS endpoint (we attempted to read it from the
+            # wrong endpoint before).
+            soc_charge = v(charge, "chargingStatus", "currentSOCPct")
+            if isinstance(soc_charge, (int, float)) and d.battery_soc is None:
+                d.battery_soc = int(soc_charge)
             # v1.24.2 (audit): safe_int + safe_float defensive coerce
             remaining_min = safe_int(v(charge, "chargingStatus", "remainingChargingTimeToComplete_min"))
             if remaining_min is not None and remaining_min > 0:
@@ -531,7 +611,10 @@ class VWNAClient:
         # legacy install that still ships the older shape.
         if isinstance(climate, dict):
             d.climatisation_state = (
-                v(climate, "climateStatusReport", "climateState")
+                # v2.11.0 (zackcornelius source-verified) - canonical
+                # key is `climateStatusInd` (NOT climateState).
+                v(climate, "climateStatusReport", "climateStatusInd")
+                or v(climate, "climateStatusReport", "climateState")
                 or v(climate, "climateStatusReport", "state")
                 or v(climate, "climatisationStatus", "climatisationState")
             )
@@ -671,28 +754,55 @@ class VWNAClient:
         )
         if not isinstance(nonce, str) or not nonce:
             return None
-        # SHA1(SPIN + nonce), uppercase hex per the NA app smali. The
-        # ``hashlib.sha1`` use is NOT a security primitive (this is a
-        # protocol-mandated digest for backend handshake), so the
-        # nosec-style suppression is intentional.
-        response = hashlib.sha1(  # noqa: S324
+        # v2.11.0 (zackcornelius source-verified) - the SPIN hash is
+        # SHA-512 of ``"{challenge}.{spin}"`` (challenge first, then
+        # the dot separator, then the spin), NOT SHA-1 of (spin+nonce).
+        # Try the modern shape first; fall back to legacy SHA-1 if
+        # the modern path returns 4xx (kept so users whose accounts
+        # still respond to the old algorithm don't regress).
+        response = hashlib.sha512(
+            f"{nonce}.{spin}".encode("utf-8")
+        ).hexdigest().upper()
+        response_legacy = hashlib.sha1(  # noqa: S324
             (spin + nonce).encode("utf-8")
         ).hexdigest().upper()
+        # v2.11.0 - try modern (SHA-512) first; on 4xx fall back to
+        # legacy (SHA-1) which the older endpoint still expects on
+        # some firmwares.
+        spin_resp = None
         try:
             spin_resp = await self._post(
                 f"{self._base}/ss/v1/user/{self._user_id}/spin",
                 json={"challenge": nonce, "response": response},
             )
         except APIError as err:
-            _LOGGER.debug(
-                "VW NA SPIN response POST failed (%s) for vin ***%s",
-                err.status, vin[-6:],
-            )
-            return None
+            if 400 <= (err.status or 0) < 500:
+                try:
+                    spin_resp = await self._post(
+                        f"{self._base}/ss/v1/user/{self._user_id}/spin",
+                        json={"challenge": nonce, "response": response_legacy},
+                    )
+                except APIError as legacy_err:
+                    _LOGGER.debug(
+                        "VW NA SPIN both modern + legacy failed (%s/%s) for vin ***%s",
+                        err.status, legacy_err.status, vin[-6:],
+                    )
+                    return None
+            else:
+                _LOGGER.debug(
+                    "VW NA SPIN POST failed (%s) for vin ***%s",
+                    err.status, vin[-6:],
+                )
+                return None
         if not isinstance(spin_resp, dict):
             return None
+        # v2.11.0 (zackcornelius source-verified) - canonical token
+        # field is `carnetVehicleToken` (NOT sessionToken). Kept the
+        # other variants as defensive fallbacks for non-canonical
+        # firmware responses.
         token = (
-            spin_resp.get("sessionToken")
+            spin_resp.get("carnetVehicleToken")
+            or spin_resp.get("sessionToken")
             or spin_resp.get("spinSessionToken")
             or spin_resp.get("token")
         )

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -129,9 +129,11 @@ BRAND_VW_NA_MODEL = BrandConfig(
     redirect_uri="kombi:///login",
     user_agent="MyVW/1.0 Android",
     api_base="https://b-h-s.spr.us00.p.con-veh.net",
-    # v2.3.0 (#269) — single ``openid`` scope per matpoulin's working
-    # NA flow. Wider EU-style scope chain was the trigger for HTTP 400.
-    scope="openid",
+    # v2.11.0 (zackcornelius source-verified) — full
+    # "openid profile cars vin" scope. Bare "openid" returns reduced
+    # consent + missing claims on the NA IDP. Kept in sync with
+    # BRAND_VW_NA in api/vw_na.py via test_v230_sprint_b.
+    scope="openid profile cars vin",
 )
 
 BRAND_PORSCHE = BrandConfig(

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.10.12"
+  "version": "2.11.0"
 }

--- a/tests/bruno/seat_cupra/48_GET_aux_heating_status.bru
+++ b/tests/bruno/seat_cupra/48_GET_aux_heating_status.bru
@@ -1,0 +1,42 @@
+meta {
+  name: GET auxiliary heating status
+  type: http
+  seq: 48
+}
+
+get {
+  url: {{base_url}}/api/auxiliary-heating/v1/{{vin}}/status
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  v2.11.0 - aux-heating status read (pycupra source-verified). We have
+  used this host for start/stop commands since v1.x; the status read
+  was never wired so auxiliary_heating_status, aux_heating_active,
+  auxiliary_heating_remaining_min and heater_source were null on
+  every car.
+
+  Response shape (pycupra get_pheater_status):
+    {
+      "status": {
+        "climatisationState": "off" | "heating" | "finished",
+        "remainingTime_min": 12,
+        "operationMode": "..."
+      },
+      "settings": {
+        "heaterSource": "automatic" | "fuel" | "electric"
+      }
+    }
+
+  Used by SeatCupraClient.get_status() at
+  custom_components/vag_connect/cariad/api/seat_cupra.py.
+}

--- a/tests/bruno/seat_cupra/49_GET_trips_short_term.bru
+++ b/tests/bruno/seat_cupra/49_GET_trips_short_term.bru
@@ -1,0 +1,41 @@
+meta {
+  name: GET trips shortTerm
+  type: http
+  seq: 49
+}
+
+get {
+  url: {{base_url}}/v1/vehicles/{{vin}}/trips/shortTerm
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  v2.11.0 - last-trip statistics (pycupra source-verified). One of three
+  trip endpoints pycupra polls (shortTerm = last trip, longTerm = lifetime,
+  lastrefuel = cyclic per-tank/per-charge totals).
+
+  Response shape (defensive multi-variant across firmwares):
+    {
+      "data": {
+        "mileage_km" | "mileage": 142,
+        "travelTime" | "traveltime": 95,
+        "averageSpeed_kmph" | "averageSpeed": 89,
+        "averageFuelConsumption": 5.4,
+        "averageElectricEngineConsumption": 18.4,
+        "tripEndTimestamp" | "timestamp": "..."
+      }
+    }
+
+  Used by SeatCupraClient.get_status() to populate last_trip_distance_km,
+  last_trip_duration_min, last_trip_avg_speed_kmh, last_trip_avg_fuel/
+  electric_consumption_l_100km/kwh_100km, last_trip_timestamp.
+}

--- a/tests/bruno/seat_cupra/50_GET_trips_long_term.bru
+++ b/tests/bruno/seat_cupra/50_GET_trips_long_term.bru
@@ -1,0 +1,36 @@
+meta {
+  name: GET trips longTerm
+  type: http
+  seq: 50
+}
+
+get {
+  url: {{base_url}}/v1/vehicles/{{vin}}/trips/longTerm
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  v2.11.0 - lifetime trip statistics (pycupra source-verified).
+
+  Response shape:
+    {
+      "data": {
+        "overallMileage_km" | "overallMileage" | "mileage_km": 25400,
+        "averageFuelConsumption": 5.8,
+        "averageElectricEngineConsumption": 18.4
+      }
+    }
+
+  Used by SeatCupraClient.get_status() to populate lifetime_distance_km,
+  lifetime_avg_fuel_consumption_l_100km,
+  lifetime_avg_electric_consumption_kwh_100km.
+}

--- a/tests/bruno/seat_cupra/51_GET_trips_lastrefuel.bru
+++ b/tests/bruno/seat_cupra/51_GET_trips_lastrefuel.bru
@@ -1,0 +1,44 @@
+meta {
+  name: GET trips lastrefuel
+  type: http
+  seq: 51
+}
+
+get {
+  url: {{base_url}}/v1/vehicles/{{vin}}/trips/lastrefuel
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  v2.11.0 - cyclic per-tank/per-charge totals (pycupra source-verified).
+  Resets at each fuel-up event or charge session completion.
+
+  Response shape:
+    {
+      "data": {
+        "mileage_km" | "mileage": 142,
+        "travelTime" | "traveltime": 95,
+        "averageSpeed_kmph" | "averageSpeed": 89,
+        "averageFuelConsumption": 5.4,
+        "averageElectricEngineConsumption": 18.4,
+        "totalFuelConsumption_l" | "totalFuelConsumption": 7.4,
+        "totalElectricConsumption_kwh" | "totalElectricConsumption": 12.3,
+        "tripEndTimestamp" | "timestamp": "..."
+      }
+    }
+
+  Used by SeatCupraClient.get_status() to populate
+  refuel_trip_distance_km, refuel_trip_duration_min,
+  refuel_trip_avg_speed_kmh, refuel_trip_avg_*_consumption_*,
+  refuel_trip_total_fuel_consumption_l,
+  refuel_trip_total_electric_consumption_kwh, refuel_trip_timestamp.
+}

--- a/tests/bruno/skoda/32_GET_vehicle_health_warning_lights.bru
+++ b/tests/bruno/skoda/32_GET_vehicle_health_warning_lights.bru
@@ -1,0 +1,45 @@
+meta {
+  name: GET vehicle health warning lights
+  type: http
+  seq: 32
+}
+
+get {
+  url: {{base_url}}/api/v1/vehicle-health-report/warning-lights/{{vin}}
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  v2.11.0 - canonical warning-lights endpoint (myskoda Health model).
+  Previously we relied on the embedded vehicleHealthWarnings block
+  inside other responses; this is the dedicated source that ships
+  per-category + per-defect data with priorities.
+
+  Response shape (verified myskoda/models/health.py):
+    {
+      "capturedAt": "2026-06-04T10:00:00Z",
+      "mileageInKm": 12345,
+      "warningLights": [
+        {
+          "category": "ENGINE" | "BRAKES" | "TYRE" | "OIL" | "FLUID" | ...,
+          "defects": [
+            { "text": "Check engine oil", "priority": "HIGH", "icon": "..." }
+          ]
+        }
+      ]
+    }
+
+  Used by SkodaClient.get_status() at
+  custom_components/vag_connect/cariad/api/skoda.py to populate
+  warning_active, warning_count, warning_engine/brakes/tyre/oil booleans
+  + concatenated warning_messages.
+}

--- a/tests/bruno/skoda/33_GET_trip_statistics.bru
+++ b/tests/bruno/skoda/33_GET_trip_statistics.bru
@@ -1,0 +1,51 @@
+meta {
+  name: GET trip statistics
+  type: http
+  seq: 33
+}
+
+get {
+  url: {{base_url}}/api/v1/trip-statistics/{{vin}}?offsetType=week&offset=0
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+params:query {
+  offsetType: week
+  offset: 0
+}
+
+docs {
+  v2.11.0 - canonical trip statistics endpoint (myskoda TripStatistics
+  model). Lifetime + average consumption + travel time per myskoda
+  schema. Skoda-only.
+
+  Response shape (verified myskoda/models/trip_statistics.py):
+    {
+      "overview": {
+        "overallAverageFuelConsumption": 5.8,
+        "overallAverageElectricConsumption": 18.4,
+        "overallMileageInKm": 25400,
+        "overallTravelTimeInMin": 12300,
+        "overallCost": { "fuelCost": 1234.56, "electricityCost": 234.56 }
+      },
+      "detailedStatistics": [
+        {
+          "mileageInKm": 142, "travelTimeInMin": 95, "averageSpeedInKmph": 89,
+          "averageFuelConsumption": 5.4, "tripEndTimestamp": "..."
+        }
+      ]
+    }
+
+  Used by SkodaClient.get_status() to populate
+  lifetime_distance_km, lifetime_avg_fuel/electric_consumption,
+  last_trip_distance_km/duration_min/avg_speed_kmh/avg_consumption.
+}

--- a/tests/bruno/skoda/34_POST_charging_statistics.bru
+++ b/tests/bruno/skoda/34_POST_charging_statistics.bru
@@ -1,0 +1,77 @@
+meta {
+  name: POST charging statistics
+  type: http
+  seq: 34
+}
+
+post {
+  url: https://prod.emea.mobile.charging.cariad.digital/charging_statistics
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+  Accept-Language: en-US
+  Content-Type: application/json
+  X-Brand: skoda
+  X-Device-Timezone: Europe/Berlin
+  X-Api-Version: 1
+}
+
+body:json {
+  {
+    "started_after": "2026-03-04",
+    "started_before": "2026-06-04",
+    "selected_filter_options": [
+      {"filter_type": "VEHICLE", "vin": "{{vin}}"}
+    ],
+    "fetch_filter_options": true
+  }
+}
+
+docs {
+  v2.11.0 - myskoda PR #586 source-verified replacement for the legacy
+  /v1/charging/{vin}/history endpoint that started returning HTTP 500
+  after the Skoda app update on 2026-05-15 (myskoda issue #585).
+
+  Lives on the same charging.cariad.digital vhost SEAT/CUPRA already
+  use but with Skoda-specific X-Brand header + a structured POST body
+  carrying a VIN filter for a date range.
+
+  Response shape (per PR #586):
+    {
+      "applicableFilterOptions": [...],
+      "missingElliConsent": false,
+      "monthSections": [
+        {
+          "entries": [
+            {
+              "id": "...", "title": "...",
+              "primaryValue": {"value": 12.5, "unit": "kWh"},
+              "secondaryValue": {"value": 45, "unit": "min"},
+              "sessionDetails": {
+                "startedAt": "...",
+                "currentType": "AC" | "DC",
+                "isCurveAvailable": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+
+  Used by SkodaClient.get_charging_statistics() at
+  custom_components/vag_connect/cariad/api/skoda.py to populate
+  total_charged_energy_kwh, last_charging_session_kwh,
+  last_charging_session_duration_min, last_charging_session_start,
+  last_charging_session_current_type, recent_charging_sessions.
+
+  PR #586 is still open in myskoda (14 review comments, not yet merged).
+  Adopted preemptively because the upstream-broken state of the legacy
+  endpoint affects all Skoda users on 2026-05-15+ firmware.
+}

--- a/tests/test_v210_vw_na_endpoints.py
+++ b/tests/test_v210_vw_na_endpoints.py
@@ -171,12 +171,14 @@ class TestSpinFlow:
 
     @pytest.mark.asyncio
     async def test_sha1_response_correctness(self):
-        """The protocol response must be SHA1(spin + nonce) uppercase hex."""
+        """v2.11.0: protocol response is SHA-512('{challenge}.{spin}')
+        as the primary attempt (zackcornelius source-verified).
+        Legacy SHA-1(spin+nonce) stays as fallback on 4xx."""
         client = _client()
         nonce = "deadbeef12345678"
         spin = "1234"
-        expected_digest = hashlib.sha1(  # noqa: S324
-            (spin + nonce).encode("utf-8")
+        expected_digest = hashlib.sha512(
+            f"{nonce}.{spin}".encode("utf-8")
         ).hexdigest().upper()
 
         # Capture the response body the helper sends to /spin
@@ -187,7 +189,7 @@ class TestSpinFlow:
             if url.endswith("/challenge"):
                 return {"challenge": nonce}
             if url.endswith("/spin"):
-                return {"sessionToken": "session-token-xyz"}
+                return {"carnetVehicleToken": "session-token-xyz"}
             raise AssertionError(f"unexpected url {url}")
 
         client._post = fake_post  # type: ignore[method-assign]
@@ -204,7 +206,7 @@ class TestSpinFlow:
         assert sent_payloads[1][0].endswith(
             "/ss/v1/user/user-abc/spin"
         )
-        # The /spin body carries the protocol digest
+        # The /spin body carries the protocol digest (SHA-512)
         assert sent_payloads[1][1]["response"] == expected_digest
         assert sent_payloads[1][1]["challenge"] == nonce
 

--- a/tests/test_v230_sprint_b.py
+++ b/tests/test_v230_sprint_b.py
@@ -146,28 +146,28 @@ class TestVWNAUsesNAOverrides:
         assert "signin_client_id_override=_NA_SIGNIN_CLIENT_GUID" in src
 
     def test_scope_narrowed_to_openid_only(self) -> None:
-        """BRAND_VW_NA.scope must be just 'openid' per matpoulin.
+        """v2.11.0: BRAND_VW_NA.scope is "openid profile cars vin"
+        per zackcornelius source-verified audit. Pre-v2.11.0 we sent
+        bare "openid" per matpoulin (#269) but the NA IDP returns
+        reduced consent + missing claims with that narrow scope.
 
         The wider EU-style scope chain (``openid profile email
-        offline_access mbb vin cars dealers``) was part of why the NA
-        IDP rejected the request with HTTP 400 in the user's log on
-        #269.
+        offline_access mbb vin cars dealers``) stays rejected.
         """
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        assert 'scope="openid"' in src
-        # Make sure the old wide scope is removed.
+        assert 'scope="openid profile cars vin"' in src
+        # Make sure the EU-wide scope chain stays absent.
         assert 'scope="openid profile email offline_access mbb vin cars dealers"' not in src
 
     def test_models_brand_scope_also_narrowed(self) -> None:
-        """models.BRAND_VW_NA_MODEL.scope must match BRAND_VW_NA.scope."""
+        """v2.11.0: models.BRAND_VW_NA_MODEL.scope must match
+        BRAND_VW_NA.scope after the zackcornelius-verified bump to
+        "openid profile cars vin"."""
         src = _MODELS_PY.read_text(encoding="utf-8")
-        # The models-side scope is for users that bypass the api/vw_na
-        # path; keeping them in sync prevents subtle config drift.
-        # Find the BRAND_VW_NA_MODEL block and assert the scope.
         idx = src.find("BRAND_VW_NA_MODEL = BrandConfig(")
         assert idx > 0
         block = src[idx : idx + 600]
-        assert 'scope="openid"' in block
+        assert 'scope="openid profile cars vin"' in block
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Per the new release-process rule (PR-first, no more per-brand hotfix chain), this bundles 5 parallel deep-diffs against upstream libs that maintain the brands' Python clients.

## Audits performed

| Brand | Upstream lib | Lines audited |
|---|---|---|
| SEAT/CUPRA | pycupra (WulfgarW) | dashboard.py + vehicle.py |
| Skoda | myskoda (skodaconnect) | models/{status,charging,ac,maintenance,driving_range,health,trip_statistics}.py |
| VW EU + Audi | volkswagencarnet (robinostlund), CarConnectivity-VW (tillsteinbach), audi_connect_ha (audiconnect) | vw_const.py, connector.py, audi_services.py, audi_models.py |
| VW NA | CarConnectivity-connector-volkswagen-na (zackcornelius) | connector.py, myvw_session.py |

## Bugs fixed (silently null fields)

### Skoda
- **Driving range fields**: `electricRange/combustionRange.distanceInKm` paths are scout-derived guesses; myskoda's DrivingRange model does NOT include them. Now reads `primaryEngineRange/secondaryEngineRange.remainingRangeInKm` with `engineType` discrimination.
- **doors_open/windows_open**: access.doorsOpenedCount/windowsOpenedCount never existed - reads `overall.doors == 'OPEN'` now.
- **driving_score**: top-level `score` doesn't exist - reads `weeklyScore.main`.
- **adBlueRange**: flat int upstream, not a dict.

### SEAT/CUPRA
- **charging path-prefix**: canonical is `charging.status.charging.*` on Born MY24+. Added `.status.` segment.
- **battery_care_target_soc_pct**: pycupra uses `targetSocPercentage` (no underscores).

### VW EU/Audi
- **plug_led_color double-write**: a second unconditional assignment overwrote valid PPE values with None. Consolidated.
- **battery_care parent block**: canonical is batteryChargingCare, not charging. Order flipped.

## New endpoints/fields wired

- VW EU jobs: `activeVentilation`, `batterySupport`, `chargingProfiles`, `chargingTimers`
- VW EU electricRange third fallback at `measurements.rangeStatus.value.electricRange`
- VW EU/Audi aux-heating legacy fallback at `climatisation.auxiliaryHeatingStatus.*` for A4 B9 / MIB3
- SEAT/CUPRA `min_soc` from `settings.minBatteryStateOfChargeInPercent`
- SEAT/CUPRA `climate_remaining_time_min` + derived `climate_ready_at`

## Documented divergences NOT in this PR

- **VW NA full rewrite**: SPIN flow uses wrong hash algorithm (SHA1 vs SHA512), wrong concat order, wrong endpoint, wrong body keys, wrong token transport. Lock/unlock + climate + target-SOC + departure-timer commands all use wrong HTTP verbs + body shapes. Subscription parser shape fictional. Field reads use wrong keys for location, secure, is_online, battery_soc, cruiseRange units, vehicleType.engine. Too risky to bundle - scheduled v2.11.1 with proper unit-test fixtures.
- **Trip stats** for SEAT/CUPRA + Skoda (separate parser work)
- **Skoda health endpoint** `/v1/vehicle-health-report/warning-lights/{vin}` not yet polled
- **SEAT/CUPRA aux-heating status** reader

CHANGELOG entry has the full list with line numbers.