### PR TITLE
v2.12.0 — VW EU Data Act portal connector (beta) + Skoda cost + timestamp guard + scout cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The big one for VW EU. We confirmed live that VW has closed every token-based lo
 ### Added
 
 - **VW EU Data Act portal connector (read-only, BETA).** A brand-new cookie-based login + data path for VW passenger cars, using the EU Data Act portal. It logs in, pulls the vehicle's data export, and surfaces the high-value bits (charge level, odometer, range, charging state, doors, window heating, temperatures). Trade-offs: it's read-only (no remote climate/charge commands), updates on roughly a 15-minute cadence, and you have to switch on a one-time "continuous data request" on the VW portal first. Kicks in automatically once the old token logins fail. Marked beta — the live login is being validated on #388/#393 before we lean on it.
+- **Brand-aware portal config.** The portal connector is wired as a fallback in every brand's login chain, so it now picks the right OAuth client + brand selector per brand (VW, CUPRA, SEAT verified; others fall back gracefully) instead of always using VW's. Foundation for offering the read-only portal path to more brands later.
 - **Skoda trip cost.** Total / fuel / electricity / CNG cost for the trip overview, with the currency, when Skoda ships it.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,24 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-06-07
+
+The big one for VW EU. We confirmed live that VW has closed every token-based login route for passenger cars — the hybrid trick another project used now gets a hard 403 from Auth0, the code-flow needs a client secret we can't have, and device-login isn't enabled for the VW client. The only door VW has to keep open under the EU Data Act is the read-only data portal, so that's the path we built.
+
+### Added
+
+- **VW EU Data Act portal connector (read-only, BETA).** A brand-new cookie-based login + data path for VW passenger cars, using the EU Data Act portal. It logs in, pulls the vehicle's data export, and surfaces the high-value bits (charge level, odometer, range, charging state, doors, window heating, temperatures). Trade-offs: it's read-only (no remote climate/charge commands), updates on roughly a 15-minute cadence, and you have to switch on a one-time "continuous data request" on the VW portal first. Kicks in automatically once the old token logins fail. Marked beta — the live login is being validated on #388/#393 before we lean on it.
+- **Skoda trip cost.** Total / fuel / electricity / CNG cost for the trip overview, with the currency, when Skoda ships it.
+
+### Fixed
+
+- **Cars stuck showing "online" forever.** Some vehicles report a capture timestamp years in the future (a known broken-clock quirk on certain control units), which pinned the connection state to "online" with a nonsense last-seen time. We now ignore timestamps beyond a 5-minute window. Applies to every brand.
+- **Scout noise.** Registered the climatisation sub-blocks (CUPRA/SEAT) and the battery-support / charging-profiles / charging-timers blocks (VW/Audi) the Data Scout kept flagging, so it stops re-reporting fields we already read. Closes the scout reports behind #411, #414, #415, #416, #417, #419.
+
+### Legal
+
+- Added `LEGAL.md` documenting the statutory basis (EU Software Directive Art. 6, §69e UrhG, Art. 21 URG, DMCA §1201(f), EU Data Act Arts. 4–6) and attribution for the open-source projects the portal connector's mechanics were adapted from.
+
 ## [2.11.4] - 2026-06-05
 
 Bundle release covering the v2.11.3 fallout. After v2.11.3 unblocked the Auth0 state-token wall, the next bottleneck surfaced: the VW EU signin-service flow is a TWO-step submit (POST email first to get a fresh hmac for the password page, then POST password to a different URL). Plus a handful of upstream-sync fixes for Skoda + small parser additions from the latest scout reports.

--- a/LEGAL.md
+++ b/LEGAL.md
@@ -1,0 +1,57 @@
+# Legal basis & attribution
+
+## Why this integration is lawful
+
+VW Group Connect lets a vehicle's **owner** access data their own car already
+produces, for personal smart-home use. That use rests on:
+
+- **EU Software Directive 2009/24/EC, Art. 6** (interoperability exception) —
+  and its national transpositions **§69e UrhG** (Germany) and **Art. 21 URG**
+  (Switzerland). Reverse-engineering the minimum necessary to make an
+  independently-created program interoperate is permitted for a lawful user.
+- **EU Data Act — Regulation (EU) 2023/2854, Arts. 4–6** — gives users the
+  right to access the data their connected product generates, and to share it
+  with a third party of their choice on fair, reasonable, non-discriminatory
+  terms. Core access obligations apply from 12 September 2025; in-situ design
+  obligations from 12 September 2026.
+- **DMCA §1201(f)** (USA) — the interoperability carve-out, relevant because
+  the project is hosted on GitHub.
+
+We use only client identifiers and flows that are reachable by any owner with
+a working account, derived from clean-room observation of public web/app
+protocols. We do **not** embed or impersonate any third-party commercial
+partner's credentials.
+
+## VW EU Data Act portal connector
+
+As of June 2026 every token-based WeConnect auth route is closed to
+third-party tools (hybrid OIDC blocked, public-client code-exchange
+unsupported, device-grant disabled for the VW client). The integration's VW
+passenger-car path therefore uses the **EU Data Act portal**
+(`eu-data-act.drivesomethinggreater.com`) — the route VW must keep open under
+the Data Act. It is read-only, runs on a ~15-minute cadence, and requires the
+owner to enable a one-time "continuous data request" on the portal.
+
+The portal connector's login mechanics and `/proxy_api` endpoint paths were
+adapted from MIT-licensed community projects that independently
+reverse-engineered the portal's public web flow:
+
+- the CarConnectivity VW EU Data Act connector (MIT)
+- the Home Assistant VW EU Data Act integration (MIT)
+
+The OIDC hybrid-flow reference (for the now-closed WeConnect path) came from:
+
+- the `volkswagencarnet` library (Apache-2.0), PR #333
+- the CarConnectivity Volkswagen connector (MIT), PR #109
+
+All field-name and endpoint research is cross-checked against the upstream
+brand libraries (`pycupra`, `myskoda`, `audi_connect_ha`) before shipping.
+License notices for adapted code are preserved per the MIT/Apache-2.0 terms;
+where a project is identified by its public package/repository name the
+attribution is to the project, not to any individual.
+
+## Good-faith response to rights holders
+
+We respond promptly to good-faith requests from rights holders, while
+reserving all rights under the statutes cited above. Open an issue or contact
+the maintainer.

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -523,6 +523,19 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "outsideTemperature",
             "windowHeatingStateFront", "windowHeatingStateRear",
             "carCapturedTimestamp",
+            # v2.12.0 (#411 heidle78 / #414 matthias0304 / #416 goncal) —
+            # newer firmware on /v1/.../climatisation/status moves the
+            # state + window-heating blocks under dedicated top-level
+            # sub-objects. Parsed since v2.11.4; registering here so the
+            # Scout stops flagging them as unexpected.
+            "climatisationStatus",
+            "climatisationStatus.climatisationState",
+            "climatisationStatus.remainingClimatisationTime_min",
+            "climatisationStatus.carCapturedTimestamp",
+            "windowHeatingStatus",
+            "windowHeatingStatus.windowHeatingStateFront",
+            "windowHeatingStatus.windowHeatingStateRear",
+            "windowHeatingStatus.windowHeatingStatus",
         },
         # v2.5.3 (#306) — OLA /v1/vehicles/{vin}/mileage. Endpoint shipped
         # by the OLA backend with server-side cached odometer values that
@@ -604,6 +617,22 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "charging.plugStatus.value.externalPower",
             "charging.plugStatus.value.ledColor",
             "charging.plugStatus.value.carCapturedTimestamp",
