### PR TITLE
chore(release): cut v2.13.0 - universal EU Data Act portal fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [Unreleased]
+## [2.13.0] - 2026-06-13
+
+The EU Data Act portal becomes the **universal read-only safety net**: as VW keeps closing native API access brand by brand (VW EU's token logins are gone, CUPRA/SEAT's online services are now behind a device-attestation wall), each affected brand now degrades gracefully to the read-only portal instead of going dark.
 
 ### Fixed
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.12.6"
+  "version": "2.13.0"
 }


### PR DESCRIPTION
Bundles the `[Unreleased]` work into v2.13.0:
- #467 — CUPRA/SEAT/Skoda route their data reads through the EU Data Act portal when the fallback is active (not just login).
- #468 — arm the portal on a native data-block (403) even when the login still succeeds — what makes the fallback real for the brands blocked today.
- #469 — skip the dead BFF capabilities call in portal mode (log-noise cleanup).

Net: the EU Data Act portal is now the universal read-only safety net across the CARIAD brands. manifest 2.12.6 → 2.13.0.