### PR TITLE
fix(vw-website): capture + broadcast host-only auth0 SSO cookie across both hosts (v2.14.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.9] - 2026-06-17
+
+### Fixed
+
+- **volkswagen.de website login (beta): a restart now actually resumes the session instead of looping / asking for a new email code.** This was the real root cause behind the redirect loop on resume. The single-sign-on cookie that keeps you logged in lives only on the identity host and has no domain attached, so the old code quietly dropped it when saving and never restored it — which meant a restart had no valid session to resume and bounced back to the login page. The login cookies (the SSO one included) are now captured and restored across both hosts, so a restart silently reuses your session. A stale session reported as `412`/`428` (not just `401`/`403`) now also correctly triggers a clean re-login. (Opt-in beta channel only.)
+
 ## [2.14.8] - 2026-06-17
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -100,6 +100,18 @@ _TIMEOUT_S = 60
 _RETRIABLE_STATUSES = frozenset({500, 502, 503, 504})
 _RETRY_DELAYS = (3.0, 6.0)
 
+# A stale authproxy session answers data calls with 401/403, but ALSO with
+# 412 Precondition Failed / 428 Precondition Required (the proxy's own
+# "your session is no longer valid" signal). Treat all four as "re-login".
+_AUTH_FAIL_STATUSES = frozenset({401, 403, 412, 428})
+
+# v2.14.9 — cookie persistence spans BOTH hosts: the portal session cookies on
+# www.volkswagen.de AND the ``auth0`` SSO cookie on identity.vwgroup.io. The
+# SSO cookie is host-only (aiohttp exposes an empty domain for it), so it must
+# be captured and broadcast across both hosts explicitly — otherwise the silent
+# session-resume can't re-establish and every restart loops / re-prompts OTP.
+_COOKIE_HOSTS = (f"{_SITE_BASE}/", f"{_IDENTITY_BASE}/")
+
 _VIN_RE = re.compile(r'"vin"\s*:\s*"([A-HJ-NPR-Z0-9]{17})"')
 
 
@@ -554,43 +566,62 @@ class WebsiteAuthProxyConnector:
     # ── cookie persistence ─────────────────────────────────────────────────
 
     def export_cookies(self) -> list[dict[str, Any]]:
-        """Serialise volkswagen.de + vwgroup.io cookies for persistence.
+        """Serialise the authproxy session cookies for persistence.
 
-        Domain-filtered so we never persist cookies that belong to other
-        integrations sharing Home Assistant's aiohttp session.
+        v2.14.9 — collect via ``cookie_jar.filter_cookies()`` for BOTH the
+        volkswagen.de and identity.vwgroup.io hosts, rather than scanning the
+        raw jar and filtering by a domain string. That string filter silently
+        dropped the host-only ``auth0`` SSO cookie (aiohttp exposes an empty
+        domain for host-only cookies), and WITHOUT that SSO cookie the silent
+        resume can never re-establish the session — the restart redirect-loop /
+        re-OTP bug. ``filter_cookies`` returns exactly the cookies each host
+        would receive (host-only ones included) and nothing from other hosts,
+        so it stays scoped to our two domains.
         """
+        from yarl import URL  # noqa: PLC0415
+
         out: list[dict[str, Any]] = []
+        seen: set[tuple[str, str]] = set()
         try:
-            jar_iter = iter(self._session.cookie_jar)
+            jar = self._session.cookie_jar
         except Exception:  # noqa: BLE001
             return out
-        for cookie in jar_iter:
+        for host in _COOKIE_HOSTS:
             try:
-                domain = str(cookie.get("domain") or cookie["domain"] or "")
-            except (KeyError, AttributeError):
-                continue
-            if "volkswagen.de" not in domain and "vwgroup.io" not in domain:
-                continue
-            try:
-                out.append({
-                    "name": cookie.key,
-                    "value": cookie.value,
-                    "domain": domain,
-                    "path": str(cookie.get("path") or "/"),
-                    "expires": str(cookie.get("expires") or ""),
-                    "secure": bool(cookie.get("secure") or False),
-                    "httponly": bool(cookie.get("httponly") or False),
-                })
+                filtered = jar.filter_cookies(URL(host))
             except Exception:  # noqa: BLE001
                 continue
+            host_name = URL(host).host or ""
+            for name, morsel in filtered.items():
+                key = (str(name), str(morsel.value))
+                if key in seen:
+                    continue
+                seen.add(key)
+                try:
+                    out.append({
+                        "name": str(name),
+                        "value": str(morsel.value),
+                        "domain": str(morsel["domain"] or host_name),
+                        "path": str(morsel["path"] or "/"),
+                        "expires": str(morsel["expires"] or ""),
+                        "secure": bool(morsel["secure"]),
+                        "httponly": bool(morsel["httponly"]),
+                    })
+                except Exception:  # noqa: BLE001
+                    continue
         return out
 
     def import_cookies(self, cookies: list[dict[str, Any]]) -> None:
-        """Hydrate persisted volkswagen.de / vwgroup.io cookies into the jar.
+        """Hydrate persisted session cookies, broadcast to BOTH authproxy hosts.
 
-        Lets a restarted Home Assistant resume the authproxy session (and skip
-        the OTP prompt) without re-running the full login. Filtered to the two
-        relevant domains so we never inject cookies for anything else.
+        v2.14.9 — each persisted cookie is injected host-only against BOTH
+        www.volkswagen.de AND identity.vwgroup.io. aiohttp loses the host for
+        host-only cookies, so binding the ``auth0`` SSO cookie to a single host
+        left it unreachable from the other; broadcasting to both guarantees the
+        SSO cookie reaches identity.vwgroup.io (the linchpin of silent resume).
+        An extra cookie a host doesn't expect is harmless. This (with the
+        matching ``export_cookies`` fix) is what makes a restart resume the
+        session instead of redirect-looping / re-prompting OTP.
         """
         if not cookies:
             return
