### PR TITLE
v2.12.4 — treat VW portal 5xx as transient, not auth failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.12.4] - 2026-06-08
+
+### Fixed
+
+- **VW portal outage no longer spams errors or triggers needless re-logins** (#428, #429, #430, #431). While VW's EU Data Act portal is in its ongoing outage, the data endpoints keep returning HTTP 500. We were treating that 500 as an authentication failure — so it logged an error every poll and kicked off pointless re-login attempts. A 500 is the portal having a bad moment, not a dead session, so it's now handled as "no data this poll" (the existing "no vehicle data" notice already explains the outage). A genuine 401/403 still re-authenticates exactly as before.
+
 ## [2.12.3] - 2026-06-08
 
 ### Changed

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -96,6 +96,14 @@ _USER_AGENT = (
 )
 _NO_CONTENT_SUFFIX = "_no_content_found.zip"
 _TIMEOUT_S = 60
+# v2.12.4 (#428/#429/#430/#431) — statuses that mean "the portal is having a
+# bad moment", not "your session is dead". During the VW-side all-brands
+# outage (since late May 2026) the data endpoints 500 constantly; that's a
+# transient server fault, not an auth failure, so we treat it as "no data
+# this poll" (the data_act_no_data notice already explains the outage) instead
+# of raising AuthenticationError and triggering pointless re-login churn + a
+# stream of error reports. 401/403 still mean a genuinely expired session.
+_TRANSIENT_STATUSES = (404, 410, 500, 502, 503, 504)
 
 
 # ── HTML / templateModel parsing (community-proven mechanics) ──────────────
@@ -497,16 +505,17 @@ class EUDataActConnector:
         """GET + parse JSON. Raises AuthenticationError on HTTP >= 400.
 
         v2.12.1 — ``soft=True`` returns None instead of raising for the
-        "not provisioned yet" statuses (404/410/500/502/503). Used for the
-        data-request metadata endpoint, which 404s/500s on accounts where
-        the continuous data request hasn't been enabled / hasn't propagated
-        yet (#393, #424) — that's an expected transient, not a hard error.
+        transient "not provisioned yet" / portal-outage statuses
+        (``_TRANSIENT_STATUSES``). Used for the data-request metadata
+        endpoint, which 404s/500s on accounts where the continuous data
+        request hasn't been enabled / hasn't propagated yet (#393, #424) —
+        that's an expected transient, not a hard error.
         """
         async with self._session.get(
             url, headers=headers, timeout=ClientTimeout(total=_TIMEOUT_S),
         ) as resp:
             if resp.status >= 400:
-                if soft and resp.status in (404, 410, 500, 502, 503):
+                if soft and resp.status in _TRANSIENT_STATUSES:
                     return None
                 raise AuthenticationError(f"EU Data Act GET {url} → HTTP {resp.status}")
             return await resp.json(content_type=None)
@@ -562,11 +571,26 @@ class EUDataActConnector:
                 vin[-6:],
             )
             return d
-        # 2. list datasets → newest non-empty zip
+        # 2. list datasets → newest non-empty zip. Soft on transient 5xx:
+        # during the VW outage this endpoint 500s constantly (#428-#431).
+        # A 500 here is the portal misbehaving, not a dead session, so we
+        # surface it as "no data this poll" (data_act_no_data notice) rather
+        # than raising AuthenticationError and re-logging in pointlessly.
+        # A genuine 401/403 still raises (→ session-expired path).
         listing = await self._get_json(
             f"{_PORTAL_BASE}{_LIST_PATH.format(vin=vin, identifier=identifier)}",
             headers={"type": "partial"},
+            soft=True,
         )
+        if listing is None:
+            self.last_no_data_reason = "empty"
+            _LOGGER.info(
+                "EU Data Act portal: data endpoint returned a transient error "
+                "for %s (most likely the ongoing VW-side portal outage). "
+                "Treating as no data this poll; will retry next cycle.",
+                vin[-6:],
+            )
+            return d
         files = listing if isinstance(listing, list) else listing.get("files", [])
         names: list[str] = []
         for f in files:
@@ -586,6 +610,16 @@ class EUDataActConnector:
             headers={"filename": newest, "type": "partial"},
             timeout=ClientTimeout(total=_TIMEOUT_S),
         ) as resp:
