### PR TITLE
fix(ci): canary-watch duplicate env: key (startup_failure)

### DIFF
--- a/.github/workflows/canary-watch.yml
+++ b/.github/workflows/canary-watch.yml
@@ -58,6 +58,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAX_PER_CANARY: ${{ github.event.inputs.max_results_per_canary || '5' }}
+          # CANARIES comes from the extract step's output; we shell out to
+          # python so this step does the heavy lifting.
+          CANARIES: ${{ steps.canaries.outputs.list }}
         run: |
           python - <<'PY'
           import json, os, subprocess, urllib.parse
@@ -95,11 +98,6 @@ jobs:
               json.dump(findings, f, indent=2)
           print(f"Findings recorded: {len(findings)}")
           PY
-        # CANARIES is set in env via the step output below; we shell out
-        # to python so this step does the heavy work.
-        env:
-          CANARIES: ${{ steps.canaries.outputs.list }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Open issue on findings
         if: success()


### PR DESCRIPTION
The canary watcher's `Search GitHub Code` step defined `env:` twice, so GitHub rejected the file with `'env' is already defined (Line 100)` — a startup_failure on every push since v2.9.0, and the weekly Monday provenance scan never ran. Merged the two `env:` blocks into one (GH_TOKEN + MAX_PER_CANARY + CANARIES). Verified the YAML now parses with a single env mapping on the step.