### PR TITLE
fix(repairs): email-2FA repair title no longer needs a placeholder (v2.14.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.4] - 2026-06-15
+
+### Fixed
+
+- **The "Email 2FA required" repair notice stops throwing translation errors for good.** v2.14.3 supplied the missing `{brand}` value, but a notice already sitting in the repairs list from an older version had no value and kept spamming `MISSING_VALUE` in the logs. The notice title no longer depends on a placeholder at all (all 8 languages), so old and new notices both render cleanly, and the repair description now also gets its `{username}` value supplied. Purely a cosmetics/log-noise fix.
+
 ## [2.14.3] - 2026-06-14
 
 ### Fixed

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.3"
+  "version": "2.14.4"
 }

--- a/custom_components/vag_connect/repairs.py
+++ b/custom_components/vag_connect/repairs.py
@@ -135,10 +135,15 @@ def raise_issue_auth_required(
         is_persistent=False,
         severity=severity,
         translation_key=translation_key,
-        # v2.14.3 — several of these titles embed {brand} (e.g. the Email-2FA
-        # one); without supplying the placeholder the frontend fails to render
-        # the title and spams "MISSING_VALUE" errors. Provide it for all.
-        translation_placeholders={"brand": (brand or "").title() or "VW Group"},
+        # v2.14.3/.4 — several of these titles/descriptions embed {brand} and
+        # {username}; without the placeholders the frontend fails to render and
+        # spams "MISSING_VALUE" errors. Supply both for every auth repair (the
+        # email_two_factor_required TITLE also had {brand} dropped in v2.14.4 so
+        # even pre-2.14.3 issues lingering in the registry render cleanly).
+        translation_placeholders={
+            "brand": (brand or "").title() or "VW Group",
+            "username": "",
+        },
         learn_more_url=_learn_url_for_reason(brand, reason),
         data={"entry_id": entry_id, "reason": reason},
     )

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -928,7 +928,7 @@
       "description": "Your {brand} account ({username}) requires an email verification code.\n\n**One-time fix:**\n1. Open the **{brand} app** on your phone\n2. Sign in manually\n3. Confirm the code sent by email\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."
     },
     "email_two_factor_required": {
-      "title": "Email 2FA — check your inbox ({brand})",
+      "title": "Email 2FA — check your inbox",
       "description": "Your {brand} account ({username}) requires an **email verification code**.\n\n**One-time fix:**\n1. **Check your email inbox** (and spam folder) for a 6-digit code from VAG IDP\n2. Open the **{brand} app** on your phone\n3. Sign in manually and enter the code\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."
     },
     "terms_and_conditions": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -944,7 +944,7 @@
       "description": "1. Otevřete aplikaci **{brand}**\n2. Přihlaste se ručně\n3. Potvrďte kód z e-mailu\n4. Restartujte Home Assistant"
     },
     "email_two_factor_required": {
-      "title": "E-mailové 2FA — zkontrolujte schránku ({brand})",
+      "title": "E-mailové 2FA — zkontrolujte schránku",
       "description": "Váš účet {brand} ({username}) vyžaduje **e-mailový ověřovací kód**.\n\n**Jednorázová oprava:**\n1. **Zkontrolujte e-mail** (i spam) — 6místný kód od VAG IDP\n2. Otevřete aplikaci **{brand}**\n3. Přihlaste se ručně a zadejte kód\n4. Restartujte Home Assistant"
     },
     "terms_and_conditions": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -928,7 +928,7 @@
       "description": "Dein {brand}-Konto ({username}) verlangt eine Bestätigung per E-Mail-Code.\n\n**Einmalige Lösung:**\n1. Öffne die **{brand}-App** auf deinem Handy\n2. Melde dich dort manuell an\n3. Bestätige den Code, der per E-Mail kommt\n4. Starte Home Assistant neu\n\nNach diesem einmaligen Schritt speichert die Integration das Login-Token — du musst das nicht wiederholen."
     },
     "email_two_factor_required": {
-      "title": "E-Mail-2FA — Postfach prüfen ({brand})",
+      "title": "E-Mail-2FA — Postfach prüfen",
       "description": "Dein {brand}-Konto ({username}) erfordert einen **E-Mail-Bestätigungscode**.\n\n**Einmalige Behebung:**\n1. **Postfach prüfen** (und Spam-Ordner) — 6-stelliger Code von VAG IDP\n2. **{brand}-App** auf dem Smartphone öffnen\n3. Manuell anmelden und Code eingeben\n4. Home Assistant neu starten\n\nNach diesem einmaligen Schritt speichert die Integration den Login-Token — du musst es nicht wiederholen."
     },
     "terms_and_conditions": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -928,7 +928,7 @@
       "description": "Your {brand} account ({username}) requires an email verification code.\n\n**One-time fix:**\n1. Open the **{brand} app** on your phone\n2. Sign in manually\n3. Confirm the code sent by email\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."
     },
     "email_two_factor_required": {
-      "title": "Email 2FA — check your inbox ({brand})",
+      "title": "Email 2FA — check your inbox",
       "description": "Your {brand} account ({username}) requires an **email verification code**.\n\n**One-time fix:**\n1. **Check your email inbox** (and spam folder) for a 6-digit code from VAG IDP\n2. Open the **{brand} app** on your phone\n3. Sign in manually and enter the code\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."
     },
     "terms_and_conditions": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -944,7 +944,7 @@
       "description": "1. Abre la app **{brand}**\n2. Inicia sesión manualmente\n3. Confirma el código de correo\n4. Reinicia Home Assistant"
     },
     "email_two_factor_required": {
-      "title": "2FA por email — revisa tu bandeja ({brand})",
+      "title": "2FA por email — revisa tu bandeja",
       "description": "Tu cuenta de {brand} ({username}) requiere un **código de verificación por email**.\n\n**Solución única:**\n1. **Revisa tu email** (y spam) — código de 6 dígitos de VAG IDP\n2. Abre la app de **{brand}**\n3. Inicia sesión manualmente e ingresa el código\n4. Reinicia Home Assistant"
     },
     "terms_and_conditions": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -944,7 +944,7 @@
       "description": "Votre compte {brand} ({username}) nécessite un code de vérification par e-mail.\n\n1. Ouvrez l'application **{brand}**\n2. Connectez-vous manuellement\n3. Confirmez le code reçu par e-mail\n4. Redémarrez Home Assistant"
     },
     "email_two_factor_required": {
-      "title": "2FA par e-mail — vérifiez votre boîte ({brand})",
+      "title": "2FA par e-mail — vérifiez votre boîte",
       "description": "Votre compte {brand} ({username}) nécessite un **code de vérification par e-mail**.\n\n**Solution unique :**\n1. **Vérifiez votre e-mail** (et spam) — code à 6 chiffres de VAG IDP\n2. Ouvrez l'application **{brand}**\n3. Connectez-vous manuellement et entrez le code\n4. Redémarrez Home Assistant"
     },
     "terms_and_conditions": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -944,7 +944,7 @@
       "description": "1. Open de **{brand}-app**\n2. Meld u handmatig aan\n3. Bevestig de e-mailcode\n4. Start Home Assistant opnieuw"
     },
     "email_two_factor_required": {
-      "title": "E-mail 2FA — controleer je inbox ({brand})",
+      "title": "E-mail 2FA — controleer je inbox",
       "description": "Je {brand}-account ({username}) vereist een **e-mailverificatiecode**.\n\n**Eenmalige oplossing:**\n1. **Controleer je e-mail** (en spam) — 6-cijferige code van VAG IDP\n2. Open de **{brand}-app**\n3. Log handmatig in en voer de code in\n4. Herstart Home Assistant"
     },
     "terms_and_conditions": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -944,7 +944,7 @@
       "description": "1. Otwórz aplikację **{brand}**\n2. Zaloguj się ręcznie\n3. Potwierdź kod e-mail\n4. Uruchom ponownie Home Assistant"
     },
     "email_two_factor_required": {
-      "title": "2FA przez e-mail — sprawdź skrzynkę ({brand})",
+      "title": "2FA przez e-mail — sprawdź skrzynkę",
       "description": "Twoje konto {brand} ({username}) wymaga **kodu weryfikacyjnego e-mail**.\n\n**Jednorazowa naprawa:**\n1. **Sprawdź e-mail** (i spam) — 6-cyfrowy kod od VAG IDP\n2. Otwórz aplikację **{brand}**\n3. Zaloguj się ręcznie i wprowadź kod\n4. Uruchom ponownie Home Assistant"
     },
     "terms_and_conditions": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -944,7 +944,7 @@
       "description": "1. Öppna **{brand}-appen**\n2. Logga in manuellt\n3. Bekräfta e-postkoden\n4. Starta om Home Assistant"
     },
     "email_two_factor_required": {
-      "title": "E-post 2FA — kolla din inkorg ({brand})",
+      "title": "E-post 2FA — kolla din inkorg",
       "description": "Ditt {brand}-konto ({username}) kräver en **e-postbekräftelsekod**.\n\n**Engångsfix:**\n1. **Kolla din e-post** (och skräppost) — 6-siffrig kod från VAG IDP\n2. Öppna **{brand}-appen**\n3. Logga in manuellt och ange koden\n4. Starta om Home Assistant"
     },
     "terms_and_conditions": {

--- a/tests/test_v220_email_2fa_detection.py
+++ b/tests/test_v220_email_2fa_detection.py
@@ -190,8 +190,11 @@ class TestTranslationCoverage:
         issue = data["issues"]["email_two_factor_required"]
         assert "title" in issue
         assert "description" in issue
-        # {brand} placeholder required for Repair-flow templating
-        assert "{brand}" in issue["title"]
+        # v2.14.4 — the title is intentionally placeholder-free now, so it
+        # renders cleanly even for a stale repair issue created (pre-2.14.3)
+        # without translation_placeholders. No {brand} dependency in the title.
+        assert issue["title"]
+        assert "{brand}" not in issue["title"]
 
     def test_strings_json_has_both(self) -> None:
         import json


### PR DESCRIPTION
Follow-up to v2.14.3: that fix supplied {brand} for NEW repair issues, but a stale `email_two_factor_required` notice already in the repairs registry from an older version (created without placeholders) kept spamming `MISSING_VALUE` on its title render. The title now uses NO placeholder (all 8 langs) so stale + new render cleanly, and the auth-repair creation also supplies {username} (descriptions embed it). Cosmetic / log-noise only — no behaviour change. v2.14.4.