### PR TITLE
v2.11.3 — bundle: SEAT/CUPRA endpoints + VW EU signin-service SPA + refresh defense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.11.3] - 2026-06-04
+
+Bundle release. Five fixes spanning SEAT / CUPRA endpoint corrections, VW EU signin-service SPA auth, and Audi token refresh defense. Built from a fresh round of upstream-lib source-walks (pycupra const.py + connection.py, audi_connect_ha audi_services.py, volkswagencarnet vw_connection.py) plus the live diags from #392 (heidle78) and #388 (swebachus).
+
+### Fixed
+
+- **SEAT / CUPRA climatisation read endpoint** (#392 heidle78 v2.11.1 trace). We were hitting `/v2/vehicles/{vin}/climatisation` for the read which 404s — that path is the command prefix only (the start / stop / settings / window-heating POSTs hang off it). The actual read endpoint is `/v1/vehicles/{vin}/climatisation/status`. Restores `climatisation_state`, `target_temperature`, `outside_temp`, `aux_heating_*` etc. on every CUPRA / SEAT that's been silently null for these fields.
+- **SEAT / CUPRA door-lock parser presence check** (same trace). The "sub-job absent" failure in `parser_stats.door_lock` was a stats-misclassification — the parser actually populates `doors_locked` + `doors_individual` correctly from `/v2/vehicles/{vin}/status`, but the presence check only looked at `mycar.access.accessStatus.value` which is empty on newer firmware. Check now accepts either source so cars don't show false-positive parser failures in the diag.
+- **SEAT / CUPRA `permission_*` + `capabilities_count` plumbing**. The `/v1/vehicles/{vin}/permissions` URL we polled for the `permission_is_owner` / `permission_can_command` entities consistently 404'd in production — the canonical endpoint is `/v1/users/{userId}/vehicles/{vin}/relation-status`. Also added a `capabilities_count` diagnostic sensor for SEAT / CUPRA (already exists for VW EU and VW NA), cached for 24h so we don't hammer the capabilities endpoint on every scan_interval tick.
+- **VW EU SPA login on the signin-service flow** (#388 swebachus, Volkswagen ID.7 Sweden). The Auth0 SPA branch we shipped in v2.10.x was Auth0-specific — it hunted for `state=hKFo...` tokens which only exist on the universal-login path, then POSTed to `/u/login`. Users routed through the legacy `signin-service/v1/<client>` flow with a SPA-rendered password page (zero hidden inputs) hit a hard "no Auth0 state token found" error. Now: when the page embeds the `templateModel: { hmac, postAction, relayState, ... }` JSON literal (the SPA shell does), we pull those three fields and POST to the signin-service authenticate URL with the proper body shape. Same approach pycupra and audi_connect_ha use. Also covers a softer fallback (relayState alone via URL / JSON / escaped-JSON) for SPA shells that don't ship a full templateModel.
+- **Audi / VW refresh-token defense** (audi_connect_ha upstream PR #749 pattern). When the IDK token endpoint returns a fresh `access_token` but omits the `refresh_token`, we used to hard-fail with `AuthenticationError` and force a full re-login. Some IDK refresh responses do exactly that — the existing refresh-token stays valid for the rotation lifetime. Now: we keep the previously-known refresh-token when the response omits it, instead of throwing the user back to the config flow.
+
 ## [2.11.2] - 2026-06-04
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -92,6 +93,12 @@ class SeatCupraClient(CariadBaseClient):
         # parkingposition). Surfaced as sensors in get_status().
         self._vin_to_license_plate: dict[str, str] = {}
         self._vin_to_nickname: dict[str, str] = {}
+        # v2.11.3 — capabilities-count cache. The full capabilities list
+        # rotates rarely (per pycupra commentary; OEM ships a static
+        # capability set per vehicle generation). We fetch once per
+        # 24h boundary and store just the count so the diagnostic
+        # sensor stays populated without N polls/day worth of extra GETs.
+        self._capabilities_count_cache: dict[str, tuple[int, float]] = {}
         # v2.10.10 (#392 heidle78) - static vehicle info cached per VIN
         # from the garage response. Pre-v2.10.10 the parser never set
         # model / modelYear / manufacturer / firmware on the dataclass
@@ -383,6 +390,33 @@ class SeatCupraClient(CariadBaseClient):
                 return {}  # Both paths 404 — give up, return empty
             raise
 
+    async def _get_capabilities_count(self, vin: str) -> int | None:
+        """v2.11.3 — cached per-VIN capabilities count.
+
+        The full capability set rotates rarely (OEM ships a static list
+        per vehicle generation), so we fetch once per 24h boundary and
+        keep just the count. Soft-fails to None on error so the diagnostic
+        sensor stays clean.
+        """
+        cached = self._capabilities_count_cache.get(vin)
+        if cached is not None:
+            count, fetched_at = cached
+            if time.monotonic() - fetched_at < 86400:
+                return count
+        try:
+            data = await self.get_capabilities(vin)
+        except Exception:  # noqa: BLE001
+            return cached[0] if cached else None
+        if not isinstance(data, dict):
+            return cached[0] if cached else None
+        caps = data.get("capabilities")
+        if isinstance(caps, list):
+            count = len(caps)
+        else:
+            count = len(data)
+        self._capabilities_count_cache[vin] = (count, time.monotonic())
+        return count
+
     async def _fetch_renders(self, vins: list[str]) -> None:
         """Fetch vehicle render images from OLA renders endpoint."""
         for vin in vins:
@@ -443,7 +477,12 @@ class SeatCupraClient(CariadBaseClient):
             self._get(f"{_BASE}/v2/vehicles/{vin}/status"),
             self._get(f"{_BASE}/v1/vehicles/{vin}/charging/status"),
             self._get(f"{_BASE}/v1/vehicles/{vin}/charging/info"),
-            self._get(f"{_BASE}/v2/vehicles/{vin}/climatisation"),
+            # v2.11.3 (#392 heidle78 v2.11.1 trace) - climatisation read
+            # endpoint is /v1/.../climatisation/status. /v2/.../climatisation
+            # is the COMMAND prefix only (used for /v2/.../climatisation/start
+            # etc.) — hitting bare /v2/.../climatisation returns 404 No static
+            # resource. pycupra source: API_CLIMATER_STATUS const.py line 109.
+            self._get(f"{_BASE}/v1/vehicles/{vin}/climatisation/status"),
             self._get(f"{_BASE}/v1/vehicles/{vin}/maintenance"),
             self._get(f"{_BASE}/v1/vehicles/{vin}/remote-availability"),
             self._get(f"{_BASE}/v1/vehicles/{vin}/mileage"),  # v2.5.3 (#306)
@@ -475,7 +514,16 @@ class SeatCupraClient(CariadBaseClient):
             # does not expose them stays clean (401, 404 typical). The
             # parsers further down accept missing dicts gracefully.
             self._get(f"{_BASE}/v1/vehicles/{vin}/notifications"),
-            self._get(f"{_BASE}/v1/vehicles/{vin}/permissions"),
+            # v2.11.3 — relation-status is the canonical pycupra source
+            # for isOwner / canCommand (const.py API_RELATION_STATUS
+            # line 125). The plain /v1/vehicles/{vin}/permissions path we
+            # used in v2.10.x consistently 404'd; relation-status returns
+            # the role + permission list that the parser already groks.
+            self._get(
+                f"{_BASE}/v1/users/{self._user_id}/vehicles/{vin}/relation-status"
+            ) if self._user_id else self._get(
+                f"{_BASE}/v1/vehicles/{vin}/permissions"
+            ),
             self._get(
                 f"{_BASE}/v1/vehicles/{vin}/measurements/engines"
             ),
@@ -560,17 +608,30 @@ class SeatCupraClient(CariadBaseClient):
         _note("parking_position", parking)
         _note("service_care", maintenance)
         # OLA flattens oil_level / tyre_pressure / auxiliary_heating
-        # into the mycar payload; door_lock lives under
-        # ``access.accessStatus.value``. Mirror the door_lock counter
-        # from there so cross-brand diagnostics line up.
-        if isinstance(mycar, BaseException):
+        # into the mycar payload. door_lock state lives in either:
+        #  - ``mycar.access.accessStatus.value`` (older firmware), OR
+        #  - ``status.doors`` from the /v2/vehicles/{vin}/status payload
+        #    (current firmware — pycupra source-verified, const.py
+        #    API_STATUS line 122).
+        # v2.11.3 (#392 heidle78 v2.11.1 trace) — flip the presence check
+        # to accept EITHER source so cars on the newer firmware no longer
+        # report a false-positive "sub-job absent" failure even when the
+        # parser actually populated door_locked / doors_individual fine.
+        if isinstance(mycar, BaseException) and isinstance(status, BaseException):
             _note("door_lock", mycar)
-        elif isinstance(mycar, dict):
-            self._note_parser_job(
-                "door_lock",
-                present=isinstance(
+        else:
+            mycar_has = (
+                isinstance(mycar, dict)
+                and isinstance(
                     self._val(mycar, "access", "accessStatus", "value"), dict,
-                ),
+                )
+            )
+            status_has = (
+                isinstance(status, dict)
+                and isinstance(self._val(status, "doors"), dict)
+            )
+            self._note_parser_job(
+                "door_lock", present=(mycar_has or status_has),
             )
 
         # ── Main vehicle data (mycar) ────────────────────────────────────────
@@ -2248,6 +2309,11 @@ class SeatCupraClient(CariadBaseClient):
         # parser populates ``available_charge_modes`` above; coordinator
         # writes the VehicleData dict into ``vehicles[vin]`` during the
         # poll merge.
+
+        # v2.11.3 — diagnostic capabilities_count sensor. Uses the 24h
+        # cached helper so we don't hammer the capabilities endpoint
+        # on every scan_interval tick.
+        d.capabilities_count = await self._get_capabilities_count(vin)
 
         return d
 

--- a/custom_components/vag_connect/cariad/auth/_data_act_portal.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_portal.py
@@ -422,6 +422,75 @@ class DataActPortalAuth:
                 )
                 state_from_url = ""
                 state_source = ""
+                # v2.11.3 (#388 swebachus VW EU ID.7 SE) — template-model
+                # extraction for signin-service SPA. When VW renders the
+                # signin-service login as a SPA shell with zero hidden
+                # <input> tags, the form data still lives inside an
+                # embedded ``templateModel: { hmac, postAction, relayState,
+                # ... }`` JSON literal in a <script> block. This is the
+                # exact fallback both pycupra (connection.py 823-897) and
+                # audi_connect_ha (audi_services.py 1449-1481) use. Pull
+                # hmac + postAction directly so the authenticate POST has
+                # the session-bound CSRF token the SPA shell would
+                # otherwise compute in JS. When found, this short-circuits
+                # the Auth0-state hunt — we know we are on signin-service
+                # and have everything we need.
+                template_hmac = ""
+                template_post_action = ""
+                template_relay_state = ""
+
+                def _extract_template_model(
+                    src_html: str,
+                ) -> tuple[str, str, str]:
+                    """Return (hmac, postAction, relayState) from any
+                    ``templateModel: {...},`` literal in *src_html*.
+                    Returns empty strings when not found.
+                    """
+                    # Match ``templateModel: {`` through the matching
+                    # closing brace before the next ``,\n`` separator —
+                    # mirrors the pycupra/audi_connect_ha regex shape.
+                    tm_match = re.search(
+                        r"templateModel\s*:\s*(\{.*?\})\s*,\s*\n",
+                        src_html, re.DOTALL,
+                    )
+                    if not tm_match:
+                        return "", "", ""
+                    tm_json = tm_match.group(1)
+                    h = re.search(
+                        r'"hmac"\s*:\s*"([^"]+)"', tm_json,
+                    )
+                    pa = re.search(
+                        r'"postAction"\s*:\s*"([^"]+)"', tm_json,
+                    )
+                    rs = re.search(
+                        r'"relayState"\s*:\s*"([^"]+)"', tm_json,
+                    )
+                    return (
+                        h.group(1) if h else "",
+                        pa.group(1) if pa else "",
+                        rs.group(1) if rs else "",
+                    )
+
+                for label, src_html in (
+                    ("password_html", password_html),
+                    ("landing_html", landing_html),
+                ):
+                    if not src_html:
+                        continue
+                    h_, pa_, rs_ = _extract_template_model(src_html)
+                    if h_ and pa_:
+                        template_hmac = h_
+                        template_post_action = pa_
+                        template_relay_state = rs_
+                        state_from_url = rs_ or "templateModel"
+                        state_source = f"{label}/templateModel"
+                        _LOGGER.debug(
+                            "Data Act portal SPA: templateModel found in "
+                            "%s — hmac len=%d, postAction=%s",
+                            label, len(template_hmac),
+                            template_post_action[:80],
+                        )
+                        break
 
                 def _extract_state_from_html(src_html: str) -> str:
                     """Walk every <input ...> tag, extract name+value as
@@ -440,9 +509,14 @@ class DataActPortalAuth:
                             return vm.group(1)
                     return ""
 
+                # Skip the Auth0-style state hunt when templateModel
+                # already gave us hmac+postAction — that flow is
+                # signin-service and uses a different POST shape below.
                 for label, src_html in (
-                    ("password_html", password_html),
-                    ("landing_html", landing_html),
+                    () if state_from_url else (
+                        ("password_html", password_html),
+                        ("landing_html", landing_html),
+                    )
                 ):
                     if not src_html:
                         continue
@@ -529,6 +603,54 @@ class DataActPortalAuth:
                             state_from_url = qs["state"][0]
                             state_source = f"{label}/url-query"
                             break
+                # v2.11.3 (#388 swebachus VW EU ID.7 SE) — when the IDP
+                # routes the user through ``signin-service/v1/<client>``
+                # instead of Auth0 Universal Login (``/u/login``), the
+                # session token is ``relayState`` not ``state``. Check
+                # all the same sources but for the signin-service token
+                # name. Tracks which auth chain we are on so the POST
+                # step below targets the correct endpoint.
+                signin_service_flow = (
+                    "signin-service" in landing_url
+                    or "signin-service" in identifier_url
+                )
+                if not state_from_url and signin_service_flow:
+                    for label, src_html in (
+                        ("password_html", password_html),
+                        ("landing_html", landing_html),
+                    ):
+                        if not src_html:
+                            continue
+                        # JSON embed (most common for SPA-rendered
+                        # signin-service shells — observed in
+                        # swebachus #388-comment-2026-06-04).
+                        m = re.search(
+                            r'"relayState"\s*:\s*"([A-Za-z0-9_\-\.%/+=]{8,})"',
+                            src_html,
+                        )
+                        if m:
+                            state_from_url = m.group(1)
+                            state_source = f"{label}/relayState-json"
+                            break
+                        # Escaped variant.
+                        m = re.search(
+                            r'\\"relayState\\"\s*:\s*\\"([A-Za-z0-9_\-\.%/+=]{8,})\\"',
+                            src_html,
+                        )
+                        if m:
+                            state_from_url = m.group(1)
+                            state_source = f"{label}/relayState-escaped"
+                            break
+                if not state_from_url and signin_service_flow:
+                    for label, src in (
+                        ("landing_url", landing_url),
+                        ("identifier_url", identifier_url),
+                    ):
+                        qs = parse_qs(_urlparse(src).query)
+                        if qs.get("relayState"):
+                            state_from_url = qs["relayState"][0]
+                            state_source = f"{label}/relayState-url"
+                            break
                 if not state_from_url:
                     # v2.10.11 (#388 swebachus) - expanded forensic dump
                     # covering BOTH HTMLs and the raw URL strings, plus
@@ -580,14 +702,19 @@ class DataActPortalAuth:
                         "__STORE__" in (landing_html or ""),
                         _state_context(landing_html or ""),
                     )
+                    flow_hint = (
+                        "signin-service v1 (legacy IDK)"
+                        if signin_service_flow
+                        else "Auth0 universal login"
+                    )
                     raise AuthenticationError(
-                        "Data Act portal: SPA password page reached but "
-                        "no Auth0 state token found (checked hidden "
-                        "input via two-step walk, JS JSON embed, data-"
-                        "state attribute, password-page URL and "
-                        "landing URL). IDP markup may have changed. "
-                        "Enable DEBUG logging for "
-                        "'custom_components.vag_connect.cariad.auth."
+                        f"Data Act portal: SPA password page reached but "
+                        f"no session token found ({flow_hint} flow detected; "
+                        "checked Auth0 'state' AND signin-service "
+                        "'relayState' via hidden input, JSON embed, "
+                        "data-attr, native msgpack signature, URL query). "
+                        "IDP markup may have changed. Enable DEBUG logging "
+                        "for 'custom_components.vag_connect.cariad.auth."
                         "_data_act_portal' and re-share the log."
                     )
                 _LOGGER.debug(
@@ -596,16 +723,74 @@ class DataActPortalAuth:
                     state_source, state_from_url[:12],
                 )
                 from urllib.parse import quote as _quote  # noqa: PLC0415
-                spa_post_url = (
-                    f"https://identity.vwgroup.io/u/login?state="
-                    f"{_quote(state_from_url, safe='')}"
-                )
-                spa_form = {
-                    "username": email,
-                    "password": password,
-                    "action": "default",
-                    "state": state_from_url,
-                }
+                # v2.11.3 — POST URL + body shape now diverges by auth
+                # chain. signin-service flow targets the classic IDK
+                # ``/login/authenticate`` endpoint with ``relayState`` in
+                # the body; Auth0 flow targets ``/u/login`` with ``state``.
+                is_signin_service_state = state_source.endswith((
+                    "relayState-json",
+                    "relayState-escaped",
+                    "relayState-url",
+                    "templateModel",
+                ))
+                if template_hmac and template_post_action:
+                    # Best-case signin-service path — templateModel gave
+                    # us everything (pycupra connection.py 823-897 +
+                    # audi_connect_ha audi_services.py 1449-1481 use this
+                    # exact shape). postAction is usually relative; build
+                    # the absolute URL via the identifier_url scheme/host.
+                    from urllib.parse import urlparse as _up  # noqa: PLC0415
+                    parsed = _up(identifier_url)
+                    pa = template_post_action
+                    if pa.startswith("/"):
+                        spa_post_url = (
+                            f"{parsed.scheme}://{parsed.netloc}{pa}"
+                        )
+                    elif pa.startswith("http"):
+                        spa_post_url = pa
+                    else:
+                        # Action relative to the identifier_url's path.
+                        base_path = parsed.path.rsplit("/", 1)[0]
+                        spa_post_url = (
+                            f"{parsed.scheme}://{parsed.netloc}"
+                            f"{base_path}/{pa}"
+                        )
+                    spa_form = {
+                        "email": email,
+                        "password": password,
+                        "hmac": template_hmac,
+                        "relayState": template_relay_state,
+                        "_csrf": template_hmac,  # legacy alias some IDPs accept
+                    }
+                elif is_signin_service_state:
+                    # Reconstruct signin-service authenticate URL from
+                    # the identifier_url shape:
+                    # signin-service/v1/<client>@apps_vw-dilab_com/login/identifier
+                    # → .../login/authenticate
+                    from urllib.parse import urlparse as _up  # noqa: PLC0415
+                    parsed = _up(identifier_url)
+                    auth_path = parsed.path.replace(
+                        "/login/identifier", "/login/authenticate"
+                    )
+                    spa_post_url = (
+                        f"{parsed.scheme}://{parsed.netloc}{auth_path}"
+                    )
+                    spa_form = {
+                        "email": email,
+                        "password": password,
+                        "relayState": state_from_url,
+                    }
+                else:
+                    spa_post_url = (
+                        f"https://identity.vwgroup.io/u/login?state="
+                        f"{_quote(state_from_url, safe='')}"
+                    )
+                    spa_form = {
+                        "username": email,
+                        "password": password,
+                        "action": "default",
+                        "state": state_from_url,
+                    }
                 spa_headers_form = {
                     "Accept": (
                         "text/html,application/xhtml+xml,"

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -1296,7 +1296,7 @@ class IDKAuth:
                 raise AuthenticationError(f"Token refresh returned HTTP {resp.status}")
             payload: dict[str, Any] = await resp.json()
 
-        return self._parse_tokens(payload)
+        return self._parse_tokens(payload, fallback_refresh=refresh_token)
 
     async def _refresh_skoda(self, refresh_token: str) -> TokenSet:
         """Škoda uses a proprietary refresh endpoint."""
@@ -1319,7 +1319,7 @@ class IDKAuth:
                 raise AuthenticationError(f"Škoda token refresh HTTP {resp.status}")
             payload: dict[str, Any] = await resp.json()
 
-        return self._parse_tokens(payload)
+        return self._parse_tokens(payload, fallback_refresh=refresh_token)
 
     # ── Auth0 Universal Login helpers ─────────────────────────────────────────
 
@@ -1824,17 +1824,37 @@ class IDKAuth:
         # VW EU, Audi, and others: CARIAD BFF — v2.5.4 migrated URL.
         return _CARIAD_TOKEN_URL
 
-    def _parse_tokens(self, payload: dict[str, Any]) -> TokenSet:
+    def _parse_tokens(
+        self,
+        payload: dict[str, Any],
+        fallback_refresh: str = "",
+    ) -> TokenSet:
         """Parse token response into a TokenSet.
 
         Handles both snake_case (OAuth standard) and camelCase (Škoda proprietary).
+
+        v2.11.3 — defensive ``fallback_refresh``: some IDK refresh-token
+        responses return a fresh ``access_token`` but NO ``refresh_token``
+        (the existing one stays valid for the rotation lifetime). Without
+        the fallback the integration crashed with a hard ``AuthenticationError``
+        and forced a full re-login. When the caller passes the previous
+        refresh-token as ``fallback_refresh`` we keep using it instead of
+        failing.
         """
         access = payload.get("access_token") or payload.get("accessToken")
-        refresh = payload.get("refresh_token") or payload.get("refreshToken")
+        refresh = (
+            payload.get("refresh_token")
+            or payload.get("refreshToken")
+            or fallback_refresh
+        )
         id_tok = payload.get("id_token") or payload.get("idToken") or ""
-        if not access or not refresh:
+        if not access:
             raise AuthenticationError(
-                f"Token response missing required fields: {list(payload)}"
+                f"Token response missing access_token: {list(payload)}"
+            )
+        if not refresh:
+            raise AuthenticationError(
+                f"Token response missing refresh_token (no fallback): {list(payload)}"
             )
         return TokenSet(access_token=access, refresh_token=refresh, id_token=id_tok)
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.11.2"
+  "version": "2.11.3"
 }

--- a/tests/bruno/seat_cupra/50_GET_climatisation_status.bru
+++ b/tests/bruno/seat_cupra/50_GET_climatisation_status.bru
@@ -1,0 +1,45 @@
+meta {
+  name: GET climatisation status (read)
+  type: http
+  seq: 50
+}
+
+get {
+  url: {{base_url}}/v1/vehicles/{{vin}}/climatisation/status
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  v2.11.3 — canonical climatisation READ endpoint for SEAT/CUPRA on
+  OLA. Replaces /v2/vehicles/{vin}/climatisation which is the COMMAND
+  prefix only (/v2/.../climatisation/start etc.) and returns
+  "404 No static resource v2/vehicles/{vin}/climati" when called
+  bare via GET (heidle78 #392 v2.11.1 trace).
+
+  Response carries climatisation state + settings + the
+  auxiliaryHeatingStatus sub-block (aux-heating runs through the
+  same payload — no separate aux endpoint, as confirmed in v2.11.2).
+
+  Response shape (defensive multi-variant across firmwares):
+    {
+      "status": {
+        "climatisationState": "off" | "heating" | "ventilation" | ...,
+        "remainingTime_min": 0,
+        "auxiliaryHeatingStatus": { ... }
+      },
+      "settings": {
+        "targetTemperatureInCelsius": 21.5,
+        "targetTemperature_K": 294.65,
+        "heaterSource": "automatic" | "fuel" | "electric"
+      }
+    }
+}

--- a/tests/bruno/seat_cupra/51_GET_relation_status.bru
+++ b/tests/bruno/seat_cupra/51_GET_relation_status.bru
@@ -1,0 +1,41 @@
+meta {
+  name: GET vehicle relation-status (permissions)
+  type: http
+  seq: 51
+}
+
+get {
+  url: {{base_url}}/v1/users/{{user_id}}/vehicles/{{vin}}/relation-status
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  v2.11.3 — canonical user-permission endpoint for SEAT/CUPRA on OLA.
+  Replaces /v1/vehicles/{vin}/permissions which consistently 404'd
+  in production (heidle78 #392 v2.11.1 trace showed permission_*
+  fields null on every poll).
+
+  Returns the user's role for this vehicle + per-permission entries.
+  Used to populate permission_is_owner + permission_can_command.
+
+  Response shape (defensive):
+    {
+      "role": "PRIMARY_USER" | "SECONDARY_USER" | "OWNER" | "GUEST",
+      "isOwner": true,
+      "canCommand": true,
+      "permissions": [
+        {"name": "CAN_LOCK", ...},
+        {"name": "CAN_START_CLIMATISATION", ...},
+        ...
+      ]
+    }
+}


### PR DESCRIPTION
## Summary

Bundle hotfix release. Five fixes spanning SEAT / CUPRA endpoint corrections, VW EU signin-service SPA auth, and Audi token refresh defense.

Built from upstream-lib source-walks (pycupra `const.py` + `connection.py`, audi_connect_ha `audi_services.py`, volkswagencarnet `vw_connection.py`) plus the live diags from #392 (heidle78 — Formentor PHEV) and #388 (swebachus — VW ID.7 SE).

### SEAT / CUPRA — three fixes from heidle78's v2.11.1 trace

- **Climatisation read URL**. `/v2/vehicles/{vin}/climatisation` is the command prefix only (returns 404 on GET); the actual read endpoint is `/v1/vehicles/{vin}/climatisation/status`. Restores `climatisation_state`, `target_temperature`, `outside_temp`, `aux_heating_*` and the rest of the climate block.
- **door_lock parser presence check**. The "sub-job absent" failure was a stats-misclassification — the parser actually populates fields correctly from `/v2/.../status`, but the presence check only looked at `mycar.access.accessStatus.value` which is empty on newer firmware. Now accepts either source.
- **`permission_*` endpoint + `capabilities_count` sensor**. Moved permission reads from the always-404 `/v1/vehicles/{vin}/permissions` to the canonical `/v1/users/{userId}/vehicles/{vin}/relation-status`. Added a `capabilities_count` diagnostic sensor (already exists for VW EU and VW NA) with a 24h cache so we don't hammer the capabilities endpoint on every scan_interval tick.

### VW EU — signin-service SPA login (#388 swebachus)

The Auth0 SPA branch we shipped in v2.10.x was Auth0-specific — it hunted for `state=hKFo...` tokens (universal-login only) and POSTed to `/u/login`. Users routed through the legacy `signin-service/v1/<client>` flow with a SPA-rendered password page (zero hidden inputs) hit a hard "no Auth0 state token found" error.

Now: when the page embeds the `templateModel: { hmac, postAction, relayState, ... }` JSON literal (the SPA shell does), we pull those three fields and POST to the signin-service authenticate URL with the proper body shape. Same approach pycupra (`connection.py` 823-897) and audi_connect_ha (`audi_services.py` 1449-1481) use.

Also covers a softer fallback (relayState alone via URL / JSON / escaped-JSON) for SPA shells that don't ship a full templateModel.

### Audi / VW — refresh-token defense

When the IDK token endpoint returns a fresh `access_token` but omits the `refresh_token`, we used to hard-fail with `AuthenticationError` and force a full re-login. Some IDK refresh responses do exactly that — the existing refresh-token stays valid for the rotation lifetime. Now we keep the previously-known refresh-token instead of throwing the user back to the config flow.

## Test plan

- [x] `ruff check` clean (pre-commit)
- [x] `mypy --strict` clean (pre-commit)
- [x] `scripts/check_bruno_url_drift.py --strict` clean across all 4 brands
- [x] CHANGELOG gated on `[2.11.3]` presence (pre-commit)
- [ ] CI green on PR
- [ ] After merge — heidle78 confirms `climatisation_*`, `aux_heating_*`, `permission_*`, `capabilities_count` populate on Formentor PHEV
- [ ] After merge — swebachus confirms VW ID.7 SE login completes past the "no state token" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)