### PR TITLE
fix(system-health): ping current IDK discovery endpoint, not the 403 legacy one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.1] - 2026-06-14
+
+### Fixed
+
+- **System Health no longer falsely reports the VW/Audi backend as unreachable.** The connectivity check pinged an old discovery URL (`/login/v1/idk/openid-configuration`) that VW has started answering with a `403` before you even log in — so Home Assistant's System Health card showed the CARIAD backend as "failed" even when everything was working. It now pings the current endpoint (the same one the login already uses), which answers normally.
+
 ## [2.14.0] - 2026-06-14
 
 ### Added

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.0"
+  "version": "2.14.1"
 }

--- a/custom_components/vag_connect/system_health.py
+++ b/custom_components/vag_connect/system_health.py
@@ -96,9 +96,14 @@ async def _system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     if push_states:
         info["push_channels"] = " | ".join(push_states)
 
-    # Reachability ping to the most-used backend (cariad bff)
+    # Reachability ping to the most-used backend (cariad bff).
+    # v2.14.1 — the legacy /login/v1/idk/openid-configuration discovery URL now
+    # returns 403 before credentials (VW flipped it to the OIDC path), which
+    # made this health probe report "failed" even on a perfectly healthy
+    # backend. Ping the current /auth/v1/idk/oidc/ discovery endpoint, which
+    # returns 200 — the same path the auth resolver already uses.
     info["cariad_bff_reachable"] = system_health.async_check_can_reach_url(
-        hass, "https://emea.bff.cariad.digital/login/v1/idk/openid-configuration"
+        hass, "https://emea.bff.cariad.digital/auth/v1/idk/oidc/openid-configuration"
     )
 
     return info


### PR DESCRIPTION
Surfaced by reading a competitor PR (audi_connect_ha #738): VW now returns 403 on the legacy /login/v1/idk/openid-configuration discovery URL before credentials. Our System Health reachability probe still pinged it, so the HA System Health card showed the CARIAD backend as unreachable on healthy setups. Switched to /auth/v1/idk/oidc/openid-configuration (the path the auth resolver already uses; returns 200). Our actual login was never affected (token endpoint migrated v2.5.4; Audi market-config discovery preferred since v2.5.11). v2.14.1.