### PR TITLE
fix(scout): 4-segment chargingTimers/chargingProfiles silencer (#446, #448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Audi scout noise on deeper charging timer/profile fields** (#446, #448). The selectivestatus backend started nesting `chargingTimers` / `chargingProfiles` one level deeper (4 segments, e.g. `…Status.value.timers`); registered the deeper wildcards so the Vehicle Data Scout stops re-flagging fields we already read.
+
 ### Changed
 
 - Housekeeping: removed an orphaned repair-notice translation key (`data_act_wake_needed`) that was superseded by the "no vehicle data" notice and is never shown. No user-facing change.

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -642,6 +642,13 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "chargingTimers", "chargingTimers.*", "chargingTimers.*.*",
             "charging.chargingTimers", "charging.chargingTimers.*",
             "charging.chargingTimers.*.*",
+            # v2.13.0 (#446 + #448 audi) — the backend nests these ONE LEVEL
+            # DEEPER again: e.g. ``chargingTimers.chargingTimersStatus.value.
+            # timers`` and ``chargingProfiles.chargingProfilesStatus.value.
+            # profiles`` (4 segments). Equal-depth matcher → add 4-deep (and
+            # the charging.-prefixed 5-deep) wildcards for each container.
+            "chargingProfiles.*.*.*", "charging.chargingProfiles.*.*.*",
+            "chargingTimers.*.*.*", "charging.chargingTimers.*.*.*",
             # v2.12.1 (#423) — DC counterpart of the long-parsed
             # autoUnlockPlugWhenChargedAC setting.
             "charging.chargingSettings.value.autoUnlockPlugWhenChargedDC",

--- a/tests/test_v2130_scout_4seg_silencer.py
+++ b/tests/test_v2130_scout_4seg_silencer.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.13.0 (#446 + #448) — 4-segment chargingTimers/chargingProfiles silencer.
+
+The Audi selectivestatus backend started nesting these one level deeper than
+v2.12.1 covered: e.g. ``chargingTimers.chargingTimersStatus.value.timers``
+(4 segments). The equal-depth wildcard matcher needs a 4-deep pattern; this
+pins that the Scout no longer flags them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_CAR = Path(__file__).resolve().parent.parent / "custom_components" / "vag_connect" / "cariad"
+
+
+def _load_uk():
+    def fake(name, path):
+        m = types.ModuleType(name)
+        m.__path__ = [str(path)]
+        sys.modules[name] = m
+
+    fake("_uk2130", _CAR.parent.parent)
+    fake("_uk2130.vag_connect", _CAR.parent)
+    fake("_uk2130.vag_connect.cariad", _CAR)
+
+    def load(n, f):
+        spec = importlib.util.spec_from_file_location(n, f)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[n] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    load("_uk2130.vag_connect.cariad._util", _CAR / "_util.py")
+    return load("_uk2130.vag_connect.cariad._unexpected_keys", _CAR / "_unexpected_keys.py")
+
+
+_SCOUT_PATHS = [
+    "chargingTimers.chargingTimersStatus.value.carCapturedTimestamp",
+    "chargingTimers.chargingTimersStatus.value.timeInCar",
+    "chargingTimers.chargingTimersStatus.value.timers",
+    "chargingProfiles.chargingProfilesStatus.value.carCapturedTimestamp",
+    "chargingProfiles.chargingProfilesStatus.value.timeInCar",
+    "chargingProfiles.chargingProfilesStatus.value.nextChargingTimer",
+    "chargingProfiles.chargingProfilesStatus.value.profiles",
+]
+
+
+@pytest.mark.parametrize("path", _SCOUT_PATHS)
+def test_4segment_charging_paths_silenced_audi(path: str) -> None:
+    uk = _load_uk()
+    expected = uk.EXPECTED_KEYS["audi"]["selectivestatus"]
+    assert uk._path_matches(path, expected), f"Scout still flags {path}"
+
+
+def test_audi_inherits_volkswagen_selectivestatus() -> None:
+    uk = _load_uk()
+    assert uk.EXPECTED_KEYS["audi"] is uk.EXPECTED_KEYS["volkswagen"]


### PR DESCRIPTION
Registers 4-deep wildcards so the Vehicle Data Scout stops re-flagging the deeper-nested Audi selectivestatus charging-timer/profile fields (e.g. chargingTimers.chargingTimersStatus.value.timers). +8 pin-tests. Part of the v2.13.0 collection (no tag yet).