@@ -606,24 +637,23 @@ class WebsiteAuthProxyConnector:
             value = ck.get("value")
             if not name or value is None:
                 continue
-            domain = str(ck.get("domain") or "")
-            if "volkswagen.de" not in domain and "vwgroup.io" not in domain:
-                continue
             morsel: Morsel[str] = Morsel()
             morsel.set(str(name), str(value), str(value))
-            for attr in ("domain", "path", "expires", "secure", "httponly"):
+            # Deliberately NO domain attr → the cookie binds host-only to each
+            # host we broadcast it to (matches the working rafaelhutter pattern).
+            for attr in ("path", "expires", "secure", "httponly"):
                 if attr in ck and ck[attr] not in (None, ""):
                     try:
                         morsel[attr] = ck[attr]
                     except (KeyError, ValueError):
                         pass
-            url = URL(f"https://{domain.lstrip('.')}/")
-            try:
-                self._session.cookie_jar.update_cookies(
-                    {str(name): morsel}, response_url=url,
-                )
-            except Exception:  # noqa: BLE001
-                continue
+            for host in _COOKIE_HOSTS:
+                try:
+                    self._session.cookie_jar.update_cookies(
+                        {str(name): morsel}, response_url=URL(host),
+                    )
+                except Exception:  # noqa: BLE001
+                    continue
 
     async def session_alive(self) -> bool:
         """Probe the relations endpoint with the currently-loaded cookies.
@@ -702,7 +732,7 @@ class WebsiteAuthProxyConnector:
                 headers=headers,
                 timeout=ClientTimeout(total=_TIMEOUT_S),
             ) as resp:
-                if resp.status in (401, 403):
+                if resp.status in _AUTH_FAIL_STATUSES:
                     raise AuthenticationError(
                         f"Website authproxy GET {url} → HTTP {resp.status}"
                     )

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -637,10 +637,19 @@ class WebsiteAuthProxyConnector:
             value = ck.get("value")
             if not name or value is None:
                 continue
+            # Scope guard: only ever inject cookies that belong to our two
+            # hosts (export stamps every persisted cookie with its real host),
+            # so a malformed/foreign entry is never broadcast. The host-only
+            # SSO cookie now carries domain="identity.vwgroup.io" from export,
+            # so it passes this guard (it was the empty-domain drop that broke).
+            domain = str(ck.get("domain") or "")
+            if "volkswagen.de" not in domain and "vwgroup.io" not in domain:
+                continue
             morsel: Morsel[str] = Morsel()
             morsel.set(str(name), str(value), str(value))
-            # Deliberately NO domain attr → the cookie binds host-only to each
-            # host we broadcast it to (matches the working rafaelhutter pattern).
+            # Deliberately do NOT copy the domain onto the morsel → the cookie
+            # binds host-only to each host we broadcast it to (matches the
+            # working rafaelhutter pattern).
             for attr in ("path", "expires", "secure", "httponly"):
                 if attr in ck and ck[attr] not in (None, ""):
                     try:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.8"
+  "version": "2.14.9"
 }

--- a/tests/test_v2140_website_authproxy.py
+++ b/tests/test_v2140_website_authproxy.py
@@ -176,6 +176,21 @@ class _FakeJarSession:
     def __iter__(self) -> Any:
         return iter(self._cookies)
 
+    def filter_cookies(self, url: Any) -> Any:
+        # v2.14.9 — mirror aiohttp's CookieJar.filter_cookies: return the
+        # cookies that would be sent for *url*'s host (host-only included).
+        from http.cookies import SimpleCookie
+
+        host = getattr(url, "host", "") or ""
+        sc: SimpleCookie = SimpleCookie()
+        for c in self._cookies:
+            dom = str(c.get("domain") or "").lstrip(".")
+            if dom and (host == dom or host.endswith("." + dom)):
+                sc[c.key] = c.value
+                sc[c.key]["domain"] = c.get("domain") or ""
+                sc[c.key]["path"] = c.get("path") or "/"
+        return sc
+
     def update_cookies(self, cookies: dict[str, Any], response_url: Any = None) -> None:
         self.updated.append((next(iter(cookies)), response_url))
 

--- a/tests/test_v2143_website_cookie_persist.py
+++ b/tests/test_v2143_website_cookie_persist.py
@@ -238,6 +238,21 @@ class _FakeJarSession:
     def __iter__(self) -> Any:
         return iter(self._cookies)
 
+    def filter_cookies(self, url: Any) -> Any:
+        # v2.14.9 — mirror aiohttp's CookieJar.filter_cookies: return the
+        # cookies that would be sent for *url*'s host (host-only included).
+        from http.cookies import SimpleCookie
+
+        host = getattr(url, "host", "") or ""
+        sc: SimpleCookie = SimpleCookie()
+        for c in self._cookies:
+            dom = str(c.get("domain") or "").lstrip(".")
+            if dom and (host == dom or host.endswith("." + dom)):
+                sc[c.key] = c.value
+                sc[c.key]["domain"] = c.get("domain") or ""
+                sc[c.key]["path"] = c.get("path") or "/"
+        return sc
+
     def update_cookies(
         self, cookies: dict[str, Any], response_url: Any = None
     ) -> None:

--- a/tests/test_v2149_website_cookie_broadcast.py
+++ b/tests/test_v2149_website_cookie_broadcast.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.14.9 — website-authproxy cookie persistence: capture + broadcast the
+host-only ``auth0`` SSO cookie across both hosts.
+
+Root cause of the restart redirect-loop / re-OTP on the vw.de beta channel:
+the ``auth0`` SSO cookie lives host-only on ``identity.vwgroup.io`` (aiohttp
+exposes an EMPTY domain for host-only cookies). The old ``export_cookies``
+scanned the raw jar and filtered by a domain string → it silently DROPPED that
+cookie, and ``import_cookies`` only injected each cookie to its own domain.
+Without the SSO cookie reaching ``identity.vwgroup.io``, the silent resume can
+never re-establish the session, so the authproxy bounces the resumed session
+to the login page (redirect loop) and the user gets re-prompted for an OTP.
+
+v2.14.9 (mirroring the independently-validated rafaelhutter approach):
+- ``export_cookies`` collects via ``cookie_jar.filter_cookies(URL(host))`` for
+  BOTH hosts → captures host-only cookies (incl. ``auth0``) while staying
+  scoped to our two domains.
+- ``import_cookies`` broadcasts every persisted cookie host-only to BOTH
+  ``www.volkswagen.de`` AND ``identity.vwgroup.io``.
+- A stale session's ``412``/``428`` now counts as auth-failure (re-login),
+  not just ``401``/``403``.
+"""
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from typing import Any
+
+import pytest
+from yarl import URL
+
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+)
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+
+
+class _FilterJar:
+    """Stand-in for aiohttp's CookieJar: per-host filter + update recorder."""
+
+    def __init__(self, per_host: dict[str, SimpleCookie]) -> None:
+        self._per_host = dict(per_host)
+        self.updates: list[tuple[str | None, str]] = []
+
+    def filter_cookies(self, url: URL) -> SimpleCookie:
+        return self._per_host.get(url.host or "", SimpleCookie())
+
+    def update_cookies(self, cookies: Any, response_url: Any = None) -> None:
+        host = response_url.host if response_url is not None else None
+        for name in cookies:
+            self.updates.append((host, name))
+
+
+class _Sess:
+    def __init__(self, jar: _FilterJar) -> None:
+        self.cookie_jar = jar
+
+
+def _conn(session: Any) -> WebsiteAuthProxyConnector:
+    return WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
+
+
+# ── export captures the host-only SSO cookie ───────────────────────────────
+
+def test_export_captures_host_only_sso_cookie() -> None:
+    """The host-only ``auth0`` cookie (empty domain) on identity.vwgroup.io is
+    captured via filter_cookies, where the old domain-string scan dropped it."""
+    vw = SimpleCookie()
+    vw["sess"] = "abc"
+    vw["sess"]["path"] = "/"
+    idp = SimpleCookie()
+    idp["auth0"] = "ssotoken"  # host-only: no domain attribute set
+
+    jar = _FilterJar({
+        "www.volkswagen.de": vw,
+        "identity.vwgroup.io": idp,
+    })
+    out = _conn(_Sess(jar)).export_cookies()
+    names = {c["name"] for c in out}
+    assert "sess" in names
+    assert "auth0" in names  # the previously-dropped SSO cookie
+    auth0 = next(c for c in out if c["name"] == "auth0")
+    # Empty domain falls back to the host we filtered for.
+    assert auth0["domain"] == "identity.vwgroup.io"
+    assert auth0["value"] == "ssotoken"
+
+
+def test_export_dedupes_cookie_present_on_both_hosts() -> None:
+    """A cookie returned for both hosts is emitted once."""
+    shared = SimpleCookie()
+    shared["common"] = "v"
+    jar = _FilterJar({
+        "www.volkswagen.de": shared,
+        "identity.vwgroup.io": shared,
+    })
+    out = _conn(_Sess(jar)).export_cookies()
+    assert [c["name"] for c in out].count("common") == 1
+
+
+# ── import broadcasts to BOTH hosts ────────────────────────────────────────
+
+def test_import_broadcasts_sso_cookie_to_both_hosts() -> None:
+    """Each persisted cookie is injected against BOTH authproxy hosts so the
+    SSO cookie reliably reaches identity.vwgroup.io."""
+    jar = _FilterJar({})
+    _conn(_Sess(jar)).import_cookies(
+        [{"name": "auth0", "value": "ssotoken", "path": "/"}]
+    )
+    hosts = {host for host, name in jar.updates if name == "auth0"}
+    assert hosts == {"www.volkswagen.de", "identity.vwgroup.io"}
+
+
+def test_import_skips_malformed_entries() -> None:
+    """Malformed entries are ignored without raising."""
+    jar = _FilterJar({})
+    _conn(_Sess(jar)).import_cookies(
+        [{"value": "noname"}, "notadict", {"name": "ok", "value": "v"}]  # type: ignore[list-item]
+    )
+    names = {name for _h, name in jar.updates}
+    assert names == {"ok"}
+
+
+# ── round-trip: SSO cookie survives export → import ────────────────────────
+
+def test_round_trip_sso_cookie_reaches_idp() -> None:
+    """End-to-end: a host-only SSO cookie is exported then re-broadcast to the
+    IDP host on import — the exact path that was broken before v2.14.9."""
+    idp = SimpleCookie()
+    idp["auth0"] = "ssotoken"
+    src = _FilterJar({"identity.vwgroup.io": idp})
+    exported = _conn(_Sess(src)).export_cookies()
+
+    dst = _FilterJar({})
+    _conn(_Sess(dst)).import_cookies(exported)
+    idp_cookies = {name for host, name in dst.updates
+                   if host == "identity.vwgroup.io"}
+    assert "auth0" in idp_cookies
+
+
+# ── 412/428 stale-session signal ───────────────────────────────────────────
+
+class _StatusResp:
+    def __init__(self, status: int) -> None:
+        self.status = status
+        self.url = "https://www.volkswagen.de/app/authproxy/x"
+
+    async def __aenter__(self) -> "_StatusResp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def json(self, content_type: Any = None) -> Any:
+        return {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [412, 428])
+async def test_get_json_412_428_raise_auth_error(status: int) -> None:
+    """A stale authproxy session answers 412/428 (not 401) — treat as re-login."""
+    class _S:
+        def get(self, *_a: Any, **_k: Any) -> _StatusResp:
+            return _StatusResp(status)
+
+    with pytest.raises(AuthenticationError):
+        await _conn(_S())._get_json("https://www.volkswagen.de/app/authproxy/x")

