### PR TITLE
fix(vw-website): persist OTP cookies + brand placeholder on 2FA repair (v2.14.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.3] - 2026-06-14
+
+### Fixed
+
+- **volkswagen.de website login (beta): you only enter the email code once now, not on every restart.** The beta channel logged you in (code and all) when you set it up, but then threw all that away and started fresh every time Home Assistant restarted — which meant it asked for a new email code on every single restart, and if you weren't there to type it in, the integration just got stuck. It now remembers the login session from setup and reuses it, so a restart picks up where it left off instead of pestering you for another code. If the saved session has genuinely gone stale, it falls back to asking you to sign in again, same as before. The session keeps itself fresh in the background after each successful login. (Opt-in beta channel only; still read-only.)
+- **Repair notifications show the brand name properly instead of a literal `{brand}`.** A couple of the "please sign in again" repair prompts (including the email-code one) had a `{brand}` placeholder that wasn't being filled in, so the title could read awkwardly. It now drops in the actual brand (or a sensible fallback) so the message reads cleanly.
+
 ## [2.14.2] - 2026-06-14
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -132,6 +132,14 @@ class CariadBaseClient:
         # the code the user enters in the config flow is handed to the
         # connector via this field before authenticate() runs.
         self._website_proxy_otp: str | None = None
+        # v2.14.3 — persisted website-authproxy session cookies. The config
+        # flow exports the volkswagen.de / vwgroup.io cookies after a
+        # successful login (incl. email-OTP) and the coordinator threads them
+        # in via set_website_authproxy_mode(..., cookies=...). _arm_website_proxy
+        # hydrates them into the connector BEFORE begin_login() so an
+        # already-authenticated session resumes WITHOUT re-prompting the OTP.
+        # None / empty = no persisted session → normal (OTP-prompting) login.
+        self._website_cookies: list[dict[str, Any]] | None = None
         self._image_data: dict[str, VehicleImageData] = {}
         self._refresh_lock: asyncio.Lock | None = None
         # Sliding window of token refresh attempt timestamps (monotonic seconds).
@@ -446,7 +454,11 @@ class CariadBaseClient:
         )
 
     def set_website_authproxy_mode(
-        self, enabled: bool, *, otp: str | None = None
+        self,
+        enabled: bool,
+        *,
+        otp: str | None = None,
+        cookies: list[dict[str, Any]] | None = None,
     ) -> None:
         """v2.14.0 — OPT-IN: route this client through the website authproxy.
 
@@ -456,9 +468,17 @@ class CariadBaseClient:
         changes and every existing strategy path runs unmodified. ``otp`` is
         the email-OTP code collected by the config flow, consumed once on the
         next ``authenticate()``.
+
+        v2.14.3 — ``cookies`` are the persisted volkswagen.de / vwgroup.io
+        session cookies (as exported by the config flow). When supplied, they
+        are hydrated into the connector BEFORE ``begin_login()`` in
+        ``_arm_website_proxy``, so an already-authenticated session resumes
+        without re-prompting the email-OTP. Defaults to None → unchanged
+        behaviour (a fresh, OTP-prompting login) for callers that don't pass it.
         """
         self._use_website_proxy = bool(enabled)
         self._website_proxy_otp = otp
