### PR TITLE
fix(portal): exponential backoff on transient EU Data Act portal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.13.1] - 2026-06-14
+
+### Fixed
+
+- **Fewer dropped polls when the EU Data Act portal is having a moment.** The portal throws transient server errors (500/502/503/504) that come and go within seconds — and until now a single blip meant skipping the whole poll and waiting 15 minutes for the next one. The integration now backs off briefly and retries (a couple of times, a few seconds apart) before giving up as "no data this poll", so a short hiccup no longer costs you a full cycle of data. The "you haven't enabled the data request yet" case (404) still returns instantly with no added delay, and a real auth failure still re-authenticates as before.
+
 ## [2.13.0] - 2026-06-13
 
 The EU Data Act portal becomes the **universal read-only safety net**: as VW keeps closing native API access brand by brand (VW EU's token logins are gone, CUPRA/SEAT's online services are now behind a device-attestation wall), each affected brand now degrades gracefully to the read-only portal instead of going dark.

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -28,6 +28,7 @@ Attribution in LEGAL.md.
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import logging
@@ -104,6 +105,12 @@ _TIMEOUT_S = 60
 # of raising AuthenticationError and triggering pointless re-login churn + a
 # stream of error reports. 401/403 still mean a genuinely expired session.
 _TRANSIENT_STATUSES = (404, 410, 500, 502, 503, 504)
+# v2.13.1 — of those, only the genuinely transient server errors are worth
+# retrying with backoff; 404/410 ("data request not provisioned yet") are a
+# stable state and return "no data" immediately, so we don't add latency to
+# the common not-set-up case.
+_RETRIABLE_STATUSES = frozenset({500, 502, 503, 504})
+_PORTAL_RETRY_DELAYS = (3.0, 6.0)  # backoff (s) before giving up on a soft call
 
 
 # ── HTML / templateModel parsing (community-proven mechanics) ──────────────
@@ -601,14 +608,30 @@ class EUDataActConnector:
         eff_headers = dict(headers or {})
         if self._bearer:
             eff_headers["Authorization"] = f"Bearer {self._bearer}"
-        async with self._session.get(
-            url, headers=eff_headers, timeout=ClientTimeout(total=_TIMEOUT_S),
-        ) as resp:
-            if resp.status >= 400:
-                if soft and resp.status in _TRANSIENT_STATUSES:
-                    return None
-                raise AuthenticationError(f"EU Data Act GET {url} → HTTP {resp.status}")
-            return await resp.json(content_type=None)
+        # v2.13.1 — the portal is flaky: transient 5xx come and go within
+        # seconds (the whole portal ecosystem hit this). On a soft call we
+        # back off and retry the genuinely-transient server errors a couple of
+        # times before giving up as "no data this poll", recovering polls the
+        # portal would otherwise drop. A 404/410 (request not provisioned)
+        # returns immediately; a real 401/403 still raises.
+        for attempt in range(len(_PORTAL_RETRY_DELAYS) + 1):
+            async with self._session.get(
+                url, headers=eff_headers, timeout=ClientTimeout(total=_TIMEOUT_S),
+            ) as resp:
+                if resp.status >= 400:
+                    if soft and resp.status in _TRANSIENT_STATUSES:
+                        if (
+                            resp.status in _RETRIABLE_STATUSES
+                            and attempt < len(_PORTAL_RETRY_DELAYS)
+                        ):
+                            await asyncio.sleep(_PORTAL_RETRY_DELAYS[attempt])
+                            continue
+                        return None
+                    raise AuthenticationError(
+                        f"EU Data Act GET {url} → HTTP {resp.status}"
+                    )
+                return await resp.json(content_type=None)
+        return None
 
     async def list_vehicle_vins(self) -> list[str]:
         """Return the VINs consented on the portal."""

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.13.0"
+  "version": "2.13.1"
 }

--- a/tests/test_v2131_portal_backoff.py
+++ b/tests/test_v2131_portal_backoff.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.13.1 — exponential backoff on the flaky EU Data Act portal.
+
+The portal returns transient 5xx that come and go within seconds (the whole
+portal ecosystem hit this). On a soft call, ``_get_json`` now backs off and
+retries the genuinely-transient server errors a couple of times before giving
+up as "no data this poll" — recovering polls the portal would otherwise drop.
+A 404/410 (data request not provisioned yet) returns immediately (no added
+latency); a real 401/403 still raises.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import EUDataActConnector
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+
+_SLEEP = "custom_components.vag_connect.cariad.auth._eu_data_act.asyncio.sleep"
+
+
+def _resp(status, json_data=None):
+    r = AsyncMock()
+    r.status = status
+    r.json = AsyncMock(return_value=json_data if json_data is not None else {})
+    r.__aenter__ = AsyncMock(return_value=r)
+    r.__aexit__ = AsyncMock(return_value=False)
+    return r
+
+
+def _session_seq(responses):
+    s = MagicMock()
+    it = iter(responses)
+    s.get = MagicMock(side_effect=lambda *a, **k: next(it))
+    return s
+
+
+def _conn(session):
+    return EUDataActConnector(session, brand="volkswagen")
+
+
+class TestPortalBackoff:
+    def test_transient_then_success(self):
+        sess = _session_seq([_resp(503), _resp(200, {"ok": 1})])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()):
+            out = asyncio.run(conn._get_json("https://x/y", soft=True))
+        assert out == {"ok": 1}
+        assert sess.get.call_count == 2
+
+    def test_persistent_transient_returns_none_after_retries(self):
+        sess = _session_seq([_resp(503), _resp(502), _resp(500)])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()):
+            out = asyncio.run(conn._get_json("https://x/y", soft=True))
+        assert out is None
+        assert sess.get.call_count == 3  # 1 try + 2 retries
+
+    def test_404_returns_immediately_without_retry(self):
+        sess = _session_seq([_resp(404)])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()) as sleep:
+            out = asyncio.run(conn._get_json("https://x/y", soft=True))
+        assert out is None
+        assert sess.get.call_count == 1  # 404 is a stable state, not retried
+        sleep.assert_not_awaited()
+
+    def test_non_soft_raises_immediately(self):
+        sess = _session_seq([_resp(500)])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()):
+            with pytest.raises(AuthenticationError):
+                asyncio.run(conn._get_json("https://x/y", soft=False))
+        assert sess.get.call_count == 1


### PR DESCRIPTION
Applies the #1 learning from the competitive audit: the EU Data Act portal is flaky right now — the whole ecosystem (evcc, ioBroker, mikrohard, pycupra) hit transient 5xx that come and go within seconds. Until now a single blip dropped the entire 15-min poll.

`_get_json` now backs off (3s, 6s) and retries the genuinely-transient server errors (500/502/503/504) before giving up soft as 'no data this poll'. A 404/410 ('data request not provisioned yet') returns **immediately** — no added latency for the common not-set-up case; non-soft callers and real 401/403 still raise.

Tests: transient-then-success, persistent-give-up-after-2-retries, 404-no-retry, non-soft-raises. v2.13.1 (resilience patch).