### PR TITLE
feat(auth): device-code portal-login foundation (v2.13.0 A1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+
+- Foundation for VW EU / CUPRA / SEAT **device-code (QR) portal login** (v2.13.0, landing in stages): the device-grant module can now mint and refresh the EU-Data-Act portal-client tokens (`PORTAL_DAG_BRANDS` + the `device_grant_portal` strategy), routed separately from the CARIAD-BFF device-grant so the portal-only token never hits the BFF. Connector Bearer mode, runtime routing and the config-flow QR step land in the same v2.13.0 release.
+
 ### Fixed
 
 - **Audi scout noise on deeper charging timer/profile fields** (#446, #448). The selectivestatus backend started nesting `chargingTimers` / `chargingProfiles` one level deeper (4 segments, e.g. `…Status.value.timers`); registered the deeper wildcards so the Vehicle Data Scout stops re-flagging fields we already read.

--- a/custom_components/vag_connect/cariad/auth/_device_grant.py
+++ b/custom_components/vag_connect/cariad/auth/_device_grant.py
@@ -133,6 +133,7 @@ class DeviceAuthorizationGrant:
         client_id: str,
         *,
         scope: str = "openid profile",
+        strategy: str = "device_grant",
     ) -> None:
         """Initialise with the brand-specific OAuth client_id + scope.
 
@@ -150,6 +151,13 @@ class DeviceAuthorizationGrant:
         self._session = session
         self._client_id = client_id
         self._scope = scope
+        # v2.13.0 — the strategy tag this grant stamps onto its TokenSet.
+        # ``device_grant`` = normal CARIAD-BFF brands (Audi/Škoda/SEAT/CUPRA).
+        # ``device_grant_portal`` = the EU-Data-Act PORTAL clients (VW EU +
+        # CUPRA/SEAT reserve) whose token the BFF rejects but the portal
+        # proxy_api accepts (read-only). The tag routes the token to the
+        # right consumer downstream (see base.py / coordinator).
+        self._strategy = strategy
 
     async def request_device_code(self) -> DeviceCodeResponse:
         """Start the flow — call ``/device_authorization`` once.
@@ -302,7 +310,7 @@ class DeviceAuthorizationGrant:
                     refresh_token=refresh_token,
                     id_token=id_token,
                     expires_at=expires_at,
-                    strategy="device_grant",
+                    strategy=self._strategy,
                 )
 
             err = payload.get("error", "")
@@ -338,6 +346,64 @@ class DeviceAuthorizationGrant:
                 f"Device grant: unexpected /token error {status} "
                 f"({err}): {err_desc}"
             )
