### PR TITLE
chore(release): cut v2.12.6 - honest CUPRA/SEAT OLA-403 repair notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [Unreleased]
+## [2.12.6] - 2026-06-13
+
+An honesty fix for the CUPRA/SEAT repair notice.
 
 ### Changed
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.12.5"
+  "version": "2.12.6"
 }


### PR DESCRIPTION
Ships the reworded `ola_headers_outdated` repair notice (8 languages) from #463: the CUPRA/SEAT 403s are a VW server-side block, not a fixable header/app-version problem. A competitor-tool audit corroborated this — the OLA backend now enforces Play-Integrity-style device attestation, so no client-side header fix exists. manifest 2.12.5 -> 2.12.6.