### PR TITLE
feat(portal): arm the portal fallback on a native data-block, not just login failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ### Fixed
 
 - **CUPRA, SEAT and Škoda now route their data reads through the EU Data Act portal when the portal fallback is active** — not just their login. Until now, when a brand's native backend went dark (e.g. CUPRA/SEAT's online services getting blocked by VW), the login correctly fell back to the read-only portal, but the very next data poll still hit the dead native endpoint — so you'd get a successful login and then no data. These brands now follow the same portal-routing path VW EU already used, both for the vehicle list and the status read. It's the EU Data Act portal becoming the universal read-only safety net: as VW keeps closing native access brand by brand, each one degrades gracefully to the portal instead of going dark. Non-breaking — the native path is completely unchanged whenever the portal fallback isn't engaged.
+- **CUPRA/SEAT now actually reach that fallback.** There was a catch: the portal fallback only ever armed when the *login* failed — but for CUPRA/SEAT the login still succeeds and it's only the data call that gets blocked (the 403 device-attestation wall). So the fallback never fired and the previous fix couldn't help. Now, when the native garage call comes back 403 despite a valid login, the integration arms the read-only EU Data Act portal on the spot and serves the vehicle list from there. This is what makes the portal safety net real for the brands that are blocked *today*.
 
 ## [2.12.6] - 2026-06-13
 

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -314,33 +314,13 @@ class CariadBaseClient:
                         **opts,
                     )
                 elif kind == "data_act_portal":
-                    # v2.12.0 — cookie-based EU Data Act portal connector.
-                    # Replaces the old PKCE-token DataActPortalAuth, which
-                    # was architecturally wrong (the portal is a confidential
-                    # Auth0 client; we can't exchange the code). The connector
-                    # logs in via cookies and serves data from /proxy_api.
-                    import time as _time  # noqa: PLC0415
-
-                    from ..auth._eu_data_act import (  # noqa: PLC0415
-                        EUDataActConnector,
-                    )
-                    connector = EUDataActConnector(
-                        self._session, brand=self._brand.name,
-                    )
-                    await connector.login(self._email, self._password)
-                    self._eu_portal = connector
-                    # Sentinel TokenSet: no real token (cookie session),
-                    # but valid() needs access_token + id_token non-empty
-                    # so downstream treats us as authenticated. Long expiry
-                    # so the coordinator doesn't churn re-logins; the
-                    # connector re-logins on 401/403 via get_status.
-                    self._tokens = TokenSet(
-                        access_token="eu-data-act-portal-cookie-session",
-                        refresh_token="",
-                        id_token="eu-data-act-portal-cookie-session",
-                        expires_at=_time.time() + 3300,
-                        strategy="data_act_portal",
-                    )
+                    # v2.12.0 — cookie-based EU Data Act portal connector
+                    # (read-only). v2.12.7 — the build+login+sentinel logic
+                    # moved to ``_arm_eu_portal`` so the SAME arming can fire
+                    # as a runtime fallback when a brand's native data backend
+                    # is blocked mid-flight (e.g. CUPRA/SEAT OLA 403) even
+                    # though the IDP login still succeeds.
+                    await self._arm_eu_portal()
                 else:
                     raise AuthenticationError(f"Unknown strategy kind: {kind}")
 
@@ -405,6 +385,36 @@ class CariadBaseClient:
                         f"Auth failed with {type(err).__name__} "
                         f"(no usable strategy left)"
                     ) from err
