### PR TITLE
v2.12.4 — token-refresh + outage resilience (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
-## [2.12.4] - 2026-06-08
+## [2.12.4] - 2026-06-09
+
+A resilience release for the ongoing VW-side backend outage: the integration now rides out transient server errors quietly instead of treating them like a broken login.
 
 ### Fixed
 
 - **VW portal outage no longer spams errors or triggers needless re-logins** (#428, #429, #430, #431). While VW's EU Data Act portal is in its ongoing outage, the data endpoints keep returning HTTP 500. We were treating that 500 as an authentication failure — so it logged an error every poll and kicked off pointless re-login attempts. A 500 is the portal having a bad moment, not a dead session, so it's now handled as "no data this poll" (the existing "no vehicle data" notice already explains the outage). A genuine 401/403 still re-authenticates exactly as before.
+- **Token-refresh hiccups no longer look like a wrong password** (#438). When the VW token server returns a transient gateway error (HTTP 502/503/504) on an otherwise-valid login — common while their backend is flaky — the integration was treating it as an authentication failure: it popped up a "please reconfigure" reauth prompt and filed error reports for what is purely a VW-side blip. Now a 5xx on the token endpoint is treated as "VW backend temporarily unavailable": your entities keep their last value, the integration retries on the next poll, and nothing prompts you to re-enter credentials. A genuinely rejected refresh token (HTTP 400) still triggers a real re-login. Applies to every brand (Audi, VW, Škoda, SEAT, CUPRA).
+- **Quieter during outages** (#435, #436, #437, #438, #439). Transient VW-backend 5xx errors — the kind above — no longer get escalated to the in-app Error Reporter. They're a server-side outage symptom, not an actionable bug, and were generating a stream of noise reports. Your entities stay available through the normal failure-tolerance window in the meantime.
 
 ## [2.12.3] - 2026-06-08
 

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -42,6 +42,12 @@ from ..models import BrandConfig, TokenSet
 _LOGGER = logging.getLogger(__name__)
 
 _AUTH_TIMEOUT = ClientTimeout(total=30)  # per-request timeout for auth flows
+# v2.12.4 (#438) — token-endpoint statuses that mean "VW backend is having a
+# bad moment", not "your refresh token is dead". A 5xx here is transient
+# (gateway/Azure-WAF flakiness during the 2026 outage) → raise
+# UpstreamUnavailableError so the coordinator tolerates it instead of
+# triggering reauth. (400 still means a genuinely rejected refresh token.)
+_TRANSIENT_TOKEN_STATUSES = (500, 502, 503, 504)
 
 _IDK_BASE = "https://identity.vwgroup.io"
 _SIGNIN_BASE = f"{_IDK_BASE}/signin-service/v1"
@@ -1292,6 +1298,17 @@ class IDKAuth:
         ) as resp:
             if resp.status == 400:
                 raise TokenExpiredError("Refresh token rejected — full re-login required.")
+            # v2.12.4 (#438) — a 5xx on the token endpoint is a transient
+            # gateway/backend fault (the VW Group Azure infra has been flaky
+            # through the late-May 2026 outage), NOT a credentials problem.
+            # Raising AuthenticationError here wrongly triggered the HA reauth
+            # flow + filed Error-Reporter issues for a server-side blip.
+            # UpstreamUnavailableError is not an AuthenticationError, so the
+            # coordinator tolerates it (entities stay available via the
+            # failure-tolerance window) and retries next poll instead of
+            # prompting for re-login.
+            if resp.status in _TRANSIENT_TOKEN_STATUSES:
+                raise UpstreamUnavailableError(resp.status, self._brand.name)
             if resp.status != 200:
                 raise AuthenticationError(f"Token refresh returned HTTP {resp.status}")
             payload: dict[str, Any] = await resp.json()
@@ -1315,6 +1332,9 @@ class IDKAuth:
         ) as resp:
             if resp.status == 400:
                 raise TokenExpiredError("Škoda refresh token rejected.")
+            # v2.12.4 (#438) — transient 5xx → upstream-unavailable, not auth.
+            if resp.status in _TRANSIENT_TOKEN_STATUSES:
+                raise UpstreamUnavailableError(resp.status, self._brand.name)
             if resp.status != 200:
                 raise AuthenticationError(f"Škoda token refresh HTTP {resp.status}")
             payload: dict[str, Any] = await resp.json()

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1054,18 +1054,36 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         # gets logged in the ring buffer with masked context so
                         # users can 1-click report it. Wrapped in try/except —
                         # error reporting must NEVER raise.
-                        try:
-                            record_error(
-                                self.error_buffer,
-                                exception=result,
-                                brand=self.entry.data.get(CONF_BRAND, ""),
-                                vin=vin,
-                                model_year=self.vehicles.get(vin, {}).get("model_year"),
-                                firmware=self.vehicles.get(vin, {}).get("firmware_version"),
-                                endpoint="get_status",
-                            )
-                        except Exception:  # noqa: BLE001
-                            pass
+                        # v2.12.4 (#438) — but DON'T escalate a transient
+                        # VW-backend 5xx (token-endpoint UpstreamUnavailableError,
+                        # or a data endpoint that exhausted its 5xx retries) to
+                        # the Error Reporter. It's not our bug and not actionable;
+                        # this is what spammed #435-#439 during the late-May
+                        # outage. The vehicle still keeps its last-known data
+                        # (above) and recovers on the next poll.
+                        from .cariad.exceptions import (  # noqa: PLC0415
+                            APIError,
+                            UpstreamUnavailableError,
+                        )
+                        is_transient_upstream = isinstance(
+                            result, UpstreamUnavailableError
+                        ) or (
+                            isinstance(result, APIError)
+                            and getattr(result, "status", 0) >= 500
+                        )
+                        if not is_transient_upstream:
+                            try:
+                                record_error(
+                                    self.error_buffer,
+                                    exception=result,
+                                    brand=self.entry.data.get(CONF_BRAND, ""),
+                                    vin=vin,
+                                    model_year=self.vehicles.get(vin, {}).get("model_year"),
+                                    firmware=self.vehicles.get(vin, {}).get("firmware_version"),
+                                    endpoint="get_status",
+                                )
+                            except Exception:  # noqa: BLE001
+                                pass
                     elif isinstance(result, VehicleData):
                         # v1.10.1 (#58 Phase 2) — wrap to_dict + _enrich
                         # in their own try/except. A single VehicleData
@@ -1223,25 +1241,43 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception as err:  # noqa: BLE001
                 # Auth failure that survived the client's refresh-then-relogin
                 # fallback means the credentials are stale. Trigger HA reauth.
-                from .cariad.exceptions import AuthenticationError  # noqa: PLC0415
+                from .cariad.exceptions import (  # noqa: PLC0415
+                    APIError,
+                    AuthenticationError,
+                    UpstreamUnavailableError,
+                )
                 if isinstance(err, AuthenticationError):
                     self._trigger_reauth(str(err) or type(err).__name__)
                     await self._async_push_update({}, success=False)
                     return
-                _LOGGER.error("VAG Connect poll error: %s", err)
-                # v1.9.0 — Error Reporter: outer poll-loop crash gets a
-                # buffer entry too. Critical because these are the kind of
-                # errors users hit and never know about (silent except).
-                try:
-                    record_error(
-                        self.error_buffer,
-                        exception=err,
-                        brand=self.entry.data.get(CONF_BRAND, ""),
-                        endpoint="poll_loop",
+                # v2.12.4 (#438) — a transient VW-backend 5xx that escaped the
+                # per-VIN handler (UpstreamUnavailableError, or a 5xx APIError)
+                # is logged but NOT escalated to the Error Reporter: it's a
+                # server-side outage symptom, not our bug, and escalating it
+                # spammed #435-#439. Entities stay available via the
+                # failure-tolerance window below.
+                is_transient_upstream = isinstance(err, UpstreamUnavailableError) or (
+                    isinstance(err, APIError) and getattr(err, "status", 0) >= 500
+                )
+                if is_transient_upstream:
+                    _LOGGER.warning(
+                        "VAG Connect: VW backend temporarily unavailable — %s", err
                     )
-                    self._refresh_reporter_issues()
-                except Exception:  # noqa: BLE001
-                    pass
+                else:
+                    _LOGGER.error("VAG Connect poll error: %s", err)
+                    # v1.9.0 — Error Reporter: outer poll-loop crash gets a
+                    # buffer entry too. Critical because these are the kind of
+                    # errors users hit and never know about (silent except).
+                    try:
+                        record_error(
+                            self.error_buffer,
+                            exception=err,
+                            brand=self.entry.data.get(CONF_BRAND, ""),
+                            endpoint="poll_loop",
+                        )
+                        self._refresh_reporter_issues()
+                    except Exception:  # noqa: BLE001
+                        pass
                 if not hasattr(self, "vehicle_success"):
                     self.vehicle_success = {}
                 if not hasattr(self, "vehicle_failure_count"):

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -2814,10 +2814,14 @@ class TestIDKAuthAdditional:
                 auth._follow_to_app_redirect("https://idp/auth", {}, "myaudi:///")
             )
 
-    def test_refresh_non_200_non_400_raises(self):
-        """Non-200/400 status on refresh raises AuthenticationError."""
+    def test_refresh_5xx_raises_upstream_unavailable(self):
+        """v2.12.4 (#438): a transient 5xx on refresh → UpstreamUnavailableError
+        (server-side outage), NOT AuthenticationError — the latter wrongly
+        triggered the HA reauth flow + Error-Reporter spam for a VW-side blip."""
         from custom_components.vag_connect.cariad.auth.idk import IDKAuth
-        from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+        from custom_components.vag_connect.cariad.exceptions import (
+            UpstreamUnavailableError,
+        )
         from custom_components.vag_connect.cariad.models import BRAND_SKODA
 
         oidc = self._resp(200, json_data={"token_endpoint": "https://idp/token"})
@@ -2826,7 +2830,23 @@ class TestIDKAuthAdditional:
         session.get = MagicMock(return_value=oidc)
         session.post = MagicMock(return_value=bad)
         auth = IDKAuth(session, BRAND_SKODA)
-        with pytest.raises(AuthenticationError, match="503"):
+        with pytest.raises(UpstreamUnavailableError, match="503"):
+            asyncio.get_event_loop().run_until_complete(auth.refresh("old_token"))
+
+    def test_refresh_non_200_non_5xx_raises_auth(self):
+        """A non-200 that is neither 400 nor a 5xx (e.g. 401) is still a genuine
+        auth failure and must raise AuthenticationError."""
+        from custom_components.vag_connect.cariad.auth.idk import IDKAuth
+        from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+        from custom_components.vag_connect.cariad.models import BRAND_SKODA
+
+        oidc = self._resp(200, json_data={"token_endpoint": "https://idp/token"})
+        bad = self._resp(401, text="Unauthorized")
+        session = MagicMock()
+        session.get = MagicMock(return_value=oidc)
+        session.post = MagicMock(return_value=bad)
+        auth = IDKAuth(session, BRAND_SKODA)
+        with pytest.raises(AuthenticationError, match="401"):
             asyncio.get_event_loop().run_until_complete(auth.refresh("old_token"))
 
     def test_idk_auth_hmac_extraction_from_js(self):

--- a/tests/test_v2124_token_refresh_transient.py
+++ b/tests/test_v2124_token_refresh_transient.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.12.4 (#438) — token-refresh transient 5xx must not be an auth failure.
+
+During the VW-side EU Data Act / CARIAD outage the token endpoint returns
+502/503 on otherwise-valid refresh tokens. Treating that as
+``AuthenticationError`` wrongly triggered the Home Assistant reauth flow and
+spammed Error-Reporter issues (#435–#439) for a server-side blip.
+
+``refresh()`` now raises ``UpstreamUnavailableError`` (a non-auth transient
+the coordinator tolerates) on 5xx. A 400 still means a genuinely rejected
+refresh token (→ full re-login), and 401/403 still raise ``AuthenticationError``.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth.idk import IDKAuth
+from custom_components.vag_connect.cariad.exceptions import (
+    AuthenticationError,
+    TokenExpiredError,
+    UpstreamUnavailableError,
+)
+
+
+class _Resp:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *_a: object) -> bool:
+        return False
+
+    async def json(self) -> dict:
+        return {}
+
+
+class _Session:
+    """Minimal aiohttp-ish session: every POST returns the canned status."""
+
+    def __init__(self, status: int) -> None:
+        self._status = status
+
+    def post(self, *_a: object, **_kw: object) -> _Resp:
+        return _Resp(self._status)
+
+
+def _brand(name: str) -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        name=name,
+        client_id="cid",
+        client_secret="",
+        user_agent="ua/1.0",
+        android_package_name="de.test.app",
+    )
+
+
+def _auth(name: str, status: int) -> IDKAuth:
+    """Build an IDKAuth without running __init__; refresh() raises on the
+    canned status before it touches anything else."""
+    a = IDKAuth.__new__(IDKAuth)
+    a._brand = _brand(name)  # type: ignore[attr-defined]
+    a._session = _Session(status)  # type: ignore[assignment]
+    a._get_token_endpoint = lambda: "https://token.example/oidc/token"  # type: ignore[method-assign]
+    return a
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+async def test_cariad_refresh_5xx_is_upstream_unavailable(status: int) -> None:
+    """A 5xx on the CARIAD token endpoint → UpstreamUnavailableError, not auth."""
+    with pytest.raises(UpstreamUnavailableError):
+        await _auth("volkswagen", status).refresh("rt")
+
+
+@pytest.mark.asyncio
+async def test_cariad_refresh_400_is_token_expired() -> None:
+    """400 still means the refresh token is genuinely rejected (full re-login)."""
+    with pytest.raises(TokenExpiredError):
+        await _auth("volkswagen", 400).refresh("rt")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [401, 403])
+async def test_cariad_refresh_auth_statuses_still_raise_auth(status: int) -> None:
+    """401/403 are genuine auth failures and must still raise (unchanged)."""
+    with pytest.raises(AuthenticationError):
+        await _auth("volkswagen", status).refresh("rt")
+
+
+@pytest.mark.asyncio
+async def test_skoda_refresh_5xx_is_upstream_unavailable() -> None:
+    """Škoda's proprietary refresh endpoint gets the same transient treatment."""
+    with pytest.raises(UpstreamUnavailableError):
+        await _auth("skoda", 503).refresh("rt")
+
+
+@pytest.mark.asyncio
+async def test_skoda_refresh_400_is_token_expired() -> None:
+    with pytest.raises(TokenExpiredError):
+        await _auth("skoda", 400).refresh("rt")


### PR DESCRIPTION
Second resilience fix for the ongoing VW backend outage, folded into the not-yet-tagged v2.12.4 (which already carries the portal-5xx fix).

## Root cause (verified against live reports + source)
The Error Reporter filed #438 (Audi, 12 errors) with:

```
Token refresh returned HTTP 502
→ idk.py refresh(): raise AuthenticationError   (line 1296)
```

`idk.py refresh()` raised `AuthenticationError` on **any** non-200 except 400. A 502/503 is a transient gateway fault (VW's Azure/CARIAD infra has been flaky through the outage), not a dead refresh token — but `AuthenticationError` makes the coordinator pop the **HA reauth prompt** ("please reconfigure credentials") and the failure gets filed to the Error Reporter (the #435–#439 noise).

This is the same fix-class as the portal-5xx fix already in v2.12.4, but a **different code path** (the token-based BFF, which Audi/VW/SEAT/CUPRA/Škoda all use — not the EU Data Act portal).

## Fix
- **`idk.py refresh()` + `_refresh_skoda()`**: a 5xx (`500/502/503/504`) now raises the existing **`UpstreamUnavailableError`** ("VW backend temporarily unavailable, not your password") instead of `AuthenticationError`. `400` still → `TokenExpiredError` (real re-login); `401/403` still → `AuthenticationError`.
- **Coordinator**: a transient VW-backend 5xx (`UpstreamUnavailableError`, or a 5xx `APIError`) is logged but **no longer escalated to the Error Reporter** — it's a server-side outage symptom, not an actionable bug. Entities stay available via the existing `_FAILURE_TOLERANCE` / 6h stale-cache window.

`UpstreamUnavailableError` is **not** a subclass of `AuthenticationError`, so the coordinator's reauth trigger is correctly skipped.

## Why "keep last value" needed no new code
The per-VIN poll handler already retains the previous data (`fresh[vin] = old`) on failure and `is_vehicle_available()` tolerates 3 consecutive failures, then a 6h stale-cache window. So entities already survive transient blips — this PR just stops the misclassification + the issue-spam.

## Deferred on purpose
- **Bootstrap-merge** (multi-ZIP latest-per-field) and **#392 Cupra Formentor PHEV mapping** — mistimed mid-outage (more downloads against a 500-ing portal; only helps with multiple non-empty datasets that don't exist now), and #392 needs a real Formentor dataset rather than guessed key paths. Both will follow as a focused change once VW recovers.

## Tests
5 regression tests: CARIAD refresh 5xx → `UpstreamUnavailableError`, 400 → `TokenExpiredError`, 401/403 → `AuthenticationError`, plus Škoda 5xx/400. Verified locally via a standalone importlib harness; full suite + hassfest run in CI.
