### PR TITLE
chore(release): cut v2.12.5 - pull device-code from config flow, ship portal hardening + scout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [Unreleased]
+## [2.12.5] - 2026-06-13
 
-### Added
-
-- Foundation for VW EU / CUPRA / SEAT **device-code (QR) portal login** (v2.13.0, landing in stages): the device-grant module can now mint and refresh the EU-Data-Act portal-client tokens (`PORTAL_DAG_BRANDS` + the `device_grant_portal` strategy), routed separately from the CARIAD-BFF device-grant so the portal-only token never hits the BFF, and the portal connector now accepts those tokens as an `Authorization: Bearer` (read-only proxy_api) instead of the fragile cookie-scrape. The runtime now routes those tokens to the portal (builds the Bearer connector at setup and after restart), refreshes them at the IDP token endpoint (a real `refresh_token`, so no more session-expiry re-login), and treats portal entries as structurally read-only. **Volkswagen EU (and the CUPRA/SEAT reserve) can now sign in via the browser/QR device-code flow** in the config flow — pick "Browser-Login (QR)", scan/open the URL, approve in your VW account, done; no password is stored in Home Assistant. (Existing email+password entries keep working as the fallback.) The sign-in step copy is translated across all 8 bundled languages.
+A data-quality patch for the EU Data Act portal, plus a scout-noise fix for Audi.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -47,18 +47,6 @@
 
 ---
 
-## Was ist neu in v2.13.0
-
-**Passwort-loser Login für VW EU — als Erste und Einzige.** Volkswagen EU (We Connect ID) kann sich jetzt per **QR-/Device-Code** anmelden: „Browser-Login (QR)" wählen, den Link auf Handy oder Laptop öffnen (oder den QR scannen), im VW-Account bestätigen — fertig. **Es wird kein Passwort und kein Session-Cookie in Home Assistant gespeichert** — nur ein OAuth-Token, das du jederzeit in deinem VW-Account widerrufen kannst. Damit sind wir die **erste und einzige** VAG-Integration, die VW-EU-Daten ganz ohne hinterlegte Login-Daten holt — sauber per QR.
-
-Technisch dahinter: ein echtes `refresh_token` (Schluss mit dem Re-Login der alten Cookie-Session, kein `data_act_session_expired` mehr), kein fragiles SPA-Scraping (das war die wiederkehrende Bruchstelle bei #388 / #393), und der Token spricht direkt das read-only EU-Data-Act-Portal an. Bestehende E-Mail+Passwort-Einträge laufen unverändert als Fallback weiter.
-
-> **Read-only, ehrlich gesagt:** der VW-EU-Portal-Pfad liefert nur Daten (kein Ver-/Entriegeln, Klima, Laden). Fernbefehle für VW EU bleiben technisch unmöglich — die CARIAD-BFF lehnt den Portal-Token ab (Google Play Integrity / App-Attestation, die ein Server/Browser nicht erzeugen kann). CUPRA/SEAT bekommen denselben QR-Login als scharfgeschalteten Reserve-Pfad, falls VWs server-seitige OLA-Sperre wieder aufgeht.
-
-**Datenqualität.** Springende SoC-/Kilometer-Werte auf dem Portal gefixt (das Portal liefert ein unsortiertes Event-Log; wir nehmen jetzt den neuesten Wert pro Feld — dasselbe Problem, an dem das ganze Portal-Ökosystem hängt). Leere oder kaputte Portal-ZIPs werden als „keine Daten" behandelt statt als Login-Fehler.
-
----
-
 ## Was ist neu in v2.10.0
 
 Das grösste Release dieser Integration bisher. Etwa 6 Wochen intensive Arbeit in einem Cut.
@@ -179,8 +167,8 @@ Settings → Devices & Services → Integration hinzufügen → "VW Group Connec
 
 **Beim ersten Setup wählst du:**
 
-- **Browser-Login (QR)** (empfohlen für Audi/Škoda/SEAT/CUPRA **und neu Volkswagen EU**): QR-Code scannen oder URL öffnen, im Brand-ID-Account bestätigen — kein Passwort in HA gespeichert. (VW EU läuft dabei read-only über das EU-Data-Act-Portal.)
-- **E-Mail + Passwort** (Fallback für VW EU; nötig für Porsche, VW US/CA): klassisch mit Brand-ID Credentials
+- **Browser-Login** (empfohlen für Audi/Škoda/SEAT/CUPRA): QR-Code scannen oder URL öffnen, kein Passwort in HA gespeichert
+- **E-Mail + Passwort** (für VW EU, Porsche, VW US/CA): klassisch mit Brand-ID Credentials
 
 **Optionen** (nach Setup verfügbar):
 - Polling-Intervall (5-60 min, Default 10 min)

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -293,11 +293,11 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             step_id="user",
             menu_options={
                 "browser_login": (
-                    "Browser-Login (QR) — Audi / Škoda / SEAT / CUPRA / "
-                    "Volkswagen EU (empfohlen, kein Passwort in HA)"
+                    "Browser-Login — Audi / Škoda / SEAT / CUPRA "
+                    "(empfohlen, kein Passwort in HA)"
                 ),
                 "email_password": (
-                    "E-Mail + Passwort — Volkswagen EU (Fallback) / Porsche"
+                    "E-Mail + Passwort — Volkswagen EU / Porsche (Legacy)"
                 ),
             },
         )