--- a/tests/test_v2149_website_cookie_broadcast.py
+++ b/tests/test_v2149_website_cookie_broadcast.py
@@ -103,18 +103,26 @@ def test_import_broadcasts_sso_cookie_to_both_hosts() -> None:
     """Each persisted cookie is injected against BOTH authproxy hosts so the
     SSO cookie reliably reaches identity.vwgroup.io."""
     jar = _FilterJar({})
+    # Domain stamped by export() (here identity.vwgroup.io) — import broadcasts
+    # it host-only to BOTH hosts regardless of the stored domain.
     _conn(_Sess(jar)).import_cookies(
-        [{"name": "auth0", "value": "ssotoken", "path": "/"}]
+        [{"name": "auth0", "value": "ssotoken",
+          "domain": "identity.vwgroup.io", "path": "/"}]
     )
     hosts = {host for host, name in jar.updates if name == "auth0"}
     assert hosts == {"www.volkswagen.de", "identity.vwgroup.io"}
 
 
 def test_import_skips_malformed_entries() -> None:
-    """Malformed entries are ignored without raising."""
+    """Malformed entries (and foreign-domain ones) are ignored without raising."""
     jar = _FilterJar({})
     _conn(_Sess(jar)).import_cookies(
-        [{"value": "noname"}, "notadict", {"name": "ok", "value": "v"}]  # type: ignore[list-item]
+        [
+            {"value": "noname"},  # no name
+            "notadict",  # not a dict
+            {"name": "foreign", "value": "v", "domain": "example.com"},  # off-domain
+            {"name": "ok", "value": "v", "domain": "www.volkswagen.de"},
+        ]  # type: ignore[list-item]
     )
     names = {name for _h, name in jar.updates}
     assert names == {"ok"}


