### PR TITLE
feat(auth): connector Bearer mode for device-code portal (v2.13.0 A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ### Added
 
-- Foundation for VW EU / CUPRA / SEAT **device-code (QR) portal login** (v2.13.0, landing in stages): the device-grant module can now mint and refresh the EU-Data-Act portal-client tokens (`PORTAL_DAG_BRANDS` + the `device_grant_portal` strategy), routed separately from the CARIAD-BFF device-grant so the portal-only token never hits the BFF. Connector Bearer mode, runtime routing and the config-flow QR step land in the same v2.13.0 release.
+- Foundation for VW EU / CUPRA / SEAT **device-code (QR) portal login** (v2.13.0, landing in stages): the device-grant module can now mint and refresh the EU-Data-Act portal-client tokens (`PORTAL_DAG_BRANDS` + the `device_grant_portal` strategy), routed separately from the CARIAD-BFF device-grant so the portal-only token never hits the BFF, and the portal connector now accepts those tokens as an `Authorization: Bearer` (read-only proxy_api) instead of the fragile cookie-scrape. Runtime routing and the config-flow QR step land in the same v2.13.0 release.
 
 ### Fixed
 

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -376,6 +376,7 @@ class EUDataActConnector:
         brand: str = "volkswagen",
         country: str = "de",
         language: str = "de",
+        access_token: str | None = None,
     ) -> None:
         self._session = session
         cfg = _EUDA_BRANDS.get(brand.lower())
@@ -399,9 +400,31 @@ class EUDataActConnector:
         #                  VW-side portal outage at the metadata layer)
         #   "empty"      → request exists but the portal delivered no dataset
         self.last_no_data_reason: str = ""
+        # v2.13.0 — device-code/QR Bearer mode. When set, every proxy_api call
+        # authenticates via ``Authorization: Bearer <token>`` (the device-grant
+        # access_token, aud=portal client) instead of the cookie-scrape session,
+        # and login() becomes a no-op. None → legacy cookie mode (unchanged).
+        self._bearer: str | None = access_token
+
+    def set_bearer(self, token: str) -> None:
+        """Inject / refresh the device-grant access_token for Bearer mode.
+
+        Switches the connector to header auth and marks it logged-in without a
+        cookie-scrape login(). Called on auth and after every token refresh so
+        the long-lived connector never carries a stale bearer (which would 401
+        mid-poll)."""
+        self._bearer = token
+        self.logged_in = True
 
     async def login(self, email: str, password: str) -> None:
-        """Run the OIDC code-flow login; portal backend sets cookies."""
+        """Run the OIDC code-flow login; portal backend sets cookies.
+
+        v2.13.0 — in device-code Bearer mode (``self._bearer`` set) this is a
+        no-op: the device-grant already minted the token, so there is no SPA
+        scrape to run (this is what retires the #388/#393 fragility)."""
+        if self._bearer:
+            self.logged_in = True
+            return
         headers = {"User-Agent": _USER_AGENT}
 
         # 0. Prime portal session cookies (AEM load-balancer state).