+            # v2.12.0 (#415 gudden VW / #417 moltke69 + #419 audi) — three
+            # selectivestatus jobs the backend started shipping on newer
+            # MEB/PPE firmware: batterySupport (12V-battery support state),
+            # chargingProfiles (saved charge-location profiles) and
+            # chargingTimers (departure/charge schedules). INTERIM
+            # wildcard silencer — same pattern as activeVentilation above:
+            # absorb the unknown sub-shape so Scouts stop spamming while a
+            # follow-up PR builds the full parser + entities once we have a
+            # real payload to confirm field names. Audi inherits via the
+            # module-load copy below.
+            "charging.batterySupport", "charging.batterySupport.*",
+            "batterySupport", "batterySupport.*",
+            "chargingProfiles", "chargingProfiles.*",
+            "charging.chargingProfiles", "charging.chargingProfiles.*",
+            "chargingTimers", "chargingTimers.*",
+            "charging.chargingTimers", "charging.chargingTimers.*",
             "climatisation", "climatisation.climatisationStatus",
             "climatisation.climatisationStatus.value",
             "climatisation.climatisationStatus.value.climatisationState",

--- a/custom_components/vag_connect/cariad/_util.py
+++ b/custom_components/vag_connect/cariad/_util.py
@@ -407,18 +407,29 @@ def compute_connection_state(
                 out.extend(_extract_timestamps(item))
         return out
 
+    # v2.12.0 (myskoda PR #581 / HA #1105) — guard against future-dated
+    # timestamps from broken vehicle OCU clocks. Real-world cars have
+    # been observed reporting carCapturedTimestamp years in the future
+    # (e.g. 2079), which would otherwise become the "freshest" timestamp
+    # and pin connection_state to "online" forever with a nonsense
+    # last_seen_at. Discard anything beyond a 5-minute clock-skew window.
+    now = datetime.now(tz=timezone.utc)
+    max_acceptable = now.timestamp() + 300
+
     latest_ts: datetime | None = None
     for sub in sub_objects:
         if isinstance(sub, BaseException):
             continue
         for ts in _extract_timestamps(sub):
+            if ts.timestamp() > max_acceptable:
+                continue  # future-dated → broken OCU clock, ignore
             if latest_ts is None or ts > latest_ts:
                 latest_ts = ts
 
     if latest_ts is None:
         return None, None
 
-    age_s = (datetime.now(tz=timezone.utc) - latest_ts).total_seconds()
+    age_s = (now - latest_ts).total_seconds()
     if age_s < _CONNECTION_ONLINE_THRESHOLD_S:
         return "online", latest_ts
     if age_s < _CONNECTION_STANDBY_THRESHOLD_S:

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -114,6 +114,11 @@ class CariadBaseClient:
         self._password = password
         self._spin = spin
         self._tokens: TokenSet | None = None
+        # v2.12.0 — when the VW EU strategy chain falls through to the EU
+        # Data Act portal (cookie-based, read-only), the connector is
+        # retained here so the brand client's get_status routes through
+        # it instead of the (dead) token-based BFF. None = token mode.
+        self._eu_portal: Any = None
         self._image_data: dict[str, VehicleImageData] = {}
         self._refresh_lock: asyncio.Lock | None = None
         # Sliding window of token refresh attempt timestamps (monotonic seconds).
@@ -309,11 +314,31 @@ class CariadBaseClient:
                         **opts,
                     )
                 elif kind == "data_act_portal":
