### PR TITLE
fix(vw-website): submit email-OTP inside the parsed challenge form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.2] - 2026-06-14
+
+### Fixed
+
+- **volkswagen.de website login (beta): the email code now submits correctly.** The OTP step was posting just the code + state, but the VW identity email-challenge page is a form with hidden fields (`_csrf` / `relayState` / …) that have to come along — without them the code didn't go through cleanly. It now parses the challenge form exactly like the password step does and submits the code inside the real form, so email-OTP logins complete. (Opt-in beta channel only.)
+
 ## [2.14.1] - 2026-06-14
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -279,6 +279,9 @@ class WebsiteAuthProxyConnector:
         # URL plus the Auth0 state needed to POST the OTP code.
         self._otp_url: str | None = None
         self._otp_state: str | None = None
+        # The email-challenge page HTML — parsed in submit_otp for its hidden
+        # form fields (_csrf / relayState / hmac), same as the password step.
+        self._otp_html: str | None = None
 
     # ── login ──────────────────────────────────────────────────────────────
 
@@ -365,6 +368,7 @@ class WebsiteAuthProxyConnector:
         #    so the UI can collect the code.
         if "/u/email-challenge" in landed or "/u/mfa" in landed:
             self._otp_url = landed
+            self._otp_html = landed_html
             self._otp_state = (
                 parse_qs(urlparse(landed).query).get("state", [auth0_state or ""])[0]
                 or auth0_state
@@ -386,9 +390,19 @@ class WebsiteAuthProxyConnector:
                 "Website authproxy: no pending OTP challenge — call "
                 "begin_login() first"
             )
+        # The Auth0 email-challenge page is a form carrying hidden fields
+        # (_csrf / relayState / hmac); a hardcoded {code, state} POST omits
+        # them, which is what made the OTP "not transmit cleanly". Parse the
+        # challenge form exactly like the password step (begin_login) and merge
+        # the code into the real fields before POSTing to the form's action.
+        fields, action = _login_fields(self._otp_html or "")
+        fields["code"] = str(code).strip()
+        if self._otp_state:
+            fields.setdefault("state", self._otp_state)
+        post_url = _resolve_action(self._otp_url, action)
         async with self._session.post(
-            self._otp_url,
-            data={"code": str(code).strip(), "state": self._otp_state or ""},
+            post_url,
+            data=fields,
             headers=self._headers({"Referer": self._otp_url}),
             allow_redirects=True,
             timeout=ClientTimeout(total=_TIMEOUT_S),
@@ -404,6 +418,7 @@ class WebsiteAuthProxyConnector:
             )
         self._otp_url = None
         self._otp_state = None
+        self._otp_html = None
         self._finalise_login(landed)
         return self.logged_in
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.1"
+  "version": "2.14.2"
 }


### PR DESCRIPTION
Maintainer live-test of the v2.14.0 beta channel: the email code didn't transmit cleanly. `submit_otp` posted only `{code, state}`, omitting the Auth0 email-challenge form's hidden fields (`_csrf` / `relayState` / `hmac`). The password step already parses the form (`_login_fields`) and works — `submit_otp` now does the same (stash challenge HTML in `begin_login`, parse, merge the code, POST to the form action). v2.14.2, beta channel only.