### PR TITLE
feat(auth): runtime routing for device-code portal tokens (v2.13.0 B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ### Added
 
-- Foundation for VW EU / CUPRA / SEAT **device-code (QR) portal login** (v2.13.0, landing in stages): the device-grant module can now mint and refresh the EU-Data-Act portal-client tokens (`PORTAL_DAG_BRANDS` + the `device_grant_portal` strategy), routed separately from the CARIAD-BFF device-grant so the portal-only token never hits the BFF, and the portal connector now accepts those tokens as an `Authorization: Bearer` (read-only proxy_api) instead of the fragile cookie-scrape. Runtime routing and the config-flow QR step land in the same v2.13.0 release.
+- Foundation for VW EU / CUPRA / SEAT **device-code (QR) portal login** (v2.13.0, landing in stages): the device-grant module can now mint and refresh the EU-Data-Act portal-client tokens (`PORTAL_DAG_BRANDS` + the `device_grant_portal` strategy), routed separately from the CARIAD-BFF device-grant so the portal-only token never hits the BFF, and the portal connector now accepts those tokens as an `Authorization: Bearer` (read-only proxy_api) instead of the fragile cookie-scrape. The runtime now routes those tokens to the portal (builds the Bearer connector at setup and after restart), refreshes them at the IDP token endpoint (a real `refresh_token`, so no more session-expiry re-login), and treats portal entries as structurally read-only. The config-flow QR step and user-facing setup land in the same v2.13.0 release.
 
 ### Fixed
 

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -430,6 +430,21 @@ class CariadBaseClient:
                 tokens.expires_at,
                 tokens.strategy or "(legacy)",
             )
+            # v2.13.0 — device-code/QR portal entries carry a REAL bearer for
+            # the EU-Data-Act proxy_api (not the BFF). Build the portal
+            # connector in Bearer mode now so the first poll — at setup AND
+            # after a restart (this is the single central token-load point for
+            # both) — routes to the portal, not the dead BFF. _refresh_tokens
+            # re-injects a fresh bearer on expiry.
+            if tokens.strategy == "device_grant_portal":
+                from ..auth._eu_data_act import (  # noqa: PLC0415
+                    EUDataActConnector,
+                )
+
+                self._eu_portal = EUDataActConnector(
+                    self._session, brand=self._brand.name,
+                    access_token=tokens.access_token,
+                )
             if tokens.auth_cookies and hasattr(
                 self._auth, "hydrate_session_cookies"
             ):
@@ -913,6 +928,35 @@ class CariadBaseClient:
                     "Token refresh storm — please reauthenticate"
                 )
             self._refresh_history.append(now)
+
+            # v2.13.0 — device-code/QR portal tokens refresh at the IDP token
+            # endpoint as a PUBLIC client, NOT via self._auth.refresh() (which
+            # routes VW to the dead CARIAD BFF). Re-inject the fresh bearer into
+            # the live portal connector so it never 401s mid-poll. If the IDP
+            # rejects the refresh (the one unverified runtime assumption), the
+            # error propagates → the coordinator triggers a QR reauth prompt.
+            if (
+                self._tokens
+                and self._tokens.strategy == "device_grant_portal"
+                and self._tokens.refresh_token
+            ):
+                from ..auth._device_grant import (  # noqa: PLC0415
+                    DeviceAuthorizationGrant,
+                    portal_dag_config,
+                )
+
+                pc = portal_dag_config(self._brand.name)
+                if pc is not None:
+                    client_id, scope = pc
+                    grant = DeviceAuthorizationGrant(
+                        self._session, client_id, scope=scope,
+                        strategy="device_grant_portal",
+                    )
+                    self._tokens = await grant.refresh(self._tokens.refresh_token)
+                    if getattr(self, "_eu_portal", None) is not None:
+                        self._eu_portal.set_bearer(self._tokens.access_token)
+                    await self._notify_tokens_changed()
+                    return
 
             if self._tokens and self._tokens.refresh_token:
                 try:

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -114,7 +114,13 @@ class VWEUClient(CariadBaseClient):
             try:
                 vins = await portal.list_vehicle_vins()
             except AuthenticationError:
-                await portal.login(self._email, self._password)
+                # v2.13.0 — device-code/QR entries store no password; a 401
+                # means the bearer expired → refresh it (re-injects a fresh
+                # token into the connector). Legacy cookie entries re-scrape.
+                if self._tokens and self._tokens.strategy == "device_grant_portal":
+                    await self._refresh_tokens()
+                else:
+                    await portal.login(self._email, self._password)
                 vins = await portal.list_vehicle_vins()
             # Best-effort nickname enrichment from the relation endpoint.
             self._vehicle_metadata: dict[str, dict[str, Any]] = {}
@@ -344,7 +350,12 @@ class VWEUClient(CariadBaseClient):
             try:
                 data: VehicleData = await portal.get_vehicle_data(vin)
             except AuthenticationError:
-                await portal.login(self._email, self._password)
+                # v2.13.0 — device-code/QR: refresh bearer (no stored password);
+                # legacy cookie entries re-scrape via login().
+                if self._tokens and self._tokens.strategy == "device_grant_portal":
+                    await self._refresh_tokens()
+                else:
+                    await portal.login(self._email, self._password)
                 data = await portal.get_vehicle_data(vin)
             return data
         # v2.1.0 — per-VIN base URL via HomeRegion lookup.

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -868,10 +868,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
 
         tokens = getattr(self._cariad_client, "_tokens", None)
         active_strategy = getattr(tokens, "strategy", "") if tokens else ""
-        if active_strategy != "data_act_portal":
+        # v2.13.0 — device-code/QR portal entries (device_grant_portal) use the
+        # same EU-Data-Act portal proxy_api, so they need the continuous
+        # data-request kickoff too, not just the cookie data_act_portal path.
+        if active_strategy not in ("data_act_portal", "device_grant_portal"):
             _LOGGER.debug(
-                "Data Act kickoff: skipped (active strategy is %r, not "
-                "data_act_portal)", active_strategy,
+                "Data Act kickoff: skipped (active strategy is %r, not a "
+                "portal strategy)", active_strategy,
             )
             return
 
@@ -1889,9 +1892,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 return False
             tokens = getattr(client, "_tokens", None)
             strategy = getattr(tokens, "strategy", "") if tokens else ""
-            # Hybrid_full / data_act_portal / device_grant all flow
+            # Hybrid_full / data_act_portal / device_grant(_portal) all flow
             # through the browser-based DAG/IDP path (v2.6.0+).
-            return strategy in ("hybrid_full", "data_act_portal", "device_grant")
+            return strategy in (
+                "hybrid_full", "data_act_portal", "device_grant",
+                "device_grant_portal",
+            )
 
         # Vehicle-data capabilities: scan VINs for a non-None field.
         fields = self._CAPABILITY_FIELD_MAP.get(capability)
@@ -3242,10 +3248,22 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         entities. Service calls that would send commands raise
         ServiceValidationError before reaching the API.
 
-        Lookup order: options (Options Flow) > data (initial config) >
-        False default. Pattern matches the existing reverse-geocoding
-        opt-in (v1.8.0).
+        Lookup order: portal strategy (structural) > options (Options Flow) >
+        data (initial config) > False default. Pattern matches the existing
+        reverse-geocoding opt-in (v1.8.0).
+
+        v2.13.0 — the EU-Data-Act portal strategies (cookie ``data_act_portal``
+        and device-code ``device_grant_portal``) are STRUCTURALLY read-only:
+        their token is rejected by the command BFF (403 "clientId not
+        whitelisted"), so command entities could only ever fail. Force
+        read-only for them regardless of the user toggle, so lock/switch/
+        button/climate/number/time platforms skip creation entirely.
         """
+        client = getattr(self, "_cariad_client", None)
+        tokens = getattr(client, "_tokens", None) if client else None
+        strategy = getattr(tokens, "strategy", "") if tokens else ""
+        if strategy in ("data_act_portal", "device_grant_portal"):
+            return True
         options = getattr(self.entry, "options", None) or {}
         data = getattr(self.entry, "data", None) or {}
         return (


### PR DESCRIPTION
Block B of the v2.13.0 device-code/QR collection. Wires device_grant_portal end-to-end: set_persisted_tokens builds the Bearer connector (setup+restart), _refresh_tokens refreshes at the IDP (not the dead BFF) + re-injects, vw_eu re-auth refreshes instead of cookie-login, coordinator kickoff/dag_login/is_read_only include device_grant_portal (both portal strategies are structurally read-only). Additive + strategy-gated. No tag yet.