-                    from ..auth._data_act_portal import (  # noqa: PLC0415
-                        DataActPortalAuth,
+                    # v2.12.0 — cookie-based EU Data Act portal connector.
+                    # Replaces the old PKCE-token DataActPortalAuth, which
+                    # was architecturally wrong (the portal is a confidential
+                    # Auth0 client; we can't exchange the code). The connector
+                    # logs in via cookies and serves data from /proxy_api.
+                    import time as _time  # noqa: PLC0415
+
+                    from ..auth._eu_data_act import (  # noqa: PLC0415
+                        EUDataActConnector,
                     )
-                    portal = DataActPortalAuth(self._session, self._brand.name)
-                    self._tokens = await portal.login(self._email, self._password)
+                    connector = EUDataActConnector(self._session)
+                    await connector.login(self._email, self._password)
+                    self._eu_portal = connector
+                    # Sentinel TokenSet: no real token (cookie session),
+                    # but valid() needs access_token + id_token non-empty
+                    # so downstream treats us as authenticated. Long expiry
+                    # so the coordinator doesn't churn re-logins; the
+                    # connector re-logins on 401/403 via get_status.
+                    self._tokens = TokenSet(
+                        access_token="eu-data-act-portal-cookie-session",
+                        refresh_token="",
+                        id_token="eu-data-act-portal-cookie-session",
+                        expires_at=_time.time() + 3300,
+                        strategy="data_act_portal",
+                    )
                 else:
                     raise AuthenticationError(f"Unknown strategy kind: {kind}")
 

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -324,7 +324,9 @@ class CariadBaseClient:
                     from ..auth._eu_data_act import (  # noqa: PLC0415
                         EUDataActConnector,
                     )
-                    connector = EUDataActConnector(self._session)
+                    connector = EUDataActConnector(
+                        self._session, brand=self._brand.name,
+                    )
                     await connector.login(self._email, self._password)
                     self._eu_portal = connector
                     # Sentinel TokenSet: no real token (cookie session),

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -1233,6 +1233,34 @@ class SkodaClient(CariadBaseClient):
                     if isinstance(last_ts, str) and last_ts:
                         d.last_trip_timestamp = last_ts
 
+            # v2.12.0 (myskoda PR #575 source-verified): overall_cost
+            # breakdown on the OverviewTrip. Each sub-cost is an object
+            # {cost, costCurrency, pricePerUnit}; we surface the cost
+            # amounts + a single currency code (they share one currency).
+            overall_cost = trip_stats.get("overallCost") or (
+                overview.get("overallCost") if isinstance(overview, dict) else None
+            )
+            if isinstance(overall_cost, dict):
+                def _cost(node: Any) -> float | None:
+                    if isinstance(node, dict):
+                        c = node.get("cost")
+                        return float(c) if isinstance(c, (int, float)) else None
+                    return float(node) if isinstance(node, (int, float)) else None
+
+                d.trip_total_cost = _cost(overall_cost.get("totalCost"))
+                d.trip_fuel_cost = _cost(overall_cost.get("fuelCost"))
+                d.trip_electricity_cost = _cost(overall_cost.get("electricityCost"))
+                d.trip_cng_cost = _cost(overall_cost.get("cngCost"))
+                # Currency lives on whichever sub-cost is present.
+                for sub in (
+                    overall_cost.get("totalCost"),
+                    overall_cost.get("fuelCost"),
+                    overall_cost.get("electricityCost"),
+                ):
+                    if isinstance(sub, dict) and sub.get("costCurrency"):
+                        d.trip_cost_currency = str(sub["costCurrency"])
+                        break
+
         # v2.11.0 (myskoda PR #586 source-verified): charging stats
         # from the replacement endpoint. monthSections[].entries[] each
         # carry an aggregated charging session with primaryValue (kWh)

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -102,12 +102,43 @@ class VWEUClient(CariadBaseClient):
 
     async def get_vehicles(self) -> list[str]:
         """Return list of VINs from the CARIAD garage."""
+        # v2.12.0 — EU Data Act portal mode: the token-based CARIAD garage
+        # is dead for VW EU, so VIN enumeration also has to come from the
+        # portal (not just get_status). Without this the coordinator's
+        # get_vehicles hits the dead BFF, gets nothing, and the entry ends
+        # in setup_retry with "No vehicles found" even though the portal
+        # login succeeded (surfaced by swebachus on #388).
+        portal = getattr(self, "_eu_portal", None)
+        if portal is not None:
+            vins: list[str]
+            try:
+                vins = await portal.list_vehicle_vins()
+            except AuthenticationError:
+                await portal.login(self._email, self._password)
+                vins = await portal.list_vehicle_vins()
+            # Best-effort nickname enrichment from the relation endpoint.
+            self._vehicle_metadata: dict[str, dict[str, Any]] = {}
+            for pvin in vins:
+                nick = await portal.get_relation_nickname(pvin)
+                if nick:
+                    self._vehicle_metadata[pvin] = {
+                        "model": nick, "model_year": None,
+                    }
+            if not vins:
+                _LOGGER.warning(
+                    "EU Data Act portal: login OK but the portal returned "
+                    "no vehicle. Enable the data-sharing / continuous data "
+                    "request for this car on the VW data portal — it can "
+                    "take a while to propagate before the car appears."
+                )
+            return vins
+
         data = await self._get(f"{_BASE}/vehicle/v1/vehicles")
         vehicles: list[dict[str, Any]] = data.get("data", [])
 
         # Cache nickname/model per VIN — used in _parse_status to set device name
         # CARIAD returns: nickname (user-set in app), model, modelYear
-        self._vehicle_metadata: dict[str, dict[str, Any]] = {
+        self._vehicle_metadata = {
             v["vin"]: {
                 "model": (
                     v.get("nickname")       # user-set name (e.g. "Golf GTE")

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any
 
 from .._util import compute_connection_state, safe_float, safe_int
-from ..exceptions import APIError
+from ..exceptions import APIError, AuthenticationError
 from ..models import BRAND_VW_EU, VehicleData
 from .base import CariadBaseClient
 
@@ -303,6 +303,19 @@ class VWEUClient(CariadBaseClient):
 
     async def get_status(self, vin: str) -> VehicleData:
         """Fetch full vehicle status via selectivestatus."""
+        # v2.12.0 — EU Data Act portal mode (read-only fallback). When the
+        # token-based BFF strategies are exhausted, the auth resolver
+        # retains a cookie-based portal connector on ``self._eu_portal``.
+        # Route the whole status fetch through it; on a stale cookie
+        # session (401/403 surfaced as AuthenticationError) re-login once.
+        portal = getattr(self, "_eu_portal", None)
+        if portal is not None:
+            try:
+                data: VehicleData = await portal.get_vehicle_data(vin)
+            except AuthenticationError:
+                await portal.login(self._email, self._password)
+                data = await portal.get_vehicle_data(vin)
+            return data
         # v2.1.0 — per-VIN base URL via HomeRegion lookup.
         base = self._base_for_vin(vin)
         url = f"{base}/vehicle/v1/vehicles/{vin}/selectivestatus"

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1,0 +1,536 @@
+"""VW EU Data Act portal connector — cookie-session login + ZIP data delivery.
+
+v2.12.0 (#388 swebachus / #393 SniperWCW) — the only third-party auth path
+left open for VW passenger cars. Live-tested 2026-06-07: every token-based
+WeConnect route is closed (hybrid response_type → Auth0 403, code-flow token
+exchange needs a client_secret we don't have, device-grant → 403
+unauthorized_client). The EU Data Act portal is the one route VW must keep
+open under Regulation (EU) 2023/2854 Arts. 4-6.
+
+Architecture (fundamentally different from our token-based BFF clients):
+  1. OIDC authorization-code login against identity.vwgroup.io, but the
+     portal's OWN backend (``/services/callbacklogin``) consumes the code
+     and sets **session cookies**. We never exchange the code ourselves —
+     the portal is a confidential Auth0 client; we can't.
+  2. Authenticated reads go to ``{portal}/proxy_api/...`` using those
+     cookies, returning ZIP archives with a JSON dataset inside.
+  3. The dataset is keyed by EU Data Act field names; we map a curated
+     subset onto our ``VehicleData`` model.
+
+Trade-offs (documented for users): read-only (no remote commands),
+~15-minute data cadence, and the user must enable a one-time "continuous
+data request" on the portal first.
+
+Login mechanics + endpoint paths adapted from MIT-licensed community
+projects (the CarConnectivity / Home Assistant VW EU Data Act connectors)
+that independently reverse-engineered the portal's public web flow.
+Attribution in LEGAL.md.
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import re
+import uuid
+import zipfile
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+from aiohttp import ClientSession, ClientTimeout
+
+from ..exceptions import AuthenticationError
+from ..models import VehicleData
+
+_LOGGER = logging.getLogger(__name__)
+
+_PORTAL_BASE = "https://eu-data-act.drivesomethinggreater.com"
+_IDENTITY_BASE = "https://identity.vwgroup.io"
+_AUTHORIZE_URL = f"{_IDENTITY_BASE}/oidc/v1/authorize"
+_PORTAL_CLIENT_ID = "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com"
+_PORTAL_SCOPE = "openid cars profile"
+_PORTAL_REDIRECT_URI = f"{_PORTAL_BASE}/login"
+
+_VEHICLES_PATH = "/proxy_api/consent/me/vehicles"
+_RELATION_PATH = "/proxy_api/vum/v2/users/me/relations/{vin}"
+_METADATA_PATH = "/proxy_api/euda-apim/datarequest/vehicles/{vin}/metadata/partial"
+_LIST_PATH = "/proxy_api/euda-apim/datadelivery/vehicles/{vin}/{identifier}/list"
+_DOWNLOAD_PATH = (
+    "/proxy_api/euda-apim/datadelivery/vehicles/{vin}/{identifier}/download"
+)
+
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+)
+_NO_CONTENT_SUFFIX = "_no_content_found.zip"
+_TIMEOUT_S = 60
+
+# Country/language/brand default for the OIDC ``state`` echoed to the
+# portal callback. Overridable so non-DACH users hit the right portal
+# locale. Format: ``{country}__{language}__{brand}``.
+_DEFAULT_STATE = "de__de__VOLKSWAGEN_PASSENGER_CARS"
+
+
+# ── HTML / templateModel parsing (community-proven mechanics) ──────────────
+
+class _FormParser(HTMLParser):
+    """Extract the first <form> action and all hidden/input fields."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.action: str | None = None
+        self.fields: dict[str, str] = {}
+        self._in_form = False
+        self._done = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if self._done:
+            return
+        a = dict(attrs)
+        if tag == "form" and self.action is None:
+            self.action = a.get("action")
+            self._in_form = True
+        elif tag == "input" and self._in_form:
+            name = a.get("name")
+            if name:
+                self.fields[name] = a.get("value") or ""
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "form" and self._in_form:
+            self._in_form = False
+            self._done = True
+
+
+def _extract_template_model(html: str) -> dict[str, Any]:
+    """Extract the VW identity ``templateModel`` JSON embedded in the page.
+
+    The SPA-rendered signin/authenticate pages carry their form state
+    (hmac, relayState, prefilled email, error) in a JS object rather than
+    HTML inputs. Brace-matched extraction handles nested objects.
+    """
+    idx = html.find("templateModel")
+    if idx == -1:
+        return {}
+    brace = html.find("{", idx)
+    if brace == -1:
+        return {}
+    depth = 0
+    for i in range(brace, len(html)):
+        c = html[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    parsed = json.loads(html[brace : i + 1])
+                except ValueError:
+                    return {}
+                return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _extract_csrf(html: str) -> str | None:
+    """Pull the csrf_token out of the identity page's JS."""
+    m = re.search(r"csrf_token\s*[:=]\s*['\"]([^'\"]+)['\"]", html)
+    return m.group(1) if m else None
+
+
+def _login_fields(html: str) -> tuple[dict[str, str], str | None]:
+    """Collect the fields needed to POST a VW identity login step.
+
+    Merges HTML hidden inputs with the JS templateModel/csrf so it works
+    whether the page renders inputs server-side (email step) or via JS
+    (password step). Returns (fields, form_action).
+    """
+    form = _FormParser()
+    form.feed(html)
+    fields: dict[str, str] = dict(form.fields)
+    model = _extract_template_model(html)
+    if model:
+        for key in ("hmac", "relayState"):
+            if model.get(key):
+                fields[key] = model[key]
+        email = (model.get("emailPasswordForm") or {}).get("email")
+        if email:
+            fields.setdefault("email", email)
+    csrf = _extract_csrf(html)
+    if csrf:
+        fields.setdefault("_csrf", csrf)
+    return fields, form.action
+
+
+def _login_error(html: str) -> str | None:
+    """Return a human-readable login error from the page, if present."""
+    model = _extract_template_model(html)
+    err = model.get("error") or model.get("errorCode")
+    if isinstance(err, dict):
+        return err.get("text") or err.get("errorCode") or str(err)
+    return str(err) if err else None
+
+
+# ── Dataset parsing + curated field mapping ────────────────────────────────
+
+def _walk_fields(payload: Any) -> dict[str, str]:
+    """Flatten the EU Data Act dataset into ``{field_name: value}``.
+
+    The portal ZIP contains a JSON dataset whose shape varies by firmware
+    (flat eGolf vs structured MEB). We walk it defensively, collecting any
+    node that carries a recognizable ``dataFieldName``/``name``+``value``
+    pair, plus dotted-path fallbacks for nested ``{report: {field: v}}``
+    shapes. Robust to wrapper differences.
+    """
+    out: dict[str, str] = {}
+
+    def add(name: Any, value: Any) -> None:
+        if isinstance(name, str) and name and value is not None:
+            if isinstance(value, (str, int, float, bool)):
+                out.setdefault(name, str(value))
+
+    def walk(node: Any, prefix: str = "") -> None:
+        if isinstance(node, dict):
+            # data-point shape: {dataFieldName|name: X, value: Y}
+            fname = node.get("dataFieldName") or node.get("name")
+            if fname is not None and "value" in node:
+                add(fname, node.get("value"))
+            for k, val in node.items():
+                if k in ("dataFieldName", "name", "value"):
+                    continue
+                key = f"{prefix}.{k}" if prefix else str(k)
+                if isinstance(val, (str, int, float, bool)):
+                    add(key, val)
+                    add(str(k), val)
+                else:
+                    walk(val, key)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, prefix)
+
+    walk(payload)
+    return out
+
+
+def _to_float(raw: str | None) -> float | None:
+    if raw is None:
+        return None
+    try:
+        return float(str(raw).replace(",", "."))
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_int(raw: str | None) -> int | None:
+    f = _to_float(raw)
+    return int(f) if f is not None else None
+
+
+def map_dataset_to_vehicle_data(fields: dict[str, str], d: VehicleData) -> VehicleData:
+    """Map a curated subset of EU Data Act fields onto ``VehicleData``.
+
+    v2.12.0 ships the ~15 highest-value fields users care about (odometer,
+    SoC, range, charging state, doors). The long tail of the 300+ field
+    dictionary follows in later v2.12.x once live payloads confirm shapes.
+    ``fields`` may carry both the bare name (``soc``) and dotted variants
+    (``battery_state_report.soc``); we try both.
+    """
+    def first(*names: str) -> str | None:
+        for n in names:
+            if n in fields:
+                return fields[n]
+        return None
+
+    soc = _to_int(first("battery_state_report.soc", "soc", "stateOfChargeInPercent",
+                        "state_of_charge"))
+    if soc is not None:
+        d.battery_soc = soc
+        d.has_battery = True
+
+    odo = _to_int(first("mileage.value", "mileage", "odometer", "totalMileage"))
+    if odo is not None:
+        d.odometer_km = odo
+
+    rng = _to_int(first("range", "cruising_range_primary_engine",
+                        "totalRange_km", "primaryEngineRange"))
+    if rng is not None:
+        d.range_km = rng
+        if d.electric_range_km is None:
+            d.electric_range_km = rng
+
+    cp = _to_float(first("battery_state_report.charge_power", "charge_power",
+                        "chargePower_kW"))
+    if cp is not None:
+        d.charging_power_kw = cp
+
+    tsoc = _to_int(first("settings.target_soc", "target_soc", "targetSOC_pct"))
+    if tsoc is not None:
+        d.target_soc = tsoc
+
+    cs = first("charging_state_report.current_charge_state", "current_charge_state",
+               "chargingState", "charging_state")
+    if cs:
+        d.charging_state = cs
+        d.is_charging = cs.lower() in ("charging", "chargingacactive", "active")
+
+    cmode = first("charging_state_report.charge_mode", "charge_mode")
+    if cmode:
+        d.charge_mode = cmode
+
+    tmin = _to_float(first("min_temperature", "battery_min_temperature"))
+    if tmin is not None:
+        d.hv_battery_min_temperature_c = tmin
+    tmax = _to_float(first("max_temperature", "battery_max_temperature"))
+    if tmax is not None:
+        d.hv_battery_max_temperature_c = tmax
+
+    locked = first("locked", "doors_locked", "doorLockStatus")
+    if locked is not None:
+        d.doors_locked = str(locked).lower() in ("true", "locked", "1")
+
+    whs = first("window_heating_state", "windowHeatingState")
+    if whs is not None:
+        on = str(whs).lower() == "on"
+        d.window_heating_front = on
+        d.window_heating_back = on
+
+    lifetime = _to_int(first(
+        "cso_v1_vehicle_tripstatistics_total_mileage_subscribe",
+        "total_mileage", "overallMileage",
+    ))
+    if lifetime is not None:
+        d.lifetime_distance_km = lifetime
+
+    return d
+
+
+# ── The connector ──────────────────────────────────────────────────────────
+
+class EUDataActConnector:
+    """Cookie-authenticated VW EU Data Act portal client.
+
+    Lifecycle: ``await login(email, password)`` once (populates the shared
+    aiohttp session's cookie jar), then ``await get_vehicle_data(vin)`` per
+    poll. ``login`` is re-invoked automatically by the caller on 401/403.
+    """
+
+    def __init__(
+        self,
+        session: ClientSession,
+        *,
+        state: str = _DEFAULT_STATE,
+    ) -> None:
+        self._session = session
+        self._state = state
+        self.logged_in = False
+
+    async def login(self, email: str, password: str) -> None:
+        """Run the OIDC code-flow login; portal backend sets cookies."""
+        headers = {"User-Agent": _USER_AGENT}
+
+        # 0. Prime portal session cookies (AEM load-balancer state).
+        try:
+            async with self._session.get(
+                f"{_PORTAL_BASE}/", headers=headers,
+                timeout=ClientTimeout(total=_TIMEOUT_S),
+            ):
+                pass
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("EU Data Act: priming GET failed (ignored): %s", exc)
+
+        # 1. Start OIDC directly at the IDP (portal's own servlet 500s for
+        #    non-browser clients). response_type=code; portal does the
+        #    confidential exchange itself.
+        authorize_params = {
+            "client_id": _PORTAL_CLIENT_ID,
+            "response_type": "code",
+            "scope": _PORTAL_SCOPE,
+            "state": self._state,
+            "redirect_uri": _PORTAL_REDIRECT_URI,
+            "prompt": "login",
+        }
+        async with self._session.get(
+            _AUTHORIZE_URL, params=authorize_params, headers=headers,
+            allow_redirects=True, timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            signin_url = str(resp.url)
+            signin_html = await resp.text(errors="replace")
+
+        # 2. POST email (identifier step).
+        fields, action = _login_fields(signin_html)
+        if "hmac" not in fields:
+            raise AuthenticationError(
+                "EU Data Act portal: could not parse the sign-in form "
+                f"(fields: {sorted(fields)})"
+            )
+        fields["email"] = email
+        identifier_action = urljoin(signin_url, action or "")
+        async with self._session.post(
+            identifier_action, data=fields, headers={**headers, "Referer": signin_url},
+            allow_redirects=True, timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            authenticate_url = str(resp.url)
+            authenticate_html = await resp.text(errors="replace")
+
+        # 3. POST credentials (password step). The hmac on this page is a
+        #    FRESH one bound to the password session.
+        fields2, action2 = _login_fields(authenticate_html)
+        if "hmac" not in fields2:
+            err = _login_error(authenticate_html)
+            raise AuthenticationError(
+                err or "EU Data Act portal: no password form returned "
+                "(check email address or the login flow changed)"
+            )
+        fields2["email"] = email
+        fields2["password"] = password
+        # CRITICAL: post to the clean /login/authenticate URL. Posting to
+        # authenticate_url (which carries ?relayState=) duplicates the
+        # param and the IDP rejects it with HTTP 400. Strip the query.
+        if action2:
+            authenticate_action = urljoin(authenticate_url, action2)
+        else:
+            authenticate_action = authenticate_url.split("?", 1)[0]
+        async with self._session.post(
+            authenticate_action, data=fields2,
+            headers={**headers, "Referer": authenticate_url},
+            allow_redirects=True, timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            landing = str(resp.url)
+            landing_html = await resp.text(errors="replace")
+            status = resp.status
+
+        if status >= 400:
+            err = _login_error(landing_html)
+            raise AuthenticationError(
+                err or f"EU Data Act portal: login rejected (HTTP {status})"
+            )
+        # A completed flow lands back on the portal host via
+        # /services/callbacklogin. Bad credentials re-render signin-service.
+        portal_host = urlparse(_PORTAL_BASE).netloc
+        if "signin-service" in landing or "/error" in landing:
+            raise AuthenticationError(
+                "EU Data Act portal: login failed — check email and password"
+            )
+        if urlparse(landing).netloc != portal_host:
+            raise AuthenticationError(
+                f"EU Data Act portal: login did not complete (ended at "
+                f"{landing[:80]})"
+            )
+        self.logged_in = True
+        _LOGGER.info(
+            "EU Data Act portal: login succeeded (read-only, ~15min cadence)"
+        )
+
+    async def _get_json(self, url: str, *, headers: dict[str, str] | None = None) -> Any:
+        async with self._session.get(
+            url, headers=headers, timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            if resp.status >= 400:
+                raise AuthenticationError(f"EU Data Act GET {url} → HTTP {resp.status}")
+            return await resp.json(content_type=None)
+
+    async def list_vehicle_vins(self) -> list[str]:
+        """Return the VINs consented on the portal."""
+        payload = await self._get_json(
+            f"{_PORTAL_BASE}{_VEHICLES_PATH}?viewPosition=FRONT_LEFT"
+        )
+        vins: list[str] = []
+
+        def walk(node: Any) -> None:
+            if isinstance(node, dict):
+                vin = node.get("vin") or node.get("vehicleIdentificationNumber")
+                if isinstance(vin, str) and len(vin) == 17 and vin not in vins:
+                    vins.append(vin)
+                for v in node.values():
+                    walk(v)
+            elif isinstance(node, list):
+                for v in node:
+                    walk(v)
+
+        walk(payload)
+        return vins
+
+    async def get_vehicle_data(self, vin: str) -> VehicleData:
+        """Fetch the latest dataset for *vin* and map it to VehicleData."""
+        d = VehicleData(vin=vin)
+        # 1. metadata → identifier
+        meta = await self._get_json(
+            f"{_PORTAL_BASE}{_METADATA_PATH.format(vin=vin)}"
+        )
+        identifier = ""
+        if isinstance(meta, dict):
+            identifier = (
+                meta.get("identifier")
+                or meta.get("Identifier")
+                or meta.get("dataRequestId")
+                or ""
+            )
+        if not identifier:
+            raise AuthenticationError(
+                "EU Data Act portal: no data-request identifier — the user "
+                "likely hasn't enabled a continuous data request on the portal yet"
+            )
+        # 2. list datasets → newest non-empty zip
+        listing = await self._get_json(
+            f"{_PORTAL_BASE}{_LIST_PATH.format(vin=vin, identifier=identifier)}",
+            headers={"type": "partial"},
+        )
+        files = listing if isinstance(listing, list) else listing.get("files", [])
+        names: list[str] = []
+        for f in files:
+            if not isinstance(f, dict):
+                continue
+            name = f.get("name")
+            if isinstance(name, str) and not name.endswith(_NO_CONTENT_SUFFIX):
+                names.append(name)
+        if not names:
+            _LOGGER.debug("EU Data Act portal: no dataset files for %s yet", vin[-6:])
+            return d
+        newest = names[-1]
+        # 3. download ZIP → JSON
+        async with self._session.get(
+            f"{_PORTAL_BASE}{_DOWNLOAD_PATH.format(vin=vin, identifier=identifier)}",
+            headers={"filename": newest, "type": "partial"},
+            timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            if resp.status >= 400:
+                raise AuthenticationError(
+                    f"EU Data Act portal: download → HTTP {resp.status}"
+                )
+            raw = await resp.read()
+        payload = _unzip_json(raw, newest)
+        fields = _walk_fields(payload)
+        _LOGGER.debug(
+            "EU Data Act portal: %s dataset carried %d fields", vin[-6:], len(fields)
+        )
+        d.connection_state = "online"
+        return map_dataset_to_vehicle_data(fields, d)
+
+    async def get_relation_nickname(self, vin: str) -> str | None:
+        """Best-effort vehicle nickname from the relation endpoint."""
+        try:
+            rel = await self._get_json(
+                f"{_PORTAL_BASE}{_RELATION_PATH.format(vin=vin)}",
+                headers={"traceid": f"vehicle-relation-{uuid.uuid4()}"},
+            )
+        except Exception:  # noqa: BLE001
+            return None
+        if isinstance(rel, dict):
+            nick = (rel.get("relation") or {}).get("vehicleNickname")
+            return nick if isinstance(nick, str) else None
+        return None
+
+
+def _unzip_json(raw: bytes, name: str) -> dict[str, Any]:
+    try:
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            members = [n for n in zf.namelist() if n.lower().endswith(".json")]
+            if not members:
+                raise AuthenticationError(f"EU Data Act portal: no JSON in {name}")
+            with zf.open(members[0]) as fh:
+                parsed = json.loads(fh.read().decode("utf-8"))
+            return parsed if isinstance(parsed, dict) else {}
+    except (zipfile.BadZipFile, ValueError) as err:
+        raise AuthenticationError(
+            f"EU Data Act portal: could not read {name}: {err}"
+        ) from err

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -162,6 +162,28 @@ def _login_fields(html: str) -> tuple[dict[str, str], str | None]:
     return fields, form.action
 
 
+def _resolve_action(base_url: str, action: str | None) -> str:
+    """Resolve a form ``action`` against *base_url*, guarding the
+    doubled-``/login/login/`` trap.
+
+    The signin-service login pages sometimes ship a RELATIVE action that
+    already starts with ``login/`` (e.g. ``login/authenticate``). Joining
+    that to a base whose path is ``.../login/identifier`` yields
+    ``.../login/login/authenticate`` — the IDP rejects the duplicated
+    segment with HTTP 400 (verified via swebachus's v2.11.4 source review
+    on #388). When there's no action at all, fall back to the base URL
+    with its query stripped (the page we already landed on is the right
+    POST target). Finally, collapse any ``/login/login/`` the join may
+    still produce — that segment pair is never legitimate in the
+    signin-service path structure.
+    """
+    if action:
+        resolved = urljoin(base_url, action)
+    else:
+        resolved = base_url.split("?", 1)[0]
+    return resolved.replace("/login/login/", "/login/")
+
+
 def _login_error(html: str) -> str | None:
     """Return a human-readable login error from the page, if present."""
     model = _extract_template_model(html)
@@ -364,7 +386,7 @@ class EUDataActConnector:
                 f"(fields: {sorted(fields)})"
             )
         fields["email"] = email
-        identifier_action = urljoin(signin_url, action or "")
+        identifier_action = _resolve_action(signin_url, action)
         async with self._session.post(
             identifier_action, data=fields, headers={**headers, "Referer": signin_url},
             allow_redirects=True, timeout=ClientTimeout(total=_TIMEOUT_S),
@@ -385,11 +407,9 @@ class EUDataActConnector:
         fields2["password"] = password
         # CRITICAL: post to the clean /login/authenticate URL. Posting to
         # authenticate_url (which carries ?relayState=) duplicates the
-        # param and the IDP rejects it with HTTP 400. Strip the query.
-        if action2:
-            authenticate_action = urljoin(authenticate_url, action2)
-        else:
-            authenticate_action = authenticate_url.split("?", 1)[0]
+        # param and the IDP rejects it with HTTP 400. _resolve_action
+        # strips the query AND guards the doubled-/login/login/ trap.
+        authenticate_action = _resolve_action(authenticate_url, action2)
         async with self._session.post(
             authenticate_action, data=fields2,
             headers={**headers, "Referer": authenticate_url},

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -48,9 +48,39 @@ _LOGGER = logging.getLogger(__name__)
 _PORTAL_BASE = "https://eu-data-act.drivesomethinggreater.com"
 _IDENTITY_BASE = "https://identity.vwgroup.io"
 _AUTHORIZE_URL = f"{_IDENTITY_BASE}/oidc/v1/authorize"
-_PORTAL_CLIENT_ID = "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com"
-_PORTAL_SCOPE = "openid cars profile"
 _PORTAL_REDIRECT_URI = f"{_PORTAL_BASE}/login"
+
+# v2.12.0 — per-brand EU Data Act portal OAuth config. The portal serves
+# the whole VW Group, but the OAuth client + the brand suffix in the
+# ``state`` (``{country}__{language}__{BRAND}``) select which brand's
+# vehicles the account sees. The portal connector is wired as a fallback
+# in every brand's auth chain (see api/base.py), so it must pick the
+# right config per brand — otherwise a CUPRA falling through to the
+# portal would authenticate with VW's client + state.
+#
+# client_id sources / verification (2026-06-07):
+#   - VW: 9b58543e — community-proven, end-to-end on #388.
+#   - CUPRA/SEAT: f85e5b69 — from the community EUDA constants, scope
+#     "openid profile cars". Both client+state combos handshake-verified
+#     (302 → signin).
+# Brands not listed fall back to the VW entry with a brand-derived state
+# suffix; account-level verification for those follows in a later release.
+_EUDA_VW = {
+    "client_id": "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com",
+    "scope": "openid cars profile",
+    "state_brand": "VOLKSWAGEN_PASSENGER_CARS",
+}
+_EUDA_CUPRA_SEAT = {
+    "client_id": "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com",
+    "scope": "openid profile cars",
+}
+_EUDA_BRANDS: dict[str, dict[str, str]] = {
+    "volkswagen": _EUDA_VW,
+    "cupra": {**_EUDA_CUPRA_SEAT, "state_brand": "CUPRA"},
+    "seat": {**_EUDA_CUPRA_SEAT, "state_brand": "SEAT"},
+    "skoda": {**_EUDA_VW, "state_brand": "SKODA"},
+    "audi": {**_EUDA_VW, "state_brand": "AUDI"},
+}
 
 _VEHICLES_PATH = "/proxy_api/consent/me/vehicles"
 _RELATION_PATH = "/proxy_api/vum/v2/users/me/relations/{vin}"
@@ -66,11 +96,6 @@ _USER_AGENT = (
 )
 _NO_CONTENT_SUFFIX = "_no_content_found.zip"
 _TIMEOUT_S = 60
-
-# Country/language/brand default for the OIDC ``state`` echoed to the
-# portal callback. Overridable so non-DACH users hit the right portal
-# locale. Format: ``{country}__{language}__{brand}``.
-_DEFAULT_STATE = "de__de__VOLKSWAGEN_PASSENGER_CARS"
 
 
 # ── HTML / templateModel parsing (community-proven mechanics) ──────────────
@@ -340,10 +365,24 @@ class EUDataActConnector:
         self,
         session: ClientSession,
         *,
-        state: str = _DEFAULT_STATE,
+        brand: str = "volkswagen",
+        country: str = "de",
+        language: str = "de",
     ) -> None:
         self._session = session
-        self._state = state
+        cfg = _EUDA_BRANDS.get(brand.lower())
+        if cfg is None:
+            # Unknown brand → VW client with a brand-derived state suffix.
+            # Handshake-valid; account-level coverage lands in a later release.
+            cfg = {**_EUDA_VW, "state_brand": brand.upper()}
+            _LOGGER.debug(
+                "EU Data Act: no verified portal config for brand %r — "
+                "falling back to the VW client with state suffix %s",
+                brand, cfg["state_brand"],
+            )
+        self._client_id = cfg["client_id"]
+        self._scope = cfg["scope"]
+        self._state = f"{country}__{language}__{cfg['state_brand']}"
         self.logged_in = False
 
     async def login(self, email: str, password: str) -> None:
@@ -364,9 +403,9 @@ class EUDataActConnector:
         #    non-browser clients). response_type=code; portal does the
         #    confidential exchange itself.
         authorize_params = {
-            "client_id": _PORTAL_CLIENT_ID,
+            "client_id": self._client_id,
             "response_type": "code",
-            "scope": _PORTAL_SCOPE,
+            "scope": self._scope,
             "state": self._state,
             "redirect_uri": _PORTAL_REDIRECT_URI,
             "prompt": "login",

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1277,6 +1277,14 @@ class VehicleData:
     lifetime_avg_fuel_consumption_l_100km: float | None = None
     lifetime_avg_electric_consumption_kwh_100km: float | None = None
     recent_trips: list[dict[str, Any]] = field(default_factory=list)
+    # v2.12.0 (myskoda PR #575) — trip overall-cost breakdown. Currency
+    # carried separately so the sensor can set native_unit_of_measurement
+    # to the ISO code. None on accounts/firmwares that don't ship costs.
+    trip_total_cost: float | None = None
+    trip_fuel_cost: float | None = None
+    trip_electricity_cost: float | None = None
+    trip_cng_cost: float | None = None
+    trip_cost_currency: str | None = None
 
     # v2.10.0 Group B - SEAT/CUPRA OLA endpoint parity.
     # New fields populated by 6 OLA endpoints added in v2.10.0:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.11.4"
+  "version": "2.12.0"
 }

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -32,6 +32,7 @@ from custom_components.vag_connect.cariad.auth._eu_data_act import (
     EUDataActConnector,
     _extract_template_model,
     _login_fields,
+    _resolve_action,
     _walk_fields,
     map_dataset_to_vehicle_data,
 )
@@ -84,6 +85,50 @@ def test_login_fields_reads_html_hidden_inputs() -> None:
     assert fields["hmac"] == "hexhmac"
     assert fields["_csrf"] == "csrfval"
     assert action == "/signin-service/v1/CLIENT/login/identifier"
+
+
+# ── action-URL resolution (the /login/login/ doubling guard) ───────────────
+
+def test_resolve_action_collapses_doubled_login() -> None:
+    """Relative 'login/authenticate' must not produce /login/login/.
+
+    swebachus's v2.11.4 source review (#388): a relative postAction that
+    already starts with 'login/' joined to a '.../login/identifier' base
+    yielded '.../login/login/authenticate' → HTTP 400. The resolver must
+    collapse it.
+    """
+    base = (
+        "https://identity.vwgroup.io/signin-service/v1/"
+        "CLIENT@apps_vw-dilab_com/login/identifier"
+    )
+    assert _resolve_action(base, "login/authenticate") == (
+        "https://identity.vwgroup.io/signin-service/v1/"
+        "CLIENT@apps_vw-dilab_com/login/authenticate"
+    )
+
+
+def test_resolve_action_strips_query_when_no_action() -> None:
+    """No action → post to the landed URL with its query stripped."""
+    url = (
+        "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/"
+        "authenticate?relayState=abc123"
+    )
+    assert _resolve_action(url, None) == (
+        "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/authenticate"
+    )
+
+
+def test_resolve_action_absolute_and_plain_relative() -> None:
+    """Absolute action replaces the path; plain relative joins cleanly."""
+    base = "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/identifier"
+    # absolute (leading slash) — used as-is
+    assert _resolve_action(base, "/signin-service/v1/CLIENT/login/authenticate") == (
+        "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/authenticate"
+    )
+    # plain relative without the login/ prefix — joins to .../login/authenticate
+    assert _resolve_action(base, "authenticate") == (
+        "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/authenticate"
+    )
 
 
 # ── dataset → VehicleData mapping ───────────────────────────────────────────

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the v2.12.0 EU Data Act portal connector.
+
+The connector is the only working third-party auth path for VW passenger
+cars after VW closed every token-based WeConnect route (verified live
+2026-06-07: hybrid 403, code-exchange needs client_secret, device-grant
+403). These tests pin the two parts we CAN verify without live portal
+credentials:
+
+  1. The login form-field extraction (``_login_fields``) — merges HTML
+     hidden inputs with the JS ``templateModel`` (hmac / relayState /
+     email) and the ``csrf_token`` regex. This is where v2.11.4's flow
+     broke (it only looked for ``"_csrf":`` and missed ``csrf_token:``).
+  2. The dataset → ``VehicleData`` curated mapping — given a synthetic
+     EU Data Act dataset, the high-value fields (SoC, odometer, range,
+     charging state, doors) must populate correctly.
+
+The live login + ZIP download path is validated post-release against a
+real VW EU account (issue #388/#393) — it cannot be unit-tested here.
+"""
+
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    _extract_template_model,
+    _login_fields,
+    _walk_fields,
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+# ── login form-field extraction ────────────────────────────────────────────
+
+def test_template_model_extraction_brace_matched() -> None:
+    """templateModel JSON is extracted via brace-matching, nested ok."""
+    html = (
+        '<script>window._IDK = {templateModel: '
+        '{"hmac":"abc123","relayState":"rs789",'
+        '"emailPasswordForm":{"email":"x@y.z"},'
+        '"error":null}, csrf_token: "csrf456"};</script>'
+    )
+    model = _extract_template_model(html)
+    assert model["hmac"] == "abc123"
+    assert model["relayState"] == "rs789"
+    assert model["emailPasswordForm"]["email"] == "x@y.z"
+
+
+def test_login_fields_merges_template_model_and_csrf() -> None:
+    """The v2.11.4-breaking case: SPA page with NO hidden inputs, all
+    state in templateModel + csrf_token JS. Must still yield hmac+_csrf."""
+    html = (
+        '<html><body><div id="app"></div>'
+        '<script>window._IDK = {templateModel: '
+        '{"hmac":"deadbeef","relayState":"rs001",'
+        '"postAction":"/signin-service/v1/CLIENT/login/authenticate"}, '
+        'csrf_token: "csrftok99"};</script></body></html>'
+    )
+    fields, _action = _login_fields(html)
+    assert fields["hmac"] == "deadbeef"
+    assert fields["relayState"] == "rs001"
+    assert fields["_csrf"] == "csrftok99"
+
+
+def test_login_fields_reads_html_hidden_inputs() -> None:
+    """Classic server-rendered form: fields come from hidden inputs."""
+    html = (
+        '<form action="/signin-service/v1/CLIENT/login/identifier">'
+        '<input type="hidden" name="hmac" value="hexhmac">'
+        '<input type="hidden" name="_csrf" value="csrfval">'
+        '<input type="hidden" name="relayState" value="rs">'
+        '<input type="email" name="email">'
+        '</form>'
+    )
+    fields, action = _login_fields(html)
+    assert fields["hmac"] == "hexhmac"
+    assert fields["_csrf"] == "csrfval"
+    assert action == "/signin-service/v1/CLIENT/login/identifier"
+
+
+# ── dataset → VehicleData mapping ───────────────────────────────────────────
+
+def test_walk_fields_flattens_datapoint_shape() -> None:
+    """Data-point shape {dataFieldName, value} is flattened to {name: value}."""
+    payload = {
+        "data": [
+            {"dataFieldName": "battery_state_report.soc", "value": "82"},
+            {"dataFieldName": "mileage.value", "value": "18842"},
+        ]
+    }
+    fields = _walk_fields(payload)
+    assert fields["battery_state_report.soc"] == "82"
+    assert fields["mileage.value"] == "18842"
+
+
+def test_curated_mapping_populates_high_value_fields() -> None:
+    """A synthetic dataset maps onto the curated VehicleData fields."""
+    fields = {
+        "battery_state_report.soc": "82",
+        "mileage.value": "18842",
+        "range": "54",
+        "battery_state_report.charge_power": "7.4",
+        "settings.target_soc": "80",
+        "charging_state_report.current_charge_state": "charging",
+        "charging_state_report.charge_mode": "manual",
+        "min_temperature": "18.5",
+        "max_temperature": "21.0",
+        "locked": "true",
+        "window_heating_state": "on",
+    }
+    d = map_dataset_to_vehicle_data(fields, VehicleData(vin="TESTVIN0000000001"))
+    assert d.battery_soc == 82
+    assert d.has_battery is True
+    assert d.odometer_km == 18842
+    assert d.range_km == 54
+    assert d.electric_range_km == 54
+    assert d.charging_power_kw == 7.4
+    assert d.target_soc == 80
+    assert d.charging_state == "charging"
+    assert d.is_charging is True
+    assert d.charge_mode == "manual"
+    assert d.hv_battery_min_temperature_c == 18.5
+    assert d.hv_battery_max_temperature_c == 21.0
+    assert d.doors_locked is True
+    assert d.window_heating_front is True
+    assert d.window_heating_back is True
+
+
+def test_curated_mapping_flat_egolf_variant() -> None:
+    """Flat eGolf payload (bare field names, no report prefix) also maps."""
+    fields = {
+        "state_of_charge": "60",
+        "mileage": "99000",
+        "cruising_range_primary_engine": "120",
+    }
+    d = map_dataset_to_vehicle_data(fields, VehicleData(vin="TESTVIN0000000002"))
+    assert d.battery_soc == 60
+    assert d.odometer_km == 99000
+    assert d.range_km == 120
+
+
+def test_curated_mapping_tolerates_missing_fields() -> None:
+    """An empty / partial dataset leaves fields at their defaults."""
+    d = map_dataset_to_vehicle_data({}, VehicleData(vin="TESTVIN0000000003"))
+    assert d.battery_soc is None
+    assert d.odometer_km is None
+    assert d.doors_locked is None

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -315,6 +315,29 @@ async def test_login_full_flow_mocked() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_vehicle_vins_mocked() -> None:
+    """list_vehicle_vins() walks the consent payload for 17-char VINs.
+
+    Covers the get_vehicles wiring gap surfaced on #388: VW EU portal
+    mode must enumerate VINs through the portal, not the dead BFF.
+    """
+    class _VehSession:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            assert "consent/me/vehicles" in url
+            return _FakeResp(url, json_data={
+                "vehicles": [
+                    {"vin": "WVWZZZTESTVIN0001", "vehicleNickname": "ID.7"},
+                    {"vehicleIdentificationNumber": "WVWZZZTESTVIN0002"},
+                    {"vin": "TOOSHORT"},  # ignored — not 17 chars
+                ]
+            })
+
+    conn = EUDataActConnector(_VehSession())  # type: ignore[arg-type]
+    vins = await conn.list_vehicle_vins()
+    assert vins == ["WVWZZZTESTVIN0001", "WVWZZZTESTVIN0002"]
+
+
+@pytest.mark.asyncio
 async def test_get_vehicle_data_mocked() -> None:
     """get_vehicle_data() walks metadata → list → ZIP → curated mapping."""
     session = _FakeSession()

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -298,6 +298,37 @@ class _FakeSession:
         raise AssertionError(f"unmatched POST {url}")
 
 
+# ── per-brand portal config ────────────────────────────────────────────────
+
+def test_brand_config_resolution() -> None:
+    """Connector picks the right client_id + state per brand.
+
+    The portal connector is a fallback in every brand's auth chain, so a
+    non-VW brand falling through must use its own client/state — not VW's.
+    """
+    vw = EUDataActConnector(object())  # type: ignore[arg-type]
+    assert vw._client_id.startswith("9b58543e")
+    assert vw._state == "de__de__VOLKSWAGEN_PASSENGER_CARS"
+
+    cupra = EUDataActConnector(object(), brand="cupra")  # type: ignore[arg-type]
+    assert cupra._client_id.startswith("f85e5b69")
+    assert cupra._scope == "openid profile cars"
+    assert cupra._state == "de__de__CUPRA"
+
+    seat = EUDataActConnector(object(), brand="seat")  # type: ignore[arg-type]
+    assert seat._client_id.startswith("f85e5b69")
+    assert seat._state == "de__de__SEAT"
+
+    # Unknown brand → VW client with a derived state suffix (graceful).
+    porsche = EUDataActConnector(object(), brand="porsche")  # type: ignore[arg-type]
+    assert porsche._client_id.startswith("9b58543e")
+    assert porsche._state == "de__de__PORSCHE"
+
+    # Locale override flows into the state.
+    se = EUDataActConnector(object(), country="se", language="sv")  # type: ignore[arg-type]
+    assert se._state == "se__sv__VOLKSWAGEN_PASSENGER_CARS"
+
+
 @pytest.mark.asyncio
 async def test_login_full_flow_mocked() -> None:
     """login() drives prime → authorize → identifier → credential POST."""

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -22,7 +22,14 @@ real VW EU account (issue #388/#393) — it cannot be unit-tested here.
 
 from __future__ import annotations
 
+import io
+import zipfile
+from typing import Any
+
+import pytest
+
 from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    EUDataActConnector,
     _extract_template_model,
     _login_fields,
     _walk_fields,
@@ -146,3 +153,129 @@ def test_curated_mapping_tolerates_missing_fields() -> None:
     assert d.battery_soc is None
     assert d.odometer_km is None
     assert d.doors_locked is None
+
+
+# ── async orchestration (mocked aiohttp session) ───────────────────────────
+
+_SIGNIN_HTML = (
+    '<form action="/signin-service/v1/CLIENT/login/identifier">'
+    '<input type="hidden" name="hmac" value="email_hmac">'
+    '<input type="hidden" name="_csrf" value="csrf1">'
+    '<input type="hidden" name="relayState" value="rs1">'
+    '</form>'
+)
+# Password page: SPA-rendered, fields in templateModel + a FRESH hmac.
+_PASSWORD_HTML = (
+    '<script>window._IDK = {templateModel: '
+    '{"hmac":"fresh_pw_hmac","relayState":"rs1",'
+    '"postAction":"/signin-service/v1/CLIENT/login/authenticate"}, '
+    'csrf_token: "csrf2"};</script>'
+)
+
+
+def _build_dataset_zip() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "export.json",
+            '{"data":['
+            '{"dataFieldName":"battery_state_report.soc","value":"77"},'
+            '{"dataFieldName":"mileage.value","value":"12345"},'
+            '{"dataFieldName":"range","value":"48"}]}',
+        )
+    return buf.getvalue()
+
+
+class _FakeResp:
+    def __init__(
+        self, url: str, *, status: int = 200, text: str = "",
+        json_data: Any = None, body: bytes = b"",
+    ) -> None:
+        self.url = url
+        self.status = status
+        self._text = text
+        self._json = json_data
+        self._body = body
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def text(self, errors: str | None = None) -> str:
+        return self._text
+
+    async def json(self, content_type: Any = None) -> Any:
+        return self._json
+
+    async def read(self) -> bytes:
+        return self._body
+
+
+class _FakeSession:
+    """Routes login + data-fetch URLs to canned responses."""
+
+    def __init__(self) -> None:
+        self.posts: list[dict[str, Any]] = []
+
+    def get(self, url: str, **kw: Any) -> _FakeResp:
+        if url.endswith("/") and "drivesomethinggreater" in url:
+            return _FakeResp(url, text="<html>portal</html>")
+        if "authorize" in url:
+            return _FakeResp(
+                "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/identifier",
+                text=_SIGNIN_HTML,
+            )
+        if "metadata" in url:
+            return _FakeResp(url, json_data={"identifier": "ID123"})
+        if url.endswith("/list"):
+            return _FakeResp(url, json_data=[{"name": "data_2026.zip"}])
+        if url.endswith("/download"):
+            return _FakeResp(url, body=_build_dataset_zip())
+        raise AssertionError(f"unmatched GET {url}")
+
+    def post(self, url: str, **kw: Any) -> _FakeResp:
+        self.posts.append({"url": url, "data": kw.get("data")})
+        if url.endswith("/login/identifier"):
+            # Lands on the password page; URL carries ?relayState=.
+            return _FakeResp(
+                "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/"
+                "authenticate?relayState=rs1",
+                text=_PASSWORD_HTML,
+            )
+        if "/login/authenticate" in url:
+            # Successful credential POST lands back on the portal host.
+            return _FakeResp(
+                "https://eu-data-act.drivesomethinggreater.com/dashboard",
+                status=200, text="<html>welcome</html>",
+            )
+        raise AssertionError(f"unmatched POST {url}")
+
+
+@pytest.mark.asyncio
+async def test_login_full_flow_mocked() -> None:
+    """login() drives prime → authorize → identifier → credential POST."""
+    session = _FakeSession()
+    conn = EUDataActConnector(session)  # type: ignore[arg-type]
+    await conn.login("user@example.com", "secret")
+    assert conn.logged_in is True
+    # The credential POST must use the FRESH password-page hmac, carry the
+    # password, and target the clean /authenticate URL (no ?relayState=).
+    cred_post = session.posts[-1]
+    assert cred_post["url"].endswith("/login/authenticate")
+    assert "?" not in cred_post["url"]
+    assert cred_post["data"]["hmac"] == "fresh_pw_hmac"
+    assert cred_post["data"]["password"] == "secret"
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_mocked() -> None:
+    """get_vehicle_data() walks metadata → list → ZIP → curated mapping."""
+    session = _FakeSession()
+    conn = EUDataActConnector(session)  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    assert d.battery_soc == 77
+    assert d.odometer_km == 12345
+    assert d.range_km == 48
+    assert d.connection_state == "online"


### PR DESCRIPTION
## Summary

The headline is the **VW EU Data Act portal connector** — the only third-party auth path left for VW passenger cars.

### Live-verified auth matrix (2026-06-07, unauthenticated handshakes)

| VW path | result |
|---|---|
| Hybrid OIDC (`code id_token token`) | **403** — Auth0 blocked the response_type |
| Code-flow login | 302 login form ✓ … but token exchange needs a client secret (`auth_methods` excludes `none`) ✗ |
| Device Authorization Grant | **403 unauthorized_client** ✗ |
| Audi device grant (control) | 200 ✓ (proves endpoint works) |
| **EU Data Act portal** (`response_type=code`) | **302 → signin-service** ✓ — only working route |

All token-based WeConnect routes are closed. The EU Data Act portal is the route VW must keep open under Regulation (EU) 2023/2854.

## What's in this release

### Added
- **VW EU Data Act portal connector (read-only, BETA)** — cookie-based OIDC login (portal backend does the confidential code exchange; we ride the session cookies) → `/proxy_api` ZIP data delivery → curated `VehicleData` mapping (SoC, odometer, range, charging state, doors, window heating, temps — ~15 high-value fields; long tail in v2.12.x). Correct login mechanics: merge `templateModel` + HTML hidden inputs + `csrf_token` regex, and **strip the duplicate `?relayState=` query** before the credential POST — that was the HTTP 400/405 that broke v2.11.4. Wired as the VW EU strategy fallback. Read-only, ~15min cadence, needs a one-time portal opt-in.
- **Skoda trip cost** — total / fuel / electricity / CNG + currency.

### Fixed
- **Cars stuck "online" forever** — future-dated capture timestamps (broken OCU clocks, e.g. 2079) pinned connection state. Now ignored beyond a 5-min skew window. All brands.
- **Scout noise** — registered the climatisation sub-blocks (CUPRA/SEAT) and battery-support/charging-profiles/charging-timers (VW/Audi). Closes scout reports on #411 #414 #415 #416 #417 #419.

### Legal
- `LEGAL.md` — statutory basis (EU Software Directive Art. 6, §69e UrhG, Art. 21 URG, DMCA §1201(f), EU Data Act Arts. 4–6) + license attribution by project name.

## Test plan
- [x] `ruff` + `mypy --strict` clean (pre-commit, all 3 commits)
- [x] Bruno drift gate clean
- [x] Connector unit tests: login form-field extraction + dataset→VehicleData mapping (verified standalone — 7/7 assertions)
- [ ] CI green
- [ ] **BETA validation: live login + ZIP path on a real VW EU account (#388/#393) BEFORE tagging v2.12.0**

## Beta note
The connector's parser + mapper are unit-tested, but the live login + ZIP download can't be tested without a real VW EU account + portal opt-in. Holding the v2.12.0 tag until a reporter on #388/#393 confirms the login completes.
