### PR TITLE
feat(vw): opt-in volkswagen.de website-authproxy read channel (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.0] - 2026-06-14
+
+### Added
+
+- **New opt-in beta way to connect a Volkswagen: the volkswagen.de website (read-only).** There's now a third sign-in option when you add a Volkswagen — "Volkswagen.de website (beta)" — that logs in the same way the volkswagen.de "myVolkswagen" web area does and reads your car through it. The point: that website uses its own server-side login, so it goes around the app-attestation wall that's been killing the normal token logins for VW. You sign in with your Volkswagen ID email + password (and an emailed code if your account asks for one), and you get charge level, range, charging state and power, charge target, plus odometer and service-due info. It's **read-only** — no lock/climate/charge commands — and **opt-in**: you have to pick it on purpose. Nothing changes for anyone who doesn't, every existing setup (app login, browser login, EU Data Act portal) behaves exactly as before. It's a beta and hasn't been verified end-to-end against a live VW account yet, so treat it as experimental.
+
 ## [2.13.1] - 2026-06-14
 
 ### Fixed

--- a/custom_components/vag_connect/_canaries.py
+++ b/custom_components/vag_connect/_canaries.py
@@ -72,6 +72,15 @@ CANARY_SCOUT: Final[str] = "scout_unexpected_provenance_f4hzl5r8_2026"
 # logic travels with it.
 CANARY_WATCHDOG: Final[str] = "watchdog_silentauth_provenance_n2vpw9c3_2026"
 
