### PR TITLE
fix(vw-website): resume saved session via data-endpoint probe instead of re-login (v2.14.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.6] - 2026-06-15
+
+### Fixed
+
+- **volkswagen.de website login (beta) now actually resumes a saved session instead of re-logging-in every time.** v2.14.5 stopped the redirect-loop crash, but it still kicked you back to a fresh email-OTP whenever the resume wobbled. Now, when the integration comes back up it does a quick, redirect-free check against the data endpoint with your saved cookies: if the session is still good it's adopted straight away — no login dance, no OTP — and only a genuinely expired session falls back to a fresh login. As a belt-and-suspenders extra, the credential step also can't get stuck in a redirect loop anymore. (Opt-in beta channel only; no change for any other brand or mode.)
+
 ## [2.14.5] - 2026-06-15
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -512,7 +512,18 @@ class CariadBaseClient:
         # begin_login() surfaces "otp_required" → the normal reauth path below.
         if self._website_cookies:
             connector.import_cookies(self._website_cookies)
-        result = await connector.begin_login()
+            # v2.14.6 — probe a data endpoint with the resumed cookies BEFORE
+            # touching the login flow. A still-valid session lets us adopt it
+            # directly and skip the /app/authproxy/login OAuth dance — which is
+            # the path that redirect-loops (TooManyRedirects) when the persisted
+            # cookies are only partially valid. A dead session (probe False)
+            # falls through to a full begin_login() → OTP, exactly as before.
+            if await connector.session_alive():
+                result = "ok"
+            else:
+                result = await connector.begin_login()
+        else:
+            result = await connector.begin_login()
         if result == "otp_required":
             if not self._website_proxy_otp:
                 raise EmailTwoFactorRequiredError()

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -41,7 +41,7 @@ import re
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
-from aiohttp import ClientSession, ClientTimeout, TooManyRedirects
+from aiohttp import ClientError, ClientSession, ClientTimeout, TooManyRedirects
 
 from ..._canaries import CANARY_WEBSITE_AUTHPROXY
 from ..exceptions import AuthenticationError, EmailTwoFactorRequiredError
@@ -368,16 +368,26 @@ class WebsiteAuthProxyConnector:
         fields.setdefault("action", "default")
         post_url = _resolve_action(login_url, action)
 
-        async with self._session.post(
-            post_url,
-            data=fields,
-            headers=self._headers({"Referer": login_url}),
-            allow_redirects=True,
-            timeout=ClientTimeout(total=_TIMEOUT_S),
-        ) as resp:
-            landed = str(resp.url)
-            landed_html = await resp.text(errors="replace")
-            landed_status = resp.status
+        try:
+            async with self._session.post(
+                post_url,
+                data=fields,
+                headers=self._headers({"Referer": login_url}),
+                allow_redirects=True,
+                max_redirects=20,
+                timeout=ClientTimeout(total=_TIMEOUT_S),
+            ) as resp:
+                landed = str(resp.url)
+                landed_html = await resp.text(errors="replace")
+                landed_status = resp.status
+        except TooManyRedirects as exc:
+            # The credential POST bouncing the authproxy against the IDP means
+            # the flow can't settle — surface a clean auth failure rather than
+            # an unguarded crash (mirrors the begin_login GET guard above).
+            raise AuthenticationError(
+                "Website authproxy: redirect loop posting credentials "
+                "— login could not complete"
+            ) from exc
 
         if landed_status == 401:
             raise AuthenticationError(
@@ -575,6 +585,45 @@ class WebsiteAuthProxyConnector:
                 )
             except Exception:  # noqa: BLE001
                 continue
