### PR TITLE
v2.12.3 — complete translations across all 8 languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.12.3] - 2026-06-08
+
+### Changed
+
+- **Everything's translated now — all eight languages, end to end.** We went through every string the integration shows and filled in the gaps: the newer entity names (battery temperature, climate zones, navigation charge target, parking-map links, plug LED colour, the "command pending" sensors and friends), the little help texts under the login and options fields, the "open the brand app" service, and the repair notices (wake the car, portal session expired, optional browser package missing, OLA headers outdated). Until now anything we hadn't translated quietly fell back to English, so non-English users saw a mix. EN, DE, NL, SV, FR, ES, PL and CS are now complete — with everyday wording for the car terms instead of literal tech-speak.
+
 ## [2.12.2] - 2026-06-08
 
 ### Added

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.12.2"
+  "version": "2.12.3"
 }

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -83,6 +83,12 @@
           "spin": "S-PIN",
           "scan_interval": "Update Interval",
           "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Zobrazují se pouze značky s podporou přihlášení přes prohlížeč. Pro Volkswagen EU a Porsche použijte „E-mail + heslo“.",
+          "force_enable_access": "Vynutit entity stavu dveří, i když vozidlo hlásí chybějící data.",
+          "scan_interval": "Minuty mezi dotazy na data vozidla.",
+          "spin": "Volitelný 4místný bezpečnostní PIN pro vzdálené akce (zamknout, odemknout, klimatizace)."
         }
       },
       "browser_login_pending": {
@@ -145,7 +151,8 @@
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
           "client_id_override": "OAuth client_id override (power users)",
-          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request",
+          "enable_data_act_browser": "Portál EU Data Act: záloha přes headless prohlížeč (EXPERIMENTÁLNÍ)"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",
@@ -159,7 +166,8 @@
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
           "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
-          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default.",
+          "enable_data_act_browser": "EXPERIMENTÁLNÍ: má smysl jen tehdy, když se integrace přepnula na portál EU Data Act (pouze pro čtení). Ovládá headless Chromium pomocí volitelného balíčku Pythonu 'playwright', aby automaticky kliknul na tlačítko exportu dat na portálu. Balíček NENÍ předinstalovaný (stáhne zhruba 100 MB Chromia). Když je zapnutý, ale chybí, oznámení Oprava vám vysvětlí, jak ho nainstalovat uvnitř kontejneru Home Assistant. Po přepnutí integraci znovu načtěte."
         }
       }
     }
@@ -561,6 +569,63 @@
       },
       "last_trip_reset_at": {
         "name": "Last Trip Reset"
+      },
+      "battery_temp_c": {
+        "name": "Teplota baterie"
+      },
+      "charging_settings_pending": {
+        "name": "Nastavení nabíjení čeká"
+      },
+      "charging_status_pending": {
+        "name": "Příkazy nabíjení čekají"
+      },
+      "climate_remaining_time_min": {
+        "name": "Klimatizace – zbývající čas"
+      },
+      "climate_without_external_power": {
+        "name": "Klimatizace bez externího napájení"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimatická zóna vpředu vlevo"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimatická zóna vpředu vpravo"
+      },
+      "climatisation_settings_pending": {
+        "name": "Nastavení klimatizace čeká"
+      },
+      "climatisation_status_pending": {
+        "name": "Příkazy klimatizace čekají"
+      },
+      "connection_active": {
+        "name": "Připojení aktivní"
+      },
+      "connection_battery_power_level": {
+        "name": "Úroveň baterie (připojení)"
+      },
+      "daily_power_budget_warning": {
+        "name": "Varování denního energetického limitu"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Varování nedostatečné úrovně baterie"
+      },
+      "nav_target_soc_pct": {
+        "name": "Cílová úroveň nabití (navigace)"
+      },
+      "parking_map_url_dark": {
+        "name": "URL mapy parkování (tmavá)"
+      },
+      "parking_map_url_light": {
+        "name": "URL mapy parkování (světlá)"
+      },
+      "plug_led_color": {
+        "name": "Barva LED konektoru"
+      },
+      "remaining_charge_time_nav_min": {
+        "name": "Zbývající čas nabíjení (navigace)"
+      },
+      "vehicle_nickname": {
+        "name": "Přezdívka vozidla"
       }
     },
     "binary_sensor": {
@@ -716,6 +781,15 @@
       },
       "permission_can_command": {
         "name": "Account can send commands"
+      },
+      "external_power_available": {
+        "name": "Externí napájení k dispozici"
+      },
+      "hood_open": {
+        "name": "Kapota otevřená"
+      },
+      "trunk_open": {
+        "name": "Kufr otevřený"
       }
     },
     "switch": {
@@ -887,6 +961,22 @@
     "data_act_no_data": {
       "title": "Portál EU Data Act: zatím žádná data vozidla ({brand})",
       "description": "Portál EU Data Act se přihlásil pro {brand}, ale zatím nevrací žádná data vozidla.\n\nObvyklé příčiny:\n\n1. **Výpadek na straně VW.** VW od konce května 2026 hlásí výpadek portálu EU Data Act napříč všemi značkami (podle jejich oznámení selhala infrastruktura pro extrakci dat pod zátěží). Dokud trvá, portál vrací prázdná data pro každý nástroj – nejen pro tuto integraci – a postupně se obnovuje značku po značce.\n2. **Není nastaven žádný požadavek na data.** Portál začne dodávat data až poté, co pro své auto vytvoříte *průběžný* požadavek na data.\n3. **Auto neodeslalo nic nového.** Nová sada dat se zveřejní až poté, co auto jelo, nabíjelo se nebo bylo zamčeno/odemčeno.\n\n**Nejrychlejší kontrola:** otevřete `eu-data-act.drivesomethinggreater.com` v prohlížeči a přihlaste se. Pokud ani tam nevidíte data svého auta, je problém na straně VW – integrace nic nezmůže, dokud to VW neobnoví. Pokud žádný požadavek na data není, vytvořte průběžný (15minutový), zaškrtněte všechny datové clustery, pak s autem jeďte nebo ho probuďte a počkejte hodinu či dvě.\n\nToto je beta portálu pouze pro čtení – upozornění zmizí samo, jakmile dorazí data."
+    },
+    "data_act_browser_missing": {
+      "description": "Zapnul jsi zálohu přes headless prohlížeč pro portál EU Data Act, ale balíček Pythonu `playwright` není v tvém kontejneru Home Assistant nainstalovaný.\n\n**Instalace:** otevři shell kontejneru HA (Doplňky → Terminal & SSH, nebo `docker exec` pro ruční instalaci) a spusť:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nStahování chromia je velké (kolem 100 MB), proto je tato závislost volitelná a není součástí integrace. Po instalaci restartuj Home Assistant.\n\nPřípadně vypni přepínač v Nastavení → Zařízení a služby → VW Group Connect → Konfigurovat → 'Portál EU Data Act: záloha přes headless prohlížeč'.",
+      "title": "Portál EU Data Act: chybí volitelný balíček 'playwright'"
+    },
+    "data_act_session_expired": {
+      "description": "Portál {brand} na adrese `eu-data-act.drivesomethinggreater.com` vrátil na volání API Custom Data Request chybu HTTP 401, což znamená, že vypršela platnost relačních cookies. Portál nepodporuje obnovu tokenu na pozadí, takže Home Assistant to nedokáže opravit automaticky.\n\n**Co dělat:** Nastavení → Zařízení a služby → VW Group Connect → nabídka se 3 tečkami → Překonfigurovat → znovu zadej přihlašovací údaje. Další konfigurační cyklus znovu otevře relaci portálu a integrace obnoví dotazování na aktivní Custom Data Request.\n\nToto upozornění zmizí samo, jakmile další volání API portálu uspěje.",
+      "title": "Relace portálu EU Data Act vypršela – přihlas se znovu"
+    },
+    "data_act_wake_needed": {
+      "description": "Integrace běží v režimu zálohy portálu EU Data Act pouze pro čtení pro {brand} ({username}) a portál vrátil **{streak}** dotazů za sebou bez nových dat pro VIN končící na {vin_suffix}.\n\nPortál zveřejní novou sadu dat až poté, co vozidlo od minula prošlo probouzecí událostí. Mezi probouzecí události patří:\n\n- Zapnutí zapalování (jízda)\n- Připojení auta k nabíječce (začne nebo skončí nabíjecí relace)\n- Zamknutí nebo odemknutí auta (jeden celý cyklus)\n\n**Co dělat:** vyvolej na vozidle kteroukoli z výše uvedených akcí. Během následujícího 15minutového cyklu portálu integrace nový export automaticky převezme a toto upozornění zmizí.\n\nPokud jsi auto opravdu několik dní nepoužil, chybějící nová data jsou očekávaná a nejde o chybu integrace.",
+      "title": "Portál EU Data Act: probuď vozidlo pro obnovení dat ({brand})"
+    },
+    "ola_headers_outdated": {
+      "description": "OLA backend skupiny VW (server SEAT/CUPRA) odmítl **{count}** požadavků za sebou s chybou HTTP 403 Forbidden – i poté, co jsme vyzkoušeli všechny vestavěné záložní sady hlaviček.\n\n**Nejpravděpodobnější příčina**: VW znovu změnil požadavky na hlavičky identifikující aplikaci. Stalo se to 2026-05-20 a může se to opakovat, jak oficiální aplikace {brand} vydává nové verze.\n\n**Co dělat:**\n\n1. **Zkontroluj aktualizaci integrace** – HACS → VW Group Connect → Aktualizovat. Správci obvykle vydají úpravu hlaviček do ~1 týdne od změn v upstreamu (sledujeme to týdenním CI workflow).\n2. **Vyzkoušej přepsání přes OptionsFlow** (pokročilé) – Nastavení → Zařízení a služby → VW Group Connect → Konfigurovat → nastav `ola_app_version_override` na novější verzi aplikace (např. verzi oficiální aplikace {brand} v tvém telefonu, viditelnou v nastavení aplikace).\n3. **Pokud nepomůže ani jedno**: otevři issue na GitHubu s logem na úrovni DEBUG, abychom to mohli prošetřit.\n\nToto upozornění zmizí samo, jakmile další požadavek uspěje.",
+      "title": "Hlavičky OLA {brand} možná potřebují aktualizaci – {count} po sobě jdoucích chyb 403"
     }
   },
   "services": {
@@ -967,6 +1057,20 @@
           "description": "Which action to dispatch."
         }
       }
