### PR TITLE
feat(vw-website): hostname-only redirect-chain debug logging for the beta channel (v2.14.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.7] - 2026-06-15
+
+### Added
+
+- **volkswagen.de website login (beta): redirect-chain debug logging, so a stuck login can finally be diagnosed.** When the website login bounces in a loop, the error message is redacted (it can carry tokens), which made the root cause invisible from a normal log. This adds a `DEBUG`-level, hostname-only trace of the redirect chain (and the resume-probe result) — e.g. `volkswagen.de → identity.vwgroup.io → volkswagen.de → …`. Only hostnames are logged; paths and query strings (where the OAuth `state`/tokens live) are never written. Turn on debug logging for `custom_components.vag_connect` to capture it. No functional change — purely diagnostics for the beta channel.
+
 ## [2.14.6] - 2026-06-15
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -326,10 +326,19 @@ class WebsiteAuthProxyConnector:
                 login_url = str(resp.url)
                 login_html = await resp.text(errors="replace")
                 login_status = resp.status
+                _LOGGER.debug(
+                    "Website authproxy begin_login GET → status %s, chain: %s",
+                    login_status,
+                    self._redirect_hosts(getattr(resp, "history", ()), login_url),
+                )
         except TooManyRedirects as exc:
             # A resumed session looping between the authproxy and the IDP means
             # the persisted cookies are stale. Surface a normal auth failure so
             # the coordinator re-authenticates rather than crashing the poll.
+            _LOGGER.debug(
+                "Website authproxy begin_login GET redirect LOOP — chain: %s",
+                self._redirect_hosts(getattr(exc, "history", ())),
+            )
             raise AuthenticationError(
                 "Website authproxy: redirect loop resuming the session "
                 "(persisted cookies stale) — re-authentication needed"
@@ -380,10 +389,19 @@ class WebsiteAuthProxyConnector:
                 landed = str(resp.url)
                 landed_html = await resp.text(errors="replace")
                 landed_status = resp.status
+                _LOGGER.debug(
+                    "Website authproxy credential POST → status %s, chain: %s",
+                    landed_status,
+                    self._redirect_hosts(getattr(resp, "history", ()), landed),
+                )
         except TooManyRedirects as exc:
             # The credential POST bouncing the authproxy against the IDP means
             # the flow can't settle — surface a clean auth failure rather than
             # an unguarded crash (mirrors the begin_login GET guard above).
+            _LOGGER.debug(
+                "Website authproxy credential POST redirect LOOP — chain: %s",
+                self._redirect_hosts(getattr(exc, "history", ())),
+            )
             raise AuthenticationError(
                 "Website authproxy: redirect loop posting credentials "
                 "— login could not complete"
@@ -503,6 +521,27 @@ class WebsiteAuthProxyConnector:
             )
 
     @staticmethod
+    def _redirect_hosts(history: Any, final_url: str | None = None) -> str:
+        """Hostname-only redirect chain, safe for DEBUG logging.
+
+        Maps each hop in an aiohttp ``resp.history`` (or a ``TooManyRedirects``
+        exception's ``.history``) to just its hostname and joins them with an
+        arrow. It deliberately drops paths and query strings — the OAuth
+        ``state`` and any tokens live in the query — so only hostnames are
+        emitted. A repeating ``A → B → A → B`` pattern is exactly the loop
+        signature we need to diagnose a stuck session-resume. Never raises.
+        """
+        hosts: list[str] = []
+        try:
+            for hop in history or ():
+                hosts.append(urlparse(str(getattr(hop, "url", ""))).hostname or "?")
+        except (TypeError, AttributeError):
+            pass
+        if final_url:
+            hosts.append(urlparse(final_url).hostname or "?")
+        return " → ".join(hosts) if hosts else "(no redirects)"
+
+    @staticmethod
     def _auth0_state(login_url: str, html: str) -> str | None:
         """Pull the Auth0 ``state`` from the page (hidden input or URL query)."""
         m = re.search(
@@ -615,7 +654,15 @@ class WebsiteAuthProxyConnector:
                 timeout=ClientTimeout(total=_TIMEOUT_S),
             ) as resp:
                 alive = resp.status == 200
-        except (ClientError, TimeoutError):
+                _LOGGER.debug(
+                    "Website authproxy resume probe → status %s (host %s)",
+                    resp.status,
+                    urlparse(str(resp.url)).hostname or "?",
+                )
+        except (ClientError, TimeoutError) as exc:
+            _LOGGER.debug(
+                "Website authproxy resume probe failed: %s", type(exc).__name__
+            )
             return False
         if alive:
             self.logged_in = True

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.6"
+  "version": "2.14.7"
 }