+
+    async def _arm_eu_portal(self) -> None:
+        """Build + log in the read-only EU Data Act portal connector and
+        retain it on ``self._eu_portal`` with a sentinel TokenSet.
+
+        v2.12.7 — used both by the ``data_act_portal`` login strategy AND as
+        a runtime fallback when a brand's native data backend is blocked
+        (e.g. the CUPRA/SEAT OLA ``403`` device-attestation wall) while the
+        IDP login still succeeds. In that case the login-time fallback never
+        fires, so the brand's read methods arm the portal here on a persistent
+        native block — reads then degrade to the portal instead of going dark.
+        """
+        import time as _time  # noqa: PLC0415
+
+        from ..auth._eu_data_act import EUDataActConnector  # noqa: PLC0415
+
+        connector = EUDataActConnector(self._session, brand=self._brand.name)
+        await connector.login(self._email, self._password)
+        self._eu_portal = connector
+        # Sentinel TokenSet: no real token (cookie session), but valid()
+        # needs access_token + id_token non-empty so downstream treats us as
+        # authenticated. Long expiry so the coordinator doesn't churn
+        # re-logins; the connector re-logins on 401/403 via the read methods.
+        self._tokens = TokenSet(
+            access_token="eu-data-act-portal-cookie-session",
+            refresh_token="",
+            id_token="eu-data-act-portal-cookie-session",
+            expires_at=_time.time() + 3300,
+            strategy="data_act_portal",
+        )
 
     def set_persisted_tokens(self, tokens: TokenSet | None) -> None:
         """v1.19.2 (#118) — inject tokens loaded from HA storage at

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -290,7 +290,7 @@ class SeatCupraClient(CariadBaseClient):
             # succeeded, so the login-time portal fallback never armed).
             # Arm the read-only EU Data Act portal now and serve VINs from
             # there instead of leaving the entry stuck with "no vehicles".
-            if "403" not in str(exc):
+            if exc.status != 403:
                 raise
             _LOGGER.warning(
                 "%s OLA garage blocked (403) despite a valid login — arming "

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -280,9 +280,26 @@ class SeatCupraClient(CariadBaseClient):
                     await portal.login(self._email, self._password)
                 portal_vins = await portal.list_vehicle_vins()
             return portal_vins
-        if not self._user_id:
-            await self._fetch_user_id()
-        data = await self._get(f"{_BASE}/v2/users/{self._user_id}/garage/vehicles")
+        try:
+            if not self._user_id:
+                await self._fetch_user_id()
+            data = await self._get(f"{_BASE}/v2/users/{self._user_id}/garage/vehicles")
+        except APIError as exc:
+            # v2.12.7 — the native OLA backend is blocked (VW's device-
+            # attestation wall returns 403 even though the IDP login
+            # succeeded, so the login-time portal fallback never armed).
+            # Arm the read-only EU Data Act portal now and serve VINs from
+            # there instead of leaving the entry stuck with "no vehicles".
+            if "403" not in str(exc):
+                raise
+            _LOGGER.warning(
+                "%s OLA garage blocked (403) despite a valid login — arming "
+                "the read-only EU Data Act portal fallback.",
+                self._brand.name.upper(),
+            )
+            await self._arm_eu_portal()
+            armed_vins: list[str] = await self._eu_portal.list_vehicle_vins()
+            return armed_vins
         vehicles: list[dict[str, Any]] = data.get("vehicles", [])
         vins = []
         for vehicle in vehicles:

--- a/tests/test_v2126_portal_fallback_routing.py
+++ b/tests/test_v2126_portal_fallback_routing.py
@@ -95,7 +95,9 @@ class TestSeatCupraRuntimeArming:
     def test_get_vehicles_arms_portal_on_ola_403(self):
         client = _seatcupra("cupra")
         client._user_id = "uid-123"
-        client._get = AsyncMock(side_effect=APIError("HTTP 403 Forbidden on ola.prod"))
+        client._get = AsyncMock(
+            side_effect=APIError(403, "https://ola.prod.code.seat.cloud.vwgroup.com/garage")
+        )
         portal = _portal(vins=["VINPORTAL09"])
 
         async def _arm():
@@ -109,7 +111,9 @@ class TestSeatCupraRuntimeArming:
     def test_get_vehicles_non_403_does_not_arm(self):
         client = _seatcupra("seat")
         client._user_id = "uid-123"
-        client._get = AsyncMock(side_effect=APIError("HTTP 500 server error"))
+        client._get = AsyncMock(
+            side_effect=APIError(500, "https://ola.prod.code.seat.cloud.vwgroup.com/garage")
+        )
         client._arm_eu_portal = AsyncMock()
         with pytest.raises(APIError):
             asyncio.run(client.get_vehicles())

--- a/tests/test_v2126_portal_fallback_routing.py
+++ b/tests/test_v2126_portal_fallback_routing.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
+import pytest
 
+from custom_components.vag_connect.cariad.exceptions import APIError
 from custom_components.vag_connect.cariad.models import VehicleData
 
 
@@ -81,3 +83,34 @@ class TestSkodaPortalRouting:
         data = asyncio.run(client.get_status("VINPORTAL04"))
         assert data.vin == "VINPORTAL04"
         portal.get_vehicle_data.assert_awaited_once_with("VINPORTAL04")
+
+
+class TestSeatCupraRuntimeArming:
+    """v2.12.7 — when the OLA login SUCCEEDS but the data backend is blocked
+    (403, VW's device-attestation wall), the login-time portal fallback never
+    fires (only login failures trigger it). get_vehicles must arm the portal
+    on the native 403 so the entry recovers via the read-only portal instead
+    of going dark with "no vehicles"."""
+
+    def test_get_vehicles_arms_portal_on_ola_403(self):
+        client = _seatcupra("cupra")
+        client._user_id = "uid-123"
+        client._get = AsyncMock(side_effect=APIError("HTTP 403 Forbidden on ola.prod"))
+        portal = _portal(vins=["VINPORTAL09"])
+
+        async def _arm():
+            client._eu_portal = portal
+
+        client._arm_eu_portal = AsyncMock(side_effect=_arm)
+        vins = asyncio.run(client.get_vehicles())
+        assert vins == ["VINPORTAL09"]
+        client._arm_eu_portal.assert_awaited_once()
+
+    def test_get_vehicles_non_403_does_not_arm(self):
+        client = _seatcupra("seat")
+        client._user_id = "uid-123"
+        client._get = AsyncMock(side_effect=APIError("HTTP 500 server error"))
+        client._arm_eu_portal = AsyncMock()
+        with pytest.raises(APIError):
+            asyncio.run(client.get_vehicles())
+        client._arm_eu_portal.assert_not_awaited()


### PR DESCRIPTION
**Makes the universal portal fallback (#467) actually engage for the brands blocked today.**

The catch: the EU Data Act portal fallback only ever armed when the *login* failed. But CUPRA/SEAT logins still **succeed** right now — it's only the OLA data call that returns `403` (VW's device-attestation wall). So the login-time fallback never fired, `self._eu_portal` stayed `None`, and the read-routing from #467 couldn't engage. It was effectively dead code for exactly the brands that are down.

This change:
- Extracts the portal build+login+sentinel into `CariadBaseClient._arm_eu_portal()` (reused by the `data_act_portal` login strategy — pure refactor).
- `SeatCupra.get_vehicles` now arms the portal **on a persistent OLA 403** (despite a valid login) and serves the vehicle list from the portal; the #467 read-routing then takes over for status.
- Non-breaking: only fires on a `403` from an otherwise-authenticated session; native path unchanged otherwise. Tests cover arm-on-403 and no-arm-on-500.

Honest caveat: still not account-verified end-to-end for CUPRA portal data (we only have a live VW EU account); the arming + routing are correct and non-breaking, dormant until a real 403 hits. Skoda mid-session arming + the get_status arming edge are deferred (recover on restart via get_vehicles).