+    },
+    "open_app": {
+      "description": "Spustí událost `vag_connect_open_app` na sběrnici událostí HA s poli payloadu `vin`, `brand`, `deeplink_url` a `action`, aby karta Lovelace mohla otevřít nativní mobilní aplikaci značky (myAudi, WeConnect, MyŠkoda, MySEAT, MyCUPRA, My Porsche nebo VW US) na zařízení, které ji volá. Integrace sama o sobě nedokáže otevřít URL na telefonu; za navigaci `window.location.href = deeplink_url` v iOS / Android odpovídá karta dashboardu.",
+      "fields": {
+        "action": {
+          "description": "Volitelný segment cesty připojený k deeplinku, aby aplikace značky přešla přímo do sekce. Výchozí `open` otevře aplikaci na domovské obrazovce.",
+          "name": "Akce aplikace"
+        },
+        "vin": {
+          "description": "VIN vozidla, jehož aplikace značky se má otevřít.",
+          "name": "VIN"
+        }
+      },
+      "name": "Otevřít nativní aplikaci značky (deeplink)"
     }
   },
   "exceptions": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -67,6 +67,12 @@
           "spin": "S-PIN",
           "scan_interval": "Aktualisierungsintervall",
           "force_enable_access": "Tür-Status erzwingen"
+        },
+        "data_description": {
+          "brand": "Es werden nur Marken mit Browser-Login-Unterstützung angezeigt. Für Volkswagen EU und Porsche 'E-Mail + Passwort' verwenden.",
+          "force_enable_access": "Tür-Status-Entitäten erzwingen, auch wenn das Fahrzeug die Daten als fehlend meldet.",
+          "scan_interval": "Minuten zwischen den Datenabfragen des Fahrzeugs.",
+          "spin": "Optionale 4-stellige Sicherheits-PIN für Fernaktionen (Verriegeln, Entriegeln, Klima)."
         }
       },
       "browser_login_pending": {
@@ -547,6 +553,63 @@
       },
       "last_trip_reset_at": {
         "name": "Letzter Trip-Reset"
+      },
+      "battery_temp_c": {
+        "name": "Batterietemperatur"
+      },
+      "charging_settings_pending": {
+        "name": "Ladeeinstellungen ausstehend"
+      },
+      "charging_status_pending": {
+        "name": "Ladebefehle ausstehend"
+      },
+      "climate_remaining_time_min": {
+        "name": "Klima-Restzeit"
+      },
+      "climate_without_external_power": {
+        "name": "Klima ohne externe Stromversorgung"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimazone vorne links"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimazone vorne rechts"
+      },
+      "climatisation_settings_pending": {
+        "name": "Klima-Einstellungen ausstehend"
+      },
+      "climatisation_status_pending": {
+        "name": "Klima-Befehle ausstehend"
+      },
+      "connection_active": {
+        "name": "Verbindung aktiv"
+      },
+      "connection_battery_power_level": {
+        "name": "Batterieladestand (Verbindung)"
+      },
+      "daily_power_budget_warning": {
+        "name": "Warnung: tägliches Strombudget"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Warnung: Batteriestand zu niedrig"
+      },
+      "nav_target_soc_pct": {
+        "name": "Ziel-Ladestand (Navigation)"
+      },
+      "parking_map_url_dark": {
+        "name": "Parkkarten-URL (dunkel)"
+      },
+      "parking_map_url_light": {
+        "name": "Parkkarten-URL (hell)"
+      },
+      "plug_led_color": {
+        "name": "Ladestecker-LED-Farbe"
+      },
+      "remaining_charge_time_nav_min": {
+        "name": "Lade-Restzeit (Navigation)"
+      },
+      "vehicle_nickname": {
+        "name": "Fahrzeug-Spitzname"
       }
     },
     "binary_sensor": {
@@ -702,6 +765,15 @@
       },
       "permission_can_command": {
         "name": "Konto darf Befehle senden"
+      },
+      "external_power_available": {
+        "name": "Externe Stromversorgung vorhanden"
+      },
+      "hood_open": {
+        "name": "Motorhaube offen"
+      },
+      "trunk_open": {
+        "name": "Kofferraum offen"
       }
     },
     "switch": {
@@ -881,6 +953,14 @@
     "data_act_no_data": {
       "title": "EU-Data-Act-Portal: noch keine Fahrzeugdaten ({brand})",
       "description": "Das EU-Data-Act-Portal hat sich für {brand} angemeldet, liefert aber noch keine Fahrzeugdaten.\n\nTypische Ursachen:\n\n1. **Eine Störung auf VW-Seite.** VW meldet seit Ende Mai 2026 eine markenübergreifende Störung des EU-Data-Act-Portals (laut deren Mitteilung ist die Infrastruktur für die Datenextraktion unter Last ausgefallen). Solange sie andauert, liefert das Portal für jedes Tool leere Daten – nicht nur für diese Integration – und erholt sich nach und nach pro Marke.\n2. **Keine Datenanfrage eingerichtet.** Das Portal liefert erst, wenn du für dein Auto eine *fortlaufende* Datenanfrage anlegst.\n3. **Das Auto hat nichts Neues gesendet.** Ein neuer Datensatz wird erst veröffentlicht, nachdem das Auto gefahren, geladen oder ab-/aufgeschlossen wurde.\n\n**Schnellster Check:** öffne `eu-data-act.drivesomethinggreater.com` im Browser und melde dich an. Siehst du auch dort keine Daten für dein Auto, liegt es an VW – die Integration kann nichts tun, bis VW es wiederherstellt. Gibt es keine Datenanfrage, lege eine fortlaufende (15-Minuten-)Anfrage an, hake alle Datencluster an, fahre oder wecke dann das Auto und warte ein bis zwei Stunden.\n\nDies ist die schreibgeschützte Portal-Beta – die Warnung verschwindet von selbst, sobald Daten ankommen."
+    },
+    "data_act_session_expired": {
+      "description": "Das {brand}-Portal unter `eu-data-act.drivesomethinggreater.com` hat einen API-Aufruf für eine Custom Data Request mit HTTP 401 beantwortet – das bedeutet, die Sitzungs-Cookies sind abgelaufen. Das Portal unterstützt keine Token-Aktualisierung im Hintergrund, daher kann Home Assistant das nicht automatisch beheben.\n\n**Was zu tun ist:** Einstellungen → Geräte & Dienste → VW Group Connect → 3-Punkte-Menü → Neu konfigurieren → Zugangsdaten erneut eingeben. Beim nächsten Einrichtungsdurchlauf wird die Portal-Sitzung neu geöffnet und die Integration nimmt das Abfragen der aktiven Custom Data Request wieder auf.\n\nDiese Warnung verschwindet von selbst, sobald der nächste API-Aufruf des Portals erfolgreich ist.",
+      "title": "EU-Data-Act-Portal-Sitzung abgelaufen – neu anmelden"
+    },
+    "ola_headers_outdated": {
+      "description": "Das OLA-Backend der VW Group (der SEAT/CUPRA-Server) hat **{count}** Anfragen in Folge mit HTTP 403 Forbidden abgelehnt – sogar nachdem wir alle eingebauten Fallback-Header-Sätze ausprobiert haben.\n\n**Wahrscheinlichste Ursache**: VW hat seine Anforderungen an die App-Identifikations-Header erneut geändert. Das ist am 2026-05-20 passiert und kann erneut passieren, wenn die offizielle {brand}-App neue Versionen veröffentlicht.\n\n**Was zu tun ist:**\n\n1. **Auf ein Integrations-Update prüfen** – HACS → VW Group Connect → Update. Maintainer liefern eine Header-Anpassung meist innerhalb von ~1 Woche nach Upstream-Änderungen (wir überwachen das per wöchentlichem CI-Workflow).\n2. **Den OptionsFlow-Override versuchen** (fortgeschritten) – Einstellungen → Geräte & Dienste → VW Group Connect → Konfigurieren → `ola_app_version_override` auf eine neuere App-Version setzen (z. B. die Version der offiziellen {brand}-App auf deinem Telefon, sichtbar in den App-Einstellungen).\n3. **Wenn beides nicht hilft**: öffne ein GitHub-Issue mit deinem Log auf DEBUG-Ebene, damit wir es untersuchen können.\n\nDiese Warnung verschwindet von selbst, sobald die nächste Anfrage erfolgreich ist.",
+      "title": "{brand}-OLA-Header müssen eventuell aktualisiert werden – {count} aufeinanderfolgende 403-Fehler"
     }
   },
   "selector": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -67,6 +67,12 @@
           "spin": "S-PIN",
           "scan_interval": "Update Interval",
           "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Only brands with browser-login support are listed. Use 'Email + Password' for Volkswagen EU and Porsche.",
+          "force_enable_access": "Force door-status entities even when the vehicle reports the data missing.",
+          "scan_interval": "Minutes between vehicle data polls.",
+          "spin": "Optional 4-digit Security-PIN for remote actions (lock, unlock, climate)."
         }
       },
       "browser_login_pending": {
@@ -129,7 +135,8 @@
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
           "client_id_override": "OAuth client_id override (power users)",
-          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request",
+          "enable_data_act_browser": "EU Data Act portal: headless-browser fallback (EXPERIMENTAL)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -143,7 +150,8 @@
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
           "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
-          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default.",
+          "enable_data_act_browser": "EXPERIMENTAL: only meaningful when the integration has fallen back to the EU Data Act portal (read-only). Drives a headless Chromium via the optional 'playwright' Python package to click the portal's data-export button automatically. The package is NOT preinstalled (it pulls roughly 100 MB of Chromium). When enabled but missing, a Repair issue tells you how to install it from inside the Home Assistant container. Reload the integration after toggling."
         }
       }
     }
