### PR TITLE
fix(portal): retry transport timeouts instead of erroring the poll (v2.14.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.8] - 2026-06-17
+
+### Fixed
+
+- **EU Data Act portal: a slow/unreachable portal no longer errors the whole poll — it just means "no data this poll".** When the portal was sluggish, the request could time out at the network layer (before any response), and that timeout slipped past the retry logic and surfaced as an error (the spike of auto-reported `TimeoutError`s on June 16). Now a timeout or dropped connection is retried with the same short backoff as a transient server error, and if it keeps failing the poll quietly skips and tries again next cycle — instead of erroring or, worse, forcing a pointless re-login. Affects both the data-listing and the dataset-download steps.
+
 ## [2.14.7] - 2026-06-15
 
 ### Added

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -39,7 +39,7 @@ from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
-from aiohttp import ClientSession, ClientTimeout
+from aiohttp import ClientConnectionError, ClientSession, ClientTimeout
 
 from ..exceptions import AuthenticationError
 from ..models import VehicleData
@@ -615,22 +615,37 @@ class EUDataActConnector:
         # portal would otherwise drop. A 404/410 (request not provisioned)
         # returns immediately; a real 401/403 still raises.
         for attempt in range(len(_PORTAL_RETRY_DELAYS) + 1):
-            async with self._session.get(
-                url, headers=eff_headers, timeout=ClientTimeout(total=_TIMEOUT_S),
-            ) as resp:
-                if resp.status >= 400:
-                    if soft and resp.status in _TRANSIENT_STATUSES:
-                        if (
-                            resp.status in _RETRIABLE_STATUSES
-                            and attempt < len(_PORTAL_RETRY_DELAYS)
-                        ):
-                            await asyncio.sleep(_PORTAL_RETRY_DELAYS[attempt])
-                            continue
-                        return None
-                    raise AuthenticationError(
-                        f"EU Data Act GET {url} → HTTP {resp.status}"
-                    )
-                return await resp.json(content_type=None)
+            try:
+                async with self._session.get(
+                    url, headers=eff_headers, timeout=ClientTimeout(total=_TIMEOUT_S),
+                ) as resp:
+                    if resp.status >= 400:
+                        if soft and resp.status in _TRANSIENT_STATUSES:
+                            if (
+                                resp.status in _RETRIABLE_STATUSES
+                                and attempt < len(_PORTAL_RETRY_DELAYS)
+                            ):
+                                await asyncio.sleep(_PORTAL_RETRY_DELAYS[attempt])
+                                continue
+                            return None
+                        raise AuthenticationError(
+                            f"EU Data Act GET {url} → HTTP {resp.status}"
+                        )
+                    return await resp.json(content_type=None)
+            except (TimeoutError, ClientConnectionError):
+                # v2.14.8 — a transport-level timeout/disconnect (portal slow or
+                # briefly unreachable) is NOT an auth failure. Retry with the
+                # same backoff as a transient 5xx; a soft call then gives up as
+                # "no data this poll", a hard call re-raises. NEVER convert it to
+                # AuthenticationError — that forces a pointless re-login (the
+                # churn v2.12.4 fixed). Fixes #481-#483, where a TimeoutError from
+                # _session.get bypassed the status-only retry entirely.
+                if attempt < len(_PORTAL_RETRY_DELAYS):
+                    await asyncio.sleep(_PORTAL_RETRY_DELAYS[attempt])
+                    continue
+                if soft:
+                    return None
+                raise
         return None
 
     async def list_vehicle_vins(self) -> list[str]:
@@ -723,26 +738,38 @@ class EUDataActConnector:
         dl_headers = {"filename": newest, "type": "partial"}
         if self._bearer:
             dl_headers["Authorization"] = f"Bearer {self._bearer}"
