### PR TITLE
v2.12.1 — VW EU portal restart fix + metadata 404 graceful + audi scout depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.12.1] - 2026-06-07
+
+Quick follow-up to the v2.12.0 VW EU portal beta, from the first round of live testing.
+
+### Fixed
+
+- **VW EU portal broke after a Home Assistant restart** (#393). The portal saves a cookie-session placeholder token, and on restart the integration reused it and skipped the login — so the portal session was never rebuilt and the next call hit the old (dead) endpoint with a useless token, ending in "No vehicles found". Now a fresh portal login runs on every restart, so the session is always re-established.
+- **"No data request" no longer spams errors** (#393, #424). Until you manually create a continuous data request for your car in the VW data portal, the data endpoint returns 404/500 — that's expected, not a failure. The integration now treats it as "no data yet" (the car still appears, data fills in once the request goes live) instead of logging an error every poll.
+- **Scout noise on Audi charging timers/profiles** (#423). Registered the deeper `chargingTimers` / `chargingProfiles` sub-paths and the DC auto-unlock setting the Scout kept flagging.
+
 ## [2.12.0] - 2026-06-07
 
 The big one for VW EU. We confirmed live that VW has closed every token-based login route for passenger cars — the hybrid trick another project used now gets a hard 403 from Auth0, the code-flow needs a client secret we can't have, and device-login isn't enabled for the VW client. The only door VW has to keep open under the EU Data Act is the read-only data portal, so that's the path we built.

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -627,12 +627,24 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             # follow-up PR builds the full parser + entities once we have a
             # real payload to confirm field names. Audi inherits via the
             # module-load copy below.
+            # v2.12.1 (#423 nekas123 audi) — the backend nests these one
+            # level deeper than v2.12.0 assumed: e.g.
+            # ``chargingTimers.chargingTimersStatus.value`` (3 segments).
+            # The matcher requires an equal-depth wildcard, so 2-segment
+            # ``chargingTimers.*`` does NOT cover the 3-segment path. Add
+            # 2- and 3-deep wildcards for each container.
             "charging.batterySupport", "charging.batterySupport.*",
-            "batterySupport", "batterySupport.*",
-            "chargingProfiles", "chargingProfiles.*",
+            "charging.batterySupport.*.*",
+            "batterySupport", "batterySupport.*", "batterySupport.*.*",
+            "chargingProfiles", "chargingProfiles.*", "chargingProfiles.*.*",
             "charging.chargingProfiles", "charging.chargingProfiles.*",
-            "chargingTimers", "chargingTimers.*",
+            "charging.chargingProfiles.*.*",
+            "chargingTimers", "chargingTimers.*", "chargingTimers.*.*",
             "charging.chargingTimers", "charging.chargingTimers.*",
+            "charging.chargingTimers.*.*",
+            # v2.12.1 (#423) — DC counterpart of the long-parsed
+            # autoUnlockPlugWhenChargedAC setting.
+            "charging.chargingSettings.value.autoUnlockPlugWhenChargedDC",
             "climatisation", "climatisation.climatisationStatus",
             "climatisation.climatisationStatus.value",
             "climatisation.climatisationStatus.value.climatisationState",

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -480,11 +480,27 @@ class EUDataActConnector:
             "EU Data Act portal: login succeeded (read-only, ~15min cadence)"
         )
 
-    async def _get_json(self, url: str, *, headers: dict[str, str] | None = None) -> Any:
+    async def _get_json(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        soft: bool = False,
+    ) -> Any:
+        """GET + parse JSON. Raises AuthenticationError on HTTP >= 400.
+
+        v2.12.1 — ``soft=True`` returns None instead of raising for the
+        "not provisioned yet" statuses (404/410/500/502/503). Used for the
+        data-request metadata endpoint, which 404s/500s on accounts where
+        the continuous data request hasn't been enabled / hasn't propagated
+        yet (#393, #424) — that's an expected transient, not a hard error.
+        """
         async with self._session.get(
             url, headers=headers, timeout=ClientTimeout(total=_TIMEOUT_S),
         ) as resp:
             if resp.status >= 400:
+                if soft and resp.status in (404, 410, 500, 502, 503):
+                    return None
                 raise AuthenticationError(f"EU Data Act GET {url} → HTTP {resp.status}")
             return await resp.json(content_type=None)
 
@@ -512,9 +528,14 @@ class EUDataActConnector:
     async def get_vehicle_data(self, vin: str) -> VehicleData:
         """Fetch the latest dataset for *vin* and map it to VehicleData."""
         d = VehicleData(vin=vin)
-        # 1. metadata → identifier
+        # 1. metadata → identifier. Soft on 404/500: when the continuous
+        # data request isn't set up / hasn't propagated yet, the endpoint
+        # 404s or 500s. Treat that as "no data yet" — return the bare
+        # VehicleData so the vehicle still appears and the data fills in
+        # once the portal request goes active, instead of erroring every
+        # poll (#393, #424).
         meta = await self._get_json(
-            f"{_PORTAL_BASE}{_METADATA_PATH.format(vin=vin)}"
+            f"{_PORTAL_BASE}{_METADATA_PATH.format(vin=vin)}", soft=True,
         )
         identifier = ""
         if isinstance(meta, dict):
@@ -525,10 +546,14 @@ class EUDataActConnector:
                 or ""
             )
         if not identifier:
-            raise AuthenticationError(
-                "EU Data Act portal: no data-request identifier — the user "
-                "likely hasn't enabled a continuous data request on the portal yet"
+            _LOGGER.info(
+                "EU Data Act portal: no data-request yet for %s — enable the "
+                "continuous data request for this car on the VW data portal "
+                "(it can take a while to propagate). Vehicle will show with no "
+                "data until then.",
+                vin[-6:],
             )
+            return d
         # 2. list datasets → newest non-empty zip
         listing = await self._get_json(
             f"{_PORTAL_BASE}{_LIST_PATH.format(vin=vin, identifier=identifier)}",

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -609,7 +609,19 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # _refresh_tokens which writes back. We still call
             # authenticate() if NO persisted tokens exist (first setup,
             # storage cleared, or version mismatch).
-            if persisted is None:
+            # v2.12.1 (#393) — the EU Data Act portal strategy persists a
+            # cookie-session SENTINEL token (no usable bearer, and the
+            # cookie jar isn't restored across restarts). Reusing it skips
+            # the portal login, so the connector is never rebuilt and
+            # get_vehicles falls through to the dead CARIAD BFF with the
+            # sentinel → HTTP 400 "missing or invalid auth header". Force a
+            # fresh login for that strategy so the cookie session + the
+            # portal connector are re-established on every restart.
+            persisted_is_portal = (
+                persisted is not None
+                and persisted.strategy == "data_act_portal"
+            )
+            if persisted is None or persisted_is_portal:
                 await self._cariad_client.authenticate()
             else:
                 _LOGGER.debug(

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.12.0"
+  "version": "2.12.1"
 }

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -378,3 +378,40 @@ async def test_get_vehicle_data_mocked() -> None:
     assert d.odometer_km == 12345
     assert d.range_km == 48
     assert d.connection_state == "online"
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_metadata_404_is_graceful() -> None:
+    """metadata 404 (no data-request created yet) → bare VehicleData, no raise.
+
+    The portal 404s the metadata endpoint until the user manually creates
+    a continuous data request. v2.12.1 treats that as "no data yet" so the
+    vehicle still appears and the entry sets up, instead of erroring every
+    poll (#393, #424).
+    """
+    class _Meta404Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, status=404, json_data={})
+            raise AssertionError(f"should not reach {url} when metadata 404s")
+
+    conn = EUDataActConnector(_Meta404Session())  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    # No exception; bare data; no false connection_state.
+    assert d.vin == "WVWZZZTESTVIN0001"
+    assert d.battery_soc is None
+    assert d.connection_state is None
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_metadata_500_is_graceful() -> None:
+    """metadata 500 is treated the same as 404 (soft, no raise)."""
+    class _Meta500Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, status=500, json_data={})
+            raise AssertionError("should not reach further on 500")
+
+    conn = EUDataActConnector(_Meta500Session())  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0009")
+    assert d.battery_soc is None


### PR DESCRIPTION
First round of live-test feedback on the v2.12.0 portal beta.

### Fixed
- **Portal broke after HA restart (#393).** The portal persists a cookie-session sentinel token; on restart the integration reused it and skipped login, so the connector was never rebuilt and `get_vehicles` hit the dead CARIAD BFF with the sentinel → HTTP 400 / "No vehicles found". Now forces a fresh portal login whenever the persisted strategy is `data_act_portal` (the cookie jar isn't restorable from a sentinel).
- **metadata 404/500 no longer spams errors (#393, #424).** Until the user manually creates a continuous data request in the VW portal, the metadata endpoint 404s/500s — expected, not fatal. `_get_json` gains a `soft` mode; `get_vehicle_data` returns a bare VehicleData (car appears, no data, actionable log) instead of erroring every poll. Verified that neither comparable project exposes an init-POST for the data request — it's a manual portal step — and our 404 handling is now more graceful than theirs.
- **Audi scout depth (#423).** `chargingTimers`/`chargingProfiles` nest one level deeper than the v2.12.0 wildcards; added equal-depth 3-segment wildcards + the DC auto-unlock leaf.

### Test plan
- [x] ruff + mypy strict (pre-commit)
- [x] Bruno drift clean
- [x] New tests: metadata 404 + 500 graceful; wildcard depth verified standalone
- [ ] CI green