@@ -545,6 +553,63 @@
       },
       "last_trip_reset_at": {
         "name": "Last Trip Reset"
+      },
+      "battery_temp_c": {
+        "name": "Battery Temperature"
+      },
+      "charging_settings_pending": {
+        "name": "Charging Settings Pending"
+      },
+      "charging_status_pending": {
+        "name": "Charging Commands Pending"
+      },
+      "climate_remaining_time_min": {
+        "name": "Climate ETA"
+      },
+      "climate_without_external_power": {
+        "name": "Climate Without External Power"
+      },
+      "climate_zone_front_left": {
+        "name": "Climate Zone Front Left"
+      },
+      "climate_zone_front_right": {
+        "name": "Climate Zone Front Right"
+      },
+      "climatisation_settings_pending": {
+        "name": "Climate Settings Pending"
+      },
+      "climatisation_status_pending": {
+        "name": "Climate Commands Pending"
+      },
+      "connection_active": {
+        "name": "Connection Active"
+      },
+      "connection_battery_power_level": {
+        "name": "Connection Battery Power Level"
+      },
+      "daily_power_budget_warning": {
+        "name": "Daily Power Budget Warning"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Insufficient Battery Level Warning"
+      },
+      "nav_target_soc_pct": {
+        "name": "Navigation Target Charge"
+      },
+      "parking_map_url_dark": {
+        "name": "Parking Map URL (dark)"
+      },
+      "parking_map_url_light": {
+        "name": "Parking Map URL (light)"
+      },
+      "plug_led_color": {
+        "name": "Plug LED Color"
+      },
+      "remaining_charge_time_nav_min": {
+        "name": "Navigation Charge ETA"
+      },
+      "vehicle_nickname": {
+        "name": "Vehicle Nickname"
       }
     },
     "binary_sensor": {
@@ -700,6 +765,15 @@
       },
       "permission_can_command": {
         "name": "Account can send commands"
+      },
+      "external_power_available": {
+        "name": "External Power Available"
+      },
+      "hood_open": {
+        "name": "Hood Open"
+      },
+      "trunk_open": {
+        "name": "Trunk Open"
       }
     },
     "switch": {
@@ -871,6 +945,22 @@
     "data_act_no_data": {
       "title": "EU Data Act portal: no vehicle data yet ({brand})",
       "description": "The EU Data Act portal signed in for {brand} but isn't returning any vehicle data yet.\n\nUsual causes:\n\n1. **A VW-side outage.** VW reported an all-brands EU Data Act portal outage from late May 2026 (their notice: the data-extraction infrastructure failed under load). While it lasts the portal returns empty data for every tool, not just this integration, and it has been recovering brand by brand.\n2. **No data request set up.** The portal only delivers once you create a *continuous* data request for your car.\n3. **The car hasn't sent anything new.** A fresh dataset is only published after the car has been driven, charged, or locked/unlocked.\n\n**Quickest check:** open `eu-data-act.drivesomethinggreater.com` in a browser and sign in. If you see no data for your car there either, it's the VW side — nothing this integration can do until VW restores it. If there is no data request, create a continuous (15-minute) one, tick all data clusters, then drive or wake the car and wait an hour or two.\n\nThis is the read-only portal beta — the warning clears by itself once data arrives."
+    },
+    "data_act_browser_missing": {
+      "description": "You enabled the headless-browser fallback for the EU Data Act portal but the `playwright` Python package is not installed in your Home Assistant container.\n\n**To install:** open the HA container shell (Add-ons → Terminal & SSH, or `docker exec` for a manual install) and run:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nThe chromium download is large (around 100 MB), which is why this dependency is opt-in instead of bundled with the integration. After installing, restart Home Assistant.\n\nAlternatively, disable the toggle under Settings → Devices & Services → VW Group Connect → Configure → 'EU Data Act portal: headless-browser fallback'.",
+      "title": "EU Data Act portal: optional 'playwright' package missing"
+    },
+    "data_act_session_expired": {
+      "description": "The {brand} portal at `eu-data-act.drivesomethinggreater.com` returned HTTP 401 to a Custom Data Request API call, which means the session cookies have expired. The portal does not support background token refresh, so Home Assistant cannot recover this automatically.\n\n**What to do:** Settings → Devices & Services → VW Group Connect → 3-dot menu → Reconfigure → re-enter your credentials. The next setup cycle will reopen the portal session and the integration will resume polling the active Custom Data Request.\n\nThis warning auto-clears as soon as the next portal API call succeeds.",
+      "title": "EU Data Act portal session expired - reauthenticate"
+    },
+    "data_act_wake_needed": {
+      "description": "The integration is operating in EU Data Act portal read-only fallback mode for {brand} ({username}) and the portal has returned **{streak}** consecutive polls without new data for VIN ending {vin_suffix}.\n\nThe portal only publishes a fresh dataset after the vehicle has had a wake event since the last drop. Wake events include:\n\n- Starting the ignition (driving)\n- Plugging the car into a charger (a charge session begins or ends)\n- Locking or unlocking the car (one full cycle)\n\n**What to do:** trigger any one of the above on the vehicle. Within the next 15-minute portal cycle the integration will pick up the fresh export automatically and this warning will clear.\n\nIf you genuinely have not used the car in days, the absence of fresh data is expected and not an integration bug.",
+      "title": "EU Data Act portal: wake the vehicle to refresh data ({brand})"
+    },
+    "ola_headers_outdated": {
+      "description": "VW Group's OLA backend (the SEAT/CUPRA server) has rejected **{count}** requests in a row with HTTP 403 Forbidden — even after we tried all built-in fallback header-sets.\n\n**Most likely cause**: VW updated their app-identifying header requirements again. This happened on 2026-05-20 and may happen again as the official {brand} app releases new versions.\n\n**What to do:**\n\n1. **Check for an integration update** — HACS → VW Group Connect → Update. Maintainers usually ship a header bump within ~1 week of upstream changes (we monitor via weekly CI workflow).\n2. **Try the OptionsFlow override** (advanced) — Settings → Devices & Services → VW Group Connect → Configure → set `ola_app_version_override` to a fresher app version (e.g. the version of the official {brand} app on your phone, visible in app settings).\n3. **If neither helps**: open a GitHub issue with your DEBUG-level log so we can investigate.\n\nThis warning auto-clears when the next request succeeds.",
+      "title": "{brand} OLA headers may need an update — {count} consecutive 403 errors"
     }
   },
   "services": {
@@ -951,6 +1041,20 @@
           "description": "Which action to dispatch."
         }
       }
+    },
+    "open_app": {
+      "description": "Fires the `vag_connect_open_app` event on the HA event bus with payload fields `vin`, `brand`, `deeplink_url` and `action` so a Lovelace card can open the brand's native mobile app (myAudi, WeConnect, MyŠkoda, MySEAT, MyCUPRA, My Porsche or VW US) on the calling device. The integration cannot open URLs on a phone by itself; the dashboard card is responsible for navigating `window.location.href = deeplink_url` on iOS / Android.",
+      "fields": {
+        "action": {
+          "description": "Optional path segment appended to the deeplink so the brand app routes directly to a section. Default `open` opens the app to its home screen.",
+          "name": "App action"
+        },
+        "vin": {
+          "description": "VIN of the vehicle whose brand-app should open.",
+          "name": "VIN"
+        }
+      },
+      "name": "Open native brand app (deeplink)"
     }
   },
   "exceptions": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -83,6 +83,12 @@
           "spin": "S-PIN",
           "scan_interval": "Update Interval",
           "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Solo se muestran las marcas compatibles con el inicio de sesión por navegador. Usa 'Correo electrónico + contraseña' para Volkswagen EU y Porsche.",
+          "force_enable_access": "Forzar las entidades de estado de las puertas aunque el vehículo informe de que faltan los datos.",
+          "scan_interval": "Minutos entre cada consulta de datos del vehículo.",
+          "spin": "PIN de seguridad de 4 dígitos opcional para acciones remotas (bloquear, desbloquear, climatización)."
         }
       },
       "browser_login_pending": {
@@ -145,7 +151,8 @@
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
           "client_id_override": "OAuth client_id override (power users)",
-          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request",
+          "enable_data_act_browser": "Portal EU Data Act: alternativa con navegador headless (EXPERIMENTAL)"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",
@@ -159,7 +166,8 @@
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
           "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
-          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default.",
+          "enable_data_act_browser": "EXPERIMENTAL: solo tiene sentido cuando la integración ha recurrido al portal EU Data Act (solo lectura). Controla un Chromium headless mediante el paquete de Python opcional 'playwright' para pulsar automáticamente el botón de exportación de datos del portal. El paquete NO viene preinstalado (descarga unos 100 MB de Chromium). Si está activado pero falta, un aviso de Reparación te explica cómo instalarlo desde dentro del contenedor de Home Assistant. Recarga la integración después de cambiar la opción."
         }
       }
     }