-        async with self._session.get(
-            f"{_PORTAL_BASE}{_DOWNLOAD_PATH.format(vin=vin, identifier=identifier)}",
-            headers=dl_headers,
-            timeout=ClientTimeout(total=_TIMEOUT_S),
-        ) as resp:
-            if resp.status in _TRANSIENT_STATUSES:
-                # Same outage story as the listing call — the ZIP download
-                # 500s mid-outage. Don't burn the session; just skip this poll.
-                self.last_no_data_reason = "empty"
-                _LOGGER.info(
-                    "EU Data Act portal: dataset download returned a transient "
-                    "error (HTTP %s) for %s; treating as no data this poll.",
-                    resp.status, vin[-6:],
-                )
-                return d
-            if resp.status >= 400:
-                raise AuthenticationError(
-                    f"EU Data Act portal: download → HTTP {resp.status}"
-                )
-            raw = await resp.read()
+        try:
+            async with self._session.get(
+                f"{_PORTAL_BASE}{_DOWNLOAD_PATH.format(vin=vin, identifier=identifier)}",
+                headers=dl_headers,
+                timeout=ClientTimeout(total=_TIMEOUT_S),
+            ) as resp:
+                if resp.status in _TRANSIENT_STATUSES:
+                    # Same outage story as the listing call — the ZIP download
+                    # 500s mid-outage. Don't burn the session; just skip this poll.
+                    self.last_no_data_reason = "empty"
+                    _LOGGER.info(
+                        "EU Data Act portal: dataset download returned a transient "
+                        "error (HTTP %s) for %s; treating as no data this poll.",
+                        resp.status, vin[-6:],
+                    )
+                    return d
+                if resp.status >= 400:
+                    raise AuthenticationError(
+                        f"EU Data Act portal: download → HTTP {resp.status}"
+                    )
+                raw = await resp.read()
+        except (TimeoutError, ClientConnectionError):
+            # v2.14.8 — same as the soft GETs: a transport timeout/disconnect on
+            # the ZIP download is a portal hiccup, not a dead session. Skip the
+            # poll instead of letting a raw TimeoutError bubble to the coordinator.
+            self.last_no_data_reason = "empty"
+            _LOGGER.info(
+                "EU Data Act portal: dataset download timed out / disconnected "
+                "for %s; treating as no data this poll.",
+                vin[-6:],
+            )
+            return d
         payload = _unzip_json(raw, newest)
         fields = _walk_fields(payload)
         _LOGGER.debug(

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.7"
+  "version": "2.14.8"
 }