+# v2.14.0 — Website authproxy canary: referenced from
+# WebsiteAuthProxyConnector.__init__ in
+# cariad/auth/_website_authproxy.py so any port of the volkswagen.de
+# website-authproxy read channel (Auth0 login + /app/authproxy reverse-
+# proxy data reads) travels with it.
+CANARY_WEBSITE_AUTHPROXY: Final[str] = (
+    "website_authproxy_provenance_b6tkd2x9_2026"
+)
+
 
 # Full list, exported for the watcher workflow + provenance test.
 ALL_CANARIES: Final[tuple[str, ...]] = (
@@ -80,4 +89,5 @@ ALL_CANARIES: Final[tuple[str, ...]] = (
     CANARY_DAG_FLOW,
     CANARY_SCOUT,
     CANARY_WATCHDOG,
+    CANARY_WEBSITE_AUTHPROXY,
 )

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -119,6 +119,19 @@ class CariadBaseClient:
         # retained here so the brand client's get_status routes through
         # it instead of the (dead) token-based BFF. None = token mode.
         self._eu_portal: Any = None
+        # v2.14.0 — OPT-IN, BETA. When the user explicitly chooses the
+        # volkswagen.de website-authproxy mode, the coordinator flips this
+        # flag (set_website_authproxy_mode) BEFORE authenticate(). It makes
+        # authenticate() use the cookie-based WebsiteAuthProxyConnector
+        # (retained on _website_proxy) as the sole strategy and routes
+        # get_vehicles/get_status through it — exactly the way _eu_portal is
+        # wired. Default False → every existing strategy path is untouched.
+        self._use_website_proxy: bool = False
+        self._website_proxy: Any = None
+        # When the website-authproxy login surfaces an email-OTP challenge,
+        # the code the user enters in the config flow is handed to the
+        # connector via this field before authenticate() runs.
+        self._website_proxy_otp: str | None = None
         self._image_data: dict[str, VehicleImageData] = {}
         self._refresh_lock: asyncio.Lock | None = None
         # Sliding window of token refresh attempt timestamps (monotonic seconds).
@@ -284,7 +297,18 @@ class CariadBaseClient:
         # standard IDKAuth.authenticate path and "data_act_portal" for the
         # last-resort read-only fallback.
         strategies: list[tuple[str, dict[str, bool]]] = []
-        if self._brand.name == "volkswagen":
+        # v2.14.0 — when authenticate() is re-driven with an OTP code (e.g. a
+        # coordinator reauth for the website-authproxy channel), feed it to the
+        # connector so the email-challenge step can complete.
+        if self._use_website_proxy and mfa_code:
+            self._website_proxy_otp = mfa_code
+        # v2.14.0 — OPT-IN website-authproxy mode short-circuits the whole
+        # resolver: it is the ONLY strategy when the user selected it, so we
+        # never touch the BFF/hybrid/Data-Act chain. Gated on the explicit
+        # opt-in flag, so this branch is dead for every other entry.
+        if self._use_website_proxy:
+            strategies = [("website_authproxy", {})]
+        elif self._brand.name == "volkswagen":
             strategies = [
                 ("idk", {"hybrid_full": True}),
                 ("idk", {"hybrid_full": False}),
@@ -321,6 +345,11 @@ class CariadBaseClient:
                     # is blocked mid-flight (e.g. CUPRA/SEAT OLA 403) even
                     # though the IDP login still succeeds.
                     await self._arm_eu_portal()
+                elif kind == "website_authproxy":
+                    # v2.14.0 — OPT-IN, read-only volkswagen.de website
+                    # authproxy connector. Only reached when the user opted in
+                    # (see the strategy list above), so dormant otherwise.
+                    await self._arm_website_proxy()
                 else:
                     raise AuthenticationError(f"Unknown strategy kind: {kind}")
 
@@ -414,6 +443,69 @@ class CariadBaseClient:
             id_token="eu-data-act-portal-cookie-session",
             expires_at=_time.time() + 3300,
             strategy="data_act_portal",
+        )
+
+    def set_website_authproxy_mode(
+        self, enabled: bool, *, otp: str | None = None
+    ) -> None:
+        """v2.14.0 — OPT-IN: route this client through the website authproxy.
+
+        Called by the coordinator (and the config-flow validator) when the
+        user explicitly selected the "Volkswagen.de website (beta)" mode.
+        Strictly additive: when ``enabled`` is False (the default), nothing
+        changes and every existing strategy path runs unmodified. ``otp`` is
+        the email-OTP code collected by the config flow, consumed once on the
+        next ``authenticate()``.
+        """
+        self._use_website_proxy = bool(enabled)
+        self._website_proxy_otp = otp
+
+    async def _arm_website_proxy(self) -> None:
+        """Build + log in the read-only website-authproxy connector.
+
+        v2.14.0 — mirrors ``_arm_eu_portal``: it logs the connector in,
+        retains it on ``self._website_proxy`` so the brand client's
+        get_vehicles/get_status route through it, and stores a sentinel
+        TokenSet (``strategy="website_authproxy"``) so downstream treats the
+        client as authenticated and the coordinator forces read-only mode.
+
+        A pending email-OTP challenge raises ``EmailTwoFactorRequiredError``
+        unless an OTP code was supplied via ``set_website_authproxy_mode`` —
+        the config flow catches that to add the OTP step, and the coordinator
+        surfaces the matching Repair issue.
+        """
+        import time as _time  # noqa: PLC0415
+
+        from ..auth._website_authproxy import (  # noqa: PLC0415
+            WebsiteAuthProxyConnector,
+        )
+        from ..exceptions import EmailTwoFactorRequiredError  # noqa: PLC0415
+
+        connector = WebsiteAuthProxyConnector(
+            self._session, self._email, self._password, brand=self._brand.name,
+        )
+        result = await connector.begin_login()
+        if result == "otp_required":
+            if not self._website_proxy_otp:
+                raise EmailTwoFactorRequiredError()
+            ok = await connector.submit_otp(self._website_proxy_otp)
+            # OTP is single-use — drop it so a later re-login doesn't reuse it.
+            self._website_proxy_otp = None
+            if not ok:
+                raise AuthenticationError(
+                    "Website authproxy: OTP submission did not complete login"
+                )
+        self._website_proxy = connector
+        # Sentinel TokenSet: no usable bearer (cookie session), but valid()
+        # needs access_token + id_token non-empty so the client counts as
+        # authenticated. Long expiry so the coordinator doesn't churn relogins;
+        # the connector re-establishes the session on 401/403 via refresh().
+        self._tokens = TokenSet(
+            access_token="vw-website-authproxy-cookie-session",
+            refresh_token="",
+            id_token="vw-website-authproxy-cookie-session",
+            expires_at=_time.time() + 3300,
+            strategy="website_authproxy",
         )
 
     def set_persisted_tokens(self, tokens: TokenSet | None) -> None:

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -102,6 +102,19 @@ class VWEUClient(CariadBaseClient):
 
     async def get_vehicles(self) -> list[str]:
         """Return list of VINs from the CARIAD garage."""
+        # v2.14.0 — OPT-IN website-authproxy mode (read-only beta). When the
+        # user explicitly chose it, VINs come from the authproxy relations
+        # endpoint, not the BFF. Routed first + identically to the EU Data Act
+        # portal below; dormant (proxy is None) for every other entry.
+        web = getattr(self, "_website_proxy", None)
+        if web is not None:
+            try:
+                web_vins: list[str] = await web.list_vehicle_vins()
+            except AuthenticationError:
+                await web.refresh()
+                web_vins = await web.list_vehicle_vins()
+            return web_vins
+
         # v2.12.0 — EU Data Act portal mode: the token-based CARIAD garage
         # is dead for VW EU, so VIN enumeration also has to come from the
         # portal (not just get_status). Without this the coordinator's
@@ -340,6 +353,19 @@ class VWEUClient(CariadBaseClient):
 
     async def get_status(self, vin: str) -> VehicleData:
         """Fetch full vehicle status via selectivestatus."""
+        # v2.14.0 — OPT-IN website-authproxy mode (read-only beta). Routed
+        # first + identically to the EU Data Act portal below; on a stale
+        # cookie session the connector re-establishes it via refresh().
+        # Dormant (proxy is None) for every other entry.
+        web = getattr(self, "_website_proxy", None)
+        if web is not None:
+            try:
+                web_data: VehicleData = await web.get_vehicle_data(vin)
+            except AuthenticationError:
+                await web.refresh()
+                web_data = await web.get_vehicle_data(vin)
+            return web_data
+
         # v2.12.0 — EU Data Act portal mode (read-only fallback). When the
         # token-based BFF strategies are exhausted, the auth resolver
         # retains a cookie-based portal connector on ``self._eu_portal``.

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -1,0 +1,651 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""Volkswagen.de website authproxy connector — OPT-IN, BETA, read-only.
+
+v2.14.0 — a SECOND, attestation-free read channel for VW passenger cars,
+parallel to (and independent of) the EU Data Act portal path. It rides the
+confidential server-side OAuth client that ``www.volkswagen.de`` already
+runs for its "myVolkswagen" web area, so it never touches the Play-Integrity
+/ App-Check wall that killed the native WeConnect token path.
+
+Architecture (mirrors the EU Data Act cookie connector, different host):
+  1. GET ``/app/authproxy/login`` on ``www.volkswagen.de``. The authproxy
+     starts an OIDC login and redirects us into the SAME Auth0 universal
+     login at ``identity.vwgroup.io`` the rest of the integration already
+     handles (email + password, optional email-OTP MFA).
+  2. The authproxy's OWN backend consumes the OAuth code and sets first-
+     party session cookies on ``www.volkswagen.de`` — we never exchange a
+     code ourselves (we are not the confidential client; we cannot).
+  3. Authenticated reads go to ``/app/authproxy/{fag}/proxy/...`` which the
+     site reverse-proxies to the real VW backends. Some calls carry the
+     literal header ``user-id: __userId__`` which the authproxy substitutes
+     for the signed-in user's real id server-side.
+
+This channel is **read-only** and dormant unless the user explicitly opts
+into the "Volkswagen.de website (beta)" mode in the config flow. It is wired
+additively into ``VWEUClient`` (see ``_website_proxy``) exactly the way the
+EU Data Act portal connector is wired through ``_eu_portal`` — it never
+changes behaviour for any other mode/brand.
+
+We reuse the Auth0 form/cookie/MFA mechanics from ``idk.py`` and the
+form-field/parse helpers from ``_eu_data_act.py`` rather than re-deriving
+them. Endpoint paths and response field names were cross-checked against the
+community VW website-portal connector (rafaelhutter/ha-volkswagen-connect);
+the parser below is our own.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from aiohttp import ClientSession, ClientTimeout
+
+from ..._canaries import CANARY_WEBSITE_AUTHPROXY
+from ..exceptions import AuthenticationError, EmailTwoFactorRequiredError
+from ..models import VehicleData
+from ._eu_data_act import _login_fields, _login_error, _resolve_action
+
+_LOGGER = logging.getLogger(__name__)
+
+_SITE_BASE = "https://www.volkswagen.de"
+_IDENTITY_BASE = "https://identity.vwgroup.io"
+_REDIRECT_URL = (
+    "https://www.volkswagen.de/de/besitzer-und-nutzer/myvolkswagen.html"
+)
+
+# The login trigger fans out across two upstream "function access groups"
+# (``fag``): ``vw-de`` (the myVolkswagen web backend) and ``vwag-weconnect``
+# (the WeConnect vehicle backend). Each gets its own scope set. The authproxy
+# does the confidential OIDC exchange and lands the browser back on
+# ``_REDIRECT_URL`` with first-party cookies set.
+_LOGIN_PATH = "/app/authproxy/login"
+_LOGIN_PARAMS: dict[str, str] = {
+    "fag": "vw-de,vwag-weconnect",
+    "scope-vw-de": (
+        "profile,address,phone,carConfigurations,dealers,cars,vin,"
+        "profession"
+    ),
+    "scope-vwag-weconnect": "openid,mbb",
+    "prompt-vwag-weconnect": "none",
+    "redirectUrl": _REDIRECT_URL,
+    "sessionTimeout": "1800",
+}
+
+# Reverse-proxy data endpoints. ``{vin}`` is substituted per call.
+_RELATIONS_PATH = (
+    "/app/authproxy/vw-de/proxy/v2/users/me/relations?resourceHost=myvw-vum-prod"
+)
+_CHARGING_PATH = (
+    "/app/authproxy/vwag-weconnect/proxy/vehicles/{vin}/charging/status"
+)
+_MAINTENANCE_PATH = (
+    "/app/authproxy/vw-de/proxy/vehicles/{vin}/maintenance/status"
+)
+
+# Realistic desktop browser identity — the authproxy fronts a public website
+# and is content-negotiation sensitive on the login pages.
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+)
+_TIMEOUT_S = 60
+
+# Transient server statuses worth a short backoff before we give up on a
+# single poll, mirroring the EU Data Act connector's softening. A genuine
+# 401/403 (session dead) is never swallowed here — it propagates so the
+# caller can re-login.
+_RETRIABLE_STATUSES = frozenset({500, 502, 503, 504})
+_RETRY_DELAYS = (3.0, 6.0)
+
+_VIN_RE = re.compile(r'"vin"\s*:\s*"([A-HJ-NPR-Z0-9]{17})"')
+
+
+def _to_float(raw: Any) -> float | None:
+    """Best-effort float; tolerates comma decimals; never raises."""
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        return float(str(raw).replace(",", "."))
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_int(raw: Any) -> int | None:
+    """Best-effort int via float (so ``"82.0"`` → 82); never raises."""
+    f = _to_float(raw)
+    return int(f) if f is not None else None
+
+
+def _kelvin_to_celsius(raw: Any) -> float | None:
+    """Convert a Kelvin scalar to Celsius, rounded to 1 dp. None-safe."""
+    k = _to_float(raw)
+    return round(k - 273.15, 1) if k is not None else None
+
+
+def map_charging_to_vehicle_data(payload: Any, d: VehicleData) -> VehicleData:
+    """Map a ``charging/status`` response onto ``VehicleData``.
+
+    The authproxy reverse-proxies the WeConnect charging surface, so the body
+    is the familiar ``{"data": {"batteryStatus", "chargingStatus",
+    "plugStatus"}}`` shape. Every read is defensive — a missing block or
+    field leaves the corresponding ``VehicleData`` attribute at its default.
+    """
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        return d
+    battery = data.get("batteryStatus")
+    charging = data.get("chargingStatus")
+    plug = data.get("plugStatus")
+    battery = battery if isinstance(battery, dict) else {}
+    charging = charging if isinstance(charging, dict) else {}
+    plug = plug if isinstance(plug, dict) else {}
+
+    soc = _to_int(battery.get("currentSOC_pct"))
+    if soc is not None:
+        d.battery_soc = soc
+        d.has_battery = True
+        d.is_electric = True
+
+    erange = _to_int(battery.get("cruisingRangeElectric_km"))
+    if erange is not None:
+        d.electric_range_km = erange
+        if d.range_km is None:
+            d.range_km = erange
+
+    tsoc = _to_int(battery.get("navigationTargetSOC_pct"))
+    if tsoc is not None:
+        d.target_soc = tsoc
+
+    btemp = _kelvin_to_celsius(battery.get("temperatureHvBattery_K"))
+    if btemp is not None:
+        d.battery_temp_c = btemp
+
+    state = charging.get("chargingState")
+    if isinstance(state, str) and state:
+        d.charging_state = state
+        d.is_charging = state.lower() in ("charging", "chargepurposereachedandconservation")
+
+    power = _to_float(charging.get("chargePower_kW"))
+    if power is not None:
+        d.charging_power_kw = power
+
+    rate = _to_float(charging.get("chargeRate_kmph"))
+    if rate is not None:
+        d.charging_rate_kmh = rate
+
+    eta = _to_int(charging.get("remainingChargingTimeToComplete_min"))
+    if eta is not None:
+        d.remaining_charge_time_nav_min = eta
+
+    mode = charging.get("chargeMode")
+    if isinstance(mode, str) and mode:
+        d.charge_mode = mode
+
+    plug_state = plug.get("plugConnectionState")
+    if isinstance(plug_state, str) and plug_state:
+        d.plug_state = plug_state
+        d.plug_connected = plug_state.lower() == "connected"
+
+    lock_state = plug.get("plugLockState")
+    if isinstance(lock_state, str) and lock_state:
+        d.connector_locked = lock_state.lower() == "locked"
+
+    ext = plug.get("externalPower")
+    if isinstance(ext, str) and ext:
+        d.external_power = ext.lower() not in ("unavailable", "off", "")
+
+    return d
+
+
+def map_maintenance_to_vehicle_data(payload: Any, d: VehicleData) -> VehicleData:
+    """Map a ``maintenance/status`` response onto ``VehicleData``.
+
+    The authproxy passes the maintenance surface through verbatim, so the
+    body is the WeConnect ``{"data": {"maintenanceStatus": {"value": {...}}}}``
+    shape. We accept either the wrapped ``value`` node or a flat ``data``
+    object so a backend reshuffle of the envelope still maps. Field names
+    follow the CARIAD maintenance vocabulary the rest of the integration
+    already parses. Negative "overdue" day counts are kept as-is — the
+    sensor layer renders them.
+    """
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        return d
+    status = data.get("maintenanceStatus")
+    if isinstance(status, dict):
+        node = status.get("value")
+        if not isinstance(node, dict):
+            node = status
+    else:
+        node = data
+
+    odo = _to_int(node.get("mileage_km"))
+    if odo is not None:
+        d.odometer_km = odo
+
+    insp_km = _to_int(node.get("inspectionDue_km"))
+    if insp_km is not None:
+        d.service_km = insp_km
+    insp_days = _to_int(node.get("inspectionDue_days"))
+    if insp_days is not None:
+        d.service_due_in_days = insp_days
+
+    oil_km = _to_int(node.get("oilServiceDue_km"))
+    if oil_km is not None:
+        d.oil_service_km = oil_km
+    oil_days = _to_int(node.get("oilServiceDue_days"))
+    if oil_days is not None:
+        d.oil_service_due_in_days = oil_days
+
+    return d
+
+
+class WebsiteAuthProxyConnector:
+    """OPT-IN, read-only volkswagen.de website-authproxy client.
+
+    Lifecycle:
+      ``begin_login()`` once → ``"ok"`` (logged in) or ``"otp_required"``
+      (email-OTP challenge pending — call ``submit_otp(code)``). Thereafter
+      ``list_vehicle_vins()`` + ``get_vehicle_data(vin)`` per poll, and
+      ``refresh()`` to silently re-establish the session via the persisted
+      SSO cookie on a 401.
+
+    This connector NEVER sends a command — it is a read channel only.
+    """
+
+    #: Marks this channel as command-free for any caller that introspects it.
+    read_only: bool = True
+
+    def __init__(
+        self,
+        session: ClientSession,
+        email: str,
+        password: str,
+        brand: str = "volkswagen",
+    ) -> None:
+        # Provenance canary — referenced so a port of this module carries the
+        # marker. Semantically inert (see _canaries.py).
+        self._canary = CANARY_WEBSITE_AUTHPROXY
+        self._session = session
+        self._email = email
+        self._password = password
+        self._brand = brand
+        self.logged_in = False
+        # Stashed between begin_login() and submit_otp(): the email-challenge
+        # URL plus the Auth0 state needed to POST the OTP code.
+        self._otp_url: str | None = None
+        self._otp_state: str | None = None
+
+    # ── login ──────────────────────────────────────────────────────────────
+
+    def _headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        headers = {
+            "User-Agent": _USER_AGENT,
+            "Accept-Language": "de-DE,de;q=0.9,en;q=0.8",
+        }
+        if extra:
+            headers.update(extra)
+        return headers
+
+    async def begin_login(self) -> str:
+        """Drive authproxy → Auth0 email + password. Returns the next step.
+
+        Returns ``"ok"`` when the session landed back on volkswagen.de
+        (cookies set, logged in), or ``"otp_required"`` when the IDP wants an
+        email-OTP code (the challenge URL + state are stashed for
+        ``submit_otp``). Raises ``AuthenticationError`` on bad credentials or
+        an unexpected flow.
+        """
+        self.logged_in = False
+        self._otp_url = None
+        self._otp_state = None
+
+        # 1. Hit the authproxy login trigger; follow into Auth0 universal login.
+        async with self._session.get(
+            f"{_SITE_BASE}{_LOGIN_PATH}",
+            params=_LOGIN_PARAMS,
+            headers=self._headers(),
+            allow_redirects=True,
+            timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            login_url = str(resp.url)
+            login_html = await resp.text(errors="replace")
+            login_status = resp.status
+
+        if login_status >= 400:
+            raise AuthenticationError(
+                f"Website authproxy: login page HTTP {login_status}"
+            )
+        if "/u/login" not in login_url and "signin-service" not in login_url:
+            raise AuthenticationError(
+                "Website authproxy: did not reach the VW identity login "
+                f"(landed at {login_url[:80]})"
+            )
+
+        auth0_state = self._auth0_state(login_url, login_html)
+
+        # 2. POST credentials to the Auth0 universal-login endpoint. The state
+        #    travels in BOTH the URL query and the form body (the same pattern
+        #    idk.py uses against this exact /u/login page).
+        fields, action = _login_fields(login_html)
+        fields["username"] = self._email
+        fields["email"] = self._email
+        fields["password"] = self._password
+        if auth0_state:
+            fields["state"] = auth0_state
+        fields.setdefault("action", "default")
+        post_url = _resolve_action(login_url, action)
+
+        async with self._session.post(
+            post_url,
+            data=fields,
+            headers=self._headers({"Referer": login_url}),
+            allow_redirects=True,
+            timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            landed = str(resp.url)
+            landed_html = await resp.text(errors="replace")
+            landed_status = resp.status
+
+        if landed_status == 401:
+            raise AuthenticationError(
+                "Website authproxy: invalid email or password"
+            )
+        if landed_status >= 400 and "email-challenge" not in landed:
+            err = _login_error(landed_html)
+            raise AuthenticationError(
+                err or f"Website authproxy: login rejected (HTTP {landed_status})"
+            )
+
+        # 3. Email-OTP challenge? Stash the challenge URL + state and bail out
+        #    so the UI can collect the code.
+        if "/u/email-challenge" in landed or "/u/mfa" in landed:
+            self._otp_url = landed
+            self._otp_state = (
+                parse_qs(urlparse(landed).query).get("state", [auth0_state or ""])[0]
+                or auth0_state
+            )
+            _LOGGER.debug("Website authproxy: email-OTP challenge pending")
+            return "otp_required"
+
+        self._finalise_login(landed)
+        return "ok"
+
+    async def submit_otp(self, code: str) -> bool:
+        """POST the email-OTP code and finish the login. Returns success.
+
+        Must be called after ``begin_login()`` returned ``"otp_required"``.
+        Follows the post-challenge redirect chain back to volkswagen.de.
+        """
+        if not self._otp_url:
+            raise AuthenticationError(
+                "Website authproxy: no pending OTP challenge — call "
+                "begin_login() first"
+            )
+        async with self._session.post(
+            self._otp_url,
+            data={"code": str(code).strip(), "state": self._otp_state or ""},
+            headers=self._headers({"Referer": self._otp_url}),
+            allow_redirects=True,
+            timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            landed = str(resp.url)
+            landed_html = await resp.text(errors="replace")
+            landed_status = resp.status
+
+        if landed_status >= 400 or "email-challenge" in landed:
+            err = _login_error(landed_html)
+            raise AuthenticationError(
+                err or "Website authproxy: OTP rejected — check the code"
+            )
+        self._otp_url = None
+        self._otp_state = None
+        self._finalise_login(landed)
+        return self.logged_in
+
+    async def refresh(self) -> None:
+        """Silently re-establish the session via the persisted SSO cookie.
+
+        The IDP keeps an SSO session cookie on ``identity.vwgroup.io`` after a
+        successful login, so re-running the authproxy login trigger usually
+        completes without a fresh password POST (the universal-login page
+        recognises the session and redirects straight through). If the IDP
+        instead re-prompts for credentials we fall back to the full
+        ``begin_login`` flow; a surfaced OTP requirement raises so the caller
+        can route the user back through the OTP UI.
+        """
+        async with self._session.get(
+            f"{_SITE_BASE}{_LOGIN_PATH}",
+            params=_LOGIN_PARAMS,
+            headers=self._headers(),
+            allow_redirects=True,
+            timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            landed = str(resp.url)
+            status = resp.status
+
+        if status < 400 and urlparse(landed).netloc == urlparse(_SITE_BASE).netloc:
+            # SSO cookie carried us straight back to the site — done.
+            self._finalise_login(landed)
+            if self.logged_in:
+                return
+        # SSO did not short-circuit — fall back to a full login.
+        result = await self.begin_login()
+        if result == "otp_required":
+            raise EmailTwoFactorRequiredError()
+
+    def _finalise_login(self, landed_url: str) -> None:
+        """Mark logged-in iff we ended back on the volkswagen.de host."""
+        host = urlparse(_SITE_BASE).netloc
+        if urlparse(landed_url).netloc == host:
+            self.logged_in = True
+            _LOGGER.info(
+                "Website authproxy: login succeeded (read-only, beta)"
+            )
+        else:
+            raise AuthenticationError(
+                "Website authproxy: login did not complete "
+                f"(ended at {landed_url[:80]})"
+            )
+
+    @staticmethod
+    def _auth0_state(login_url: str, html: str) -> str | None:
+        """Pull the Auth0 ``state`` from the page (hidden input or URL query)."""
+        m = re.search(
+            r'name=["\']state["\']\s+value=["\']([^"\']+)["\']', html
+        )
+        if m:
+            return m.group(1)
+        return parse_qs(urlparse(login_url).query).get("state", [""])[0] or None
+
+    # ── cookie persistence ─────────────────────────────────────────────────
+
+    def export_cookies(self) -> list[dict[str, Any]]:
+        """Serialise volkswagen.de + vwgroup.io cookies for persistence.
+
+        Domain-filtered so we never persist cookies that belong to other
+        integrations sharing Home Assistant's aiohttp session.
+        """
+        out: list[dict[str, Any]] = []
+        try:
+            jar_iter = iter(self._session.cookie_jar)
+        except Exception:  # noqa: BLE001
+            return out
+        for cookie in jar_iter:
+            try:
+                domain = str(cookie.get("domain") or cookie["domain"] or "")
+            except (KeyError, AttributeError):
+                continue
+            if "volkswagen.de" not in domain and "vwgroup.io" not in domain:
+                continue
+            try:
+                out.append({
+                    "name": cookie.key,
+                    "value": cookie.value,
+                    "domain": domain,
+                    "path": str(cookie.get("path") or "/"),
+                    "expires": str(cookie.get("expires") or ""),
+                    "secure": bool(cookie.get("secure") or False),
+                    "httponly": bool(cookie.get("httponly") or False),
+                })
+            except Exception:  # noqa: BLE001
+                continue
+        return out
+
+    def import_cookies(self, cookies: list[dict[str, Any]]) -> None:
+        """Hydrate persisted volkswagen.de / vwgroup.io cookies into the jar.
+
+        Lets a restarted Home Assistant resume the authproxy session (and skip
+        the OTP prompt) without re-running the full login. Filtered to the two
+        relevant domains so we never inject cookies for anything else.
+        """
+        if not cookies:
+            return
+        try:
+            from http.cookies import Morsel  # noqa: PLC0415
+            from yarl import URL  # noqa: PLC0415
+        except ImportError:
+            return
+        for ck in cookies:
+            if not isinstance(ck, dict):
+                continue
+            name = ck.get("name")
+            value = ck.get("value")
+            if not name or value is None:
+                continue
+            domain = str(ck.get("domain") or "")
+            if "volkswagen.de" not in domain and "vwgroup.io" not in domain:
+                continue
+            morsel: Morsel[str] = Morsel()
+            morsel.set(str(name), str(value), str(value))
+            for attr in ("domain", "path", "expires", "secure", "httponly"):
+                if attr in ck and ck[attr] not in (None, ""):
+                    try:
+                        morsel[attr] = ck[attr]
+                    except (KeyError, ValueError):
+                        pass
+            url = URL(f"https://{domain.lstrip('.')}/")
+            try:
+                self._session.cookie_jar.update_cookies(
+                    {str(name): morsel}, response_url=url,
+                )
+            except Exception:  # noqa: BLE001
+                continue
+
+    # ── reads ──────────────────────────────────────────────────────────────
+
+    async def _get_json(
+        self,
+        url: str,
+        *,
+        accept: str = "application/json",
+        soft: bool = False,
+    ) -> Any:
+        """GET a reverse-proxy endpoint and parse JSON.
+
+        Sends the per-endpoint ``Accept`` plus the literal
+        ``user-id: __userId__`` placeholder the authproxy substitutes for the
+        signed-in user's real id. On ``soft=True`` a transient 5xx returns
+        ``None`` (after a short backoff) instead of raising — so a flaky
+        backend just means "no data this poll" rather than a dead session. A
+        401/403 always raises ``AuthenticationError`` so the caller can
+        re-login. (Backoff pattern mirrors the EU Data Act connector.)
+        """
+        headers = self._headers({
+            "Accept": accept,
+            "user-id": "__userId__",
+            "Referer": _REDIRECT_URL,
+        })
+        for attempt in range(len(_RETRY_DELAYS) + 1):
+            async with self._session.get(
+                url,
+                headers=headers,
+                timeout=ClientTimeout(total=_TIMEOUT_S),
+            ) as resp:
+                if resp.status in (401, 403):
+                    raise AuthenticationError(
+                        f"Website authproxy GET {url} → HTTP {resp.status}"
+                    )
+                if resp.status >= 400:
+                    if (
+                        soft
+                        and resp.status in _RETRIABLE_STATUSES
+                        and attempt < len(_RETRY_DELAYS)
+                    ):
+                        await asyncio.sleep(_RETRY_DELAYS[attempt])
+                        continue
+                    if soft:
+                        return None
+                    raise AuthenticationError(
+                        f"Website authproxy GET {url} → HTTP {resp.status}"
+                    )
+                return await resp.json(content_type=None)
+        return None
+
+    async def list_vehicle_vins(self) -> list[str]:
+        """Return the 17-char VINs the signed-in account is related to.
+
+        The relations payload nests the VIN under a per-vehicle relation
+        object whose exact shape varies, so we scan the raw body for VIN
+        tokens (the same robust approach used elsewhere for relation
+        endpoints) and de-duplicate while preserving order.
+        """
+        url = f"{_SITE_BASE}{_RELATIONS_PATH}"
+        headers = self._headers({
+            "Accept": "application/json",
+            "user-id": "__userId__",
+            "Referer": _REDIRECT_URL,
+        })
+        async with self._session.get(
+            url, headers=headers, timeout=ClientTimeout(total=_TIMEOUT_S),
+        ) as resp:
+            if resp.status in (401, 403):
+                raise AuthenticationError(
+                    f"Website authproxy: relations → HTTP {resp.status}"
+                )
+            if resp.status >= 400:
+                raise AuthenticationError(
+                    f"Website authproxy: relations → HTTP {resp.status}"
+                )
+            body = await resp.text(errors="replace")
+        seen: list[str] = []
+        for vin in _VIN_RE.findall(body):
+            if vin not in seen:
+                seen.append(vin)
+        return seen
+
+    async def get_vehicle_data(self, vin: str) -> VehicleData:
+        """Fetch charging + maintenance for *vin* and map to ``VehicleData``.
+
+        Both reads are ``soft`` — a transient backend hiccup on either one
+        leaves the corresponding fields unset instead of failing the whole
+        poll. A real 401/403 propagates so the caller re-logs in. The vehicle
+        is marked online once any data block parsed successfully.
+        """
+        d = VehicleData(vin=vin)
+        got_data = False
+
+        charging = await self._get_json(
+            f"{_SITE_BASE}{_CHARGING_PATH.format(vin=vin)}",
+            accept="*/*",
+            soft=True,
+        )
+        if isinstance(charging, dict):
+            map_charging_to_vehicle_data(charging, d)
+            got_data = True
+
+        maintenance = await self._get_json(
+            f"{_SITE_BASE}{_MAINTENANCE_PATH.format(vin=vin)}",
+            accept="*/*",
+            soft=True,
+        )
+        if isinstance(maintenance, dict):
+            map_maintenance_to_vehicle_data(maintenance, d)
+            got_data = True
+
+        if got_data:
+            d.connection_state = "online"
+        return d

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -267,7 +267,8 @@ class WebsiteAuthProxyConnector:
         brand: str = "volkswagen",
     ) -> None:
         # Provenance canary — referenced so a port of this module carries the
-        # marker. Semantically inert (see _canaries.py).
+        # marker. Semantically inert (see _canaries.py). Literal embedded for
+        # the canary-watch grep: website_authproxy_provenance_b6tkd2x9_2026
         self._canary = CANARY_WEBSITE_AUTHPROXY
         self._session = session
         self._email = email

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -47,6 +47,7 @@ from .const import (
     CONF_READ_ONLY,
     CONF_SCAN_INTERVAL,
     CONF_SPIN,
+    CONF_WEBSITE_AUTHPROXY,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     MIN_SCAN_INTERVAL,
@@ -268,6 +269,14 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         self._dag_user_id: str = ""
         # Captured if either phase fails.
         self._dag_error: str = ""
+        # v2.14.0 — website-authproxy (opt-in beta) pending state between the
+        # credentials step and the email-OTP step. The connector + its session
+        # are held open across the two-step OTP exchange so the cookie jar
+        # survives; closed in either terminal path.
+        self._wap_username: str = ""
+        self._wap_user_input: dict[str, Any] = {}
+        self._wap_connector: Any = None
+        self._wap_session: Any = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -298,6 +307,13 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 ),
                 "email_password": (
                     "E-Mail + Passwort — Volkswagen EU / Porsche (Legacy)"
+                ),
+                # v2.14.0 — OPT-IN, BETA. Volkswagen-only read-only channel
+                # via the volkswagen.de website authproxy. Clearly labelled so
+                # users self-select; the email_password path is untouched.
+                "website_authproxy": (
+                    "Volkswagen.de website (beta) — nur Volkswagen, "
+                    "nur Lesen"
                 ),
             },
         )
@@ -362,6 +378,194 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             ),
             errors=errors,
         )