@@ -561,6 +569,63 @@
       },
       "last_trip_reset_at": {
         "name": "Last Trip Reset"
+      },
+      "battery_temp_c": {
+        "name": "Temperatura de la batería"
+      },
+      "charging_settings_pending": {
+        "name": "Ajustes de carga pendientes"
+      },
+      "charging_status_pending": {
+        "name": "Comandos de carga pendientes"
+      },
+      "climate_remaining_time_min": {
+        "name": "Climatización – tiempo restante"
+      },
+      "climate_without_external_power": {
+        "name": "Climatización sin alimentación externa"
+      },
+      "climate_zone_front_left": {
+        "name": "Zona de climatización delantera izquierda"
+      },
+      "climate_zone_front_right": {
+        "name": "Zona de climatización delantera derecha"
+      },
+      "climatisation_settings_pending": {
+        "name": "Ajustes de climatización pendientes"
+      },
+      "climatisation_status_pending": {
+        "name": "Comandos de climatización pendientes"
+      },
+      "connection_active": {
+        "name": "Conexión activa"
+      },
+      "connection_battery_power_level": {
+        "name": "Nivel de batería (conexión)"
+      },
+      "daily_power_budget_warning": {
+        "name": "Aviso de presupuesto de energía diario"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Aviso de nivel de batería insuficiente"
+      },
+      "nav_target_soc_pct": {
+        "name": "Carga objetivo (navegación)"
+      },
+      "parking_map_url_dark": {
+        "name": "URL del mapa de aparcamiento (oscuro)"
+      },
+      "parking_map_url_light": {
+        "name": "URL del mapa de aparcamiento (claro)"
+      },
+      "plug_led_color": {
+        "name": "Color del LED del enchufe"
+      },
+      "remaining_charge_time_nav_min": {
+        "name": "Tiempo de carga restante (navegación)"
+      },
+      "vehicle_nickname": {
+        "name": "Apodo del vehículo"
       }
     },
     "binary_sensor": {
@@ -716,6 +781,15 @@
       },
       "permission_can_command": {
         "name": "Account can send commands"
+      },
+      "external_power_available": {
+        "name": "Alimentación externa disponible"
+      },
+      "hood_open": {
+        "name": "Capó abierto"
+      },
+      "trunk_open": {
+        "name": "Maletero abierto"
       }
     },
     "switch": {
@@ -887,6 +961,22 @@
     "data_act_no_data": {
       "title": "Portal EU Data Act: aún no hay datos del vehículo ({brand})",
       "description": "El portal EU Data Act inició sesión para {brand} pero todavía no devuelve datos del vehículo.\n\nCausas habituales:\n\n1. **Una caída del lado de VW.** VW notifica una caída del portal EU Data Act que afecta a todas las marcas desde finales de mayo de 2026 (según su aviso, la infraestructura de extracción de datos falló por la carga). Mientras dure, el portal devuelve datos vacíos para cualquier herramienta —no solo esta integración— y se va recuperando marca por marca.\n2. **No hay una solicitud de datos configurada.** El portal solo entrega datos cuando creas una solicitud de datos *continua* para tu coche.\n3. **El coche no ha enviado nada nuevo.** Solo se publica un conjunto de datos nuevo después de conducir, cargar o bloquear/desbloquear el coche.\n\n**Comprobación más rápida:** abre `eu-data-act.drivesomethinggreater.com` en un navegador e inicia sesión. Si ahí tampoco ves datos de tu coche, el problema es de VW: la integración no puede hacer nada hasta que VW lo restablezca. Si no hay solicitud de datos, crea una continua (de 15 minutos), marca todos los clústeres de datos, luego conduce o despierta el coche y espera una hora o dos.\n\nEsta es la beta del portal de solo lectura: el aviso desaparece solo en cuanto llegan datos."
+    },
+    "data_act_browser_missing": {
+      "description": "Activaste la alternativa con navegador headless para el portal EU Data Act, pero el paquete de Python `playwright` no está instalado en tu contenedor de Home Assistant.\n\n**Para instalarlo:** abre el shell del contenedor de HA (Complementos → Terminal & SSH, o `docker exec` para una instalación manual) y ejecuta:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nLa descarga de chromium es grande (unos 100 MB), por eso esta dependencia es opcional en lugar de venir incluida en la integración. Reinicia Home Assistant después de instalarla.\n\nComo alternativa, desactiva la opción en Ajustes → Dispositivos y servicios → VW Group Connect → Configurar → 'Portal EU Data Act: alternativa con navegador headless'.",
+      "title": "Portal EU Data Act: falta el paquete opcional 'playwright'"
+    },
+    "data_act_session_expired": {
+      "description": "El portal de {brand} en `eu-data-act.drivesomethinggreater.com` devolvió HTTP 401 a una llamada de la API de Custom Data Request, lo que significa que las cookies de sesión han caducado. El portal no admite la renovación de token en segundo plano, así que Home Assistant no puede recuperarlo automáticamente.\n\n**Qué hacer:** Ajustes → Dispositivos y servicios → VW Group Connect → menú de 3 puntos → Reconfigurar → vuelve a introducir tus credenciales. El siguiente ciclo de configuración reabrirá la sesión del portal y la integración reanudará la consulta de la Custom Data Request activa.\n\nEste aviso desaparece solo en cuanto la siguiente llamada a la API del portal tiene éxito.",
+      "title": "La sesión del portal EU Data Act ha caducado: vuelve a autenticarte"
+    },
+    "data_act_wake_needed": {
+      "description": "La integración funciona en el modo alternativo de solo lectura del portal EU Data Act para {brand} ({username}), y el portal ha devuelto **{streak}** consultas seguidas sin datos nuevos para el VIN que termina en {vin_suffix}.\n\nEl portal solo publica un conjunto de datos nuevo después de que el vehículo haya tenido un evento de activación desde la última vez. Los eventos de activación incluyen:\n\n- Poner el contacto (conducir)\n- Enchufar el coche a un cargador (una sesión de carga empieza o termina)\n- Bloquear o desbloquear el coche (un ciclo completo)\n\n**Qué hacer:** provoca cualquiera de los anteriores en el vehículo. En el siguiente ciclo de 15 minutos del portal, la integración recogerá la nueva exportación automáticamente y este aviso desaparecerá.\n\nSi de verdad llevas días sin usar el coche, la falta de datos nuevos es lo esperado y no es un fallo de la integración.",
+      "title": "Portal EU Data Act: despierta el vehículo para actualizar los datos ({brand})"
+    },
+    "ola_headers_outdated": {
+      "description": "El backend OLA de VW Group (el servidor de SEAT/CUPRA) ha rechazado **{count}** peticiones seguidas con HTTP 403 Forbidden, incluso después de probar todos los conjuntos de cabeceras de reserva integrados.\n\n**Causa más probable**: VW ha vuelto a cambiar los requisitos de sus cabeceras de identificación de la app. Ocurrió el 2026-05-20 y puede volver a ocurrir cuando la app oficial de {brand} publique versiones nuevas.\n\n**Qué hacer:**\n\n1. **Comprueba si hay una actualización de la integración** – HACS → VW Group Connect → Actualizar. Los mantenedores suelen publicar un ajuste de cabeceras en aproximadamente 1 semana tras los cambios upstream (lo vigilamos con un flujo de CI semanal).\n2. **Prueba la anulación de OptionsFlow** (avanzado) – Ajustes → Dispositivos y servicios → VW Group Connect → Configurar → establece `ola_app_version_override` en una versión de app más reciente (p. ej. la versión de la app oficial de {brand} en tu teléfono, visible en los ajustes de la app).\n3. **Si nada de esto ayuda**: abre una incidencia en GitHub con tu registro a nivel DEBUG para que podamos investigarlo.\n\nEste aviso desaparece solo cuando la siguiente petición tiene éxito.",
+      "title": "Puede que las cabeceras OLA de {brand} necesiten actualizarse – {count} errores 403 seguidos"
     }
   },
   "services": {
@@ -967,6 +1057,20 @@
           "description": "Which action to dispatch."
         }
       }
+    },
+    "open_app": {
+      "description": "Dispara el evento `vag_connect_open_app` en el bus de eventos de HA con los campos de carga útil `vin`, `brand`, `deeplink_url` y `action` para que una tarjeta Lovelace pueda abrir la app móvil nativa de la marca (myAudi, WeConnect, MyŠkoda, MySEAT, MyCUPRA, My Porsche o VW US) en el dispositivo que la invoca. La integración no puede abrir URL en un teléfono por sí misma; la tarjeta del panel es la responsable de navegar a `window.location.href = deeplink_url` en iOS / Android.",
+      "fields": {
+        "action": {
+          "description": "Segmento de ruta opcional que se añade al enlace directo para que la app de la marca abra directamente una sección. El valor predeterminado `open` abre la app en su pantalla de inicio.",
+          "name": "Acción de la app"
+        },
+        "vin": {
+          "description": "VIN del vehículo cuya app de marca debe abrirse.",
+          "name": "VIN"
+        }
+      },
+      "name": "Abrir la app nativa de la marca (enlace directo)"
     }
   },
   "exceptions": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -83,6 +83,12 @@
           "spin": "S-PIN",
           "scan_interval": "Update Interval",
           "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Seules les marques prenant en charge la connexion par navigateur sont listées. Utilisez « E-mail + mot de passe » pour Volkswagen EU et Porsche.",
+          "force_enable_access": "Forcer les entités d'état des portes même lorsque le véhicule signale les données comme manquantes.",
+          "scan_interval": "Minutes entre chaque interrogation des données du véhicule.",
+          "spin": "Code de sécurité (S-PIN) à 4 chiffres facultatif pour les actions à distance (verrouillage, déverrouillage, climatisation)."
         }
       },
       "browser_login_pending": {
@@ -145,7 +151,8 @@
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
           "client_id_override": "OAuth client_id override (power users)",
-          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request",
+          "enable_data_act_browser": "Portail EU Data Act : repli navigateur headless (EXPÉRIMENTAL)"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",
@@ -159,7 +166,8 @@
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
           "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
-          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default.",
+          "enable_data_act_browser": "EXPÉRIMENTAL : utile uniquement lorsque l'intégration est repassée sur le portail EU Data Act (lecture seule). Pilote un Chromium headless via le paquet Python facultatif 'playwright' pour cliquer automatiquement sur le bouton d'export des données du portail. Le paquet n'est PAS préinstallé (il télécharge environ 100 Mo de Chromium). S'il est activé mais absent, un signalement de Réparation explique comment l'installer depuis le conteneur Home Assistant. Rechargez l'intégration après avoir basculé l'option."
         }
       }
     }