+            if resp.status in _TRANSIENT_STATUSES:
+                # Same outage story as the listing call — the ZIP download
+                # 500s mid-outage. Don't burn the session; just skip this poll.
+                self.last_no_data_reason = "empty"
+                _LOGGER.info(
+                    "EU Data Act portal: dataset download returned a transient "
+                    "error (HTTP %s) for %s; treating as no data this poll.",
+                    resp.status, vin[-6:],
+                )
+                return d
             if resp.status >= 400:
                 raise AuthenticationError(
                     f"EU Data Act portal: download → HTTP {resp.status}"

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.12.3"
+  "version": "2.12.4"
 }

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -36,6 +36,7 @@ from custom_components.vag_connect.cariad.auth._eu_data_act import (
     _walk_fields,
     map_dataset_to_vehicle_data,
 )
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
 from custom_components.vag_connect.cariad.models import VehicleData
 
 
@@ -420,3 +421,73 @@ async def test_get_vehicle_data_metadata_500_is_graceful() -> None:
     conn = EUDataActConnector(_Meta500Session())  # type: ignore[arg-type]
     d = await conn.get_vehicle_data("WVWZZZTESTVIN0009")
     assert d.battery_soc is None
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_listing_500_is_graceful() -> None:
+    """list endpoint 500 (VW outage) → bare VehicleData, no AuthenticationError.
+
+    #428-#431: during the VW-side portal outage the datadelivery ``list``
+    endpoint 500s on a valid session. v2.12.4 treats that as a transient
+    ("no data this poll") instead of misclassifying it as an
+    AuthenticationError and triggering re-login churn + error reports.
+    """
+    class _List500Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, json_data={"identifier": "ID123"})
+            if url.endswith("/list"):
+                return _FakeResp(url, status=500, json_data={})
+            raise AssertionError(f"should not reach {url} after list 500s")
+
+    conn = EUDataActConnector(_List500Session())  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    assert d.battery_soc is None
+    assert d.connection_state is None
+    assert conn.last_no_data_reason == "empty"
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_download_503_is_graceful() -> None:
+    """download endpoint 5xx (VW outage) → bare VehicleData, no raise.
+
+    The same transient story as the listing call, one step later: the
+    listing succeeds with a real file but the ZIP download 5xxs mid-outage.
+    Must not burn the session — skip the poll and surface "no data".
+    """
+    class _Download503Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, json_data={"identifier": "ID123"})
+            if url.endswith("/list"):
+                return _FakeResp(url, json_data=[{"name": "data_2026.zip"}])
+            if url.endswith("/download"):
+                return _FakeResp(url, status=503)
+            raise AssertionError(f"unmatched GET {url}")
+
+    conn = EUDataActConnector(_Download503Session())  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    assert d.battery_soc is None
+    assert d.connection_state is None
+    assert conn.last_no_data_reason == "empty"
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_listing_401_still_raises() -> None:
+    """A genuine 401 on the data endpoint must STILL raise (session expired).
+
+    The v2.12.4 transient-softening must not swallow real auth failures:
+    401/403 propagate so the re-login / session-expired path runs, while
+    only the transient 5xx/404 family is treated as "no data this poll".
+    """
+    class _List401Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, json_data={"identifier": "ID123"})
+            if url.endswith("/list"):
+                return _FakeResp(url, status=401, json_data={})
+            raise AssertionError(f"should not reach {url} on a 401")
+
+    conn = EUDataActConnector(_List401Session())  # type: ignore[arg-type]
+    with pytest.raises(AuthenticationError):
+        await conn.get_vehicle_data("WVWZZZTESTVIN0001")


### PR DESCRIPTION
Stops the error-spam users hit while VW's EU Data Act portal is in its ongoing outage.

## Root cause (verified against live reports)
The auto Error-Reporter filed #428/#429/#430/#431, all the same trace:

```
EU Data Act GET .../datadelivery/vehicles/... → HTTP 500
→ raise AuthenticationError  (_eu_data_act.py, listing call)
```

The metadata call already softened transient statuses (`soft=True`), but the **datadelivery listing** call right after it did not — so a portal 500 was raised as `AuthenticationError`. That logged an error every poll and kicked off needless re-login attempts. A 500 is the portal misbehaving, not a dead session.

## Fix
- Shared `_TRANSIENT_STATUSES` tuple (404, 410, 500, 502, 503, 504).
- The listing call now uses `soft=True`; a transient result is handled as "no data this poll" (the existing `data_act_no_data` notice already explains the VW outage) and returns the bare `VehicleData`.
- The ZIP download step gets the same treatment (it 5xxs one step later mid-outage).
- A genuine **401/403 still raises** → the session-expired / re-login path is unchanged.

No new strings/translations (reuses the existing no-data notice).

## Tests
3 regression tests added: listing 500 → no-data, download 503 → no-data, and a guard that listing 401 **still** raises `AuthenticationError`. Verified locally via a standalone importlib harness (all pass); full suite + hassfest run in CI.
