### PR TITLE
feat(portal): universal EU Data Act portal read-fallback for CUPRA/SEAT/Skoda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased]
+
+### Fixed
+
+- **CUPRA, SEAT and Škoda now route their data reads through the EU Data Act portal when the portal fallback is active** — not just their login. Until now, when a brand's native backend went dark (e.g. CUPRA/SEAT's online services getting blocked by VW), the login correctly fell back to the read-only portal, but the very next data poll still hit the dead native endpoint — so you'd get a successful login and then no data. These brands now follow the same portal-routing path VW EU already used, both for the vehicle list and the status read. It's the EU Data Act portal becoming the universal read-only safety net: as VW keeps closing native access brand by brand, each one degrades gracefully to the portal instead of going dark. Non-breaking — the native path is completely unchanged whenever the portal fallback isn't engaged.
+
 ## [2.12.6] - 2026-06-13
 
 An honesty fix for the CUPRA/SEAT repair notice.

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -25,7 +25,7 @@ from .._util import (
     workshop_phone_from_contact,
 )
 from .._ola_headers import get_fallback_count, get_ola_headers
-from ..exceptions import APIError, SpinError
+from ..exceptions import APIError, AuthenticationError, SpinError
 from ..models import BRAND_CUPRA, BRAND_SEAT, BrandConfig, VehicleData
 from .base import CariadBaseClient
 