+
+    async def session_alive(self) -> bool:
+        """Probe the relations endpoint with the currently-loaded cookies.
+
+        The resume partner to ``import_cookies``: a cheap authenticated read
+        that tells us whether a persisted session is still good WITHOUT
+        re-running the redirect-loop-prone ``/app/authproxy/login`` OAuth
+        dance. Returns ``True`` only on a clean authenticated ``200``. A stale
+        session — ``401``/``403``, or a ``3xx`` redirect to the login page —
+        returns ``False`` WITHOUT following the hop (``allow_redirects=False``),
+        so a dead session degrades to a fresh login instead of bouncing the
+        authproxy against the IDP in a ``TooManyRedirects`` loop.
+
+        On success it marks the connector logged-in so the caller can adopt the
+        resumed session directly and skip ``begin_login()`` altogether.
+        """
+        url = f"{_SITE_BASE}{_RELATIONS_PATH}"
+        headers = self._headers({
+            "Accept": "application/json",
+            "user-id": "__userId__",
+            "Referer": _REDIRECT_URL,
+        })
+        try:
+            async with self._session.get(
+                url,
+                headers=headers,
+                allow_redirects=False,
+                timeout=ClientTimeout(total=_TIMEOUT_S),
+            ) as resp:
+                alive = resp.status == 200
+        except (ClientError, TimeoutError):
+            return False
+        if alive:
+            self.logged_in = True
+            _LOGGER.info(
+                "Website authproxy: resumed session still valid "
+                "(read-only, beta) — skipped re-login"
+            )
+        return alive
 
     # ── reads ──────────────────────────────────────────────────────────────
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.5"
+  "version": "2.14.6"
 }

--- a/tests/test_v2143_website_cookie_persist.py
+++ b/tests/test_v2143_website_cookie_persist.py
@@ -14,8 +14,9 @@ The pieces pinned here are the ones verifiable without a live VW account:
   1. ``set_website_authproxy_mode(True, cookies=[...])`` stores the cookies on
      the client (and the param defaults to None → no behaviour change).
   2. ``_arm_website_proxy`` imports the persisted cookies into the connector
-     BEFORE ``begin_login()``, so a valid session short-circuits to "ok" and
-     NO OTP is requested.
+     and probes the data endpoint (``session_alive``, v2.14.6); a still-valid
+     session is adopted directly — ``begin_login()`` is skipped and NO OTP is
+     requested. Stale cookies fall through to the full login.
   3. Stale cookies still surface the OTP requirement (normal reauth path).
   4. ``get_website_proxy_cookies`` exports the live jar for refresh-back, and
      ``export_cookies``/``import_cookies`` round-trip the two VW domains.
@@ -99,12 +100,13 @@ def test_set_mode_disabled_is_inert() -> None:
 
 @pytest.mark.asyncio
 async def test_arm_imports_cookies_and_skips_otp(monkeypatch: Any) -> None:
-    """With persisted cookies, the connector's session is already valid:
-    begin_login() returns "ok" and NO OTP is requested."""
+    """With persisted cookies that are still valid, the v2.14.6 data-endpoint
+    probe (session_alive) returns True → the session is adopted directly,
+    begin_login() is SKIPPED entirely and NO OTP is requested."""
     connector = MagicMock()
     connector.import_cookies = MagicMock()
-    # A valid session short-circuits straight to "ok" (the authproxy redirects
-    # an already-authenticated session back to volkswagen.de).
+    # A valid resumed session: the probe confirms it without the login dance.
+    connector.session_alive = AsyncMock(return_value=True)
     connector.begin_login = AsyncMock(return_value="ok")
     connector.submit_otp = AsyncMock(return_value=True)
     connector.export_cookies = MagicMock(return_value=_PERSISTED_COOKIES)
@@ -120,9 +122,10 @@ async def test_arm_imports_cookies_and_skips_otp(monkeypatch: Any) -> None:
     c.set_website_authproxy_mode(True, cookies=_PERSISTED_COOKIES)
     await c._arm_website_proxy()
 
-    # Cookies were imported BEFORE begin_login() short-circuited.
+    # Cookies imported, then the probe short-circuited the login flow.
     connector.import_cookies.assert_called_once_with(_PERSISTED_COOKIES)