+        self._website_cookies = cookies
 
     async def _arm_website_proxy(self) -> None:
         """Build + log in the read-only website-authproxy connector.
@@ -484,6 +504,14 @@ class CariadBaseClient:
         connector = WebsiteAuthProxyConnector(
             self._session, self._email, self._password, brand=self._brand.name,
         )
+        # v2.14.3 — hydrate persisted session cookies BEFORE begin_login(). When
+        # the cookies are still valid, the authproxy redirects the already-
+        # authenticated session straight back to volkswagen.de and begin_login()
+        # returns "ok" WITHOUT an OTP challenge — fixing the re-prompt-on-every-
+        # restart bug. If the cookies are stale the IDP re-prompts and
+        # begin_login() surfaces "otp_required" → the normal reauth path below.
+        if self._website_cookies:
+            connector.import_cookies(self._website_cookies)
         result = await connector.begin_login()
         if result == "otp_required":
             if not self._website_proxy_otp:
@@ -507,6 +535,27 @@ class CariadBaseClient:
             expires_at=_time.time() + 3300,
             strategy="website_authproxy",
         )
+
+    def get_website_proxy_cookies(self) -> list[dict[str, Any]]:
+        """v2.14.3 — export the live website-authproxy session cookies.
+
+        The coordinator calls this after a successful website-authproxy login/
+        refresh to persist the (rotated) cookies back into the config entry, so
+        the next setup/restart resumes the session without an OTP prompt.
+        Returns an empty list (never raises) when the connector is unarmed or
+        the export fails, so a capture hiccup never breaks the poll.
+        """
+        connector = self._website_proxy
+        if connector is None:
+            return []
+        try:
+            cookies = connector.export_cookies()
+        except Exception:  # noqa: BLE001
+            return []
+        # Typed intermediate so mypy doesn't flag a Returning-Any on the
+        # connector's loosely-typed export.
+        result: list[dict[str, Any]] = cookies if isinstance(cookies, list) else []
+        return result
 
     def set_persisted_tokens(self, tokens: TokenSet | None) -> None:
         """v1.19.2 (#118) — inject tokens loaded from HA storage at

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -48,6 +48,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_SPIN,
     CONF_WEBSITE_AUTHPROXY,
+    CONF_WEBSITE_COOKIES,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     MIN_SCAN_INTERVAL,
@@ -277,6 +278,11 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         self._wap_user_input: dict[str, Any] = {}
         self._wap_connector: Any = None
         self._wap_session: Any = None
+        # v2.14.3 — session cookies captured after a successful website-authproxy
+        # login (no-OTP path in _wap_begin_login OR after _wap_submit_otp). Saved
+        # into entry.data under CONF_WEBSITE_COOKIES so the runtime coordinator
+        # can hydrate the jar and skip re-prompting the email-OTP on setup.
+        self._wap_cookies: list[dict[str, Any]] = []
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -409,7 +415,9 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                     return await self.async_step_website_authproxy_otp()
                 return self.async_create_entry(
                     title=f"Volkswagen.de (beta) — {username}",
-                    data=self._build_website_entry_data(username, user_input),
+                    data=self._build_website_entry_data(
+                        username, user_input, self._wap_cookies,
+                    ),
                 )
 
         suggested = user_input or {}
@@ -449,6 +457,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                         title=f"Volkswagen.de (beta) — {self._wap_username}",
                         data=self._build_website_entry_data(
                             self._wap_username, self._wap_user_input,
+                            self._wap_cookies,
                         ),
                     )
                 errors["base"] = "invalid_credentials"
@@ -506,9 +515,10 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             raise ValueError("cannot_connect") from err
         if result == "otp_required":
             return True
-        # Logged in without OTP — the validation succeeded. The runtime
-        # coordinator re-runs the login on its own session; this throwaway
-        # validation session can be closed now.
+        # Logged in without OTP — the validation succeeded. Capture the fresh
+        # session cookies BEFORE closing the throwaway session so the runtime
+        # coordinator can hydrate them and skip a fresh login + OTP prompt.
+        self._wap_cookies = self._wap_capture_cookies()
         await self._wap_close_session()
         return False
 
@@ -520,6 +530,10 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             raise ValueError("cannot_connect")
         try:
             ok = bool(await self._wap_connector.submit_otp(code))
+            # Capture the post-OTP session cookies BEFORE the finally-block
+            # closes the session, so they can be persisted into entry.data.
+            if ok:
+                self._wap_cookies = self._wap_capture_cookies()
         except AuthenticationError as err:
             _LOGGER.warning("Website authproxy OTP failed: %s", err)
             raise ValueError("invalid_credentials") from err
@@ -532,6 +546,22 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         finally:
             await self._wap_close_session()
         return ok