@@ -561,6 +569,63 @@
       },
       "last_trip_reset_at": {
         "name": "Last Trip Reset"
+      },
+      "battery_temp_c": {
+        "name": "Température de la batterie"
+      },
+      "charging_settings_pending": {
+        "name": "Réglages de charge en attente"
+      },
+      "charging_status_pending": {
+        "name": "Commandes de charge en attente"
+      },
+      "climate_remaining_time_min": {
+        "name": "Climatisation – temps restant"
+      },
+      "climate_without_external_power": {
+        "name": "Climatisation sans alimentation externe"
+      },
+      "climate_zone_front_left": {
+        "name": "Zone climatique avant gauche"
+      },
+      "climate_zone_front_right": {
+        "name": "Zone climatique avant droite"
+      },
+      "climatisation_settings_pending": {
+        "name": "Réglages de climatisation en attente"
+      },
+      "climatisation_status_pending": {
+        "name": "Commandes de climatisation en attente"
+      },
+      "connection_active": {
+        "name": "Connexion active"
+      },
+      "connection_battery_power_level": {
+        "name": "Niveau de batterie (connexion)"
+      },
+      "daily_power_budget_warning": {
+        "name": "Alerte budget d'énergie quotidien"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Alerte niveau de batterie insuffisant"
+      },
+      "nav_target_soc_pct": {
+        "name": "Charge cible (navigation)"
+      },
+      "parking_map_url_dark": {
+        "name": "URL de la carte de stationnement (sombre)"
+      },
+      "parking_map_url_light": {
+        "name": "URL de la carte de stationnement (clair)"
+      },
+      "plug_led_color": {
+        "name": "Couleur LED de la prise"
+      },
+      "remaining_charge_time_nav_min": {
+        "name": "Temps de charge restant (navigation)"
+      },
+      "vehicle_nickname": {
+        "name": "Surnom du véhicule"
       }
     },
     "binary_sensor": {
@@ -716,6 +781,15 @@
       },
       "permission_can_command": {
         "name": "Account can send commands"
+      },
+      "external_power_available": {
+        "name": "Alimentation externe disponible"
+      },
+      "hood_open": {
+        "name": "Capot ouvert"
+      },
+      "trunk_open": {
+        "name": "Coffre ouvert"
       }
     },
     "switch": {
@@ -887,6 +961,22 @@
     "data_act_no_data": {
       "title": "Portail EU Data Act : pas encore de données du véhicule ({brand})",
       "description": "Le portail EU Data Act s'est connecté pour {brand} mais ne renvoie pas encore de données du véhicule.\n\nCauses habituelles :\n\n1. **Une panne côté VW.** VW signale une panne multimarque du portail EU Data Act depuis fin mai 2026 (selon leur avis, l'infrastructure d'extraction des données est tombée en panne sous la charge). Tant qu'elle dure, le portail renvoie des données vides pour tous les outils – pas seulement cette intégration – et se rétablit marque par marque.\n2. **Aucune demande de données configurée.** Le portail ne fournit des données qu'une fois que vous créez une demande de données *continue* pour votre voiture.\n3. **La voiture n'a rien envoyé de nouveau.** Un nouveau jeu de données n'est publié qu'après que la voiture a roulé, a été rechargée ou verrouillée/déverrouillée.\n\n**Vérification la plus rapide :** ouvrez `eu-data-act.drivesomethinggreater.com` dans un navigateur et connectez-vous. Si vous n'y voyez pas non plus de données pour votre voiture, le problème vient de VW – l'intégration ne peut rien faire tant que VW ne l'a pas rétabli. S'il n'y a pas de demande de données, créez-en une continue (15 minutes), cochez tous les clusters de données, puis roulez ou réveillez la voiture et attendez une heure ou deux.\n\nCeci est la bêta du portail en lecture seule – l'avertissement disparaît tout seul dès que des données arrivent."
+    },
+    "data_act_browser_missing": {
+      "description": "Vous avez activé le repli navigateur headless pour le portail EU Data Act, mais le paquet Python `playwright` n'est pas installé dans votre conteneur Home Assistant.\n\n**Pour l'installer :** ouvrez le shell du conteneur HA (Modules complémentaires → Terminal & SSH, ou `docker exec` pour une installation manuelle) et exécutez :\n\n```\npip install playwright\nplaywright install chromium\n```\n\nLe téléchargement de chromium est volumineux (environ 100 Mo), c'est pourquoi cette dépendance est optionnelle plutôt qu'incluse dans l'intégration. Redémarrez Home Assistant après l'installation.\n\nVous pouvez aussi désactiver l'option dans Paramètres → Appareils et services → VW Group Connect → Configurer → « Portail EU Data Act : repli navigateur headless ».",
+      "title": "Portail EU Data Act : le paquet facultatif 'playwright' est manquant"
+    },
+    "data_act_session_expired": {
+      "description": "Le portail {brand} sur `eu-data-act.drivesomethinggreater.com` a renvoyé une erreur HTTP 401 lors d'un appel API de Custom Data Request, ce qui signifie que les cookies de session ont expiré. Le portail ne prend pas en charge le renouvellement de jeton en arrière-plan, donc Home Assistant ne peut pas corriger cela automatiquement.\n\n**Que faire :** Paramètres → Appareils et services → VW Group Connect → menu à 3 points → Reconfigurer → ressaisissez vos identifiants. Le prochain cycle de configuration rouvrira la session du portail et l'intégration reprendra l'interrogation de la Custom Data Request active.\n\nCet avertissement disparaît tout seul dès que le prochain appel API du portail réussit.",
+      "title": "Session du portail EU Data Act expirée – reconnectez-vous"
+    },
+    "data_act_wake_needed": {
+      "description": "L'intégration fonctionne en mode de repli lecture seule du portail EU Data Act pour {brand} ({username}), et le portail a renvoyé **{streak}** interrogations consécutives sans nouvelles données pour le VIN se terminant par {vin_suffix}.\n\nLe portail ne publie un nouveau jeu de données qu'après que le véhicule a connu un événement de réveil depuis la dernière fois. Les événements de réveil incluent :\n\n- Mettre le contact (conduire)\n- Brancher la voiture sur un chargeur (une session de charge commence ou se termine)\n- Verrouiller ou déverrouiller la voiture (un cycle complet)\n\n**Que faire :** déclenchez l'un des événements ci-dessus sur le véhicule. Lors du prochain cycle de 15 minutes du portail, l'intégration récupérera automatiquement le nouvel export et cet avertissement disparaîtra.\n\nSi vous n'avez réellement pas utilisé la voiture depuis des jours, l'absence de nouvelles données est normale et ne constitue pas un bogue de l'intégration.",
+      "title": "Portail EU Data Act : réveillez le véhicule pour rafraîchir les données ({brand})"
+    },
+    "ola_headers_outdated": {
+      "description": "Le backend OLA de VW Group (le serveur SEAT/CUPRA) a rejeté **{count}** requêtes d'affilée avec une erreur HTTP 403 Forbidden – même après que nous ayons essayé tous les jeux d'en-têtes de repli intégrés.\n\n**Cause la plus probable** : VW a de nouveau modifié les exigences de ses en-têtes d'identification d'application. C'est arrivé le 2026-05-20 et cela peut se reproduire à mesure que l'application officielle {brand} publie de nouvelles versions.\n\n**Que faire :**\n\n1. **Vérifiez s'il existe une mise à jour de l'intégration** – HACS → VW Group Connect → Mettre à jour. Les mainteneurs publient généralement un ajustement d'en-têtes dans la semaine suivant les changements en amont (nous surveillons via un workflow CI hebdomadaire).\n2. **Essayez la surcharge OptionsFlow** (avancé) – Paramètres → Appareils et services → VW Group Connect → Configurer → définissez `ola_app_version_override` sur une version d'application plus récente (p. ex. la version de l'application officielle {brand} sur votre téléphone, visible dans les paramètres de l'application).\n3. **Si rien ne fonctionne** : ouvrez un ticket GitHub avec votre journal au niveau DEBUG pour que nous puissions enquêter.\n\nCet avertissement disparaît tout seul lorsque la requête suivante réussit.",
+      "title": "Les en-têtes OLA {brand} doivent peut-être être mis à jour – {count} erreurs 403 consécutives"
     }
   },
   "services": {
@@ -967,6 +1057,20 @@
           "description": "Which action to dispatch."
         }
       }
+    },
+    "open_app": {
+      "description": "Déclenche l'événement `vag_connect_open_app` sur le bus d'événements HA avec les champs de charge utile `vin`, `brand`, `deeplink_url` et `action`, afin qu'une carte Lovelace puisse ouvrir l'application mobile native de la marque (myAudi, WeConnect, MyŠkoda, MySEAT, MyCUPRA, My Porsche ou VW US) sur l'appareil appelant. L'intégration ne peut pas ouvrir d'URL sur un téléphone par elle-même ; la carte du tableau de bord est chargée de naviguer vers `window.location.href = deeplink_url` sous iOS / Android.",
+      "fields": {
+        "action": {
+          "description": "Segment de chemin facultatif ajouté au lien profond pour que l'application de la marque ouvre directement une section. La valeur par défaut `open` ouvre l'application sur son écran d'accueil.",
+          "name": "Action de l'application"
+        },
+        "vin": {
+          "description": "VIN du véhicule dont l'application de la marque doit s'ouvrir.",
+          "name": "VIN"
+        }
+      },
+      "name": "Ouvrir l'application native de la marque (lien profond)"
     }
   },
   "exceptions": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -83,6 +83,12 @@
           "spin": "S-PIN",
           "scan_interval": "Update Interval",
           "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Alleen merken met browser-login-ondersteuning worden getoond. Gebruik 'E-mail + wachtwoord' voor Volkswagen EU en Porsche.",
+          "force_enable_access": "Forceer deurstatus-entiteiten, ook als het voertuig de gegevens als ontbrekend meldt.",
+          "scan_interval": "Minuten tussen de gegevensopvragingen van het voertuig.",
+          "spin": "Optionele 4-cijferige beveiligings-PIN voor acties op afstand (vergrendelen, ontgrendelen, klimaat)."
         }
       },
       "browser_login_pending": {
@@ -145,7 +151,8 @@
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
           "client_id_override": "OAuth client_id override (power users)",
-          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request",
+          "enable_data_act_browser": "EU Data Act-portaal: headless-browser-fallback (EXPERIMENTEEL)"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",
@@ -159,7 +166,8 @@
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
           "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
-          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default.",
+          "enable_data_act_browser": "EXPERIMENTEEL: alleen zinvol wanneer de integratie is teruggevallen op het EU Data Act-portaal (alleen-lezen). Stuurt een headless Chromium aan via het optionele Python-pakket 'playwright' om de data-exportknop van het portaal automatisch te klikken. Het pakket is NIET voorgeïnstalleerd (het haalt ongeveer 100 MB Chromium op). Wanneer ingeschakeld maar ontbrekend, legt een Reparatie-melding uit hoe je het installeert in de Home Assistant-container. Herlaad de integratie na het omschakelen."
         }
       }
     }