-    connector.begin_login.assert_awaited_once()
+    connector.session_alive.assert_awaited_once()
+    connector.begin_login.assert_not_awaited()
     connector.submit_otp.assert_not_awaited()
     # Connector retained + sentinel token marks the client authenticated.
     assert c._website_proxy is connector
@@ -154,10 +157,13 @@ async def test_arm_no_cookies_does_not_import(monkeypatch: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_arm_stale_cookies_surface_otp(monkeypatch: Any) -> None:
-    """Stale cookies → the IDP still re-prompts; with no OTP code on hand the
-    arm raises EmailTwoFactorRequiredError (routes to the normal reauth path)."""
+    """Stale cookies → the probe (session_alive) returns False, so we fall
+    through to a full begin_login(); the IDP re-prompts and with no OTP code on
+    hand the arm raises EmailTwoFactorRequiredError (normal reauth path)."""
     connector = MagicMock()
     connector.import_cookies = MagicMock()
+    # Stale session: the probe fails → fall through to the full login flow.
+    connector.session_alive = AsyncMock(return_value=False)
     connector.begin_login = AsyncMock(return_value="otp_required")
     connector.submit_otp = AsyncMock(return_value=True)
     factory = MagicMock(return_value=connector)
@@ -173,6 +179,8 @@ async def test_arm_stale_cookies_surface_otp(monkeypatch: Any) -> None:
     with pytest.raises(EmailTwoFactorRequiredError):
         await c._arm_website_proxy()
     connector.import_cookies.assert_called_once_with(_PERSISTED_COOKIES)
+    connector.session_alive.assert_awaited_once()
+    connector.begin_login.assert_awaited_once()
     connector.submit_otp.assert_not_awaited()
 
 

--- a/tests/test_v2146_website_resume_probe.py
+++ b/tests/test_v2146_website_resume_probe.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.14.6 — website-authproxy session-resume probe (skip the login dance).
+
+Pre-2.14.6 a cookie-resumed website-authproxy session ALWAYS re-ran
+``begin_login()`` — it re-hit ``/app/authproxy/login`` and restarted the OIDC
+dance even when the persisted cookies were still perfectly valid. When those
+cookies were only PARTIALLY valid the authproxy bounced against the IDP and
+aiohttp raised ``TooManyRedirects``, which (pre-2.14.5) crashed the poll and
+(on 2.14.5) degraded to an unnecessary re-OTP.
+
+v2.14.6 adds ``session_alive()`` — a cheap, redirect-free probe of the
+relations data endpoint with the resumed cookies. If the session is still
+good we adopt it directly and skip the login flow; only a genuinely dead
+session (401/403, or a 3xx bounce to the login page) falls through to
+``begin_login()``. That is what makes silent resume actually WORK rather than
+merely not-crash.
+
+Also pins the defensive ``TooManyRedirects`` guard added to the credential
+POST inside ``begin_login`` (mirrors the begin_login GET guard from 2.14.5).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aiohttp import ClientError, TooManyRedirects
+
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+)
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+
+_LOGIN_HTML = (
+    '<html><body><form action="/u/login?state=ST">'
+    '<input type="hidden" name="state" value="ST">'
+    '<input type="hidden" name="hmac" value="h"></form></body></html>'
+)
+
+
+class _Resp:
+    def __init__(self, url: str, status: int = 200, text: str = "") -> None:
+        self.url = url
+        self.status = status
+        self._text = text
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def text(self, errors: str | None = None) -> str:
+        return self._text
+
+    async def json(self, content_type: Any = None) -> Any:
+        return {}
+
+
+# ── session_alive() probe ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_session_alive_true_on_200_skips_redirects() -> None:
+    """A clean 200 on the relations probe marks the session alive, and the
+    probe must NOT follow redirects (so a stale-session 3xx → login can't be
+    mistaken for success, and can't loop)."""
+    seen: dict[str, Any] = {}
+
+    class _S:
+        def get(self, url: str, **kw: Any) -> _Resp:
+            seen["url"] = url
+            seen["allow_redirects"] = kw.get("allow_redirects")
+            return _Resp(url, 200)
+
+    conn = WebsiteAuthProxyConnector(_S(), "u@x.z", "pw")  # type: ignore[arg-type]
+    assert await conn.session_alive() is True
+    assert conn.logged_in is True
+    assert seen["allow_redirects"] is False
+    assert "relations" in seen["url"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [301, 302, 303, 401, 403, 500])
+async def test_session_alive_false_on_non_200(status: int) -> None:
+    """Anything but 200 — a redirect-to-login or an auth failure — is dead,
+    and never marks the connector logged-in."""
+    class _S:
+        def get(self, url: str, **kw: Any) -> _Resp:
+            return _Resp(url, status)
+
+    conn = WebsiteAuthProxyConnector(_S(), "u@x.z", "pw")  # type: ignore[arg-type]
+    assert await conn.session_alive() is False
+    assert conn.logged_in is False
+
+
+@pytest.mark.asyncio
+async def test_session_alive_false_on_transport_error() -> None:
+    """A transport error during the probe is treated as a dead session."""
+    class _S:
+        def get(self, url: str, **kw: Any) -> Any:
+            raise ClientError("boom")
+
+    conn = WebsiteAuthProxyConnector(_S(), "u@x.z", "pw")  # type: ignore[arg-type]
+    assert await conn.session_alive() is False
+    assert conn.logged_in is False
+
+
+# ── credential-POST redirect-loop guard ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_credential_post_redirect_loop_is_clean_auth_error() -> None:
+    """A ``TooManyRedirects`` on the credential POST surfaces as a clean
+    ``AuthenticationError`` (handled), not an unguarded crash."""
+    class _S:
+        def get(self, url: str, **kw: Any) -> _Resp:
+            return _Resp(
+                "https://identity.vwgroup.io/u/login?state=ST", 200, _LOGIN_HTML
+            )
+
+        def post(self, url: str, **kw: Any) -> Any:
+            raise TooManyRedirects(None, ())  # type: ignore[arg-type]
+
+    conn = WebsiteAuthProxyConnector(_S(), "u@x.z", "pw")  # type: ignore[arg-type]
+    with pytest.raises(AuthenticationError) as ei:
+        await conn.begin_login()
+    assert "redirect loop" in str(ei.value).lower()