@@ -262,6 +262,24 @@ class SeatCupraClient(CariadBaseClient):
         sensors. The garage response already includes these; we just
         weren't reading them.
         """
+        # v2.12.6 — EU Data Act portal mode (read-only fallback). When the
+        # OLA backend is blocked (CUPRA/SEAT behind VW's 2026-06 device-
+        # attestation wall), the auth resolver retains a portal connector on
+        # ``self._eu_portal``. VIN enumeration must come from the portal too —
+        # otherwise the login falls back but the next poll still hits the dead
+        # OLA garage and the entry ends with "no vehicles" (the same gap VW EU
+        # closed for itself in #388).
+        portal = getattr(self, "_eu_portal", None)
+        if portal is not None:
+            try:
+                portal_vins: list[str] = await portal.list_vehicle_vins()
+            except AuthenticationError:
+                if self._tokens and self._tokens.strategy == "device_grant_portal":
+                    await self._refresh_tokens()
+                else:
+                    await portal.login(self._email, self._password)
+                portal_vins = await portal.list_vehicle_vins()
+            return portal_vins
         if not self._user_id:
             await self._fetch_user_id()
         data = await self._get(f"{_BASE}/v2/users/{self._user_id}/garage/vehicles")
@@ -439,6 +457,20 @@ class SeatCupraClient(CariadBaseClient):
 
     async def get_status(self, vin: str) -> VehicleData:
         """Fetch full status from OLA server."""
+        # v2.12.6 — EU Data Act portal mode (read-only fallback). Route the
+        # whole status read through the portal connector on ``self._eu_portal``
+        # when the OLA backend is blocked (same pattern as VW EU).
+        portal = getattr(self, "_eu_portal", None)
+        if portal is not None:
+            try:
+                data: VehicleData = await portal.get_vehicle_data(vin)
+            except AuthenticationError:
+                if self._tokens and self._tokens.strategy == "device_grant_portal":
+                    await self._refresh_tokens()
+                else:
+                    await portal.login(self._email, self._password)
+                data = await portal.get_vehicle_data(vin)
+            return data
         v = self._val
         d = VehicleData(vin=vin)
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -23,6 +23,7 @@ from .._util import (
     safe_int,
     workshop_phone_from_contact,
 )
+from ..exceptions import AuthenticationError
 from ..models import BRAND_SKODA, VehicleData
 from .base import CariadBaseClient
 
@@ -40,6 +41,21 @@ class SkodaClient(CariadBaseClient):
 
     async def get_vehicles(self) -> list[str]:
         """Return VINs from Škoda garage."""
+        # v2.12.6 — EU Data Act portal mode (read-only fallback). If the
+        # native Škoda backend is blocked, VIN enumeration comes from the
+        # portal connector on ``self._eu_portal`` (same pattern as VW EU) so
+        # the entry doesn't end with "no vehicles" after a portal login.
+        portal = getattr(self, "_eu_portal", None)
+        if portal is not None:
+            try:
+                portal_vins: list[str] = await portal.list_vehicle_vins()
+            except AuthenticationError:
+                if self._tokens and self._tokens.strategy == "device_grant_portal":
+                    await self._refresh_tokens()
+                else:
+                    await portal.login(self._email, self._password)
+                portal_vins = await portal.list_vehicle_vins()
+            return portal_vins
         params = {
             "connectivityGenerations": ["MOD1", "MOD2", "MOD3", "MOD4"],
         }
@@ -413,6 +429,20 @@ class SkodaClient(CariadBaseClient):
 
     async def get_status(self, vin: str) -> VehicleData:
         """Fetch full status from Škoda API."""
+        # v2.12.6 — EU Data Act portal mode (read-only fallback). Route the
+        # whole status read through the portal connector on ``self._eu_portal``
+        # when the native backend is blocked (same pattern as VW EU).
+        portal = getattr(self, "_eu_portal", None)
+        if portal is not None:
+            try:
+                data: VehicleData = await portal.get_vehicle_data(vin)
+            except AuthenticationError:
+                if self._tokens and self._tokens.strategy == "device_grant_portal":
+                    await self._refresh_tokens()
+                else:
+                    await portal.login(self._email, self._password)
+                data = await portal.get_vehicle_data(vin)
+            return data
         v = self._val
         d = VehicleData(vin=vin)
 

--- a/tests/test_v2126_portal_fallback_routing.py
+++ b/tests/test_v2126_portal_fallback_routing.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.12.6 — universal EU Data Act portal read-routing fallback.
+
+When a brand's native backend is blocked (e.g. CUPRA/SEAT online services
+behind VW's 2026-06 device-attestation wall) the auth resolver falls the
+login back to the read-only EU Data Act portal and retains the connector on
+``self._eu_portal``. Before this change, only VW EU re-routed its *reads*
+through the portal — CUPRA/SEAT/Škoda fell back at login but the next poll
+still hit the dead native endpoint, so you'd get a successful login and then
+no data. These tests pin that get_vehicles()/get_status() now route through
+the portal when it's active, and that the native path is untouched when it
+isn't.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _portal(vins=None, vin="VINPORTAL01"):
+    p = MagicMock()
+    p.list_vehicle_vins = AsyncMock(return_value=vins if vins is not None else [vin])
+    p.get_vehicle_data = AsyncMock(return_value=VehicleData(vin=vin))
+    p.login = AsyncMock()
+    p.get_relation_nickname = AsyncMock(return_value=None)
+    return p
+
+
+def _seatcupra(brand="cupra"):
+    from custom_components.vag_connect.cariad.api.seat_cupra import SeatCupraClient
+    return SeatCupraClient(MagicMock(), brand, "u@t.de", "pw")
+
+
+def _skoda():
+    from custom_components.vag_connect.cariad.api.skoda import SkodaClient
+    return SkodaClient(MagicMock(), "u@t.de", "pw")
+
+
+class TestSeatCupraPortalRouting:
+    def test_get_vehicles_routes_through_portal(self):
+        client = _seatcupra("cupra")
+        portal = _portal(vins=["VINPORTAL01"])
+        client._eu_portal = portal
+        vins = asyncio.run(client.get_vehicles())
+        assert vins == ["VINPORTAL01"]
+        portal.list_vehicle_vins.assert_awaited_once()
+
+    def test_get_status_routes_through_portal(self):
+        client = _seatcupra("seat")
+        portal = _portal(vin="VINPORTAL02")
+        client._eu_portal = portal
+        data = asyncio.run(client.get_status("VINPORTAL02"))
+        assert data.vin == "VINPORTAL02"
+        portal.get_vehicle_data.assert_awaited_once_with("VINPORTAL02")
+
+    def test_no_portal_uses_native_garage(self):
+        # _eu_portal unset (None) → native OLA garage path, not the portal.
+        client = _seatcupra("cupra")
+        client._user_id = "uid-123"
+        client._get = AsyncMock(return_value={"vehicles": [{"vin": "NATIVE0001"}]})
+        vins = asyncio.run(client.get_vehicles())
+        assert "NATIVE0001" in vins
+
+
+class TestSkodaPortalRouting:
+    def test_get_vehicles_routes_through_portal(self):
+        client = _skoda()
+        portal = _portal(vins=["VINPORTAL03"])
+        client._eu_portal = portal
+        vins = asyncio.run(client.get_vehicles())
+        assert vins == ["VINPORTAL03"]
+        portal.list_vehicle_vins.assert_awaited_once()
+
+    def test_get_status_routes_through_portal(self):
+        client = _skoda()
+        portal = _portal(vin="VINPORTAL04")
+        client._eu_portal = portal
+        data = asyncio.run(client.get_status("VINPORTAL04"))
+        assert data.vin == "VINPORTAL04"
+        portal.get_vehicle_data.assert_awaited_once_with("VINPORTAL04")


### PR DESCRIPTION
**Closes the half-wired portal fallback.** Only VW EU re-routed its `get_vehicles`/`get_status` through the retained portal connector. CUPRA/SEAT/Skoda fell back to the portal at **login** but their read methods kept hitting the dead native endpoint — so a successful portal login still yielded **no data** (exactly why CUPRA shows nothing once OLA went behind VW's device-attestation wall).

They now route reads through `self._eu_portal` when it's set, matching the proven VW EU pattern (same device-grant refresh / cookie re-login handling). The EU Data Act portal becomes the **universal read-only safety net** — as VW closes native access brand by brand, each degrades gracefully to the portal instead of going dark.

- Non-breaking: native path is completely unchanged when no portal fallback is engaged (gated on `self._eu_portal` being set).
- Routing tests added (mock portal connector; no account needed).
- **Honest caveat:** portal data-reach for CUPRA/SEAT/Skoda is not account-verified yet (only VW EU is live-verified). The wiring is additive + dormant until the fallback actually engages.

Addresses the pending 'CUPRA/SEAT portal-fallback brand-routing' work; Porsche / VW US-CA stay out of scope (separate auth stacks, no EU Data Act portal).