@@ -561,6 +569,63 @@
       },
       "last_trip_reset_at": {
         "name": "Last Trip Reset"
+      },
+      "battery_temp_c": {
+        "name": "Batterijtemperatuur"
+      },
+      "charging_settings_pending": {
+        "name": "Laadinstellingen in behandeling"
+      },
+      "charging_status_pending": {
+        "name": "Laadopdrachten in behandeling"
+      },
+      "climate_remaining_time_min": {
+        "name": "Klimaat resterende tijd"
+      },
+      "climate_without_external_power": {
+        "name": "Klimaat zonder externe voeding"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimaatzone linksvoor"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimaatzone rechtsvoor"
+      },
+      "climatisation_settings_pending": {
+        "name": "Klimaatinstellingen in behandeling"
+      },
+      "climatisation_status_pending": {
+        "name": "Klimaatopdrachten in behandeling"
+      },
+      "connection_active": {
+        "name": "Verbinding actief"
+      },
+      "connection_battery_power_level": {
+        "name": "Batterijniveau (verbinding)"
+      },
+      "daily_power_budget_warning": {
+        "name": "Waarschuwing dagelijks energiebudget"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Waarschuwing batterijniveau te laag"
+      },
+      "nav_target_soc_pct": {
+        "name": "Doellaadniveau (navigatie)"
+      },
+      "parking_map_url_dark": {
+        "name": "Parkeerkaart-URL (donker)"
+      },
+      "parking_map_url_light": {
+        "name": "Parkeerkaart-URL (licht)"
+      },
+      "plug_led_color": {
+        "name": "Kleur laadstekker-LED"
+      },
+      "remaining_charge_time_nav_min": {
+        "name": "Resterende laadtijd (navigatie)"
+      },
+      "vehicle_nickname": {
+        "name": "Voertuigbijnaam"
       }
     },
     "binary_sensor": {
@@ -716,6 +781,15 @@
       },
       "permission_can_command": {
         "name": "Account can send commands"
+      },
+      "external_power_available": {
+        "name": "Externe voeding beschikbaar"
+      },
+      "hood_open": {
+        "name": "Motorkap open"
+      },
+      "trunk_open": {
+        "name": "Kofferbak open"
       }
     },
     "switch": {
@@ -887,6 +961,22 @@
     "data_act_no_data": {
       "title": "EU Data Act-portaal: nog geen voertuiggegevens ({brand})",
       "description": "Het EU Data Act-portaal is ingelogd voor {brand}, maar levert nog geen voertuiggegevens.\n\nGebruikelijke oorzaken:\n\n1. **Een storing aan VW-kant.** VW meldt sinds eind mei 2026 een merkbrede storing van het EU Data Act-portaal (volgens hun bericht is de infrastructuur voor data-extractie onder belasting uitgevallen). Zolang die duurt levert het portaal voor elk hulpmiddel lege gegevens – niet alleen voor deze integratie – en herstelt het zich merk voor merk.\n2. **Geen gegevensverzoek ingesteld.** Het portaal levert pas zodra je voor je auto een *doorlopend* gegevensverzoek aanmaakt.\n3. **De auto heeft niets nieuws gestuurd.** Een nieuwe dataset verschijnt pas nadat de auto is gereden, geladen of vergrendeld/ontgrendeld.\n\n**Snelste controle:** open `eu-data-act.drivesomethinggreater.com` in een browser en log in. Zie je daar ook geen gegevens voor je auto, dan ligt het aan VW – de integratie kan niets doen tot VW het herstelt. Is er geen gegevensverzoek, maak dan een doorlopend (15-minuten) verzoek aan, vink alle dataclusters aan, rijd of wek daarna de auto en wacht een uur of twee.\n\nDit is de alleen-lezen portaal-beta – de waarschuwing verdwijnt vanzelf zodra er gegevens binnenkomen."
+    },
+    "data_act_browser_missing": {
+      "description": "Je hebt de headless-browser-fallback voor het EU Data Act-portaal ingeschakeld, maar het Python-pakket `playwright` is niet geïnstalleerd in je Home Assistant-container.\n\n**Installeren:** open de shell van de HA-container (Add-ons → Terminal & SSH, of `docker exec` voor een handmatige installatie) en voer uit:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nDe chromium-download is groot (ongeveer 100 MB), daarom is deze afhankelijkheid optioneel in plaats van meegeleverd met de integratie. Herstart Home Assistant na de installatie.\n\nJe kunt de schakelaar ook uitzetten via Instellingen → Apparaten & diensten → VW Group Connect → Configureren → 'EU Data Act-portaal: headless-browser-fallback'.",
+      "title": "EU Data Act-portaal: optioneel pakket 'playwright' ontbreekt"
+    },
+    "data_act_session_expired": {
+      "description": "Het {brand}-portaal op `eu-data-act.drivesomethinggreater.com` gaf HTTP 401 terug op een API-aanroep voor een Custom Data Request, wat betekent dat de sessiecookies zijn verlopen. Het portaal ondersteunt geen tokenvernieuwing op de achtergrond, dus Home Assistant kan dit niet automatisch herstellen.\n\n**Wat te doen:** Instellingen → Apparaten & diensten → VW Group Connect → menu met 3 puntjes → Herconfigureren → voer je inloggegevens opnieuw in. De volgende setupronde opent de portaalsessie opnieuw en de integratie hervat het opvragen van de actieve Custom Data Request.\n\nDeze waarschuwing verdwijnt vanzelf zodra de volgende API-aanroep van het portaal slaagt.",
+      "title": "EU Data Act-portaalsessie verlopen – opnieuw aanmelden"
+    },
+    "data_act_wake_needed": {
+      "description": "De integratie draait voor {brand} ({username}) in de alleen-lezen fallback-modus van het EU Data Act-portaal, en het portaal heeft **{streak}** opvragingen op rij zonder nieuwe gegevens geleverd voor de VIN die eindigt op {vin_suffix}.\n\nHet portaal publiceert pas een nieuwe dataset nadat het voertuig sinds de laatste keer een wek-gebeurtenis heeft gehad. Wek-gebeurtenissen zijn onder andere:\n\n- Het contact aanzetten (rijden)\n- De auto op een lader aansluiten (een laadsessie begint of eindigt)\n- De auto vergrendelen of ontgrendelen (één volledige cyclus)\n\n**Wat te doen:** doe een van bovenstaande met het voertuig. Binnen de volgende 15-minuten-portaalcyclus pikt de integratie de nieuwe export automatisch op en verdwijnt deze waarschuwing.\n\nAls je de auto echt al dagen niet hebt gebruikt, is het ontbreken van nieuwe gegevens te verwachten en geen fout van de integratie.",
+      "title": "EU Data Act-portaal: wek het voertuig om gegevens te verversen ({brand})"
+    },
+    "ola_headers_outdated": {
+      "description": "De OLA-backend van VW Group (de SEAT/CUPRA-server) heeft **{count}** verzoeken op rij geweigerd met HTTP 403 Forbidden – zelfs nadat we alle ingebouwde fallback-headersets hadden geprobeerd.\n\n**Meest waarschijnlijke oorzaak**: VW heeft de eisen voor de app-identificerende headers opnieuw gewijzigd. Dit gebeurde op 2026-05-20 en kan opnieuw gebeuren wanneer de officiële {brand}-app nieuwe versies uitbrengt.\n\n**Wat te doen:**\n\n1. **Controleer op een integratie-update** – HACS → VW Group Connect → Update. Beheerders leveren meestal binnen ~1 week na upstream-wijzigingen een header-aanpassing (we monitoren dit via een wekelijkse CI-workflow).\n2. **Probeer de OptionsFlow-override** (geavanceerd) – Instellingen → Apparaten & diensten → VW Group Connect → Configureren → stel `ola_app_version_override` in op een nieuwere app-versie (bijv. de versie van de officiële {brand}-app op je telefoon, zichtbaar in de app-instellingen).\n3. **Als geen van beide helpt**: open een GitHub-issue met je log op DEBUG-niveau zodat we het kunnen onderzoeken.\n\nDeze waarschuwing verdwijnt vanzelf zodra het volgende verzoek slaagt.",
+      "title": "{brand}-OLA-headers moeten mogelijk worden bijgewerkt – {count} opeenvolgende 403-fouten"
     }
   },
   "services": {
@@ -967,6 +1057,20 @@
           "description": "Which action to dispatch."
         }
       }
+    },
+    "open_app": {
+      "description": "Activeert het event `vag_connect_open_app` op de HA-eventbus met de payloadvelden `vin`, `brand`, `deeplink_url` en `action`, zodat een Lovelace-kaart de native mobiele app van het merk (myAudi, WeConnect, MyŠkoda, MySEAT, MyCUPRA, My Porsche of VW US) op het aanroepende apparaat kan openen. De integratie kan zelf geen URL's op een telefoon openen; de dashboardkaart is verantwoordelijk voor het navigeren naar `window.location.href = deeplink_url` op iOS / Android.",
+      "fields": {
+        "action": {
+          "description": "Optioneel padsegment dat aan de deeplink wordt toegevoegd zodat de merk-app direct naar een sectie navigeert. Standaard `open` opent de app op het startscherm.",
+          "name": "App-actie"
+        },
+        "vin": {
+          "description": "VIN van het voertuig waarvan de merk-app moet worden geopend.",
+          "name": "VIN"
+        }
+      },
+      "name": "Native merk-app openen (deeplink)"
     }
   },
   "exceptions": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -83,6 +83,12 @@
           "spin": "S-PIN",
           "scan_interval": "Update Interval",
           "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Wyświetlane są tylko marki obsługujące logowanie przez przeglądarkę. Dla Volkswagen EU i Porsche użyj 'E-mail + hasło'.",
+          "force_enable_access": "Wymuś encje stanu drzwi, nawet gdy pojazd zgłasza brak danych.",
+          "scan_interval": "Minuty między odpytaniami danych pojazdu.",
+          "spin": "Opcjonalny 4-cyfrowy PIN bezpieczeństwa do akcji zdalnych (blokowanie, odblokowanie, klimatyzacja)."
         }
       },
       "browser_login_pending": {
@@ -145,7 +151,8 @@
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
           "client_id_override": "OAuth client_id override (power users)",
-          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request",
+          "enable_data_act_browser": "Portal EU Data Act: rezerwowy tryb przeglądarki headless (EKSPERYMENTALNE)"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",
@@ -159,7 +166,8 @@
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
           "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
-          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default.",
+          "enable_data_act_browser": "EKSPERYMENTALNE: ma sens tylko, gdy integracja przeszła w tryb awaryjny portalu EU Data Act (tylko do odczytu). Steruje przeglądarką headless Chromium za pomocą opcjonalnego pakietu Pythona 'playwright', aby automatycznie kliknąć przycisk eksportu danych w portalu. Pakiet NIE jest preinstalowany (pobiera około 100 MB Chromium). Gdy jest włączony, ale go brakuje, zgłoszenie Naprawy wyjaśnia, jak zainstalować go wewnątrz kontenera Home Assistant. Po przełączeniu przeładuj integrację."
         }
       }
     }