### PR DESCRIPTION
## What

The opt-in **volkswagen.de website (beta)** channel re-ran the full `/app/authproxy/login` OIDC dance on **every** session resume — even when the persisted cookies were still perfectly valid. That dance is the redirect-loop-prone path:

- **pre-2.14.5:** a partially-valid resume looped → `TooManyRedirects` → crashed the poll (surfaced as a bogus "invalid credentials").
- **2.14.5:** stopped the crash, but still degraded to an unnecessary re-OTP on every wobble.

## Fix

Adds `session_alive()` — a cheap, **redirect-free** (`allow_redirects=False`) probe of the relations data endpoint using the resumed cookies. `_arm_website_proxy()` now **probes first**:

- **200** → adopt the session directly. No `begin_login()`, no OTP.
- **401/403, or a 3xx bounce to the login page** → stale session, fall through to the full `begin_login()` exactly as before.

Belt-and-suspenders: the credential POST inside `begin_login` now carries the same `TooManyRedirects` guard the initial GET already had (2.14.5).

## Scope / safety

- Strictly **additive**, **opt-in beta channel only** — no behaviour change for any other brand or mode.
- New tests in `test_v2146_website_resume_probe.py` (probe true/false/transport-error + the POST redirect-loop guard); two `test_v2143` cases updated to assert the new probe-first path.
- mypy-strict + ruff green via pre-commit.

The live cookie-resume itself is still validated post-release (needs a real VW account).