+
+    def _wap_capture_cookies(self) -> list[dict[str, Any]]:
+        """Export the connector's volkswagen.de / vwgroup.io session cookies.
+
+        Returns an empty list (never raises) when no connector is held or the
+        export fails, so a capture hiccup can never block entry creation — the
+        worst case is the runtime path falling back to a fresh login.
+        """
+        connector = self._wap_connector
+        if connector is None:
+            return []
+        try:
+            cookies = connector.export_cookies()
+        except Exception:  # noqa: BLE001
+            return []
+        return cookies if isinstance(cookies, list) else []
 
     async def _wap_close_session(self) -> None:
         """Close the throwaway validation session + drop the connector."""
@@ -546,7 +576,9 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
 
     @staticmethod
     def _build_website_entry_data(
-        username: str, user_input: dict[str, Any]
+        username: str,
+        user_input: dict[str, Any],
+        cookies: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Entry data for the website-authproxy (opt-in beta) mode.
 
@@ -554,12 +586,19 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         plus the standard credentials/interval. ``CONF_READ_ONLY`` is forced
         True (the channel cannot send commands), and ``CONF_BRAND`` is pinned
         to volkswagen.
+
+        v2.14.3 — ``cookies`` are the volkswagen.de / vwgroup.io session cookies
+        captured by the config flow after the login (incl. email-OTP) succeeded.
+        Persisting them under ``CONF_WEBSITE_COOKIES`` lets the coordinator
+        hydrate the jar at runtime so ``_arm_website_proxy`` resumes the session
+        instead of re-prompting the email-OTP on every setup/restart.
         """
         return {
             CONF_BRAND:            "volkswagen",
             CONF_USERNAME:         username,
             CONF_PASSWORD:         user_input.get(CONF_PASSWORD, ""),
             CONF_WEBSITE_AUTHPROXY: True,
+            CONF_WEBSITE_COOKIES:  cookies or [],
             CONF_READ_ONLY:        True,
             CONF_SCAN_INTERVAL: max(
                 int(user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)),

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -145,6 +145,19 @@ CONF_DATA_ACT_IDENTIFIERS     = "data_act_identifiers"
 # via the dedicated "Volkswagen.de website (beta)" config-flow option.
 CONF_WEBSITE_AUTHPROXY        = "website_authproxy"
 
+# v2.14.3 — persisted login cookies for the website-authproxy channel. The
+# config flow logs in once (incl. email-OTP) and stashes the resulting
+# volkswagen.de / vwgroup.io session cookies here in entry.data. At runtime the
+# coordinator hands them to the brand client so ``_arm_website_proxy`` hydrates
+# the cookie jar BEFORE ``begin_login()`` — an already-authenticated session
+# redirects straight back to volkswagen.de WITHOUT re-prompting the email-OTP,
+# which was previously raised on every setup/restart. The jar rotates on each
+# successful login/refresh, so the coordinator writes the fresh cookies back to
+# the entry. STRICTLY additive: only ever read/written for website-authproxy
+# entries; absent for every other mode/brand. Value: a list of cookie dicts as
+# produced by ``WebsiteAuthProxyConnector.export_cookies``.
+CONF_WEBSITE_COOKIES          = "website_cookies"
+
 # Supported brands — must match CariadClientFactory.create() keys
 BRANDS = {
     "audi":           "Audi (myAudi)",

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -558,16 +558,29 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Gated on the explicit per-entry flag + brand == volkswagen + the
         # client supporting the setter, so this is a no-op for every other
         # entry and leaves all existing strategy paths untouched.
-        from .const import CONF_WEBSITE_AUTHPROXY  # noqa: PLC0415
+        from .const import (  # noqa: PLC0415
+            CONF_WEBSITE_AUTHPROXY,
+            CONF_WEBSITE_COOKIES,
+        )
         if (
             brand == "volkswagen"
             and self.entry.data.get(CONF_WEBSITE_AUTHPROXY)
             and hasattr(self._cariad_client, "set_website_authproxy_mode")
         ):
-            self._cariad_client.set_website_authproxy_mode(True)
+            # v2.14.3 — hand the brand client the cookies the config flow
+            # persisted after its login (incl. email-OTP). _arm_website_proxy
+            # hydrates them before begin_login() so the session resumes without
+            # re-prompting the OTP on this setup/restart. Empty list / absent =
+            # the prior fresh-login behaviour (which re-raised on 2FA).
+            persisted_cookies = self.entry.data.get(CONF_WEBSITE_COOKIES) or []
+            self._cariad_client.set_website_authproxy_mode(
+                True, cookies=persisted_cookies,
+            )
             _LOGGER.info(
                 "VAG Connect: volkswagen.de website-authproxy mode enabled "
-                "(opt-in, read-only beta) for this entry."
+                "(opt-in, read-only beta) for this entry%s.",
+                " — resuming from persisted cookies" if persisted_cookies
+                else "",
             )
 
         # v1.19.2 (#118 eismarkt) — token persistence wire-up.
@@ -648,6 +661,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             )
             if persisted is None or persisted_is_portal:
                 await self._cariad_client.authenticate()
+                # v2.14.3 — the website-authproxy login rotates the cookie jar;
+                # persist the fresh cookies back so the NEXT setup/restart
+                # resumes the session (and keeps skipping the OTP prompt).
+                # Guarded so it only ever touches website-authproxy entries.
+                self._persist_website_cookies()
             else:
                 _LOGGER.debug(
                     "VAG Connect: using persisted IDK tokens for %s "
@@ -2841,6 +2859,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         data = result.to_dict()
                         data["_client"] = self._cariad_client
                         self.vehicles[vin] = await self._enrich(data)
+            # v2.14.3 — a mid-poll 401 may have silently re-logged the
+            # website-authproxy session (rotating its cookie jar). Persist the
+            # fresh cookies so the next restart keeps skipping the OTP prompt.
+            # No-op (and cheap) for every non-website-authproxy entry.
+            self._persist_website_cookies()
             _LOGGER.debug("VAG Connect: Manual refresh OK")
             return dict(self.vehicles)
         except Exception as err:  # noqa: BLE001
@@ -3275,6 +3298,57 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         """v1.13.0 (#63 Phase 2) / v1.25.0 PR-D delegated — True if a
         command for this VIN+command-class is currently locked."""
         return self._ensure_dispatcher().is_command_in_flight(vin, command_class)  # type: ignore[no-any-return]
+
+    def _persist_website_cookies(self) -> None:
+        """v2.14.3 — write the live website-authproxy cookies back to the entry.
+
+        The website-authproxy session cookie jar rotates on each successful
+        login/refresh. After such a login we export the fresh cookies and store
+        them on ``entry.data[CONF_WEBSITE_COOKIES]`` so the next setup/restart
+        resumes the session and keeps skipping the email-OTP prompt.
+
+        STRICTLY guarded: a no-op unless this is a website-authproxy entry and
+        the client actually exported a non-empty cookie set, and it only writes
+        when the cookies actually changed (avoids a pointless entry update +
+        listener churn on every poll). Never raises — a persistence hiccup must
+        not break polling; the in-memory session stays valid regardless.
+        """
+        from .const import (  # noqa: PLC0415
+            CONF_WEBSITE_AUTHPROXY,
+            CONF_WEBSITE_COOKIES,
+        )
+
+        if not self.entry.data.get(CONF_WEBSITE_AUTHPROXY):
+            return
+        client = getattr(self, "_cariad_client", None)
+        if client is None or not hasattr(client, "get_website_proxy_cookies"):
+            return
+        try:
+            fresh: list[dict[str, Any]] = client.get_website_proxy_cookies()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "VAG Connect: website-authproxy cookie export failed (%s) "
+                "— session still valid in-memory", type(err).__name__,
+            )
+            return
+        if not fresh:
+            return
+        if fresh == (self.entry.data.get(CONF_WEBSITE_COOKIES) or []):
+            return
+        try:
+            self.hass.config_entries.async_update_entry(
+                self.entry,
+                data={**self.entry.data, CONF_WEBSITE_COOKIES: fresh},
+            )
+            _LOGGER.debug(
+                "VAG Connect: persisted %d refreshed website-authproxy "
+                "cookie(s) back to the entry.", len(fresh),
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "VAG Connect: could not persist website-authproxy cookies "
+                "(%s) — will retry next login.", type(err).__name__,
+            )
 
     def is_read_only(self) -> bool:
         """v1.12.0 (#63) — return True if user enabled Read-only Mode.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.2"
+  "version": "2.14.3"
 }

--- a/custom_components/vag_connect/repairs.py
+++ b/custom_components/vag_connect/repairs.py
@@ -135,6 +135,10 @@ def raise_issue_auth_required(
         is_persistent=False,
         severity=severity,
         translation_key=translation_key,
+        # v2.14.3 — several of these titles embed {brand} (e.g. the Email-2FA
+        # one); without supplying the placeholder the frontend fails to render
+        # the title and spams "MISSING_VALUE" errors. Provide it for all.
+        translation_placeholders={"brand": (brand or "").title() or "VW Group"},
         learn_more_url=_learn_url_for_reason(brand, reason),
         data={"entry_id": entry_id, "reason": reason},
     )

--- a/tests/test_v2143_website_cookie_persist.py
+++ b/tests/test_v2143_website_cookie_persist.py
@@ -1,0 +1,255 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.14.3 - website-authproxy login-cookie persistence.
+
+The OPT-IN volkswagen.de website-authproxy channel (v2.14.0) logged in once
+in the config flow (incl. email-OTP) but the coordinator later built a FRESH
+connector with an empty cookie jar, so every setup/restart re-prompted the
+email-OTP and raised ``EmailTwoFactorRequiredError``. v2.14.3 persists the
+login cookies from the config flow and hydrates them at runtime so the session
+resumes WITHOUT a fresh OTP.
+
+The pieces pinned here are the ones verifiable without a live VW account:
+
+  1. ``set_website_authproxy_mode(True, cookies=[...])`` stores the cookies on
+     the client (and the param defaults to None → no behaviour change).
+  2. ``_arm_website_proxy`` imports the persisted cookies into the connector
+     BEFORE ``begin_login()``, so a valid session short-circuits to "ok" and
+     NO OTP is requested.
+  3. Stale cookies still surface the OTP requirement (normal reauth path).
+  4. ``get_website_proxy_cookies`` exports the live jar for refresh-back, and
+     ``export_cookies``/``import_cookies`` round-trip the two VW domains.
+
+The live login + reverse-proxy reads require the maintainer's VW account and
+are validated post-release; they cannot be unit-tested here.
+
+NOTE: VINs in this file deliberately avoid I/O/Q (the VIN regex rejects them).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.base import CariadBaseClient
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+)
+from custom_components.vag_connect.cariad.exceptions import (
+    EmailTwoFactorRequiredError,
+)
+
+
+_PERSISTED_COOKIES: list[dict[str, Any]] = [
+    {"name": "sess", "value": "abc", "domain": "www.volkswagen.de", "path": "/"},
+    {"name": "idp", "value": "xyz", "domain": "identity.vwgroup.io", "path": "/"},
+]
+
+
+def _base_client() -> CariadBaseClient:
+    """Build a CariadBaseClient skipping the HA setup chain (test idiom).
+
+    Mirrors the ``__new__`` pattern used across the suite (see
+    test_v290_account_lock.py) — we set only the attributes the
+    website-authproxy code paths touch.
+    """
+    c = CariadBaseClient.__new__(CariadBaseClient)
+    c._brand = type("B", (), {"name": "volkswagen"})()
+    c._session = object()
+    c._email = "user@example.com"
+    c._password = "secret"
+    c._tokens = None
+    c._use_website_proxy = False
+    c._website_proxy = None
+    c._website_proxy_otp = None
+    c._website_cookies = None
+    c.on_tokens_changed = None
+    return c
+
+
+# ── set_website_authproxy_mode stores cookies (and defaults to None) ──────────
+
+def test_set_mode_stores_cookies() -> None:
+    """set_website_authproxy_mode(True, cookies=[...]) stashes them."""
+    c = _base_client()
+    c.set_website_authproxy_mode(True, cookies=_PERSISTED_COOKIES)
+    assert c._use_website_proxy is True
+    assert c._website_cookies == _PERSISTED_COOKIES
+
+
+def test_set_mode_cookies_default_none() -> None:
+    """The cookies param defaults to None — no behaviour change for callers
+    that don't pass it (strictly additive guarantee)."""
+    c = _base_client()
+    c.set_website_authproxy_mode(True)
+    assert c._use_website_proxy is True
+    assert c._website_cookies is None
+
+
+def test_set_mode_disabled_is_inert() -> None:
+    """enabled=False leaves the client in the default (no-proxy) state."""
+    c = _base_client()
+    c.set_website_authproxy_mode(False)
+    assert c._use_website_proxy is False
+
+
+# ── _arm_website_proxy hydrates cookies and skips OTP ─────────────────────────
+
+@pytest.mark.asyncio
+async def test_arm_imports_cookies_and_skips_otp(monkeypatch: Any) -> None:
+    """With persisted cookies, the connector's session is already valid:
+    begin_login() returns "ok" and NO OTP is requested."""
+    connector = MagicMock()
+    connector.import_cookies = MagicMock()
+    # A valid session short-circuits straight to "ok" (the authproxy redirects
+    # an already-authenticated session back to volkswagen.de).
+    connector.begin_login = AsyncMock(return_value="ok")
+    connector.submit_otp = AsyncMock(return_value=True)
+    connector.export_cookies = MagicMock(return_value=_PERSISTED_COOKIES)
+
+    factory = MagicMock(return_value=connector)
+    monkeypatch.setattr(
+        "custom_components.vag_connect.cariad.auth."
+        "_website_authproxy.WebsiteAuthProxyConnector",
+        factory,
+    )
+
+    c = _base_client()
+    c.set_website_authproxy_mode(True, cookies=_PERSISTED_COOKIES)
+    await c._arm_website_proxy()
+
+    # Cookies were imported BEFORE begin_login() short-circuited.
+    connector.import_cookies.assert_called_once_with(_PERSISTED_COOKIES)
+    connector.begin_login.assert_awaited_once()
+    connector.submit_otp.assert_not_awaited()
+    # Connector retained + sentinel token marks the client authenticated.
+    assert c._website_proxy is connector
+    assert c._tokens is not None
+    assert c._tokens.strategy == "website_authproxy"
+
+
+@pytest.mark.asyncio
+async def test_arm_no_cookies_does_not_import(monkeypatch: Any) -> None:
+    """Without persisted cookies, import_cookies is never called and a logged-in
+    session still arms cleanly (baseline / no behaviour change)."""
+    connector = MagicMock()
+    connector.import_cookies = MagicMock()
+    connector.begin_login = AsyncMock(return_value="ok")
+    factory = MagicMock(return_value=connector)
+    monkeypatch.setattr(
+        "custom_components.vag_connect.cariad.auth."
+        "_website_authproxy.WebsiteAuthProxyConnector",
+        factory,
+    )
+
+    c = _base_client()
+    c.set_website_authproxy_mode(True)  # no cookies
+    await c._arm_website_proxy()
+
+    connector.import_cookies.assert_not_called()
+    assert c._website_proxy is connector
+
+
+@pytest.mark.asyncio
+async def test_arm_stale_cookies_surface_otp(monkeypatch: Any) -> None:
+    """Stale cookies → the IDP still re-prompts; with no OTP code on hand the
+    arm raises EmailTwoFactorRequiredError (routes to the normal reauth path)."""
+    connector = MagicMock()
+    connector.import_cookies = MagicMock()
+    connector.begin_login = AsyncMock(return_value="otp_required")
+    connector.submit_otp = AsyncMock(return_value=True)
+    factory = MagicMock(return_value=connector)
+    monkeypatch.setattr(
+        "custom_components.vag_connect.cariad.auth."
+        "_website_authproxy.WebsiteAuthProxyConnector",
+        factory,
+    )
+
+    c = _base_client()
+    # Cookies supplied but stale; no OTP code available at runtime.
+    c.set_website_authproxy_mode(True, cookies=_PERSISTED_COOKIES)
+    with pytest.raises(EmailTwoFactorRequiredError):
+        await c._arm_website_proxy()
+    connector.import_cookies.assert_called_once_with(_PERSISTED_COOKIES)
+    connector.submit_otp.assert_not_awaited()
+
+
+# ── get_website_proxy_cookies exports the live jar (refresh-back) ─────────────
+
+def test_get_website_proxy_cookies_exports() -> None:
+    """After arming, get_website_proxy_cookies returns the connector's jar."""
+    c = _base_client()
+    connector = MagicMock()
+    connector.export_cookies = MagicMock(return_value=_PERSISTED_COOKIES)
+    c._website_proxy = connector
+    assert c.get_website_proxy_cookies() == _PERSISTED_COOKIES
+
+
+def test_get_website_proxy_cookies_unarmed_is_empty() -> None:
+    """With no connector armed, the export is an empty list (never raises)."""
+    c = _base_client()
+    c._website_proxy = None
+    assert c.get_website_proxy_cookies() == []
+
+
+def test_get_website_proxy_cookies_swallows_export_error() -> None:
+    """An export hiccup yields [] rather than breaking the poll."""
+    c = _base_client()
+    connector = MagicMock()
+    connector.export_cookies = MagicMock(side_effect=RuntimeError("boom"))
+    c._website_proxy = connector
+    assert c.get_website_proxy_cookies() == []
+
+
+# ── export/import round-trip on the real connector ────────────────────────────
+
+class _FakeCookie(dict):
+    """Minimal stand-in for an aiohttp Morsel-like cookie."""
+
+    def __init__(self, key: str, value: str, domain: str) -> None:
+        super().__init__()
+        self.key = key
+        self.value = value
+        self["domain"] = domain
+        self["path"] = "/"
+
+
+class _FakeJarSession:
+    """Session whose cookie_jar yields a fixed set of cookies."""
+
+    def __init__(self, cookies: list[_FakeCookie]) -> None:
+        self._cookies = cookies
+        self.updated: list[tuple[str, Any]] = []
+
+    @property
+    def cookie_jar(self) -> "_FakeJarSession":
+        return self
+
+    def __iter__(self) -> Any:
+        return iter(self._cookies)
+
+    def update_cookies(
+        self, cookies: dict[str, Any], response_url: Any = None
+    ) -> None:
+        self.updated.append((next(iter(cookies)), response_url))
+
+
+def test_export_then_import_round_trip() -> None:
+    """A connector exports its VW-domain cookies; a second connector imports
+    exactly those (and drops anything off-domain)."""
+    src = _FakeJarSession([
+        _FakeCookie("sess", "abc", "www.volkswagen.de"),
+        _FakeCookie("idp", "xyz", "identity.vwgroup.io"),
+        _FakeCookie("other", "nope", "example.com"),
+    ])
+    exporter = WebsiteAuthProxyConnector(src, "u@x.z", "pw")  # type: ignore[arg-type]
+    exported = exporter.export_cookies()
+    assert {c["name"] for c in exported} == {"sess", "idp"}
+
+    dst = _FakeJarSession([])
+    importer = WebsiteAuthProxyConnector(dst, "u@x.z", "pw")  # type: ignore[arg-type]
+    importer.import_cookies(exported)
+    injected = {name for name, _url in dst.updated}
+    assert injected == {"sess", "idp"}


### PR DESCRIPTION
Two fixes for the opt-in **volkswagen.de website (beta)** channel, both from the maintainer's live test:

**A — repair-title crash (the error spam you saw):** the `email_two_factor_required` repair title embeds `{brand}` but the issue was created without the placeholder → frontend `MISSING_VALUE` spam (40x). Now supplied for all auth repairs.

**B — the real one (re-prompted 2FA every restart):** the config-flow login (incl. email-OTP) ran on a throwaway connector; the coordinator then built a fresh session with no cookies → re-hit the OTP wall and raised `EmailTwoFactorRequiredError` on every setup/restart. Now the config flow exports the session cookies after login, stores them in `entry.data`, and the coordinator hydrates them into the connector **before** `begin_login()` → the session resumes without OTP. Rotated cookies persist back (guarded, only-on-change, never raises; `CONF_WEBSITE_COOKIES` is not a reload key → no reload loop).

Strictly additive + opt-in. v2.14.3. **BETA — key unverified assumption: that begin_login() short-circuits to ok with valid cookies; if not, it degrades safely to the OTP path (no regression).**