@@ -561,6 +569,63 @@
       },
       "last_trip_reset_at": {
         "name": "Last Trip Reset"
+      },
+      "battery_temp_c": {
+        "name": "Temperatura akumulatora"
+      },
+      "charging_settings_pending": {
+        "name": "Ustawienia ładowania oczekują"
+      },
+      "charging_status_pending": {
+        "name": "Polecenia ładowania oczekują"
+      },
+      "climate_remaining_time_min": {
+        "name": "Klimatyzacja – pozostały czas"
+      },
+      "climate_without_external_power": {
+        "name": "Klimatyzacja bez zasilania zewnętrznego"
+      },
+      "climate_zone_front_left": {
+        "name": "Strefa klimatyzacji przód lewa"
+      },
+      "climate_zone_front_right": {
+        "name": "Strefa klimatyzacji przód prawa"
+      },
+      "climatisation_settings_pending": {
+        "name": "Ustawienia klimatyzacji oczekują"
+      },
+      "climatisation_status_pending": {
+        "name": "Polecenia klimatyzacji oczekują"
+      },
+      "connection_active": {
+        "name": "Połączenie aktywne"
+      },
+      "connection_battery_power_level": {
+        "name": "Poziom baterii (połączenie)"
+      },
+      "daily_power_budget_warning": {
+        "name": "Ostrzeżenie o dziennym limicie energii"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Ostrzeżenie o zbyt niskim poziomie baterii"
+      },
+      "nav_target_soc_pct": {
+        "name": "Docelowy poziom ładowania (nawigacja)"
+      },
+      "parking_map_url_dark": {
+        "name": "URL mapy parkowania (ciemna)"
+      },
+      "parking_map_url_light": {
+        "name": "URL mapy parkowania (jasna)"
+      },
+      "plug_led_color": {
+        "name": "Kolor LED wtyczki"
+      },
+      "remaining_charge_time_nav_min": {
+        "name": "Pozostały czas ładowania (nawigacja)"
+      },
+      "vehicle_nickname": {
+        "name": "Pseudonim pojazdu"
       }
     },
     "binary_sensor": {
@@ -716,6 +781,15 @@
       },
       "permission_can_command": {
         "name": "Account can send commands"
+      },
+      "external_power_available": {
+        "name": "Zasilanie zewnętrzne dostępne"
+      },
+      "hood_open": {
+        "name": "Maska otwarta"
+      },
+      "trunk_open": {
+        "name": "Bagażnik otwarty"
       }
     },
     "switch": {
@@ -887,6 +961,22 @@
     "data_act_no_data": {
       "title": "Portal EU Data Act: brak danych pojazdu ({brand})",
       "description": "Portal EU Data Act zalogował się dla {brand}, ale nie zwraca jeszcze żadnych danych pojazdu.\n\nTypowe przyczyny:\n\n1. **Awaria po stronie VW.** VW zgłosił awarię portalu EU Data Act obejmującą wszystkie marki od końca maja 2026 (według ich komunikatu infrastruktura do ekstrakcji danych przestała działać pod obciążeniem). Dopóki trwa, portal zwraca puste dane dla każdego narzędzia – nie tylko dla tej integracji – i jest stopniowo przywracany marka po marce.\n2. **Brak skonfigurowanego żądania danych.** Portal dostarcza dane dopiero po utworzeniu *ciągłego* żądania danych dla Twojego samochodu.\n3. **Samochód nie wysłał nic nowego.** Nowy zestaw danych jest publikowany dopiero po jeździe, ładowaniu lub zamknięciu/otwarciu samochodu.\n\n**Najszybsze sprawdzenie:** otwórz `eu-data-act.drivesomethinggreater.com` w przeglądarce i zaloguj się. Jeśli tam również nie widzisz danych swojego samochodu, problem leży po stronie VW – integracja nic nie może zrobić, dopóki VW tego nie przywróci. Jeśli nie ma żądania danych, utwórz ciągłe (15-minutowe), zaznacz wszystkie klastry danych, a następnie przejedź się lub wybudź samochód i odczekaj godzinę lub dwie.\n\nTo wersja beta portalu tylko do odczytu – ostrzeżenie zniknie samo, gdy tylko pojawią się dane."
+    },
+    "data_act_browser_missing": {
+      "description": "Włączyłeś rezerwowy tryb przeglądarki headless dla portalu EU Data Act, ale pakiet Pythona `playwright` nie jest zainstalowany w Twoim kontenerze Home Assistant.\n\n**Aby zainstalować:** otwórz powłokę kontenera HA (Dodatki → Terminal & SSH lub `docker exec` przy instalacji ręcznej) i uruchom:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nPobranie chromium jest duże (około 100 MB), dlatego ta zależność jest opcjonalna, a nie dołączona do integracji. Po instalacji uruchom ponownie Home Assistant.\n\nAlternatywnie wyłącz przełącznik w Ustawienia → Urządzenia i usługi → VW Group Connect → Konfiguruj → 'Portal EU Data Act: rezerwowy tryb przeglądarki headless'.",
+      "title": "Portal EU Data Act: brak opcjonalnego pakietu 'playwright'"
+    },
+    "data_act_session_expired": {
+      "description": "Portal {brand} pod adresem `eu-data-act.drivesomethinggreater.com` zwrócił HTTP 401 na wywołanie API Custom Data Request, co oznacza, że pliki cookie sesji wygasły. Portal nie obsługuje odświeżania tokenu w tle, więc Home Assistant nie może tego naprawić automatycznie.\n\n**Co zrobić:** Ustawienia → Urządzenia i usługi → VW Group Connect → menu z 3 kropkami → Skonfiguruj ponownie → wprowadź ponownie swoje dane logowania. Następny cykl konfiguracji ponownie otworzy sesję portalu, a integracja wznowi odpytywanie aktywnego Custom Data Request.\n\nTo ostrzeżenie zniknie samo, gdy tylko następne wywołanie API portalu się powiedzie.",
+      "title": "Sesja portalu EU Data Act wygasła – zaloguj się ponownie"
+    },
+    "data_act_wake_needed": {
+      "description": "Integracja działa w trybie awaryjnym tylko do odczytu portalu EU Data Act dla {brand} ({username}), a portal zwrócił **{streak}** odpytań z rzędu bez nowych danych dla VIN kończącego się na {vin_suffix}.\n\nPortal publikuje nowy zestaw danych dopiero po tym, jak pojazd od ostatniego razu miał zdarzenie wybudzenia. Zdarzenia wybudzenia to m.in.:\n\n- Włączenie zapłonu (jazda)\n- Podłączenie auta do ładowarki (rozpoczęcie lub zakończenie sesji ładowania)\n- Zamknięcie lub otwarcie auta (jeden pełny cykl)\n\n**Co zrobić:** wykonaj dowolną z powyższych czynności na pojeździe. W ciągu następnego 15-minutowego cyklu portalu integracja automatycznie pobierze nowy eksport, a to ostrzeżenie zniknie.\n\nJeśli naprawdę nie używałeś auta od kilku dni, brak nowych danych jest oczekiwany i nie jest błędem integracji.",
+      "title": "Portal EU Data Act: wybudź pojazd, aby odświeżyć dane ({brand})"
+    },
+    "ola_headers_outdated": {
+      "description": "Backend OLA grupy VW (serwer SEAT/CUPRA) odrzucił **{count}** żądań z rzędu z błędem HTTP 403 Forbidden – nawet po wypróbowaniu wszystkich wbudowanych zapasowych zestawów nagłówków.\n\n**Najbardziej prawdopodobna przyczyna**: VW ponownie zmienił wymagania dotyczące nagłówków identyfikujących aplikację. Zdarzyło się to 2026-05-20 i może się powtórzyć, gdy oficjalna aplikacja {brand} wyda nowe wersje.\n\n**Co zrobić:**\n\n1. **Sprawdź aktualizację integracji** – HACS → VW Group Connect → Aktualizuj. Opiekunowie zwykle wydają poprawkę nagłówków w ciągu ~1 tygodnia od zmian w upstream (monitorujemy to cotygodniowym workflow CI).\n2. **Wypróbuj nadpisanie OptionsFlow** (zaawansowane) – Ustawienia → Urządzenia i usługi → VW Group Connect → Konfiguruj → ustaw `ola_app_version_override` na nowszą wersję aplikacji (np. wersję oficjalnej aplikacji {brand} na Twoim telefonie, widoczną w ustawieniach aplikacji).\n3. **Jeśli żadne z tego nie pomoże**: otwórz zgłoszenie na GitHubie ze swoim logiem na poziomie DEBUG, abyśmy mogli to zbadać.\n\nTo ostrzeżenie zniknie samo, gdy następne żądanie się powiedzie.",
+      "title": "Nagłówki OLA {brand} mogą wymagać aktualizacji – {count} kolejnych błędów 403"
     }
   },
   "services": {
@@ -967,6 +1057,20 @@
           "description": "Which action to dispatch."
         }
       }
+    },
+    "open_app": {
+      "description": "Wyzwala zdarzenie `vag_connect_open_app` na magistrali zdarzeń HA z polami ładunku `vin`, `brand`, `deeplink_url` i `action`, aby karta Lovelace mogła otworzyć natywną aplikację mobilną marki (myAudi, WeConnect, MyŠkoda, MySEAT, MyCUPRA, My Porsche lub VW US) na urządzeniu wywołującym. Integracja nie potrafi sama otworzyć adresów URL na telefonie; za nawigację `window.location.href = deeplink_url` w iOS / Android odpowiada karta pulpitu.",
+      "fields": {
+        "action": {
+          "description": "Opcjonalny segment ścieżki dołączany do deeplinku, aby aplikacja marki przeszła bezpośrednio do sekcji. Domyślne `open` otwiera aplikację na ekranie głównym.",
+          "name": "Akcja aplikacji"
+        },
+        "vin": {
+          "description": "VIN pojazdu, którego aplikacja marki ma zostać otwarta.",
+          "name": "VIN"
+        }
+      },
+      "name": "Otwórz natywną aplikację marki (deeplink)"
     }
   },
   "exceptions": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -83,6 +83,12 @@
           "spin": "S-PIN",
           "scan_interval": "Update Interval",
           "force_enable_access": "Force Door Status"
+        },
+        "data_description": {
+          "brand": "Endast märken med stöd för webbläsarinloggning visas. Använd 'E-post + lösenord' för Volkswagen EU och Porsche.",
+          "force_enable_access": "Tvinga fram dörrstatus-entiteter även när fordonet rapporterar att data saknas.",
+          "scan_interval": "Minuter mellan fordonets datahämtningar.",
+          "spin": "Valfri 4-siffrig säkerhets-PIN för fjärråtgärder (lås, lås upp, klimat)."
         }
       },
       "browser_login_pending": {
@@ -145,7 +151,8 @@
           "wake_before_poll": "Active vehicle wake-up before status poll",
           "wake_delay_seconds": "Wake delay (seconds)",
           "client_id_override": "OAuth client_id override (power users)",
-          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request"
+          "eu_data_act_auto_kickoff": "EU Data Act: auto-kickoff Custom Data Request",
+          "enable_data_act_browser": "EU Data Act-portalen: headless-webbläsar-fallback (EXPERIMENTELL)"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",
@@ -159,7 +166,8 @@
           "wake_before_poll": "When enabled, the integration sends a wake POST to the vehicle before fetching status for any VIN that was OFFLINE on the previous poll. The car receives a server-side wake-up and pushes fresh data, then the integration waits the wake delay before the status read. Closes the 'all sensors unknown for parked cars' gap but costs one extra API call per offline VIN per poll cycle. Off by default. Reload the integration after toggling.",
           "wake_delay_seconds": "Seconds to wait between the wake-up POST and the status fetch. The default of 15 seconds is what most brand backends need to ingest the wake-induced data push. Lower values risk reading stale data; higher values stretch the poll cycle without further benefit.",
           "client_id_override": "Power-user escape hatch for when the community spots a fresh OAuth client_id in a new VW Group APK before our daily atlas builder catches it. Paste the full UUID@apps_vw-dilab_com string here and the resolver tries it FIRST on every authenticate, with all the existing client_ids still in the chain as fallback. Leave empty for default behaviour. Format: 8-4-4-4-12 hex digits followed by @apps_vw-dilab_com. Malformed values are silently ignored.",
-          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default."
+          "eu_data_act_auto_kickoff": "Only meaningful when the integration is operating in read-only EU Data Act portal mode (live BFF strategies have failed). When ON, the coordinator checks for an active 15-min Custom Data Request per VIN at startup and creates one when none exists. The kickoff implies a 1-month data subscription on your account at the portal, so this is opt-in. The portal accepts AT MOST ONE active custom request per VIN at a time. Off by default.",
+          "enable_data_act_browser": "EXPERIMENTELL: bara meningsfullt när integrationen har fallit tillbaka på EU Data Act-portalen (skrivskyddad). Styr en headless Chromium via det valfria Python-paketet 'playwright' för att automatiskt klicka på portalens dataexport-knapp. Paketet är INTE förinstallerat (det hämtar runt 100 MB Chromium). När det är aktiverat men saknas förklarar en Reparation-avisering hur du installerar det inifrån Home Assistant-containern. Ladda om integrationen efter att du växlat."
         }
       }
     }