@@ -511,8 +534,14 @@ class EUDataActConnector:
         request hasn't been enabled / hasn't propagated yet (#393, #424) —
         that's an expected transient, not a hard error.
         """
+        # v2.13.0 — Bearer mode: attach the device-grant token. Covers every
+        # JSON proxy_api call (vehicles list, metadata, datadelivery list,
+        # relation) since they all funnel through here. No-op in cookie mode.
+        eff_headers = dict(headers or {})
+        if self._bearer:
+            eff_headers["Authorization"] = f"Bearer {self._bearer}"
         async with self._session.get(
-            url, headers=headers, timeout=ClientTimeout(total=_TIMEOUT_S),
+            url, headers=eff_headers, timeout=ClientTimeout(total=_TIMEOUT_S),
         ) as resp:
             if resp.status >= 400:
                 if soft and resp.status in _TRANSIENT_STATUSES:
@@ -604,10 +633,15 @@ class EUDataActConnector:
             _LOGGER.debug("EU Data Act portal: no dataset files for %s yet", vin[-6:])
             return d
         newest = names[-1]
-        # 3. download ZIP → JSON
+        # 3. download ZIP → JSON. This GET bypasses _get_json, so the Bearer
+        # header (v2.13.0) must be merged in separately without clobbering the
+        # filename/type headers the download endpoint requires.
+        dl_headers = {"filename": newest, "type": "partial"}
+        if self._bearer:
+            dl_headers["Authorization"] = f"Bearer {self._bearer}"
         async with self._session.get(
             f"{_PORTAL_BASE}{_DOWNLOAD_PATH.format(vin=vin, identifier=identifier)}",
-            headers={"filename": newest, "type": "partial"},
+            headers=dl_headers,
             timeout=ClientTimeout(total=_TIMEOUT_S),
         ) as resp:
             if resp.status in _TRANSIENT_STATUSES:

--- a/tests/test_v2130_connector_bearer.py
+++ b/tests/test_v2130_connector_bearer.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.13.0 Block A2 — EUDataActConnector device-code Bearer mode.
+
+When constructed with an access_token (the device-grant portal token), the
+connector authenticates every proxy_api call via Authorization: Bearer instead
+of the cookie-scrape session, and login() becomes a no-op. With no token the
+cookie path is byte-identical to before (existing entries keep working).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import EUDataActConnector
+
+
+class _Resp:
+    def __init__(self, headers: dict | None) -> None:
+        self.status = 200
+        self._h = headers
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def json(self, content_type: Any = None) -> Any:
+        return {"vehicles": [{"vin": "WVWZZZ1KZAW000001"}]}
+
+    async def read(self) -> bytes:
+        return b""
+
+
+class _RecordSession:
+    """Records the headers of the last GET so tests can assert Bearer auth."""
+
+    def __init__(self) -> None:
+        self.last_headers: dict = {}
+
+    def get(self, url: str, headers: dict | None = None, **kw: Any) -> _Resp:
+        self.last_headers = headers or {}
+        return _Resp(headers)
+
+
+@pytest.mark.asyncio
+async def test_bearer_injected_on_proxy_api_calls() -> None:
+    s = _RecordSession()
+    conn = EUDataActConnector(s, brand="volkswagen", access_token="TOK123")  # type: ignore[arg-type]
+    await conn.list_vehicle_vins()
+    assert s.last_headers.get("Authorization") == "Bearer TOK123"
+
+
+@pytest.mark.asyncio
+async def test_cookie_mode_has_no_authorization_header() -> None:
+    s = _RecordSession()
+    conn = EUDataActConnector(s, brand="volkswagen")  # type: ignore[arg-type]  # no token → cookie mode
+    await conn.list_vehicle_vins()
+    assert "Authorization" not in s.last_headers
+
+
+@pytest.mark.asyncio
+async def test_login_is_noop_in_bearer_mode() -> None:
+    conn = EUDataActConnector(_RecordSession(), brand="volkswagen", access_token="TOK")  # type: ignore[arg-type]
+    await conn.login("user@example.com", "secret")  # must NOT scrape
+    assert conn.logged_in is True
+
+
+def test_set_bearer_switches_mode() -> None:
+    conn = EUDataActConnector(_RecordSession(), brand="volkswagen")  # type: ignore[arg-type]
+    assert conn._bearer is None
+    conn.set_bearer("LATER")
+    assert conn._bearer == "LATER"
+    assert conn.logged_in is True


### PR DESCRIPTION
Block A2 of the v2.13.0 device-code/QR collection. EUDataActConnector gains a Bearer mode (device-grant token → Authorization: Bearer on proxy_api), login() no-op in bearer mode, set_bearer() re-inject, download GET Bearer (separate edit). access_token=None keeps cookie mode byte-identical. +4 tests. No tag yet.