--- a/tests/test_v2147_redirect_chain_logging.py
+++ b/tests/test_v2147_redirect_chain_logging.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.14.7 — sanitized redirect-chain helper for the website-authproxy beta.
+
+When the volkswagen.de website login loops, the surfaced error is redacted
+(it can carry tokens), so the root cause is invisible from a normal log.
+v2.14.7 adds a DEBUG-level, **hostname-only** trace of the redirect chain so a
+stuck session-resume can be diagnosed (a repeating ``A → B → A → B`` is the
+loop signature).
+
+The single safety-critical property pinned here: the helper emits **only
+hostnames** — never paths or query strings, because the OAuth ``state`` and any
+tokens live in the query. A regression that leaked the full URL into a DEBUG
+log would be a token-disclosure bug, so this test is the guard.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+)
+
+_rh = WebsiteAuthProxyConnector._redirect_hosts
+
+
+class _Hop:
+    """Minimal stand-in for an aiohttp history entry (carries a ``.url``)."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+
+def test_chain_emits_hostnames_only_no_query() -> None:
+    """A chain whose URLs carry sensitive query strings logs ONLY hostnames."""
+    history = [
+        _Hop("https://www.volkswagen.de/app/authproxy/login?fag=vw-de"),
+        _Hop("https://identity.vwgroup.io/u/login?state=SECRET_TOKEN_abc123"),
+    ]
+    final = "https://www.volkswagen.de/de/besitzer.html?code=SENSITIVE"
+    out = _rh(history, final)
+
+    assert out == "www.volkswagen.de → identity.vwgroup.io → www.volkswagen.de"
+    # Hard guard: nothing token-ish from any query string leaked through.
+    for leaked in ("state=", "SECRET_TOKEN", "code=", "SENSITIVE", "?", "/u/login"):
+        assert leaked not in out
+
+
+def test_loop_signature_is_visible() -> None:
+    """A bouncing A→B→A→B chain renders as the repeating loop signature."""
+    history = [
+        _Hop("https://www.volkswagen.de/app/authproxy/login"),
+        _Hop("https://identity.vwgroup.io/oidc/v1/authorize"),
+        _Hop("https://www.volkswagen.de/app/authproxy/callback"),
+        _Hop("https://identity.vwgroup.io/oidc/v1/authorize"),
+    ]
+    out = _rh(history)
+    assert out == (
+        "www.volkswagen.de → identity.vwgroup.io → "
+        "www.volkswagen.de → identity.vwgroup.io"
+    )
+
+
+def test_empty_and_malformed_history_never_raise() -> None:
+    """No redirects / None / junk entries degrade gracefully, never raise."""
+    assert _rh([]) == "(no redirects)"
+    assert _rh(None) == "(no redirects)"
+    assert _rh(None, "https://www.volkswagen.de/x?y=z") == "www.volkswagen.de"
+    # A junk entry without a usable url becomes "?" rather than crashing.
+    junk: Any = [object()]
+    assert _rh(junk) == "?"


### PR DESCRIPTION
## Why

The volkswagen.de website-authproxy redirect-loop error is **redacted** (it can carry tokens), so when a live session-resume gets stuck the root cause is invisible from a normal log. We've been diagnosing blind.

## What

Adds a `DEBUG`-level, **hostname-only** trace of the redirect chain at the three redirect points:
- `begin_login` initial GET (success + loop)
- `begin_login` credential POST (success + loop)
- `session_alive` resume probe (status + host)

`_redirect_hosts()` maps each hop to just its hostname — e.g. `www.volkswagen.de → identity.vwgroup.io → www.volkswagen.de → …`. A repeating `A → B → A → B` is the loop signature we need.

## Safety

- **Only hostnames** are logged. Paths and query strings — where the OAuth `state` and tokens live — are **never** written. New test `test_v2147` guards this exact property (asserts no `state=`/`code=`/token fragments leak).
- Purely diagnostic — **no functional change**. Opt-in beta channel only.
- ruff + mypy-strict green via pre-commit.

To capture it: set `custom_components.vag_connect` to debug and reproduce the website-login failure.