### PR TITLE
chore(release): cut v2.13.0 — manifest bump + CHANGELOG finalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-06-12
+
 ### Added
 
 - Foundation for VW EU / CUPRA / SEAT **device-code (QR) portal login** (v2.13.0, landing in stages): the device-grant module can now mint and refresh the EU-Data-Act portal-client tokens (`PORTAL_DAG_BRANDS` + the `device_grant_portal` strategy), routed separately from the CARIAD-BFF device-grant so the portal-only token never hits the BFF, and the portal connector now accepts those tokens as an `Authorization: Bearer` (read-only proxy_api) instead of the fragile cookie-scrape. The runtime now routes those tokens to the portal (builds the Bearer connector at setup and after restart), refreshes them at the IDP token endpoint (a real `refresh_token`, so no more session-expiry re-login), and treats portal entries as structurally read-only. **Volkswagen EU (and the CUPRA/SEAT reserve) can now sign in via the browser/QR device-code flow** in the config flow — pick "Browser-Login (QR)", scan/open the URL, approve in your VW account, done; no password is stored in Home Assistant. (Existing email+password entries keep working as the fallback.) The sign-in step copy is translated across all 8 bundled languages.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.12.4"
+  "version": "2.13.0"
 }


### PR DESCRIPTION
## Release prep for v2.13.0

All v2.13.0 functional work is already merged on `main`; this PR only cuts the release.

### Changes
- **`manifest.json`**: bump `2.12.4` → `2.13.0`
- **`CHANGELOG.md`**: promote `## [Unreleased]` → `## [2.13.0] - 2026-06-12`, open a fresh empty `## [Unreleased]` block on top

### What 2.13.0 bundles (already on main)
- Device-code / QR portal login for VW EU / CUPRA / SEAT — blocks A1, A2, B, C, D (#451, #452, #453, #454, #455)
- Config-flow reachability for the browser/QR sign-in (#454)
- i18n across 8 languages (#458) + README marketing (#457)
- Fixes: jumping SoC/odometer (latest-wins event-log) + graceful empty ZIPs, Audi scout noise on deeper charging timer/profile fields (#446, #448)

### After merge
Tag `v2.13.0` on the merge commit to trigger the release build (`vag_connect.zip` asset via `github-actions[bot]`).

https://claude.ai/code/session_01MPsC5WJF1nDyg8sxKmoJm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPsC5WJF1nDyg8sxKmoJm2)_