+
+    async def refresh(self, refresh_token: str) -> TokenSet:
+        """Refresh a device-grant token at the IDP token endpoint.
+
+        v2.13.0 — public client, no secret: POST ``grant_type=refresh_token``
+        to ``identity.vwgroup.io/oidc/v1/token`` with our ``client_id`` +
+        ``scope``. Mirrors ``poll_for_tokens`` 200-handling and preserves
+        ``self._strategy`` so a refreshed ``device_grant_portal`` token stays
+        portal-tagged. Any non-200 raises ``AuthenticationError`` so the caller
+        can fall back (to a fresh device-code prompt).
+
+        NOTE: the refresh round-trip for the PORTAL client (``9b58543e``) was
+        not live-verified at design time — only mint + proxy_api read were. If
+        the IDP rejects it at runtime, the integration degrades to re-prompting
+        the QR login; no data loss, just a re-auth.
+        """
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
+        data = {
+            "grant_type": "refresh_token",
+            "client_id": self._client_id,
+            "refresh_token": refresh_token,
+            "scope": self._scope,
+        }
+        try:
+            async with self._session.post(
+                _IDP_TOKEN_URL,
+                data=data,
+                timeout=ClientTimeout(total=_REQUEST_TIMEOUT_S),
+            ) as resp:
+                status = resp.status
+                payload = await resp.json(content_type=None)
+        except AuthenticationError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise AuthenticationError(
+                f"Device grant refresh: request failed ({exc})"
+            ) from exc
+
+        if status != 200:
+            err = payload.get("error", "") if isinstance(payload, dict) else ""
+            raise AuthenticationError(
+                f"Device grant refresh: IDP returned HTTP {status} ({err})"
+            )
+        access_token = payload.get("access_token", "")
+        if not access_token:
+            raise AuthenticationError(
+                "Device grant refresh: 200 but no access_token in payload"
+            )
+        return TokenSet(
+            access_token=access_token,
+            # The IDP may rotate the refresh_token; reuse the old one if it
+            # doesn't return a fresh one.
+            refresh_token=payload.get("refresh_token") or refresh_token,
+            id_token=payload.get("id_token", ""),
+            expires_at=time.time() + int(payload.get("expires_in", 3600)) - 60,
+            strategy=self._strategy,
+        )
 
     async def run(
         self,
@@ -402,3 +468,42 @@ def is_dag_eligible(brand_name: str) -> bool:
     the given brand. Strategy resolver in base.py consults this before
     putting DAG at the head of the chain."""
     return brand_name.lower() in DAG_ENABLED_BRANDS
+
+
+# v2.13.0 — PORTAL device grant. SEPARATE from DAG_ENABLED_BRANDS because the
+# token these brands mint comes from the EU-Data-Act PORTAL client
+# (aud=9b58543e VW / f85e5b69 CUPRA·SEAT) which the CARIAD BFF REJECTS (403
+# "clientId not whitelisted") but the portal proxy_api ACCEPTS (read-only).
+# The VW EU *app* clients above are still DAG-dead; the *portal* client is NOT
+# — it returns a working RFC-8628 flow at /oidc/v1/device_authorization.
+# Live-verified 2026-06-12 (VW, real EU account: device_code → bearer →
+# proxy_api 200). CUPRA/SEAT: device_authorization 200 confirmed; proxy_api
+# Bearer data path UNVERIFIED — armed reserve while the OLA route is
+# server-side blocked (may recover).
+PORTAL_DAG_BRANDS = frozenset({"volkswagen", "cupra", "seat"})
+
+
+def is_portal_dag_eligible(brand_name: str) -> bool:
+    """True for brands whose device grant must use the EU-Data-Act PORTAL
+    client + read-only proxy_api path (NOT the CARIAD-BFF app client)."""
+    return brand_name.lower() in PORTAL_DAG_BRANDS
+
+
+def portal_dag_config(brand_name: str) -> tuple[str, str] | None:
+    """``(client_id, scope)`` for the portal device grant, sourced from the
+    proven ``_EUDA_BRANDS`` table — but ONLY for ``PORTAL_DAG_BRANDS``.
+
+    Returns ``None`` for any other brand. NOTE (v2.13.0 audit): audi/skoda map
+    to the VW client inside ``_EUDA_BRANDS``, so a bare table lookup would
+    wrongly self-gate them into portal mode. The ``PORTAL_DAG_BRANDS`` guard
+    prevents that, so callers may safely gate on
+    ``portal_dag_config(brand) is not None``.
+    """
+    if brand_name.lower() not in PORTAL_DAG_BRANDS:
+        return None
+    from ._eu_data_act import _EUDA_BRANDS  # noqa: PLC0415
+
+    cfg = _EUDA_BRANDS.get(brand_name.lower())
+    if cfg is None:
+        return None
+    return cfg["client_id"], cfg["scope"]

--- a/tests/test_v2130_portal_device_grant.py
+++ b/tests/test_v2130_portal_device_grant.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.13.0 Block A1 — portal device-grant plumbing in _device_grant.py.
+
+The EU-Data-Act PORTAL clients (VW 9b58543e, CUPRA/SEAT f85e5b69) support a
+public device-grant whose token the portal proxy_api accepts (read-only) but
+the CARIAD BFF rejects. These are routed via PORTAL_DAG_BRANDS + the
+device_grant_portal strategy tag, SEPARATE from the BFF DAG path.
+
+Audit-pinned: portal_dag_config MUST return None for audi/skoda (they map to
+the VW client inside _EUDA_BRANDS, so a bare table lookup would wrongly
+self-gate them into portal mode).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_CAR = Path(__file__).resolve().parent.parent / "custom_components" / "vag_connect" / "cariad"
+
+
+def _load_dg():
+    for n, p in [
+        ("_pg", _CAR.parent.parent),
+        ("_pg.vag_connect", _CAR.parent),
+        ("_pg.vag_connect.cariad", _CAR),
+        ("_pg.vag_connect.cariad.auth", _CAR / "auth"),
+    ]:
+        m = types.ModuleType(n)
+        m.__path__ = [str(p)]
+        sys.modules[n] = m
+
+    def load(n, f):
+        spec = importlib.util.spec_from_file_location(n, f)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[n] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    load("_pg.vag_connect.cariad.exceptions", _CAR / "exceptions.py")
+    load("_pg.vag_connect.cariad.models", _CAR / "models.py")
+    load("_pg.vag_connect.cariad.auth._eu_data_act", _CAR / "auth" / "_eu_data_act.py")
+    return load("_pg.vag_connect.cariad.auth._device_grant", _CAR / "auth" / "_device_grant.py")
+
+
+def test_portal_dag_config_vw():
+    dg = _load_dg()
+    cid, scope = dg.portal_dag_config("volkswagen")
+    assert cid.startswith("9b58543e")
+    assert scope == "openid cars profile"
+
+
+@pytest.mark.parametrize("brand", ["cupra", "seat"])
+def test_portal_dag_config_cupra_seat(brand):
+    dg = _load_dg()
+    cid, scope = dg.portal_dag_config(brand)
+    assert cid.startswith("f85e5b69")
+    assert scope == "openid profile cars"
+
+
+@pytest.mark.parametrize("brand", ["audi", "skoda", "porsche"])
+def test_portal_dag_config_none_for_non_portal_brands(brand):
+    """Audit #1 — audi/skoda map to the VW client in _EUDA_BRANDS, but the
+    PORTAL_DAG_BRANDS guard must keep them OUT of portal device-grant."""
+    dg = _load_dg()
+    assert dg.portal_dag_config(brand) is None
+
+
+def test_is_portal_dag_eligible():
+    dg = _load_dg()
+    assert dg.is_portal_dag_eligible("volkswagen")
+    assert dg.is_portal_dag_eligible("cupra")
+    assert not dg.is_portal_dag_eligible("audi")
+
+
+def test_dag_enabled_brands_unchanged():
+    """The BFF DAG set must NOT gain volkswagen (would route to the dead BFF)."""
+    dg = _load_dg()
+    assert dg.DAG_ENABLED_BRANDS == frozenset({"audi", "skoda", "seat", "cupra"})
+    assert "volkswagen" not in dg.DAG_ENABLED_BRANDS
+
+
+def test_strategy_param_wired():
+    dg = _load_dg()
+    g = dg.DeviceAuthorizationGrant(None, "cid", scope="s", strategy="device_grant_portal")
+    assert g._strategy == "device_grant_portal"
+    g2 = dg.DeviceAuthorizationGrant(None, "cid")
+    assert g2._strategy == "device_grant"  # backward-compatible default


### PR DESCRIPTION
First block of the v2.13.0 device-code/QR portal-login collection. Adds PORTAL_DAG_BRANDS + portal_dag_config (gated so audi/skoda return None) + a strategy param + refresh() on DeviceAuthorizationGrant. Non-breaking, additive, +9 tests. Foundation only — connector Bearer mode, routing and the config-flow QR step land next in the same v2.13.0 cut (no tag yet).