### PR TITLE
v2.11.1 hotfix: SEAT/CUPRA max_charge_current enum-to-amperage mapping (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.11.1] - 2026-06-04
+
+### Fixed
+
+- **SEAT / CUPRA `max_charge_current` enum → amperage** (#392 heidle78 v2.11.0 trace regression). v2.11.0's pycupra-verified `settings.maxChargeCurrentAc` reader now correctly hits the canonical key on Formentor PHEV MJ22-23 firmware, but that firmware returns the enum string `"maximum"` / `"reduced"` instead of an integer amperage. The HA `sensor.cupra_max_ladestrom` is registered as `device_class=current, unit=A, numeric` and blew up with `ValueError: could not convert string to float: 'maximum'`. Now: prefer the explicit integer field when present, otherwise map the enum to the canonical amperage values verified against zackcornelius's VW NA APK decompile (`maximum`/`max` → 32 A, `reduced`/`min`/`minimum` → 10 A). Leaves the field `None` when neither path produces a usable value.
+
 ## [2.11.0] - 2026-06-04
 
 Cross-brand parser audit against upstream lib source code. Five parallel deep diffs (pycupra, myskoda, volkswagencarnet, audi_connect_ha + CarConnectivity-VW, CarConnectivity-connector-volkswagen-na) surfaced field-name and parsing bugs that have been silently returning null on every car for some time. Bundled into one PR rather than the per-brand hotfix chain pattern.

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -1254,14 +1254,36 @@ class SeatCupraClient(CariadBaseClient):
                 or v(charge_info, "targetSOC_pct")
                 or v(charge_info, "targetStateOfChargeInPercent")
             )
-            d.max_charge_current = (
-                (settings.get("maxChargeCurrentAcInAmperes")
-                 if isinstance(settings, dict) else None)
-                or (settings.get("maxChargeCurrentAc")
-                    if isinstance(settings, dict) else None)
-                or v(charge_info, "maxChargeCurrentAC")
-                or v(charge_info, "maxChargeCurrent")
-            )
+            # v2.11.1 hotfix (#392 heidle78 v2.11.0 regression): the OLA
+            # API returns `settings.maxChargeCurrentAc` as an enum string
+            # ("maximum" / "reduced") on Formentor PHEV MJ22-23 firmware,
+            # NOT as an integer amperage. HA sensor.max_charge_current
+            # is device_class=current unit=A numeric so the raw enum
+            # blew up entity rendering with ValueError. Now: prefer the
+            # explicit integer field first, fall through to enum->amp
+            # mapping verified by zackcornelius's VW NA APK decompile
+            # (maximum/max -> 32 A, reduced/min/minimum -> 10 A).
+            max_charge_raw = None
+            if isinstance(settings, dict):
+                max_charge_raw = (
+                    settings.get("maxChargeCurrentAcInAmperes")
+                    or settings.get("maxChargeCurrentAc")
+                )
+            if max_charge_raw is None:
+                max_charge_raw = (
+                    v(charge_info, "maxChargeCurrentAC")
+                    or v(charge_info, "maxChargeCurrent")
+                )
+            if isinstance(max_charge_raw, (int, float)):
+                d.max_charge_current = float(max_charge_raw)
+            elif isinstance(max_charge_raw, str):
+                _ENUM_TO_AMP = {
+                    "maximum": 32.0, "max": 32.0,
+                    "reduced": 10.0, "min": 10.0, "minimum": 10.0,
+                }
+                normalized = _ENUM_TO_AMP.get(max_charge_raw.lower())
+                if normalized is not None:
+                    d.max_charge_current = normalized
             # v2.11.0 (pycupra source-verified): min_soc lives at
             # `settings.minBatteryStateOfChargeInPercent` on /v1/charging/info.
             # Pre-v2.11.0 we never read it - sensor stayed null on every car.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.11.0"
+  "version": "2.11.1"
 }


### PR DESCRIPTION
v2.11.0 regression: the pycupra-verified `settings.maxChargeCurrentAc` reader correctly hits the canonical key on Formentor PHEV MJ22-23 firmware, but that firmware returns the enum string `"maximum"` / `"reduced"` instead of an integer amperage.

The HA `sensor.cupra_max_ladestrom` is registered as `device_class=current, unit=A, numeric` and blew up with:

```
ValueError: could not convert string to float: 'maximum'
```

## Fix

- Try `settings.maxChargeCurrentAcInAmperes` (integer amps) first
- Fall back to `settings.maxChargeCurrentAc` (enum)
- If we got an int → use it as float amperage
- If we got an enum string → map via canonical values from zackcornelius's VW NA APK decompile: `maximum`/`max` → 32 A, `reduced`/`min`/`minimum` → 10 A
- Leave `None` when neither produces a usable value

Sourced from heidle78's #392 v2.11.0 trace - the ValueError was breaking entity rendering on the entire integration setup for affected users.