@@ -372,21 +372,13 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         Submits → we start the background DAG task and transition to the
         pending step (which shows progress + verification URL).
         """
-        from .cariad.auth._device_grant import (  # noqa: PLC0415
-            DAG_ENABLED_BRANDS,
-            PORTAL_DAG_BRANDS,
-        )
-
-        # v2.13.0 — browser-login (device-code/QR) now also covers the
-        # EU-Data-Act PORTAL brands (VW EU + the CUPRA/SEAT reserve), not just
-        # the CARIAD-BFF DAG brands.
-        eligible_dag_brands = DAG_ENABLED_BRANDS | PORTAL_DAG_BRANDS
+        from .cariad.auth._device_grant import DAG_ENABLED_BRANDS  # noqa: PLC0415
 
         errors: dict[str, str] = {}
 
         if user_input is not None:
             brand = user_input[CONF_BRAND]
-            if brand not in eligible_dag_brands:
+            if brand not in DAG_ENABLED_BRANDS:
                 # Defence in depth — the form should have filtered these
                 # out already, but the user could send a crafted payload.
                 errors["base"] = "brand_not_dag_eligible"
@@ -407,7 +399,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         # DAG-eligible brand options only (subset of the standard list).
         dag_brand_options: list[SelectOptionDict] = [
             opt for opt in _BRAND_OPTIONS
-            if opt["value"] in eligible_dag_brands
+            if opt["value"] in DAG_ENABLED_BRANDS
         ]
         dag_brand_selector = SelectSelector(
             SelectSelectorConfig(
@@ -684,32 +676,12 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 cookie_jar=aiohttp.CookieJar(unsafe=True),
             )
             from .cariad.models import BRANDS as BRAND_CONFIGS  # noqa: PLC0415
-            from .cariad.auth._device_grant import (  # noqa: PLC0415
-                is_portal_dag_eligible,
-                portal_dag_config,
-            )
 
-            # v2.13.0 — portal brands (VW EU + CUPRA/SEAT reserve) mint the
-            # EU-Data-Act PORTAL client token tagged device_grant_portal, so it
-            # routes to the read-only proxy_api (Bearer) rather than the dead
-            # BFF. Other DAG brands keep the app client + device_grant tag.
-            pc = (
-                portal_dag_config(self._dag_brand)
-                if is_portal_dag_eligible(self._dag_brand)
-                else None
-            )
-            if pc is not None:
-                client_id, scope = pc
-                self._dag_strategy = "device_grant_portal"
-            else:
-                brand_cfg = BRAND_CONFIGS[self._dag_brand]
-                client_id, scope = brand_cfg.client_id, brand_cfg.scope
-                self._dag_strategy = "device_grant"
+            brand_cfg = BRAND_CONFIGS[self._dag_brand]
             self._dag_client = DeviceAuthorizationGrant(
                 self._dag_session,
-                client_id,
-                scope=scope,
-                strategy=self._dag_strategy,
+                brand_cfg.client_id,
+                scope=brand_cfg.scope,
             )
             code = await self._dag_client.request_device_code()
             self._dag_device_code = code.device_code
@@ -801,10 +773,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             "refresh_token": self._dag_tokens.refresh_token,
             "id_token": self._dag_tokens.id_token,
             "expires_at": self._dag_tokens.expires_at,
-            # v2.13.0 — carry the chosen strategy so portal brands (VW EU +
-            # CUPRA/SEAT) are tagged device_grant_portal and routed to the
-            # read-only proxy_api, not the BFF.
-            "strategy": getattr(self, "_dag_strategy", "device_grant"),
+            "strategy": "device_grant",
         }
         return self.async_create_entry(
             title=f"{BRANDS[self._dag_brand]} — {self._dag_user_id[:8]}…",

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.12.4"
+  "version": "2.12.5"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "Set up VW Group Connect",
-        "description": "How would you like to sign in?\n\n**Browser-Login / QR (recommended)** — open a URL (or scan a QR) on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT, CUPRA and Volkswagen EU (read-only EU Data Act portal).\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Still available as a fallback for Volkswagen EU; required for Porsche.",
+        "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU and Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
           "email_password": "Email + Password (legacy)"
@@ -69,7 +69,7 @@
           "force_enable_access": "Force Door Status"
         },
         "data_description": {
-          "brand": "Brands with browser-login (QR) support — now including Volkswagen EU (read-only). Use 'Email + Password' for Porsche.",
+          "brand": "Only brands with browser-login support are listed. Use 'Email + Password' for Volkswagen EU and Porsche.",
           "spin": "Optional 4-digit Security-PIN for remote actions (lock, unlock, climate).",
           "scan_interval": "Minutes between vehicle data polls.",
           "force_enable_access": "Force door-status entities even when the vehicle reports the data missing."

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Nastavit VW Group Connect",
-        "description": "Jak se chcete přihlásit?\n\n**Přihlášení přes prohlížeč / QR (doporučeno)** — otevřete URL (nebo naskenujte QR) na telefonu či notebooku, přihlaste se k účtu Brand ID, potvrďte zařízení. V Home Assistantu se nikdy neukládá žádné heslo. Dostupné pro Audi, Škoda, SEAT, CUPRA a Volkswagen EU (portál EU Data Act pouze pro čtení).\n\n**E-mail + heslo (starší)** — zadejte přihlašovací údaje Brand ID přímo. Stále dostupné jako záloha pro Volkswagen EU; nutné pro Porsche.",
+        "description": "Připojte své vozidlo k Home Assistant.\n\nVyberte značku a zadejte přihlašovací údaje z aplikace výrobce.",
         "data": {
           "brand": "Značka vozidla",
           "username": "E-mailová adresa",
@@ -85,7 +85,7 @@
           "force_enable_access": "Force Door Status"
         },
         "data_description": {
-          "brand": "Značky s přihlášením přes prohlížeč (QR) — nově i Volkswagen EU (pouze pro čtení). Pro Porsche použijte „E-mail + heslo“.",
+          "brand": "Zobrazují se pouze značky s podporou přihlášení přes prohlížeč. Pro Volkswagen EU a Porsche použijte „E-mail + heslo“.",
           "force_enable_access": "Vynutit entity stavu dveří, i když vozidlo hlásí chybějící data.",
           "scan_interval": "Minuty mezi dotazy na data vozidla.",
           "spin": "Volitelný 4místný bezpečnostní PIN pro vzdálené akce (zamknout, odemknout, klimatizace)."

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "VW Group Connect einrichten",
-        "description": "Wie möchtest du dich anmelden?\n\n**Browser-Login / QR (empfohlen)** — öffne eine URL (oder scanne einen QR) auf Handy oder Laptop, melde dich in deinem Brand-ID-Account an, bestätige das Gerät. Es wird kein Passwort in Home Assistant gespeichert. Verfügbar für Audi, Škoda, SEAT, CUPRA und Volkswagen EU (read-only EU-Data-Act-Portal).\n\n**E-Mail + Passwort (Legacy)** — gib deine Brand-ID-Zugangsdaten direkt ein. Weiterhin als Fallback für Volkswagen EU verfügbar; nötig für Porsche.",
+        "description": "Wie möchtest du dich anmelden?\n\n**Browser-Login (empfohlen)** — öffne eine URL auf Handy oder Laptop, melde dich mit deinem Brand-ID-Konto an, bestätige das Gerät. Kein Passwort wird in Home Assistant gespeichert. Verfügbar für Audi, Škoda, SEAT und CUPRA.\n\n**E-Mail + Passwort (Legacy)** — gib deine Brand-ID-Zugangsdaten direkt ein. Erforderlich für Volkswagen EU und Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (empfohlen)",
           "email_password": "E-Mail + Passwort (Legacy)"
@@ -69,7 +69,7 @@
           "force_enable_access": "Tür-Status erzwingen"
         },
         "data_description": {
-          "brand": "Marken mit Browser-Login-(QR)-Unterstützung — jetzt auch Volkswagen EU (read-only). Für Porsche 'E-Mail + Passwort' verwenden.",
+          "brand": "Es werden nur Marken mit Browser-Login-Unterstützung angezeigt. Für Volkswagen EU und Porsche 'E-Mail + Passwort' verwenden.",
           "force_enable_access": "Tür-Status-Entitäten erzwingen, auch wenn das Fahrzeug die Daten als fehlend meldet.",
           "scan_interval": "Minuten zwischen den Datenabfragen des Fahrzeugs.",
           "spin": "Optionale 4-stellige Sicherheits-PIN für Fernaktionen (Verriegeln, Entriegeln, Klima)."

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "Set up VW Group Connect",
-        "description": "How would you like to sign in?\n\n**Browser-Login / QR (recommended)** — open a URL (or scan a QR) on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT, CUPRA and Volkswagen EU (read-only EU Data Act portal).\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Still available as a fallback for Volkswagen EU; required for Porsche.",
+        "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU and Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
           "email_password": "Email + Password (legacy)"
@@ -69,7 +69,7 @@
           "force_enable_access": "Force Door Status"
         },
         "data_description": {
-          "brand": "Brands with browser-login (QR) support — now including Volkswagen EU (read-only). Use 'Email + Password' for Porsche.",
+          "brand": "Only brands with browser-login support are listed. Use 'Email + Password' for Volkswagen EU and Porsche.",
           "force_enable_access": "Force door-status entities even when the vehicle reports the data missing.",
           "scan_interval": "Minutes between vehicle data polls.",
           "spin": "Optional 4-digit Security-PIN for remote actions (lock, unlock, climate)."

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configurar VW Group Connect",
-        "description": "¿Cómo quieres iniciar sesión?\n\n**Inicio por navegador / QR (recomendado)** — abre una URL (o escanea un QR) en tu teléfono o portátil, inicia sesión en tu cuenta Brand ID, aprueba el dispositivo. Nunca se guarda ninguna contraseña en Home Assistant. Disponible para Audi, Škoda, SEAT, CUPRA y Volkswagen EU (portal EU Data Act de solo lectura).\n\n**Correo + contraseña (heredado)** — introduce tus credenciales Brand ID directamente. Sigue disponible como alternativa para Volkswagen EU; necesario para Porsche.",
+        "description": "Conecta tu vehículo a Home Assistant.\n\nElige tu marca e introduce las credenciales de la app del fabricante.",
         "data": {
           "brand": "Marca del vehículo",
           "username": "Correo electrónico",
@@ -85,7 +85,7 @@
           "force_enable_access": "Force Door Status"
         },
         "data_description": {
-          "brand": "Marcas compatibles con el inicio por navegador (QR) — ahora también Volkswagen EU (solo lectura). Usa 'Correo + contraseña' para Porsche.",
+          "brand": "Solo se muestran las marcas compatibles con el inicio de sesión por navegador. Usa 'Correo electrónico + contraseña' para Volkswagen EU y Porsche.",
           "force_enable_access": "Forzar las entidades de estado de las puertas aunque el vehículo informe de que faltan los datos.",
           "scan_interval": "Minutos entre cada consulta de datos del vehículo.",
           "spin": "PIN de seguridad de 4 dígitos opcional para acciones remotas (bloquear, desbloquear, climatización)."

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configurer VW Group Connect",
-        "description": "Comment souhaitez-vous vous connecter ?\n\n**Connexion par navigateur / QR (recommandé)** — ouvrez une URL (ou scannez un QR) sur votre téléphone ou ordinateur, connectez-vous à votre compte Brand ID, approuvez l'appareil. Aucun mot de passe n'est jamais stocké dans Home Assistant. Disponible pour Audi, Škoda, SEAT, CUPRA et Volkswagen EU (portail EU Data Act en lecture seule).\n\n**E-mail + mot de passe (ancien)** — saisissez directement vos identifiants Brand ID. Toujours disponible en repli pour Volkswagen EU ; requis pour Porsche.",
+        "description": "Connectez votre véhicule à Home Assistant.\n\nChoisissez votre marque et entrez les identifiants de l'application fabricant.",
         "data": {
           "brand": "Marque du véhicule",
           "username": "Adresse e-mail",
@@ -85,7 +85,7 @@
           "force_enable_access": "Force Door Status"
         },
         "data_description": {
-          "brand": "Marques prenant en charge la connexion par navigateur (QR) — désormais aussi Volkswagen EU (lecture seule). Utilisez « E-mail + mot de passe » pour Porsche.",
+          "brand": "Seules les marques prenant en charge la connexion par navigateur sont listées. Utilisez « E-mail + mot de passe » pour Volkswagen EU et Porsche.",
           "force_enable_access": "Forcer les entités d'état des portes même lorsque le véhicule signale les données comme manquantes.",
           "scan_interval": "Minutes entre chaque interrogation des données du véhicule.",
           "spin": "Code de sécurité (S-PIN) à 4 chiffres facultatif pour les actions à distance (verrouillage, déverrouillage, climatisation)."

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "VW Group Connect instellen",
-        "description": "Hoe wil je inloggen?\n\n**Browser-login / QR (aanbevolen)** — open een URL (of scan een QR) op je telefoon of laptop, log in op je Brand ID-account, keur het apparaat goed. Er wordt nooit een wachtwoord opgeslagen in Home Assistant. Beschikbaar voor Audi, Škoda, SEAT, CUPRA en Volkswagen EU (alleen-lezen EU Data Act-portaal).\n\n**E-mail + wachtwoord (legacy)** — voer je Brand ID-gegevens rechtstreeks in. Nog steeds beschikbaar als fallback voor Volkswagen EU; vereist voor Porsche.",
+        "description": "Verbind je voertuig met Home Assistant.\n\nKies je merk en voer de inloggegevens van de fabrieksapp in.",
         "data": {
           "brand": "Voertuigmerk",
           "username": "E-mailadres",
@@ -85,7 +85,7 @@
           "force_enable_access": "Force Door Status"
         },
         "data_description": {
-          "brand": "Merken met browser-login (QR) — nu ook Volkswagen EU (alleen-lezen). Gebruik 'E-mail + wachtwoord' voor Porsche.",
+          "brand": "Alleen merken met browser-login-ondersteuning worden getoond. Gebruik 'E-mail + wachtwoord' voor Volkswagen EU en Porsche.",
           "force_enable_access": "Forceer deurstatus-entiteiten, ook als het voertuig de gegevens als ontbrekend meldt.",
           "scan_interval": "Minuten tussen de gegevensopvragingen van het voertuig.",
           "spin": "Optionele 4-cijferige beveiligings-PIN voor acties op afstand (vergrendelen, ontgrendelen, klimaat)."

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Skonfiguruj VW Group Connect",
-        "description": "Jak chcesz się zalogować?\n\n**Logowanie przez przeglądarkę / QR (zalecane)** — otwórz adres URL (lub zeskanuj kod QR) na telefonie albo laptopie, zaloguj się na konto Brand ID, zatwierdź urządzenie. W Home Assistant nie jest przechowywane żadne hasło. Dostępne dla Audi, Škoda, SEAT, CUPRA i Volkswagen EU (portal EU Data Act tylko do odczytu).\n\n**E-mail + hasło (starsze)** — wprowadź dane logowania Brand ID bezpośrednio. Nadal dostępne jako rezerwa dla Volkswagen EU; wymagane dla Porsche.",
+        "description": "Połącz swój pojazd z Home Assistant.\n\nWybierz markę i wprowadź dane logowania z aplikacji producenta.",
         "data": {
           "brand": "Marka pojazdu",
           "username": "Adres e-mail",
@@ -85,7 +85,7 @@
           "force_enable_access": "Force Door Status"
         },
         "data_description": {
-          "brand": "Marki obsługujące logowanie przez przeglądarkę (QR) — teraz także Volkswagen EU (tylko do odczytu). Dla Porsche użyj 'E-mail + hasło'.",
+          "brand": "Wyświetlane są tylko marki obsługujące logowanie przez przeglądarkę. Dla Volkswagen EU i Porsche użyj 'E-mail + hasło'.",
           "force_enable_access": "Wymuś encje stanu drzwi, nawet gdy pojazd zgłasza brak danych.",
           "scan_interval": "Minuty między odpytaniami danych pojazdu.",
           "spin": "Opcjonalny 4-cyfrowy PIN bezpieczeństwa do akcji zdalnych (blokowanie, odblokowanie, klimatyzacja)."

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfigurera VW Group Connect",
-        "description": "Hur vill du logga in?\n\n**Webbläsarinloggning / QR (rekommenderas)** — öppna en URL (eller skanna en QR) på din telefon eller laptop, logga in på ditt Brand ID-konto, godkänn enheten. Inget lösenord lagras någonsin i Home Assistant. Tillgängligt för Audi, Škoda, SEAT, CUPRA och Volkswagen EU (skrivskyddad EU Data Act-portal).\n\n**E-post + lösenord (äldre)** — ange dina Brand ID-uppgifter direkt. Fortfarande tillgängligt som reserv för Volkswagen EU; krävs för Porsche.",
+        "description": "Anslut ditt fordon till Home Assistant.\n\nVälj ditt märke och ange inloggningsuppgifterna från tillverkarens app.",
         "data": {
           "brand": "Fordonsvarumärke",
           "username": "E-postadress",
@@ -85,7 +85,7 @@
           "force_enable_access": "Force Door Status"
         },
         "data_description": {
-          "brand": "Märken med webbläsarinloggning (QR) — nu även Volkswagen EU (skrivskyddat). Använd 'E-post + lösenord' för Porsche.",
+          "brand": "Endast märken med stöd för webbläsarinloggning visas. Använd 'E-post + lösenord' för Volkswagen EU och Porsche.",
           "force_enable_access": "Tvinga fram dörrstatus-entiteter även när fordonet rapporterar att data saknas.",
           "scan_interval": "Minuter mellan fordonets datahämtningar.",
           "spin": "Valfri 4-siffrig säkerhets-PIN för fjärråtgärder (lås, lås upp, klimat)."


### PR DESCRIPTION
## v2.12.5 — re-scoped from the planned 2.13.0

The VW EU device-code/QR login is **pulled from the config flow**. A live test showed the EU Data Act portal token can't refresh as a public client — it's a 1-hour, non-refreshable token (the IDP returns `401 invalid_client` on the `refresh_token` grant without a client secret we don't have). That means hourly QR re-approval, so it isn't viable as unattended primary auth yet. The earlier "real refresh_token / no session-expiry" framing was wrong, so the feature is out until a refreshable path exists.

The backend plumbing (`device_grant_portal` strategy, Bearer-mode portal connector, routing) stays **dormant** in main — strategy-gated and never produced now that the config flow doesn't tag it. It's ready to re-arm if a refreshable client ever lands.

### What actually ships (all PATCH-level)

- **Latest-wins SoC / odometer** on the EU Data Act portal. The portal ships an unordered event-log; we now keep the newest value per field by timestamp instead of the first one we happened to see, so battery level and mileage stop bouncing.
- **Graceful empty / corrupt portal ZIPs** — treated as "no data this poll" instead of a login failure that triggered a pointless re-login.
- **Audi scout 4-segment silencer** (#446, #448) — registered the deeper `chargingTimers` / `chargingProfiles` wildcards so the Vehicle Data Scout stops re-flagging fields we already read.

Manifest 2.12.4 → 2.12.5. VW EU keeps email+password; CUPRA/SEAT keep their app-client device-grant. Supersedes #460.