### PR DESCRIPTION
## Root cause (the restart redirect-loop / re-OTP)

The `auth0` **SSO cookie** that keeps the session alive lives **host-only on identity.vwgroup.io** — aiohttp exposes an *empty domain* for host-only cookies. So:
- old `export_cookies` scanned the raw jar and filtered by a domain string → **silently dropped** the SSO cookie (empty domain matched neither host string).
- old `import_cookies` only injected each cookie to its own domain.

Result: after a restart the SSO cookie never reached `identity.vwgroup.io`, the silent resume couldn't re-establish, and the authproxy bounced the resumed session to `/u/login` → **redirect loop / re-OTP every restart**.

## Fix

- `export_cookies` → collect via `cookie_jar.filter_cookies(URL(host))` for **both** hosts: captures host-only cookies (incl. `auth0`) while staying scoped to our two domains.
- `import_cookies` → broadcast every persisted cookie host-only to **both** `www.volkswagen.de` AND `identity.vwgroup.io`.
- `412`/`428` (the authproxy's stale-session signal, *not* `401`) now count as auth-failure → clean re-login.

## Provenance / safety

Independently validated by **rafaelhutter/ha-volkswagen-connect**, whose source documents the identical host-only-SSO-cookie bug ("previously got misfiled under www.volkswagen.de, breaking silent refresh") and the both-hosts broadcast fix. Our implementation is our own.

Opt-in **beta channel only** — no change for any other brand/mode. New tests `test_v2149` (host-only capture, both-host broadcast, dedupe, round-trip, 412/428). ruff + mypy-strict green.

**Honest caveat:** high-confidence root-cause fix, but the live cookie-resume still needs field verification (no VW account on the dev side).