@@ -561,6 +569,63 @@
       },
       "last_trip_reset_at": {
         "name": "Last Trip Reset"
+      },
+      "battery_temp_c": {
+        "name": "Batteritemperatur"
+      },
+      "charging_settings_pending": {
+        "name": "Laddinställningar väntar"
+      },
+      "charging_status_pending": {
+        "name": "Laddkommandon väntar"
+      },
+      "climate_remaining_time_min": {
+        "name": "Klimat – återstående tid"
+      },
+      "climate_without_external_power": {
+        "name": "Klimat utan extern ström"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimatzon fram vänster"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimatzon fram höger"
+      },
+      "climatisation_settings_pending": {
+        "name": "Klimatinställningar väntar"
+      },
+      "climatisation_status_pending": {
+        "name": "Klimatkommandon väntar"
+      },
+      "connection_active": {
+        "name": "Anslutning aktiv"
+      },
+      "connection_battery_power_level": {
+        "name": "Batterinivå (anslutning)"
+      },
+      "daily_power_budget_warning": {
+        "name": "Varning för daglig energibudget"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Varning för låg batterinivå"
+      },
+      "nav_target_soc_pct": {
+        "name": "Mål-laddnivå (navigation)"
+      },
+      "parking_map_url_dark": {
+        "name": "Parkeringskarta-URL (mörk)"
+      },
+      "parking_map_url_light": {
+        "name": "Parkeringskarta-URL (ljus)"
+      },
+      "plug_led_color": {
+        "name": "Laddkontaktens LED-färg"
+      },
+      "remaining_charge_time_nav_min": {
+        "name": "Återstående laddtid (navigation)"
+      },
+      "vehicle_nickname": {
+        "name": "Fordonets smeknamn"
       }
     },
     "binary_sensor": {
@@ -716,6 +781,15 @@
       },
       "permission_can_command": {
         "name": "Account can send commands"
+      },
+      "external_power_available": {
+        "name": "Extern strömförsörjning tillgänglig"
+      },
+      "hood_open": {
+        "name": "Motorhuv öppen"
+      },
+      "trunk_open": {
+        "name": "Bagagelucka öppen"
       }
     },
     "switch": {
@@ -887,6 +961,22 @@
     "data_act_no_data": {
       "title": "EU Data Act-portalen: ingen fordonsdata ännu ({brand})",
       "description": "EU Data Act-portalen loggade in för {brand} men returnerar ännu ingen fordonsdata.\n\nVanliga orsaker:\n\n1. **Ett avbrott på VW:s sida.** VW rapporterar ett varumärkesövergripande avbrott i EU Data Act-portalen sedan slutet av maj 2026 (enligt deras meddelande slutade infrastrukturen för dataextraktion fungera under belastning). Så länge det pågår returnerar portalen tom data för alla verktyg – inte bara den här integrationen – och återhämtar sig märke för märke.\n2. **Ingen databegäran inställd.** Portalen levererar först när du skapar en *kontinuerlig* databegäran för din bil.\n3. **Bilen har inte skickat något nytt.** En ny datamängd publiceras först efter att bilen har körts, laddats eller låsts/låsts upp.\n\n**Snabbaste kollen:** öppna `eu-data-act.drivesomethinggreater.com` i en webbläsare och logga in. Om du inte ser någon data för din bil där heller ligger felet hos VW – integrationen kan inte göra något förrän VW återställer det. Finns ingen databegäran, skapa en kontinuerlig (15-minuters), kryssa i alla datakluster, kör eller väck sedan bilen och vänta en timme eller två.\n\nDet här är den skrivskyddade portal-betan – varningen försvinner av sig själv när data kommer in."
+    },
+    "data_act_browser_missing": {
+      "description": "Du aktiverade headless-webbläsar-fallbacken för EU Data Act-portalen, men Python-paketet `playwright` är inte installerat i din Home Assistant-container.\n\n**För att installera:** öppna HA-containerns skal (Tillägg → Terminal & SSH, eller `docker exec` för en manuell installation) och kör:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nChromium-nedladdningen är stor (runt 100 MB), därför är detta beroende valfritt i stället för inbyggt i integrationen. Starta om Home Assistant efter installationen.\n\nAlternativt kan du stänga av reglaget under Inställningar → Enheter & tjänster → VW Group Connect → Konfigurera → 'EU Data Act-portalen: headless-webbläsar-fallback'.",
+      "title": "EU Data Act-portalen: valfritt paket 'playwright' saknas"
+    },
+    "data_act_session_expired": {
+      "description": "{brand}-portalen på `eu-data-act.drivesomethinggreater.com` svarade med HTTP 401 på ett API-anrop för en Custom Data Request, vilket betyder att sessionscookies har gått ut. Portalen stöder inte tokenförnyelse i bakgrunden, så Home Assistant kan inte återställa detta automatiskt.\n\n**Vad du ska göra:** Inställningar → Enheter & tjänster → VW Group Connect → 3-punktsmeny → Konfigurera om → ange dina uppgifter igen. Nästa konfigurationscykel öppnar portalsessionen på nytt och integrationen återupptar hämtningen av den aktiva Custom Data Request.\n\nDen här varningen försvinner av sig själv så snart nästa API-anrop till portalen lyckas.",
+      "title": "EU Data Act-portalsessionen har gått ut – autentisera på nytt"
+    },
+    "data_act_wake_needed": {
+      "description": "Integrationen körs i EU Data Act-portalens skrivskyddade fallback-läge för {brand} ({username}), och portalen har returnerat **{streak}** hämtningar i rad utan nya data för VIN som slutar på {vin_suffix}.\n\nPortalen publicerar en ny datamängd först efter att fordonet har haft en väckhändelse sedan förra gången. Väckhändelser inkluderar:\n\n- Att slå på tändningen (köra)\n- Att ansluta bilen till en laddare (en laddsession börjar eller slutar)\n- Att låsa eller låsa upp bilen (en hel cykel)\n\n**Vad du ska göra:** utlös någon av ovanstående på fordonet. Inom nästa 15-minuters portalcykel hämtar integrationen den nya exporten automatiskt och den här varningen försvinner.\n\nOm du verkligen inte har använt bilen på flera dagar är avsaknaden av nya data förväntad och inte ett fel i integrationen.",
+      "title": "EU Data Act-portalen: väck fordonet för att uppdatera data ({brand})"
+    },
+    "ola_headers_outdated": {
+      "description": "VW Groups OLA-backend (SEAT/CUPRA-servern) har avvisat **{count}** förfrågningar i rad med HTTP 403 Forbidden – även efter att vi provat alla inbyggda fallback-headeruppsättningar.\n\n**Mest sannolik orsak**: VW har ändrat kraven på de app-identifierande headerna igen. Det hände 2026-05-20 och kan hända igen när den officiella {brand}-appen släpper nya versioner.\n\n**Vad du ska göra:**\n\n1. **Sök efter en integrationsuppdatering** – HACS → VW Group Connect → Uppdatera. Underhållarna brukar leverera en header-justering inom ~1 vecka efter uppströmsändringar (vi övervakar via ett veckovis CI-arbetsflöde).\n2. **Prova OptionsFlow-överstyrningen** (avancerat) – Inställningar → Enheter & tjänster → VW Group Connect → Konfigurera → ställ in `ola_app_version_override` på en nyare appversion (t.ex. versionen av den officiella {brand}-appen på din telefon, synlig i appens inställningar).\n3. **Om inget hjälper**: öppna ett GitHub-ärende med din logg på DEBUG-nivå så att vi kan undersöka det.\n\nDen här varningen försvinner av sig själv när nästa förfrågan lyckas.",
+      "title": "{brand}-OLA-headers kan behöva uppdateras – {count} 403-fel i rad"
     }
   },
   "services": {
@@ -967,6 +1057,20 @@
           "description": "Which action to dispatch."
         }
       }
+    },
+    "open_app": {
+      "description": "Utlöser händelsen `vag_connect_open_app` på HA:s händelsebuss med nyttolastfälten `vin`, `brand`, `deeplink_url` och `action` så att ett Lovelace-kort kan öppna märkets nativa mobilapp (myAudi, WeConnect, MyŠkoda, MySEAT, MyCUPRA, My Porsche eller VW US) på den anropande enheten. Integrationen kan inte själv öppna URL:er på en telefon; dashboardkortet ansvarar för att navigera `window.location.href = deeplink_url` på iOS / Android.",
+      "fields": {
+        "action": {
+          "description": "Valfritt sökvägssegment som läggs till djuplänken så att märkets app går direkt till en sektion. Standardvärdet `open` öppnar appen på startskärmen.",
+          "name": "App-åtgärd"
+        },
+        "vin": {
+          "description": "VIN för fordonet vars märkesapp ska öppnas.",
+          "name": "VIN"
+        }
+      },
+      "name": "Öppna märkets app (djuplänk)"
     }
   },
   "exceptions": {


### PR DESCRIPTION
Fills every previously-untranslated string so non-English users no longer see a mix of their language and English fallback.

## What
42 leaf-paths per language were missing a translation and silently fell back to English. This completes all of them across **EN, DE, NL, SV, FR, ES, PL, CS**:

- **Entity names** — battery temperature, climate zones (front L/R), navigation charge target & ETA, parking-map links (light/dark), plug LED colour, the external-power / hood / trunk binary sensors, and the "settings/command pending" sensors.
- **Config & options helper texts** — the descriptions under the brand / S-PIN / scan-interval / force-access fields and the experimental headless-browser toggle.
- **`open_app` service** — name, description and field labels.
- **Repair notices** — wake-the-vehicle, portal session expired, optional `playwright` package missing, OLA headers outdated.

## How it was kept correct
- `en.json` synced verbatim from `strings.json` (the canonical English source).
- The seven other languages translated with everyday automotive wording rather than literal tech-speak.
- Automated placeholder-parity check: the set of `{brand}` / `{username}` / `{streak}` / `{vin_suffix}` / `{count}` tokens in every translated value must equal the English source, else the build of these files hard-fails.
- No literal URLs in any string (hassfest rule); all nine i18n files validate as JSON.
- Audit result: **0 missing / 432 leaves** in every language (was 30–42 missing each).

## Tests
All HA-independent translation/consistency tests pass locally (silencer parity, cross-lang entity-key parity, no-SoC-jargon, no-English-residue, strings↔en sync). HA-runtime tests + hassfest run in CI.