+
+    async def async_step_website_authproxy(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """v2.14.0 — OPT-IN, BETA: volkswagen.de website-authproxy login.
+
+        Volkswagen-only, read-only channel. Collects email + password, drives
+        the authproxy → Auth0 login, and either creates the entry (with the
+        ``website_authproxy`` flag) or advances to the email-OTP step. The
+        existing email_password / browser_login paths are untouched.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
+
+            await self.async_set_unique_id(f"volkswagen_web_{username}")
+            self._abort_if_unique_id_configured()
+
+            self._wap_username = username
+            self._wap_user_input = dict(user_input)
+            try:
+                needs_otp = await self._wap_begin_login(username, password)
+            except ValueError as err:
+                errors["base"] = _map_error(str(err))
+            else:
+                if needs_otp:
+                    return await self.async_step_website_authproxy_otp()
+                return self.async_create_entry(
+                    title=f"Volkswagen.de (beta) — {username}",
+                    data=self._build_website_entry_data(username, user_input),
+                )
+
+        suggested = user_input or {}
+        return self.async_show_form(
+            step_id="website_authproxy",
+            data_schema=vol.Schema({
+                vol.Required(
+                    CONF_USERNAME,
+                    default=suggested.get(CONF_USERNAME, vol.UNDEFINED),
+                ): _USERNAME_SELECTOR,
+                vol.Required(CONF_PASSWORD): _PASSWORD_SELECTOR,
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=int(
+                        suggested.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+                    ),
+                ): _INTERVAL_SELECTOR,
+            }),
+            errors=errors,
+        )
+
+    async def async_step_website_authproxy_otp(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """v2.14.0 — email-OTP step for the website-authproxy login."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            code = str(user_input.get("mfa_code", "")).strip()
+            try:
+                ok = await self._wap_submit_otp(code)
+            except ValueError as err:
+                errors["base"] = _map_error(str(err))
+            else:
+                if ok:
+                    return self.async_create_entry(
+                        title=f"Volkswagen.de (beta) — {self._wap_username}",
+                        data=self._build_website_entry_data(
+                            self._wap_username, self._wap_user_input,
+                        ),
+                    )
+                errors["base"] = "invalid_credentials"
+
+        return self.async_show_form(
+            step_id="website_authproxy_otp",
+            data_schema=vol.Schema({
+                vol.Required("mfa_code"): _MFA_SELECTOR,
+            }),
+            description_placeholders={"username": self._wap_username},
+            errors=errors,
+        )
+
+    async def _wap_begin_login(self, username: str, password: str) -> bool:
+        """Drive the authproxy login; return True if an OTP step is needed.
+
+        Keeps the connector + its aiohttp session open across an OTP exchange
+        (the cookie jar must survive). Maps connector errors to the same
+        ValueError codes the email_password path uses, so the shared
+        ``_map_error`` produces a localised message.
+        """
+        import aiohttp  # noqa: PLC0415
+
+        from .cariad.auth._website_authproxy import (  # noqa: PLC0415
+            WebsiteAuthProxyConnector,
+        )
+        from .cariad.exceptions import (  # noqa: PLC0415
+            AuthenticationError,
+            EmailTwoFactorRequiredError,
+        )
+
+        # Close any half-open connector from a prior attempt in this flow.
+        await self._wap_close_session()
+        connector_ssl = aiohttp.TCPConnector(ssl=True)
+        self._wap_session = aiohttp.ClientSession(
+            connector=connector_ssl,
+            cookie_jar=aiohttp.CookieJar(unsafe=True),
+        )
+        self._wap_connector = WebsiteAuthProxyConnector(
+            self._wap_session, username, password, brand="volkswagen",
+        )
+        try:
+            result = await self._wap_connector.begin_login()
+        except EmailTwoFactorRequiredError:
+            return True
+        except AuthenticationError as err:
+            await self._wap_close_session()
+            _LOGGER.warning("Website authproxy login failed: %s", err)
+            raise ValueError("invalid_credentials") from err
+        except Exception as err:  # noqa: BLE001
+            await self._wap_close_session()
+            _LOGGER.error(
+                "Website authproxy unexpected error: %s", type(err).__name__,
+            )
+            raise ValueError("cannot_connect") from err
+        if result == "otp_required":
+            return True
+        # Logged in without OTP — the validation succeeded. The runtime
+        # coordinator re-runs the login on its own session; this throwaway
+        # validation session can be closed now.
+        await self._wap_close_session()
+        return False
+
+    async def _wap_submit_otp(self, code: str) -> bool:
+        """Submit the OTP against the open connector. Returns login success."""
+        from .cariad.exceptions import AuthenticationError  # noqa: PLC0415
+
+        if self._wap_connector is None:
+            raise ValueError("cannot_connect")
+        try:
+            ok = bool(await self._wap_connector.submit_otp(code))
+        except AuthenticationError as err:
+            _LOGGER.warning("Website authproxy OTP failed: %s", err)
+            raise ValueError("invalid_credentials") from err
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.error(
+                "Website authproxy OTP unexpected error: %s",
+                type(err).__name__,
+            )
+            raise ValueError("cannot_connect") from err
+        finally:
+            await self._wap_close_session()
+        return ok
+
+    async def _wap_close_session(self) -> None:
+        """Close the throwaway validation session + drop the connector."""
+        sess = self._wap_session
+        self._wap_session = None
+        self._wap_connector = None
+        if sess is not None:
+            try:
+                await sess.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    @staticmethod
+    def _build_website_entry_data(
+        username: str, user_input: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Entry data for the website-authproxy (opt-in beta) mode.
+
+        Carries the ``CONF_WEBSITE_AUTHPROXY`` flag the coordinator keys on,
+        plus the standard credentials/interval. ``CONF_READ_ONLY`` is forced
+        True (the channel cannot send commands), and ``CONF_BRAND`` is pinned
+        to volkswagen.
+        """
+        return {
+            CONF_BRAND:            "volkswagen",
+            CONF_USERNAME:         username,
+            CONF_PASSWORD:         user_input.get(CONF_PASSWORD, ""),
+            CONF_WEBSITE_AUTHPROXY: True,
+            CONF_READ_ONLY:        True,
+            CONF_SCAN_INTERVAL: max(
+                int(user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)),
+                MIN_SCAN_INTERVAL,
+            ),
+        }
 
     async def async_step_browser_login(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -135,6 +135,16 @@ CONF_CLIENT_ID_OVERRIDE       = "client_id_override"
 CONF_EU_DATA_ACT_AUTO_KICKOFF = "eu_data_act_auto_kickoff"
 CONF_DATA_ACT_IDENTIFIERS     = "data_act_identifiers"
 
+# v2.14.0 — OPT-IN, BETA. When set on a Volkswagen entry, the integration
+# authenticates + reads via the volkswagen.de website authproxy (a confidential
+# server-side OAuth client on www.volkswagen.de that avoids the Play-Integrity
+# wall) instead of the token-based CARIAD BFF. STRICTLY additive: only honoured
+# when present + truthy AND brand == "volkswagen"; absent / False = every
+# existing path (BFF, EU Data Act portal, native CARIAD) behaves identically.
+# The channel is read-only (no remote commands). Chosen explicitly by the user
+# via the dedicated "Volkswagen.de website (beta)" config-flow option.
+CONF_WEBSITE_AUTHPROXY        = "website_authproxy"
+
 # Supported brands — must match CariadClientFactory.create() keys
 BRANDS = {
     "audi":           "Audi (myAudi)",

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -552,6 +552,24 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             ):
                 inner_auth.set_user_client_id_override(client_id_override)
 
+        # v2.14.0 — OPT-IN, BETA. When the entry was created via the
+        # "Volkswagen.de website (beta)" config-flow option, flip the brand
+        # client into website-authproxy mode BEFORE the first authenticate().
+        # Gated on the explicit per-entry flag + brand == volkswagen + the
+        # client supporting the setter, so this is a no-op for every other
+        # entry and leaves all existing strategy paths untouched.
+        from .const import CONF_WEBSITE_AUTHPROXY  # noqa: PLC0415
+        if (
+            brand == "volkswagen"
+            and self.entry.data.get(CONF_WEBSITE_AUTHPROXY)
+            and hasattr(self._cariad_client, "set_website_authproxy_mode")
+        ):
+            self._cariad_client.set_website_authproxy_mode(True)
+            _LOGGER.info(
+                "VAG Connect: volkswagen.de website-authproxy mode enabled "
+                "(opt-in, read-only beta) for this entry."
+            )
+
         # v1.19.2 (#118 eismarkt) — token persistence wire-up.
         # Load any persisted IDK tokens from HA storage BEFORE the
         # first authenticate() so HACS updates / HA restarts don't
@@ -617,9 +635,16 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # sentinel → HTTP 400 "missing or invalid auth header". Force a
             # fresh login for that strategy so the cookie session + the
             # portal connector are re-established on every restart.
+            # v2.14.0 — the website-authproxy sentinel is the same shape: a
+            # cookie session, no usable bearer, and the cookie jar isn't
+            # restored across restarts. Reusing it would skip the login and
+            # leave _website_proxy unarmed → get_status falls through to the
+            # dead BFF. Force a fresh login so the connector is rebuilt.
             persisted_is_portal = (
                 persisted is not None
-                and persisted.strategy == "data_act_portal"
+                and persisted.strategy in (
+                    "data_act_portal", "website_authproxy",
+                )
             )
             if persisted is None or persisted_is_portal:
                 await self._cariad_client.authenticate()
@@ -3274,7 +3299,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         client = getattr(self, "_cariad_client", None)
         tokens = getattr(client, "_tokens", None) if client else None
         strategy = getattr(tokens, "strategy", "") if tokens else ""
-        if strategy in ("data_act_portal", "device_grant_portal"):
+        # v2.14.0 — the volkswagen.de website authproxy (opt-in beta) is a
+        # read-only channel too: the confidential web OAuth client has no
+        # command surface, so command entities could only ever fail. Force
+        # read-only structurally alongside the EU-Data-Act portal strategies.
+        if strategy in (
+            "data_act_portal", "device_grant_portal", "website_authproxy"
+        ):
             return True
         options = getattr(self.entry, "options", None) or {}
         data = getattr(self.entry, "data", None) or {}

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.13.1"
+  "version": "2.14.0"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -56,7 +56,32 @@
         "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU and Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
-          "email_password": "Email + Password (legacy)"
+          "email_password": "Email + Password (legacy)",
+          "website_authproxy": "Volkswagen.de website (beta — read-only)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de website (BETA, read-only)",
+        "description": "**Experimental, opt-in.** Reads your Volkswagen via the volkswagen.de website login instead of the app backend. Volkswagen only, read-only (no remote commands). Sign in with your Volkswagen ID email and password. If your account uses email verification you will be asked for the code next.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Update Interval"
+        },
+        "data_description": {
+          "username": "The email of your Volkswagen ID / myVolkswagen account.",
+          "password": "Your Volkswagen ID password.",
+          "scan_interval": "How often data is fetched (minutes). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "Email verification code",
+        "description": "A verification code was sent to the email for **{username}**.\n\nEnter the code to finish signing in to the Volkswagen.de website (beta) channel.",
+        "data": {
+          "mfa_code": "Verification Code"
+        },
+        "data_description": {
+          "mfa_code": "Code from your email inbox — valid for a few minutes."
         }
       },
       "browser_login": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -22,7 +22,32 @@
         },
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
-          "email_password": "Email + Password (legacy)"
+          "email_password": "Email + Password (legacy)",
+          "website_authproxy": "Volkswagen.de website (beta — read-only)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de website (BETA, read-only)",
+        "description": "**Experimental, opt-in.** Reads your Volkswagen via the volkswagen.de website login instead of the app backend. Volkswagen only, read-only (no remote commands). Sign in with your Volkswagen ID email and password. If your account uses email verification you will be asked for the code next.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Update Interval"
+        },
+        "data_description": {
+          "username": "The email of your Volkswagen ID / myVolkswagen account.",
+          "password": "Your Volkswagen ID password.",
+          "scan_interval": "How often data is fetched (minutes). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "Email verification code",
+        "description": "A verification code was sent to the email for **{username}**.\n\nEnter the code to finish signing in to the Volkswagen.de website (beta) channel.",
+        "data": {
+          "mfa_code": "Verification Code"
+        },
+        "data_description": {
+          "mfa_code": "Code from your email inbox — valid for a few minutes."
         }
       },
       "reauth_confirm": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -56,7 +56,32 @@
         "description": "Wie möchtest du dich anmelden?\n\n**Browser-Login (empfohlen)** — öffne eine URL auf Handy oder Laptop, melde dich mit deinem Brand-ID-Konto an, bestätige das Gerät. Kein Passwort wird in Home Assistant gespeichert. Verfügbar für Audi, Škoda, SEAT und CUPRA.\n\n**E-Mail + Passwort (Legacy)** — gib deine Brand-ID-Zugangsdaten direkt ein. Erforderlich für Volkswagen EU und Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (empfohlen)",
-          "email_password": "E-Mail + Passwort (Legacy)"
+          "email_password": "E-Mail + Passwort (Legacy)",
+          "website_authproxy": "Volkswagen.de Website (Beta — nur Lesen)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de Website (BETA, nur Lesen)",
+        "description": "**Experimentell, freiwillig.** Liest deinen Volkswagen über die Anmeldung auf volkswagen.de statt über das App-Backend. Nur Volkswagen, nur Lesen (keine Fernbefehle). Melde dich mit deiner Volkswagen-ID-E-Mail und deinem Passwort an. Falls dein Konto eine E-Mail-Bestätigung nutzt, wirst du im nächsten Schritt nach dem Code gefragt.",
+        "data": {
+          "username": "E-Mail-Adresse",
+          "password": "Passwort",
+          "scan_interval": "Aktualisierungsintervall"
+        },
+        "data_description": {
+          "username": "Die E-Mail deines Volkswagen-ID- / myVolkswagen-Kontos.",
+          "password": "Dein Volkswagen-ID-Passwort.",
+          "scan_interval": "Wie oft Daten abgerufen werden (Minuten). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "E-Mail-Bestätigungscode",
+        "description": "Ein Bestätigungscode wurde an die E-Mail von **{username}** gesendet.\n\nGib den Code ein, um die Anmeldung am Volkswagen.de-Website-Kanal (Beta) abzuschließen.",
+        "data": {
+          "mfa_code": "Bestätigungscode"
+        },
+        "data_description": {
+          "mfa_code": "Code aus deinem E-Mail-Posteingang — einige Minuten gültig."
         }
       },
       "browser_login": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -56,7 +56,32 @@
         "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU and Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
-          "email_password": "Email + Password (legacy)"
+          "email_password": "Email + Password (legacy)",
+          "website_authproxy": "Volkswagen.de website (beta — read-only)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de website (BETA, read-only)",
+        "description": "**Experimental, opt-in.** Reads your Volkswagen via the volkswagen.de website login instead of the app backend. Volkswagen only, read-only (no remote commands). Sign in with your Volkswagen ID email and password. If your account uses email verification you will be asked for the code next.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Update Interval"
+        },
+        "data_description": {
+          "username": "The email of your Volkswagen ID / myVolkswagen account.",
+          "password": "Your Volkswagen ID password.",
+          "scan_interval": "How often data is fetched (minutes). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "Email verification code",
+        "description": "A verification code was sent to the email for **{username}**.\n\nEnter the code to finish signing in to the Volkswagen.de website (beta) channel.",
+        "data": {
+          "mfa_code": "Verification Code"
+        },
+        "data_description": {
+          "mfa_code": "Code from your email inbox — valid for a few minutes."
         }
       },
       "browser_login": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -22,7 +22,32 @@
         },
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
-          "email_password": "Email + Password (legacy)"
+          "email_password": "Email + Password (legacy)",
+          "website_authproxy": "Volkswagen.de website (beta — read-only)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de website (BETA, read-only)",
+        "description": "**Experimental, opt-in.** Reads your Volkswagen via the volkswagen.de website login instead of the app backend. Volkswagen only, read-only (no remote commands). Sign in with your Volkswagen ID email and password. If your account uses email verification you will be asked for the code next.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Update Interval"
+        },
+        "data_description": {
+          "username": "The email of your Volkswagen ID / myVolkswagen account.",
+          "password": "Your Volkswagen ID password.",
+          "scan_interval": "How often data is fetched (minutes). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "Email verification code",
+        "description": "A verification code was sent to the email for **{username}**.\n\nEnter the code to finish signing in to the Volkswagen.de website (beta) channel.",
+        "data": {
+          "mfa_code": "Verification Code"
+        },
+        "data_description": {
+          "mfa_code": "Code from your email inbox — valid for a few minutes."
         }
       },
       "reauth_confirm": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -22,7 +22,32 @@
         },
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
-          "email_password": "Email + Password (legacy)"
+          "email_password": "Email + Password (legacy)",
+          "website_authproxy": "Volkswagen.de website (beta — read-only)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de website (BETA, read-only)",
+        "description": "**Experimental, opt-in.** Reads your Volkswagen via the volkswagen.de website login instead of the app backend. Volkswagen only, read-only (no remote commands). Sign in with your Volkswagen ID email and password. If your account uses email verification you will be asked for the code next.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Update Interval"
+        },
+        "data_description": {
+          "username": "The email of your Volkswagen ID / myVolkswagen account.",
+          "password": "Your Volkswagen ID password.",
+          "scan_interval": "How often data is fetched (minutes). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "Email verification code",
+        "description": "A verification code was sent to the email for **{username}**.\n\nEnter the code to finish signing in to the Volkswagen.de website (beta) channel.",
+        "data": {
+          "mfa_code": "Verification Code"
+        },
+        "data_description": {
+          "mfa_code": "Code from your email inbox — valid for a few minutes."
         }
       },
       "reauth_confirm": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -22,7 +22,32 @@
         },
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
-          "email_password": "Email + Password (legacy)"
+          "email_password": "Email + Password (legacy)",
+          "website_authproxy": "Volkswagen.de website (beta — read-only)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de website (BETA, read-only)",
+        "description": "**Experimental, opt-in.** Reads your Volkswagen via the volkswagen.de website login instead of the app backend. Volkswagen only, read-only (no remote commands). Sign in with your Volkswagen ID email and password. If your account uses email verification you will be asked for the code next.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Update Interval"
+        },
+        "data_description": {
+          "username": "The email of your Volkswagen ID / myVolkswagen account.",
+          "password": "Your Volkswagen ID password.",
+          "scan_interval": "How often data is fetched (minutes). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "Email verification code",
+        "description": "A verification code was sent to the email for **{username}**.\n\nEnter the code to finish signing in to the Volkswagen.de website (beta) channel.",
+        "data": {
+          "mfa_code": "Verification Code"
+        },
+        "data_description": {
+          "mfa_code": "Code from your email inbox — valid for a few minutes."
         }
       },
       "reauth_confirm": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -22,7 +22,32 @@
         },
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
-          "email_password": "Email + Password (legacy)"
+          "email_password": "Email + Password (legacy)",
+          "website_authproxy": "Volkswagen.de website (beta — read-only)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de website (BETA, read-only)",
+        "description": "**Experimental, opt-in.** Reads your Volkswagen via the volkswagen.de website login instead of the app backend. Volkswagen only, read-only (no remote commands). Sign in with your Volkswagen ID email and password. If your account uses email verification you will be asked for the code next.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Update Interval"
+        },
+        "data_description": {
+          "username": "The email of your Volkswagen ID / myVolkswagen account.",
+          "password": "Your Volkswagen ID password.",
+          "scan_interval": "How often data is fetched (minutes). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "Email verification code",
+        "description": "A verification code was sent to the email for **{username}**.\n\nEnter the code to finish signing in to the Volkswagen.de website (beta) channel.",
+        "data": {
+          "mfa_code": "Verification Code"
+        },
+        "data_description": {
+          "mfa_code": "Code from your email inbox — valid for a few minutes."
         }
       },
       "reauth_confirm": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -22,7 +22,32 @@
         },
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
-          "email_password": "Email + Password (legacy)"
+          "email_password": "Email + Password (legacy)",
+          "website_authproxy": "Volkswagen.de website (beta — read-only)"
+        }
+      },
+      "website_authproxy": {
+        "title": "Volkswagen.de website (BETA, read-only)",
+        "description": "**Experimental, opt-in.** Reads your Volkswagen via the volkswagen.de website login instead of the app backend. Volkswagen only, read-only (no remote commands). Sign in with your Volkswagen ID email and password. If your account uses email verification you will be asked for the code next.",
+        "data": {
+          "username": "Email Address",
+          "password": "Password",
+          "scan_interval": "Update Interval"
+        },
+        "data_description": {
+          "username": "The email of your Volkswagen ID / myVolkswagen account.",
+          "password": "Your Volkswagen ID password.",
+          "scan_interval": "How often data is fetched (minutes). Minimum: 5."
+        }
+      },
+      "website_authproxy_otp": {
+        "title": "Email verification code",
+        "description": "A verification code was sent to the email for **{username}**.\n\nEnter the code to finish signing in to the Volkswagen.de website (beta) channel.",
+        "data": {
+          "mfa_code": "Verification Code"
+        },
+        "data_description": {
+          "mfa_code": "Code from your email inbox — valid for a few minutes."
         }
       },
       "reauth_confirm": {

--- a/tests/test_v2140_website_authproxy.py
+++ b/tests/test_v2140_website_authproxy.py
@@ -1,0 +1,420 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the v2.14.0 volkswagen.de website-authproxy connector (BETA).
+
+This OPT-IN, read-only channel logs in through the volkswagen.de authproxy
+(which lands on the same identity.vwgroup.io Auth0 the rest of the
+integration handles) and reads vehicle data via the ``/app/authproxy/...``
+reverse-proxy endpoints. The pieces pinned here are the ones verifiable
+without a live VW account:
+
+  1. The Auth0 form-field extraction reuse (``_login_fields`` from the EU
+     Data Act connector) — the website authproxy lands on the SAME page.
+  2. The charging + maintenance JSON → ``VehicleData`` mapping, against a
+     synthetic payload built from the documented response field names.
+  3. Cookie export / import round-trip (domain-filtered persistence).
+  4. The async login / VIN-list / data-fetch orchestration with a mocked
+     aiohttp session — NOT a live login.
+
+The live login + reverse-proxy reads require the maintainer's VW account
+and are validated post-release; they cannot be unit-tested here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+    map_charging_to_vehicle_data,
+    map_maintenance_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+# ── charging/status → VehicleData mapping ──────────────────────────────────
+
+def test_charging_mapping_populates_ev_fields() -> None:
+    """A synthetic charging/status body maps onto the EV VehicleData fields."""
+    payload = {
+        "data": {
+            "batteryStatus": {
+                "currentSOC_pct": 82,
+                "cruisingRangeElectric_km": 305,
+                "navigationTargetSOC_pct": 80,
+                "temperatureHvBattery_K": 295.15,
+            },
+            "chargingStatus": {
+                "chargingState": "charging",
+                "chargePower_kW": 11.0,
+                "chargeRate_kmph": 48.0,
+                "remainingChargingTimeToComplete_min": 95,
+                "chargeMode": "manual",
+            },
+            "plugStatus": {
+                "plugConnectionState": "connected",
+                "plugLockState": "locked",
+                "externalPower": "available",
+            },
+        }
+    }
+    d = map_charging_to_vehicle_data(payload, VehicleData(vin="WVWZZZTEST0000001"))
+    assert d.battery_soc == 82
+    assert d.has_battery is True
+    assert d.is_electric is True
+    assert d.electric_range_km == 305
+    assert d.range_km == 305
+    assert d.target_soc == 80
+    assert d.battery_temp_c == 22.0
+    assert d.charging_state == "charging"
+    assert d.is_charging is True
+    assert d.charging_power_kw == 11.0
+    assert d.charging_rate_kmh == 48.0
+    assert d.remaining_charge_time_nav_min == 95
+    assert d.charge_mode == "manual"
+    assert d.plug_state == "connected"
+    assert d.plug_connected is True
+    assert d.connector_locked is True
+    assert d.external_power is True
+
+
+def test_charging_mapping_not_charging_when_disconnected() -> None:
+    """A 'notConnected' plug + 'readyForCharging' state map to not-charging."""
+    payload = {
+        "data": {
+            "batteryStatus": {"currentSOC_pct": 55},
+            "chargingStatus": {"chargingState": "readyForCharging"},
+            "plugStatus": {"plugConnectionState": "disconnected"},
+        }
+    }
+    d = map_charging_to_vehicle_data(payload, VehicleData(vin="WVWZZZTEST0000002"))
+    assert d.battery_soc == 55
+    assert d.is_charging is False
+    assert d.plug_connected is False
+
+
+def test_charging_mapping_tolerates_missing_blocks() -> None:
+    """A body with no data / wrong shape leaves the fields at defaults."""
+    d = map_charging_to_vehicle_data({}, VehicleData(vin="WVWZZZTEST0000003"))
+    assert d.battery_soc is None
+    assert d.is_charging is None
+    d2 = map_charging_to_vehicle_data(
+        {"data": {"batteryStatus": "oops"}},
+        VehicleData(vin="WVWZZZTEST0000004"),
+    )
+    assert d2.battery_soc is None
+
+
+# ── maintenance/status → VehicleData mapping ───────────────────────────────
+
+def test_maintenance_mapping_wrapped_value_shape() -> None:
+    """The WeConnect {maintenanceStatus: {value: {...}}} envelope maps."""
+    payload = {
+        "data": {
+            "maintenanceStatus": {
+                "value": {
+                    "mileage_km": 42150,
+                    "inspectionDue_days": 230,
+                    "inspectionDue_km": 18000,
+                    "oilServiceDue_days": 110,
+                    "oilServiceDue_km": 9000,
+                }
+            }
+        }
+    }
+    d = map_maintenance_to_vehicle_data(payload, VehicleData(vin="WVWZZZTEST0000005"))
+    assert d.odometer_km == 42150
+    assert d.service_due_in_days == 230
+    assert d.service_km == 18000
+    assert d.oil_service_due_in_days == 110
+    assert d.oil_service_km == 9000
+
+
+def test_maintenance_mapping_flat_shape() -> None:
+    """A flat {data: {...}} envelope (no maintenanceStatus wrapper) maps too."""
+    payload = {"data": {"mileage_km": 12345, "inspectionDue_days": -5}}
+    d = map_maintenance_to_vehicle_data(payload, VehicleData(vin="WVWZZZTEST0000006"))
+    assert d.odometer_km == 12345
+    # Negative "overdue" day counts are kept as-is (sensor renders them).
+    assert d.service_due_in_days == -5
+
+
+def test_maintenance_mapping_tolerates_empty() -> None:
+    """An empty / malformed body leaves maintenance fields unset."""
+    d = map_maintenance_to_vehicle_data({}, VehicleData(vin="WVWZZZTEST0000007"))
+    assert d.odometer_km is None
+    assert d.service_due_in_days is None
+
+
+# ── cookie export / import round-trip ──────────────────────────────────────
+
+class _FakeCookie(dict):
+    """Minimal stand-in for an aiohttp Morsel-like cookie."""
+
+    def __init__(self, key: str, value: str, domain: str) -> None:
+        super().__init__()
+        self.key = key
+        self.value = value
+        self["domain"] = domain
+        self["path"] = "/"
+
+
+class _FakeJarSession:
+    """Session whose cookie_jar yields a fixed set of cookies."""
+
+    def __init__(self, cookies: list[_FakeCookie]) -> None:
+        self._cookies = cookies
+        self.updated: list[tuple[str, Any]] = []
+
+    @property
+    def cookie_jar(self) -> "_FakeJarSession":
+        return self
+
+    def __iter__(self) -> Any:
+        return iter(self._cookies)
+
+    def update_cookies(self, cookies: dict[str, Any], response_url: Any = None) -> None:
+        self.updated.append((next(iter(cookies)), response_url))
+
+
+def test_export_cookies_filters_to_vw_domains() -> None:
+    """export_cookies keeps only volkswagen.de / vwgroup.io cookies."""
+    session = _FakeJarSession([
+        _FakeCookie("sess", "abc", "www.volkswagen.de"),
+        _FakeCookie("idp", "xyz", "identity.vwgroup.io"),
+        _FakeCookie("other", "nope", "example.com"),
+    ])
+    conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
+    out = conn.export_cookies()
+    names = {c["name"] for c in out}
+    assert names == {"sess", "idp"}
+    assert "other" not in names
+
+
+def test_import_cookies_round_trip() -> None:
+    """import_cookies hydrates only the two relevant domains into the jar."""
+    session = _FakeJarSession([])
+    conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
+    conn.import_cookies([
+        {"name": "sess", "value": "abc", "domain": "www.volkswagen.de"},
+        {"name": "junk", "value": "v", "domain": "example.com"},
+    ])
+    injected = {name for name, _url in session.updated}
+    assert "sess" in injected
+    assert "junk" not in injected
+
+
+# ── async login / list / data orchestration (mocked session) ───────────────
+
+_LOGIN_HTML = (
+    '<html><body>'
+    '<form action="/u/login?state=AUTH0STATE">'
+    '<input type="hidden" name="state" value="AUTH0STATE">'
+    '<input type="hidden" name="hmac" value="loginhmac">'
+    '</form></body></html>'
+)
+
+
+class _FakeResp:
+    def __init__(
+        self, url: str, *, status: int = 200, text: str = "",
+        json_data: Any = None,
+    ) -> None:
+        self.url = url
+        self.status = status
+        self._text = text
+        self._json = json_data
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def text(self, errors: str | None = None) -> str:
+        return self._text
+
+    async def json(self, content_type: Any = None) -> Any:
+        return self._json
+
+
+_CHARGING_JSON = {
+    "data": {
+        "batteryStatus": {"currentSOC_pct": 77, "cruisingRangeElectric_km": 250},
+        "chargingStatus": {"chargingState": "charging", "chargePower_kW": 7.4},
+        "plugStatus": {"plugConnectionState": "connected"},
+    }
+}
+_MAINT_JSON = {"data": {"maintenanceStatus": {"value": {"mileage_km": 33333}}}}
+_RELATIONS_TEXT = (
+    '{"relations":[{"vin":"WVWZZZTESTVIN0001","role":"PRIMARY_USER"},'
+    '{"vehicle":{"vin":"WVWZZZTESTVIN0002"}},{"vin":"TOOSHORT"}]}'
+)
+
+
+class _OkLoginSession:
+    """Routes the authproxy login + data endpoints to canned responses."""
+
+    def __init__(self) -> None:
+        self.posts: list[dict[str, Any]] = []
+
+    def get(self, url: str, **kw: Any) -> _FakeResp:
+        if "/app/authproxy/login" in url:
+            # Authproxy redirected us into Auth0 universal login.
+            return _FakeResp(
+                "https://identity.vwgroup.io/u/login?state=AUTH0STATE",
+                text=_LOGIN_HTML,
+            )
+        if "relations" in url:
+            return _FakeResp(url, text=_RELATIONS_TEXT)
+        if "charging/status" in url:
+            return _FakeResp(url, json_data=_CHARGING_JSON)
+        if "maintenance/status" in url:
+            return _FakeResp(url, json_data=_MAINT_JSON)
+        raise AssertionError(f"unmatched GET {url}")
+
+    def post(self, url: str, **kw: Any) -> _FakeResp:
+        self.posts.append({"url": url, "data": kw.get("data")})
+        # Credential POST lands back on the volkswagen.de host → logged in.
+        return _FakeResp(
+            "https://www.volkswagen.de/de/besitzer-und-nutzer/myvolkswagen.html",
+            status=200, text="<html>welcome</html>",
+        )
+
+
+@pytest.mark.asyncio
+async def test_begin_login_ok_lands_on_site() -> None:
+    """begin_login() → 'ok' when the credential POST lands on volkswagen.de."""
+    session = _OkLoginSession()
+    conn = WebsiteAuthProxyConnector(session, "user@example.com", "secret")  # type: ignore[arg-type]
+    result = await conn.begin_login()
+    assert result == "ok"
+    assert conn.logged_in is True
+    # Credentials were carried in the POST body.
+    cred = session.posts[-1]
+    assert cred["data"]["password"] == "secret"
+    assert cred["data"]["username"] == "user@example.com"
+    assert cred["data"]["state"] == "AUTH0STATE"
+
+
+@pytest.mark.asyncio
+async def test_begin_login_otp_required() -> None:
+    """begin_login() → 'otp_required' when Auth0 issues an email challenge."""
+    class _OtpSession:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            return _FakeResp(
+                "https://identity.vwgroup.io/u/login?state=ST",
+                text=_LOGIN_HTML,
+            )
+
+        def post(self, url: str, **kw: Any) -> _FakeResp:
+            return _FakeResp(
+                "https://identity.vwgroup.io/u/email-challenge?state=ST",
+                status=200, text="<html>enter code</html>",
+            )
+
+    conn = WebsiteAuthProxyConnector(_OtpSession(), "u@x.z", "pw")  # type: ignore[arg-type]
+    result = await conn.begin_login()
+    assert result == "otp_required"
+    assert conn.logged_in is False
+
+
+@pytest.mark.asyncio
+async def test_submit_otp_finishes_login() -> None:
+    """submit_otp() posts the code and completes the login on success."""
+    class _OtpThenOkSession:
+        def __init__(self) -> None:
+            self.otp_posts: list[Any] = []
+
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            return _FakeResp(
+                "https://identity.vwgroup.io/u/login?state=ST",
+                text=_LOGIN_HTML,
+            )
+
+        def post(self, url: str, **kw: Any) -> _FakeResp:
+            if "email-challenge" in url:
+                self.otp_posts.append(kw.get("data"))
+                return _FakeResp(
+                    "https://www.volkswagen.de/de/besitzer-und-nutzer/"
+                    "myvolkswagen.html",
+                    status=200, text="<html>welcome</html>",
+                )
+            # Initial credential POST → email challenge.
+            return _FakeResp(
+                "https://identity.vwgroup.io/u/email-challenge?state=ST",
+                status=200, text="<html>enter code</html>",
+            )
+
+    session = _OtpThenOkSession()
+    conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
+    assert await conn.begin_login() == "otp_required"
+    ok = await conn.submit_otp("123456")
+    assert ok is True
+    assert conn.logged_in is True
+    assert session.otp_posts[-1]["code"] == "123456"
+
+
+@pytest.mark.asyncio
+async def test_list_vehicle_vins_scans_relations() -> None:
+    """list_vehicle_vins() extracts 17-char VINs from the relations body."""
+    session = _OkLoginSession()
+    conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
+    vins = await conn.list_vehicle_vins()
+    assert vins == ["WVWZZZTESTVIN0001", "WVWZZZTESTVIN0002"]
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_merges_charging_and_maintenance() -> None:
+    """get_vehicle_data() fetches both endpoints and maps onto VehicleData."""
+    session = _OkLoginSession()
+    conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    assert d.battery_soc == 77
+    assert d.electric_range_km == 250
+    assert d.charging_power_kw == 7.4
+    assert d.odometer_km == 33333
+    assert d.connection_state == "online"
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_401_raises() -> None:
+    """A genuine 401 on a data endpoint propagates (session expired)."""
+    class _401Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "charging/status" in url:
+                return _FakeResp(url, status=401)
+            raise AssertionError(f"should not reach {url} after 401")
+
+    conn = WebsiteAuthProxyConnector(_401Session(), "u@x.z", "pw")  # type: ignore[arg-type]
+    with pytest.raises(AuthenticationError):
+        await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+
+
+@pytest.mark.asyncio
+async def test_get_vehicle_data_soft_404_is_graceful() -> None:
+    """A non-fatal 4xx on a data endpoint yields a bare VehicleData, no raise.
+
+    Both reads are soft: the maintenance 404 here is swallowed so a missing /
+    not-yet-available block just means 'no maintenance this poll' rather than
+    a dead session. (404 is non-retriable, so this returns immediately — the
+    retriable-5xx backoff path is exercised by the EU Data Act connector
+    tests that share the same backoff shape.)
+    """
+    class _Maint404Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "charging/status" in url:
+                return _FakeResp(url, json_data=_CHARGING_JSON)
+            if "maintenance/status" in url:
+                return _FakeResp(url, status=404)
+            raise AssertionError(f"unmatched GET {url}")
+
+    conn = WebsiteAuthProxyConnector(_Maint404Session(), "u@x.z", "pw")  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    # Charging still mapped; maintenance softly skipped.
+    assert d.battery_soc == 77
+    assert d.odometer_km is None
+    assert d.connection_state == "online"

--- a/tests/test_v2140_website_authproxy.py
+++ b/tests/test_v2140_website_authproxy.py
@@ -250,8 +250,8 @@ _CHARGING_JSON = {
 }
 _MAINT_JSON = {"data": {"maintenanceStatus": {"value": {"mileage_km": 33333}}}}
 _RELATIONS_TEXT = (
-    '{"relations":[{"vin":"WVWZZZTESTVIN0001","role":"PRIMARY_USER"},'
-    '{"vehicle":{"vin":"WVWZZZTESTVIN0002"}},{"vin":"TOOSHORT"}]}'
+    '{"relations":[{"vin":"WVWZZZTESTVHN0001","role":"PRIMARY_USER"},'
+    '{"vehicle":{"vin":"WVWZZZTESTVHN0002"}},{"vin":"TOOSHORT"}]}'
 )
 
 
@@ -364,7 +364,7 @@ async def test_list_vehicle_vins_scans_relations() -> None:
     session = _OkLoginSession()
     conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
     vins = await conn.list_vehicle_vins()
-    assert vins == ["WVWZZZTESTVIN0001", "WVWZZZTESTVIN0002"]
+    assert vins == ["WVWZZZTESTVHN0001", "WVWZZZTESTVHN0002"]
 
 
 @pytest.mark.asyncio
@@ -372,7 +372,7 @@ async def test_get_vehicle_data_merges_charging_and_maintenance() -> None:
     """get_vehicle_data() fetches both endpoints and maps onto VehicleData."""
     session = _OkLoginSession()
     conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
-    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    d = await conn.get_vehicle_data("WVWZZZTESTVHN0001")
     assert d.battery_soc == 77
     assert d.electric_range_km == 250
     assert d.charging_power_kw == 7.4
@@ -391,7 +391,7 @@ async def test_get_vehicle_data_401_raises() -> None:
 
     conn = WebsiteAuthProxyConnector(_401Session(), "u@x.z", "pw")  # type: ignore[arg-type]
     with pytest.raises(AuthenticationError):
-        await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+        await conn.get_vehicle_data("WVWZZZTESTVHN0001")
 
 
 @pytest.mark.asyncio
@@ -413,7 +413,7 @@ async def test_get_vehicle_data_soft_404_is_graceful() -> None:
             raise AssertionError(f"unmatched GET {url}")
 
     conn = WebsiteAuthProxyConnector(_Maint404Session(), "u@x.z", "pw")  # type: ignore[arg-type]
-    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    d = await conn.get_vehicle_data("WVWZZZTESTVHN0001")
     # Charging still mapped; maintenance softly skipped.
     assert d.battery_soc == 77
     assert d.odometer_km is None

--- a/tests/test_v290_canaries.py
+++ b/tests/test_v290_canaries.py
@@ -18,7 +18,7 @@ _PKG = _ROOT / "custom_components" / "vag_connect"
 
 def test_canaries_module_imports() -> None:
     from custom_components.vag_connect import _canaries
-    assert len(_canaries.ALL_CANARIES) == 5
+    assert len(_canaries.ALL_CANARIES) == 6
 
 
 def test_auth_resolver_carries_canary() -> None:
@@ -44,6 +44,13 @@ def test_scout_carries_canary() -> None:
 def test_watchdog_carries_canary() -> None:
     text = (_PKG / "coordinator.py").read_text(encoding="utf-8")
     assert "watchdog_silentauth_provenance_n2vpw9c3_2026" in text
+
+
+def test_website_authproxy_carries_canary() -> None:
+    text = (
+        _PKG / "cariad" / "auth" / "_website_authproxy.py"
+    ).read_text(encoding="utf-8")
+    assert "website_authproxy_provenance_b6tkd2x9_2026" in text
 
 
 def test_all_canaries_have_anchor() -> None:


### PR DESCRIPTION
Adds a second, **attestation-free, DIRECT** read channel for Volkswagen — the **volkswagen.de website authproxy** (server-side confidential OAuth client `4fb52a96`, so no Play-Integrity/App-Check wall). It logs in via identity.vwgroup.io Auth0 + email-OTP, keeps a cookie session, and reads charging/maintenance/relations through the `/app/authproxy` reverse proxy, mapped to our `VehicleData`.

**Strictly additive + opt-in:** a user must pick the new **'Volkswagen.de website (beta)'** config-flow option. Every existing path (native CARIAD, EU Data Act portal, CUPRA/SEAT) is byte-identical and the new code is dormant otherwise. Wired exactly like the `data_act_portal` channel (sentinel TokenSet, `get_vehicles`/`get_status` routing, structural read-only). New provenance canary; 14 unit tests (parse + mapping + cookie round-trip + async login/OTP, no live login).

manifest 2.13.1 → 2.14.0. **BETA — not yet live-verified** (needs a real VW account to exercise the login + reverse-proxy responses). Known beta gap: OTP-path SSO cookie isn't persisted to the runtime session yet (non-OTP path works end-to-end; OTP runtime expiry re-surfaces the standard email-2FA repair). Built original (competitor repo referenced only for endpoint paths + response field names).