--- a/tests/test_v2148_portal_timeout_retry.py
+++ b/tests/test_v2148_portal_timeout_retry.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.14.8 — EU Data Act portal: transport-timeout retry (no pointless re-login).
+
+v2.13.1 added backoff/retry for transient HTTP 5xx, but only for a *received*
+response — the retry loop inspected ``resp.status``. A transport-level
+``asyncio.TimeoutError`` (or ``ClientConnectionError``) from ``_session.get()``
+itself never produced a ``resp``, so it bypassed the retry entirely and
+propagated. That's exactly the cluster seen in the auto-filed Error Reporter
+issues #481/#482/#483 (``TimeoutError`` at ``get_status`` → ``get_vehicle_data``
+→ ``_get_json``), and it surfaced as a failed poll instead of "no data this
+poll".
+
+v2.14.8 wraps the network call in the retry loop: a timeout/disconnect is
+treated like a transient 5xx — retried with the same backoff, then a ``soft``
+call gives up as ``None`` ("no data this poll") and a hard call re-raises the
+ORIGINAL error. It is never converted to ``AuthenticationError`` (that would
+force the pointless re-login v2.12.4 fought).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    _PORTAL_RETRY_DELAYS,
+    EUDataActConnector,
+)
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+
+_SLEEP = "custom_components.vag_connect.cariad.auth._eu_data_act.asyncio.sleep"
+
+
+def _ok(json_data: Any) -> AsyncMock:
+    r = AsyncMock()
+    r.status = 200
+    r.json = AsyncMock(return_value=json_data)
+    r.__aenter__ = AsyncMock(return_value=r)
+    r.__aexit__ = AsyncMock(return_value=False)
+    return r
+
+
+def _timeout_cm() -> AsyncMock:
+    """A ``session.get(...)`` CM whose ``__aenter__`` raises like a real
+    aiohttp request timeout (the transport error, before any response)."""
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(side_effect=TimeoutError("portal slow"))
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _session_seq(items: list[Any]) -> MagicMock:
+    s = MagicMock()
+    it = iter(items)
+    s.get = MagicMock(side_effect=lambda *a, **k: next(it))
+    return s
+
+
+def _conn(session: Any) -> EUDataActConnector:
+    return EUDataActConnector(session, brand="volkswagen")
+
+
+_ATTEMPTS = len(_PORTAL_RETRY_DELAYS) + 1  # initial try + retries
+
+
+class TestPortalTimeoutRetry:
+    def test_soft_timeout_then_success_recovers_poll(self) -> None:
+        """A timeout that clears on retry recovers the poll (no error)."""
+        sess = _session_seq([_timeout_cm(), _ok({"ok": 1})])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()):
+            out = asyncio.run(conn._get_json("https://x/y", soft=True))
+        assert out == {"ok": 1}
+        assert sess.get.call_count == 2
+
+    def test_soft_persistent_timeout_returns_none_not_auth_error(self) -> None:
+        """Persistent timeouts on a soft call → None ("no data this poll"),
+        NOT AuthenticationError, and the call was retried."""
+        sess = _session_seq([_timeout_cm() for _ in range(_ATTEMPTS)])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()):
+            out = asyncio.run(conn._get_json("https://x/y", soft=True))
+        assert out is None
+        assert sess.get.call_count == _ATTEMPTS  # 1 try + retries
+
+    def test_hard_timeout_reraises_timeout_not_auth_error(self) -> None:
+        """A hard (non-soft) call re-raises the original TimeoutError after
+        retries — it must NOT become AuthenticationError (no re-login churn)."""
+        sess = _session_seq([_timeout_cm() for _ in range(_ATTEMPTS)])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()):
+            with pytest.raises(TimeoutError):
+                asyncio.run(conn._get_json("https://x/y", soft=False))
+        assert sess.get.call_count == _ATTEMPTS
+
+    def test_status_5xx_path_still_works(self) -> None:
+        """Regression shield: the existing HTTP-status retry path is untouched —
+        a non-soft 5xx still raises AuthenticationError immediately."""
+        r = AsyncMock()
+        r.status = 500
+        r.__aenter__ = AsyncMock(return_value=r)
+        r.__aexit__ = AsyncMock(return_value=False)
+        sess = _session_seq([r])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()):
+            with pytest.raises(AuthenticationError):
+                asyncio.run(conn._get_json("https://x/y", soft=False))
+        assert sess.get.call_count == 1


### PR DESCRIPTION
## Why

The auto-filed Error Reporter issues #481/#482/#483 (June 16) are all the same: `TimeoutError` at `get_status` → `get_vehicle_data` → `_get_json`, clustered across multiple users/VINs = a portal-wide slowdown, not a client bug.

v2.13.1 added backoff/retry for transient portal **5xx** — but only for a *received* response (it inspected `resp.status`). A transport-level `asyncio.TimeoutError` / `ClientConnectionError` from `_session.get()` itself never yields a `resp`, so it **bypassed the retry entirely** and surfaced as a failed poll.

## Fix

Wrap the network call in the retry loop (`_get_json`) and the dataset-download GET:
- timeout/disconnect → retried with the **same backoff** as a transient 5xx
- soft call → then returns `None` ("no data this poll")
- hard call → re-raises the **original** error
- **never** converted to `AuthenticationError` (that would force the pointless re-login v2.12.4 fixed)

Field-learned (openWB treats 500/timeout as wait-not-relogin).

## Scope / safety

- Strictly additive. The existing HTTP-status retry path is **untouched** — regression test `test_status_5xx_path_still_works` pins it.
- New `test_v2148`: timeout-then-success recovers, persistent-timeout→None (soft) / re-raise (hard), and the 5xx regression shield.
- ruff + mypy-strict green via pre-commit.