### PR TITLE
docs(readme): refresh all 8 languages to current state + honest competitive claims

### DIFF
--- a/README.cs.md
+++ b/README.cs.md
@@ -5,347 +5,253 @@
 <h1 align="center">VW Group Connect</h1>
 
 <p align="center">
-  <strong>Integrace Home Assistant pro Audi · VW · Škoda · SEAT · CUPRA</strong>
+  <strong>Integrace Home Assistant pro Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
+  <em>Jedna integrace pro všech 7 značek VAG, přímý přístup k API, bez middleware</em>
 </p>
 
 <p align="center">
-  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
-  <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha" alt="Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Lizenz"></a>
+  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-blue" alt="Home Assistant"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://www.home-assistant.io/docs/quality_scale/"><img src="https://img.shields.io/badge/quality_scale-platinum-d4af37" alt="Quality Scale Platinum"></a>
 </p>
 
 <p align="center">
-  <a href="../README.md">Deutsch</a> ·
+  <a href="README.md">Deutsch</a> ·
   <a href="README.en.md">English</a> ·
   <a href="README.fr.md">Français</a> ·
-  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.es.md">Español</a> ·
+  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.pl.md">Polski</a> ·
-  <a href="README.cs.md">Čeština</a> ·
   <a href="README.sv.md">Svenska</a>
 </p>
 
 ---
 
 > ### 📛 Note on the rename
-> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
-> Turns out that abbreviation reads *quite* differently to English speakers 😅
+> Dříve publikováno jako **`vag-connect-ha`** (VAG = Volkswagen AG, běžná DACH zkratka).
+> Ukázalo se, že tahle zkratka zní pro anglicky mluvící *výrazně jinak* 😅
 >
-> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
-> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
-> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
-> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+> **Co funguje beze změny**: všechny entity (např. `sensor.audi_q4_battery_soc`),
+> všechny service-cally (`vag_connect.lock`, `vag_connect.show_vag` atd.), všechny automatizace,
+> instalace přes HACS — **nic se nerozbije**. Mění se marketingový/zobrazovaný název,
+> vnitřnosti kódu zůstávají stejné. Detaily v [`MIGRATION.md`](MIGRATION.md).
 >
-> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
-> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+> Obrovský dík komunitám **Home Assistant UK** a **HA Ideas, Projects and Solutions**
+> za upozornění — zvlášť **Si Gregory**, **Ben Johnson** a **Evets David**.
 >
-> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
-> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
+> A speciální pozdrav pro **Jordan Waeles**, jehož komentář `show_vag()` je dnes oficiálně
+> podporovaný easter egg v této integraci (service `vag_connect.show_vag`, viz CHANGELOG v2.2.3).
 
 ---
 
+## Co to je?
 
-## Co je nového ve v2.10.0
+**VW Group Connect je integrace [Home Assistant](https://www.home-assistant.io) pro data a ovládání propojených aut napříč všemi sedmi značkami koncernu Volkswagen — Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche a VW US/Canada — z jediného config entry, instalovatelná přes [HACS](https://hacs.xyz).**
 
-Největší release této integrace doposud. Cca 6 týdnů intenzivní práce v jednom cut.
+Zpřístupňuje stav baterie a nabíjení, dojezd, stav tachometru, klimatizaci, dveře/okna a polohu a — kde to backend dané značky ještě dovoluje (např. Audi) — posílá příkazy jako zamknout/odemknout, ovládání klimatizace a nabíjení. Aby zůstala funkční i přes změny VW API v roce 2026, mluví několika kanály a automaticky se přepne, když je jeden zablokovaný: backendy nativní pro značku, read-only portál pro data vozidel podle **EU Data Act** a opt-in webový kanál `volkswagen.de`.
 
-- **Oprava loginu VW EU Auth0 SPA (#388)**: VW kolem 2026-05-31 migroval stránku hesla na full-SPA template. Retry JSON Content-Type na `/u/login` plus zpřísněná detekce consent odblokuje uživatele na classic-auth.
-- **Cross-brand parser parita**: VW EU Group A (10 nových polí - 12V, aktivní ventilace, zadní střešní okno, kabriolet střecha, součty per-jízda), SEAT/CUPRA Group B (6 OLA endpointů - warning-lights v3, nastavitelný battery-care, charging-statistics, preferovaný servis), VW NA Group C (4 endpointy - migrace na `data.exteriorStatus.*`, opravuje symptom "všechno null" na ID.4 US 2023 #322).
-- **Detekce uzamčení účtu VW** s vedeným Repairs issue + auto-clear.
-- **Vynucování Scout Policy**: každá silenced JSON cesta musí být také parsována do entity, nebo nést explicitní T2-T5 exemption komentář. Uzavírá #384, #389.
-- **Provenance canaries + weekly watcher** + hardening (SPDX, Bruno drift-gate, mypy strict).
+Na rozdíl od integrací využívajících jen portál pokrývá i **Porsche** (které portál EU Data Act vylučuje) a zachovává **obousměrné ovládání Audi**.
 
-Zbytek z v2.7-v2.9 stále běží: Browser-Login DAG, multi-strategy auth, Data Act Portal, MFA, FCM push, Standheizung, brake-service, parser telemetry.
+> Integrace [Home Assistant](https://www.home-assistant.io) pro data a ovládání propojených vozidel napříč všemi sedmi značkami koncernu VW (Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche, VW US/CA) — jedna integrace, více datových kanálů, automatický fallback, instalace přes HACS.
 
-Plný [CHANGELOG](CHANGELOG.md#2100---2026-06-02).
+---
 
-## Co je nového v v2.7.x
+## Aktuální stav
 
-**Přihlášení přes prohlížeč (žádné heslo v HA) pro Audi, Škoda, SEAT, CUPRA.** OAuth Device Authorization Grant podle RFC 8628. Naskenuj QR kód telefonem nebo otevři URL na libovolném zařízení, potvrď krátký kód, hotovo. Skutečný refresh_token, žádné opakované přihlašování každé dvě hodiny.
+VW v roce 2026 postupně uzavřel přímý přístup k vozidlům pro nástroje třetích stran (CARIAD-BFF s atestací zařízení, CUPRA/SEAT-OLA za Play Integrity od června 2026). Tato integrace zůstává použitelná, protože mluví **více kanály** a automaticky se přepne, jakmile je jeden zablokovaný:
 
-**Multi-strategie auth resolver.** Až tři záložní strategie na značku (Browser-Login, OIDC Hybrid Flow, EU Data Act Portal pouze pro čtení). Jedna strategie umírá, integrace běží dál na další.
+- **Backendy nativní pro značku** — plný přístup včetně ovládání, kde je dostupný (Audi, Škoda, Porsche, VW US/CA).
+- **Portál EU Data Act** — read-only fallback pro všechny značky (bez atestace, cadence ~15 min).
+- **Webový kanál volkswagen.de (Beta, opt-in)** — druhý čtecí kanál pro VW bez atestace.
 
-**Data Act Portal jako fallback pouze pro čtení.** Vlastní implementace přihlášení do EU Data Act portálu, integrovaná jako strategie 3. úrovně. Pouze pro čtení ale bez attestation, takže nerozbitná když VW utáhne OAuth cestu.
+Probíhající práce se točí kolem robustnosti portálu (retry při timeoutu, čerstvost dat) a odolnosti napříč kanály.
 
-**Mnohem více datových bodů.** Statistiky jízdy (životnostní vzdálenost, poslední jízda), hladina oleje, tlak v každé pneumatice, dveře / okna / střecha / kufr per pozice, venkovní teplota na MY24+, Webasto přídavné topení, všechna upozornění výrobce včetně značkově specifických jako Audi STO.
-
-Viz [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+➡️ Kompletní historie verzí: **[CHANGELOG.md](CHANGELOG.md)**.
 
 ---
 
 ## Kde vedeme
 
-Stav k 2026-05-31, po backendové změně VW z 2026-05-27 která zasáhla celou komunitu integrací HA-VAG současně:
+Poctivý stav v polovině roku 2026: portál EU Data Act se mezitím stal de-facto standardním kanálem a používá ho mnoho integrací. Co nás konkrétně odlišuje:
 
-| Funkce | Status zde | Status u ostatních |
+| Síla | My | Alternativy jen s portálem |
 |---|---|---|
-| OAuth Device Authorization Grant (QR-Login) pro Audi/Škoda/SEAT/CUPRA | ✅ od v2.7.0 | Nikdo |
-| Multi-strategie auth fallback řetězec (3 úrovně na značku) | ✅ od v2.6.0 | Nikdo |
-| Portál EU Data Act jako 3. úroveň pouze pro čtení | ✅ od v2.6.0 | Pouze jako samostatná integrace |
-| Bezpečnostní síť InvalidURL proti úniku tokenů | ✅ od v2.7.2 | Nikdo |
-| Watcher attestation gate na straně serveru | ✅ od v2.7.0 | Nikdo |
-| Vehicle Data Scout, auto-detekce API driftu | ✅ od v1.9.0 | Nic srovnatelného |
-| Všech 7 značek VAG v jedné integraci | ✅ | Ostatní projekty mají jeden repo na značku |
+| **Všech 7 značek koncernu včetně Porsche** v jedné integraci | ✅ | Portál EU Data Act **strukturálně vylučuje Porsche** — nástroje jen s portálem nemůžou Porsche nikdy pokrýt |
+| **Obousměrné ovládání Audi** (zámek/klima/nabíjení, nastavení target SoC) | ✅ | Portál je by-design **read-only** |
+| **Multi-channel auth s auto-fallbackem** (backend značky → portál EU Data Act → opt-in vw.de web) | ✅ | většinou single-source — výpadek portálu = totální výpadek |
+| **Vehicle Data Scout** — automaticky detekuje drift API, generuje bug-reporty na 1 klik | ✅ | nic srovnatelného |
 
 ---
 
 ## Kde jsou hranice (poctivě)
 
-**VW EU je tvrdě zablokované Play Integrity od backendové změny 2026-05-27.** Tato zeď zasahuje každou Python-based VAG integraci (naši včetně). Není to dočasné zpoždění z naší strany, je to backendová politika VW:
+**VW EU a CUPRA/SEAT-OLA jsou od roku 2026 za atestací zařízení.** Tahle zeď (Google Play Integrity / Firebase App Check) zasahuje každou VAG integraci postavenou na Pythonu — naši včetně. Není to zpoždění z naší strany, je to politika backendu VW:
 
-- Token endpoint validuje hlavičku `X-Assertion` která musí být JWS podepsaný Google Play Integrity
-- Python nemůže tento token vygenerovat, podpisový klíč žije pouze v Google attestation service
-- Důsledek: VW EU uživatelé nedostávají skutečný refresh_token a musí se znovu přihlašovat každé ~2h
+- Token/OLA endpoint vyžaduje atestační token podepsaný oficiální aplikací, který Python nedokáže vygenerovat (podpisový klíč žije pouze v atestační službě Google/Firebase).
+- Důsledek: **VW EU** nedostane trvalý `refresh_token` (OIDC hybrid flow vydrží ~2 h) a **CUPRA/SEAT** přes OLA dostávají od ~2026-06-08 `403 "Forbidden device detected"`.
 
-Co nabízíme pro VW EU: OIDC Hybrid Flow jako primární strategie (čtení + zápis, 2h re-login), EU Data Act portál jako fallback pouze pro čtení (cadence 15 min, bez attestation), týdenní watcher který automaticky otevírá issue jakmile VW otevře bránu.
+Co i přesto nabízíme:
 
-**Termín EU Data Act 2026-09-12.** Do tohoto data musí VW legálně poskytnout přímý přístup k datům vozidla majitelům bez attestation gatingu. Naše `_data_act_portal.py` je připraveno na tento den.
+1. **Portál EU Data Act** jako read-only fallback pro všechny značky (bez atestace, cadence ~15 min) — automaticky převezme štafetu, když nativní backend zablokuje.
+2. **Webový kanál volkswagen.de (Beta, opt-in)** jako druhý čtecí kanál pro VW bez atestace.
+3. **OIDC hybrid flow** pro VW EU jako read+write strategie (cenou je 2h re-login).
 
-## ✨ v2.0.0 Big-Bang Highlights — also available in English
+**Termín EU Data Act 2026-09-12.** Do tohoto data musí VW podle nařízení EU nabídnout přímý přístup k datům majitele bez atestace — pokrytí polí v portálu do té doby pravděpodobně dál poroste.
 
-> The detailed v2.0.0 highlights table + "What makes us unique" USP section
-> are maintained in English on the German + English READMEs. They are
-> provided here as the canonical source so non-DE/EN readers can still
-> see all v2.0 features with `` markers without waiting on
-> 6 parallel translations.
+Status podle značky:
 
-### Latest highlights — v2.0.0 Big-Bang
-
-| Feature | Status |
-|---|---|
-| **Skoda Driving-Score Sensor** | Efficiency score 0-100 + class bucket for Skoda MY24+ |
-| **Cross-brand Aux-Heating parity (Skoda)** | SkodaClient now inherits the Webasto switch from SEAT/CUPRA |
-| **Porsche TPMS sensors** | 4 tire-pressure sensors + warning binary_sensor (PPA TIRE_PRESSURE) |
-| **Long-Term Trip Aggregates** | Lifetime distance / avg fuel / avg electric (Audi + VW EU) |
-| **Departure-Timer Read-Only Binary-Sensors** | 3 pure-read enabled-sensors |
-| **Weekly Preheat (`recurring_on`)** | Service param for weekday lists (Audi + VW EU + VW NA) |
-| **Charging-Station POI Lookup** | `vag_connect.find_charging_stations` service |
-| **Vehicle Alarm sensors** | closes issue #33 |
-| **heaterSource sensor** | closes issue #163 |
-| **Push Manager Lifecycle Wiring** | Skoda MQTT + CUPRA/SEAT FCM + Audi/VW Cariad FCM (opt-in) |
-| **EU Data Act Abstraction Shim** | Architectural seam for the 2026-09-12 EUDA Art. 3 deadline |
-| **Auth Resilience One-Click Repair** | Repair button for 4 auth reasons triggers reauth flow |
-| **System Health Panel** | Drop-in `system_health.py` |
-| **Quality Scale Platinum** | Re-introduced after v1.26.x revert |
-| **DeviceInfo `configuration_url` + `suggested_area`** | Brand-aware "Open in App" button |
-
-### What makes us unique
-
-- **Native coverage of all 7 VAG brands** in a single integration
-- **Direct manufacturer-API access** without middleware / Docker / 3rd service
-- **Vehicle Data Scout** — automatic JSON-field drift detection with Repair notification + 1-click GitHub issue
-- **Capability-Filter Phase 3** — phantom entities suppressed before spawn
-- **Per-VIN wakeup cap + cooldown** — protects 12V battery
-- **Auth Resilience One-Click Repair** — reauth flow from Repairs panel
-- **System Health Panel** — at-a-glance push channel status, API quota, last poll
-- **Bruno-CI Stage 2** — strict URL-drift check
-- **Token persistence across HA updates** — no re-login after HACS updates since v1.19.2
-- **Diagnostics anonymisation by default** — VINs, GPS, tokens stripped before export
-
-
-Chtěl jsem plně ovládat své Audi v Home Assistant. Tak jsem to postavil.
-
-**VW Group Connect** je samostatná integrace Home Assistant pro všechny značky VAG. Bez externích závislostí, bez Dockeru, bez externích služeb.
-
-Od v0.14.1 integrace **přímo** komunikuje s CARIAD API — vlastní async klient, plně autonomní. Architektura cloud-polling, 80+ entit napříč 10 platformami, 14 služeb.
-
-> ✅ **Aktivně udržovaný multi-značkový nástupce** projektů [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivováno 2025-10-29) a [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). Jedna integrace pro Audi, VW, Škoda, SEAT, CUPRA, Porsche a VW US/CA — bez samostatného pluginu pro každou značku.
-
-## Aktuální stav a upřímné limity / Current Status & Honest Limits (v1.12.3)
-
-VW Group Connect se aktivně vyvíjí. Abys věděl, co funguje a co přijde:
-
-### ✅ Co funguje TEĎ (všech 7 značek)
-
-**🛰️ Bug reporty a žádosti o funkce 1 kliknutím (LIVE od v1.9.0)**
-
-Dva diagnostické sensory se sdílenou reporter pipeline — **první skutečná live-validace komunitními uživateli** v v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) a v1.12.3 (DnnsJp74 / Audi):
-
-- 🔬 **Vehicle Data Scout** — automaticky detekuje neznámá JSON pole v API tvého auta. Lokalizovaný per značku v 8 jazycích (DE: API-Beobachter, FR: Observateur d'API, etc.).
-- 🚨 **Error Reporter** — Ring-buffer posledních 20 chyb integrace s anonymizovaným kontextem (model, firmware, stack trace).
-- 🔘 **Reporter Pipeline:** oba sensory automaticky vytvářejí HA Repair notifikace s předvyplněným GitHub-Issue jako 1-klik linkem. Plus diagnostics-download se vším maskovaným pro fórum/Facebook.
-- 🔒 **Slib soukromí:** Nic neopustí tvou HA bez tvého explicitního kliknutí. VINy maskovány, GPS zaokrouhlené na 1 desetinné místo, JWT/UUID/e-maily odstraněny. GDPR-compliant.
-
-**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
-
-Sensor `connection_state` (online / standby / offline) pro Audi, VW EU, Škoda, SEAT, CUPRA — první VAG integrace s centralizovaným stavem připojení. Brand-agnostický helper `compute_connection_state` s rekurzivním procházením `carCapturedTimestamp`.
-
-**🔋 Monitoring 12V baterie + Smart-Wake (v1.12.0)**
-
-- Sensor `voltage_12v` (V) + binary `warning_12v_low` při <11.5V — zabraňuje tichým výpadkům API kvůli vybité startovací baterii
-- Sensor `wake_count_today` + soft-cap na 3 wakes/den (`_WAKE_BUDGET_PER_DAY`) chrání 12V před wake-loops, vyvolá `wake_budget_exhausted` PŘED API voláním
-
-**💨 Optimistické UI pro Lock/Climate/Charging (v1.11.1)**
-
-Switche se přepínají okamžitě po kliknutí (vzor myskoda PR #832), API roundtrip na pozadí. Při selhání: revert + ServiceValidationError. 8 actuator metod převedeno.
-
-**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up v v1.11.1)**
-
-Tři explicitní range sensory: `electric_range_km`, `combustion_range_km`, `total_range_km`. Parser VW EU/Audi klasifikuje podle typu motoru (4 zdroje místo 2). Audi-diesel-fallback z `measurements.rangeStatus.value.dieselRange`. Ověřeno přes evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity logy.
-
-**🔒 Read-only režim Fáze 1 (v1.12.0)**
-
-Toggle možností "Read-only Mode" → přeskočí lock/switch/button(non-refresh)/climate/number platformy pro privacy/safety-konzervativní vlastníky. Sensors + binary_sensors + device_tracker zůstávají.
-
-**⚡ Zapisovatelné Max-Charge-Current Number (v1.12.0)**
-
-Slider 6-32A místo pouze read-only sensoru. Nový `command_set_max_charge_current` POST chargingSettings.
-
-**💡 Per-Light Binary-Sensors (v1.12.0)**
-
-Dynamicky per typ světla z dict `lights_individual` + agregáty `lights_on` + `lights_count`.
-
-**🛠️ Defenzivní stabilita (v1.8.7 + v1.10.1)**
-
-- 504-retry, transient-network-error retry, 6h stale-cache + tolerance 3 selhání
-- Ochrana před token-refresh-storm (max 3/h) — zabraňuje IP banům
-- Helpery `safe_int` / `safe_float` / `safe_enum` — tolerují backend quirks
-
-**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhardova #53 první live-validace)**
-
-Field-name fallback řetězec: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerance pro `"connected"` / `"locked"`. Zpětná kompatibilita zachována.
-
-**🔓 Lock + Wake pro Audi/VW (v1.9.1, #92 Audi S6 C8)**
-
-`command_lock` posílá nyní S-PIN pro Audi/VW (CARIAD BFF odpovídal `403 spin_error`). `command_wake` používá v1→v2 fallback.
-
-**🛡️ Capability-Filter Fáze 2 (v1.9.1, #56)**
-
-Body-sniffing `classify_command_failure` pro `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error` markery. `_cariad_cmd` zapisuje každý výsledek do FeatureState. Command-bound entity (Lock/Climate/Switch/Buttons) jdou automaticky unavailable při definitivním "ne" backendu.
-
-### ⚠️ Ještě v procesu / What's still in progress (plánované sessions)
-
-- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Fáze 3 (`capability.active && user-enabled` PRE-vytvoření-entity, skrývá tlačítka jako MyCupra aplikace) + Read-only Fáze 2/3 (Command-Locking + oddělení služeb cloud_refresh vs wake_vehicle).
-- **v1.14.0 MINOR** — Trip Statistics z Audi `tripstatistics/v1` (#24, #35).
-- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26).
-- **v1.16.0 MINOR** — Lokalitně-specifický Cíl SoC nabíjení + nabíjecí profily (#25, #31).
-- **v1.17.0 MINOR** — Remote Start ICE (#28, vzor upstream #717).
-- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) pro real-time updaty bez pollingu (#57, #27).
-- **v2.0.0 MAJOR** — HACS Default + Live-Tests všech značek + EU Data Act ready (pycupra `EUDAConnection` jako reference, deadline září 2026) (#13, #59).
-
-### 🚫 Vědomé limity / Conscious limits
-
-- **Image platforma:** neexistuje oficiální CARIAD render-image API. Image entita přejde v budoucí release na URL dodávané uživatelem.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nová architektura E³ 1.2, ještě veřejně reverse-engineered (ani v upstream ani v CarConnectivity). VW Group Connect tato vozidla detekuje a dělá **graceful degradation** místo 404 chyb.
-- **Ford / značky mimo VAG:** mimo rozsah — viz [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) pro Ford.
-
-### 🔧 Předpoklad ochrany soukromí
-
-Aby GPS poloha, stav vozidla a topení fungovaly, musí být **"Sdílet mou polohu"** aktivní v tvé aplikaci My-VW / My-Audi / MySkoda / MyCupra — jinak backend odpovídá 403.
-
-### 📚 Více informací / More info
-
-- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — kompletní P0/P1/P2/P3 priorizace všech otevřených issues
-- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + architektonické rozhodnutí + externí source-refs
-- 🎨 Průvodce Dashboards + Lovelace karta BETA: [`docs/dashboards.md`](docs/dashboards.md) — řešení problémů s „Přidat na panel" + dedikovaná Lovelace karta (BETA)
-- 🤝 Session Handoff (pro přispěvatele a AI nástroje): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔒 Pravidla soukromí a zacházení s daty: sekce [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
-- 📋 FAQ Subscription / Service Plus / diagnóza `missing-capability`: FAQ sekce v [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
----
-
-## Podporované Značky
-
-| Brand | Auth | API | Status |
+| Značka | Ovládání | Data | Poznámka |
 |---|---|---|---|
-| **Volkswagen EU** | IDK | emea.bff.cariad.digital | ✅ |
-| **Audi** | IDK + AZS/MBB | emea.bff.cariad.digital | ✅ |
-| **Škoda** | IDK | mysmob.api.connect.skoda-auto.cz | ✅ |
-| **SEAT** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| **CUPRA** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
-| VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
-
-> **Porsche & VW NA:** Obě značky jsou od v1.0.0 k dispozici jako Beta. Hledáme testery — zpětnou vazbu hlaste jako [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
+| **Audi** | ✅ obousměrné | ✅ plné | myAudi backend, bez atestační zdi |
+| **Škoda** | ✅ obousměrné | ✅ plné | vlastní Škoda backend |
+| **Porsche** | ✅ obousměrné | ✅ plné | Auth0 + PPA, stabilní |
+| **VW US/CA** | ✅ obousměrné | ✅ plné | VW NA cloud (Beta) |
+| **VW EU** | ⚠️ přes OIDC hybrid (~2h re-login) | ✅ read-only portál / vw.de Beta | gated atestací backendu |
+| **CUPRA / SEAT** | ❌ OLA blokováno (App Check) | ✅ read-only portál | od ~2026-06-08, neopravitelné přes hlavičku |
 
 ---
 
-## Funkce
+## Co dostaneš
 
-| Feature | Audi | VW EU | Škoda | SEAT/CUPRA |
-|---|:---:|:---:|:---:|:---:|
-| Fuel / Battery level | ✓ | ✓ | ✓ | ✓ |
-| Range | ✓ | ✓ | ✓ | ✓ |
-| Odometer | ✓ | ✓ | ✓ | ✓ |
-| GPS position | ✓ | ✓ | ✓ | ✓ |
-| Doors (total + per door) | ✓ | ✓ | ✓ | ✓ |
-| Windows | ✓ | ✓ | ✓ | ✓ |
-| Climate start/stop | ✓ | ✓ | ✓ | ✓ |
-| Target temperature | ✓ | ✓ | ✓ | ✓ |
-| Lock / Unlock | ✓ | ✓ | ✓ | ✓ |
-| Flash lights | ✓ | ✓ | ✓ | ✓ |
-| Wake vehicle | ✓ | ✓ | ✓ | ✓ |
-| Service due km/days | ✓ | ✓ | ✓ | ✓ |
-| Online status | ✓ | ✓ | ✓ | ✓ |
-| Battery SoC % | ✓ | ✓ | ✓ | ✓ |
-| Charge state | ✓ | ✓ | ✓ | ✓ |
-| Charge power kW | ✓ | ✓ | ✓ | ✓ |
-| Charge speed km/h | ✓ | ✓ | ✓ | ✓ |
-| Charge ETA | ✓ | ✓ | ✓ | ✓ |
-| Charge target % | ✓ | ✓ | ✓ | ✓ |
-| Trunk / hood / sunroof | ✓ | ✓ | ✓ | ✓ |
-| Window heating | ✓ | ✓ | ✓ | ✓ |
-| Vehicle renders | ✓ | — | — | ✓ |
-| Departure timers 1–3 | ✓ | ✓ | — | — |
-| Battery temperature | ✓ | ✓ | — | — |
-| AdBlue range | ✓ | ✓ | — | ✓ |
+100+ entit napříč 11 HA platformami, 20+ service-callů, nativní podpora více vozidel na účet. Quality Scale Platinum.
+
+**Senzory** (na vozidlo): Battery SoC, Range (electric / combustion / total), Fuel Level, Odometer, Outside Temp, Battery Temp, 12V Voltage, Service Days, Oil Service Days, Charging Power / Rate / Type, Last Trip Stats, Lifetime Trip Aggregates, Charging History, Plug State, Lights Count, Equipment Count, Software Version, API Quota Remaining, Connection State, Last Seen, Skoda Driving Score, Porsche TPMS 4 Corners, Last Alarm Timestamp, Heater Source pro ID.x, Oil Level Warning, varování vozidla (textový senzor se všemi backend warningy).
+
+**Binární senzory**: Doors Locked, Doors Open na každé dveře, Windows Open na každé okno, Trunk / Hood / Sunroof, Plug Connected, Charging, OTA Update Available, 12V Low Warning, Lights On na každé světlo, Vehicle Online, Departure-Timer 1-3 Enabled, Alarm Active + Siren Active, TPMS Warning.
+
+**Ovládání**: Lock/Unlock, Climate Start/Stop, Charging Start/Stop, Window Heating, Cabin Ventilation (CUPRA/SEAT), Aux Heating (Webasto), Departure Timer 1-3 s týdenním předtopením, Set Target SoC, Set Target Temp, Set Max Charge Current, Set Charge Mode, Honk-and-Flash, Wake Vehicle, Refresh, Find Charging Stations.
+
+**Image platforma**: 1-7 renderů vozidla na VIN (Audi/VW přes GraphQL MediaService, CUPRA/SEAT přes OLA viewPoints, Škoda přes Widget + multi-angle kompozity).
+
+**Device Tracker**: GPS poloha jako TrackerEntity pro mapu HA Lovelace.
 
 ---
 
 ## Instalace
 
-### HACS
+### Možnost 1: One-Click (doporučeno)
+
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vwgroup-connect-ha&category=integration)
+
+### Možnost 2: HACS Custom Repository
 
 1. HACS → Integrace → ⋮ → Vlastní repozitáře
-2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Kategorie: Integrace
-3. Nainstalovat **VW Group Connect** → Restartovat Home Assistant
-4. Nastavení → Integrace → **+ Integrace** → **VW Group Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha`
+3. Kategorie: Integration
+4. Nainstalovat **VW Group Connect**
+5. Restartovat Home Assistant
 
-### Manual
+### Možnost 3: Manuálně
 
 ```bash
-cp -r custom_components/vag_connect ~/.homeassistant/custom_components/
+cd /config/custom_components
+git clone https://github.com/its-me-prash/vwgroup-connect-ha.git
+mv vwgroup-connect-ha/custom_components/vag_connect .
+rm -rf vwgroup-connect-ha
 ```
 
-Restartujte Home Assistant.
+Poté restartuj HA.
 
 ---
 
 ## Konfigurace
 
-| Field | Required | Description |
-|---|---|---|
-| Značka | ✓ | Audi / Volkswagen / Škoda / SEAT / CUPRA |
-| E-mail | ✓ | Přihlašovací e-mail z aplikace výrobce |
-| Heslo | ✓ | Heslo z aplikace |
-| S-PIN | — | Vyžadováno pro zamykání (v Zabezpečení v aplikaci) |
-| Interval | — | Minuty mezi aktualizacemi (výchozí: 5) |
+Nastavení → Zařízení a služby → Přidat integraci → "VW Group Connect"
 
-**Která aplikace?** Audi → myAudi · VW → WeConnect · Škoda → MyŠkoda · SEAT → My SEAT · CUPRA → MyCupra
+**Při prvním nastavení si vybereš:**
 
----
+- **Přihlášení přes prohlížeč** (doporučeno pro Audi/Škoda/SEAT/CUPRA): naskenuj QR kód nebo otevři URL, žádné heslo uložené v HA
+- **E-mail + heslo** (pro VW EU, Porsche, VW US/CA): klasicky s přihlašovacími údaji Brand-ID
 
-## Známá Omezení
-
-- **S-PIN** vyžadováno pro zamykání
-- **Interval** minimum 5 minut
-- **2FA** — jednou ručně potvrdit v aplikaci
-- **Porsche / VW NA** — funkční jako Beta, hledáme testery
+**Možnosti** (dostupné po nastavení):
+- Interval pollingu (5-60 min, výchozí 10 min)
+- Read-only režim pro bezpečné automatizace bez nechtěných příkazů
+- Reverzní geokódování opt-in (posílá GPS na OpenStreetMap pro rozlišení adresy)
+- Push-toggly (Skoda MQTT, CUPRA/SEAT FCM, Audi/VW FCM) jako základ, live aktivace čeká na zprovoznění
 
 ---
 
+## Příklady Lovelace
+
+### Map Card
+
+```yaml
+type: map
+title: Fuhrpark
+default_zoom: 12
+hours_to_show: 24
+entities:
+  - device_tracker.audi_a4_b9_position
+  - device_tracker.vw_golf_7_gte_position
+  - zone.home
+```
+
+### Picture-Entity Card s renderem vozidla
+
+```yaml
+type: picture-entity
+entity: image.audi_a4_b9_render_side_lg
+camera_view: live
+show_state: false
+show_name: false
+```
+
+### Vyhledání nabíjecí stanice
+
+```yaml
+action: vag_connect.find_charging_stations
+data:
+  vin: WAUZZZ...
+  latitude: 47.3769
+  longitude: 8.5417
+  radius_m: 5000
+  max_results: 25
+response_variable: result
+```
+
+Více příkladů v [`docs/FAQ.md`](docs/FAQ.md). Vlastní Lovelace karty se integrují automaticky přes `extra_state_attributes.image_url`.
+
+---
+
+## Časté dotazy
+
+| Otázka | Odpověď |
+|---|---|
+| Kdy se moje auto probudí? | Jen při service-callech (Lock/Climate/Wake), nikdy při status pollech. Smart-Wake-Cap: max 3 probuzení/den na auto, 5min cooldown. |
+| Kolik API quota? | MyCupra/MySeat: ~1500 callů/den. Při 10min pollingu: ~144 callů/den = 10 % budgetu. Senzor `requests_remaining_today` ukazuje stav. |
+| Proč se u VW EU musím každé 2h znovu přihlašovat? | VW od 2026-05-27 postavil token endpoint za Google Play Integrity. To zasahuje každou VAG integraci postavenou na Pythonu. EU Data Act 2026-09-12 by to měl vyřešit. |
+| Zůstane token po HACS updatu? | Ano, od v1.19.2 přes Store persistenci HA. |
+| Jak nahlásím bugy? | HA → Integrace → 🔧 Opravit → Bug-Report. Diagnostika je anonymizovaná (VINy maskované, GPS zaokrouhlené, tokeny odstraněné). |
+| Popisky polí ukazují raw klíče (`brand`, `spin`) po updatu? | Tvrdý refresh prohlížeče (Ctrl+Shift+R). HA cachuje překlady na straně klienta. |
+
+Kompletní FAQ v [`docs/FAQ.md`](docs/FAQ.md). Řešení problémů s dashboardy v [`docs/dashboards.md`](docs/dashboards.md).
+
+---
+
+## Soukromí a bezpečnost
+
+- Žádné externí služby, vše přímo mezi HA a API výrobce
+- Token-cache lokálně v `.storage/` HA (per config entry, JSON, automaticky odstraněný při odebrání integrace)
+- Diagnostika anonymizovaná: VINy maskované, GPS zaokrouhlené na 1 desetinné místo, tokeny a hesla kompletně odstraněné
+- Reverzní geokódování opt-in, ve výchozím stavu vypnuté
+- Maskování VIN průběžně ve všech logách
+- Token-URL jsou v ERROR-logu redigované (v2.7.2+)
+
+Detaily v [`PRIVACY.md`](PRIVACY.md) a [`SECURITY.md`](SECURITY.md).
+
+---
+
+## Contributing
+
+PRs vítány, viz [`CONTRIBUTING.md`](CONTRIBUTING.md). Pravidla stylu v [`STYLE.md`](STYLE.md) (privátně v `_private/STYLE.md` pro maintainery).
+
+**Vehicle Data Scout** (live od v1.9.0): Když tvoje integrace detekuje neznámá JSON pole, automaticky vytvoří HA Repair notifikaci s předvyplněným odkazem na GitHub issue. Bug-report na 1 klik bez studia kódu.
+
+---
 
 ## Licence
 
-Apache License 2.0 — [LICENSE](LICENSE)
-
-**VW Group Connect™** je neregistrovaná ochranná známka (™, ne ®). Prosíme, nepoužívejte tento název ve forkách, abyste předešli záměně.
-
-Tato integrace je nezávislý komunitní projekt bez jakéhokoliv spojení s Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG nebo jakoukoliv pobočkou Volkswagen Group.
-
----
-
-*Copyright 2026 [Prash Balan](https://github.com/its-me-prash) · Apache License 2.0*
+[Apache License 2.0](LICENSE) pro kód integrace. [CC BY-NC-ND 4.0](LICENSE-RESEARCH) pro obsah `docs/research/`. Atribuce upstream open-source projektům viz [`NOTICE.md`](NOTICE.md).

--- a/README.en.md
+++ b/README.en.md
@@ -47,74 +47,68 @@
 
 ---
 
-## What is new in v2.10.0
+## What is this?
 
-The biggest release of this integration so far. ~6 weeks of intensive work folded into a single cut.
+**VW Group Connect is a [Home Assistant](https://www.home-assistant.io) integration for connected-car data and control across all seven Volkswagen Group brands — Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche and VW US/Canada — from a single config entry, installable through [HACS](https://hacs.xyz).**
 
-**VW EU Auth0 SPA login fixed (#388 BalooDK + swebachus).** Around 2026-05-31 VW migrated the universal-login password page to a full-SPA template. Our form-encoded POST started returning 400 even with correct credentials, and the Data Act portal fallback misidentified the SPA's `consent.js` asset as a consent wall. Both legs fixed: JSON Content-Type retry against the same `/u/login` URL when the form path 400s, and consent detection now requires specific markers (`data act`, `datenverarbeitung`, `shape the future`, `/u/consent`) instead of the bare word `consent`. VW EU users on classic-auth strategy are unblocked again.
+It surfaces battery and charging state, range, odometer, climate, doors/windows and location, and — where the brand's backend still allows it (e.g. Audi) — sends commands such as lock/unlock, climate and charge control. To stay working through Volkswagen's 2026 API changes it speaks several channels and falls back automatically when one is blocked: the brand-native backends, the read-only **EU Data Act** vehicle-data portal, and an opt-in `volkswagen.de` web channel.
 
-**Across-brand parser parity.** Three coordinated parser-gap closures so every brand surfaces what its backend already returns:
-- **VW EU (Group A) - 10 new fields**: 12V starter battery health, optimised battery use, active ventilation state + remaining time, rear sunroof, convertible roof cover, per-trip totals (fuel + electric kWh), tire pressure fallback via `measurements.tirePressureStatus` for newer PPC firmware.
-- **SEAT / CUPRA (Group B) - 6 new OLA endpoints**: dedicated warning-lights v3 endpoint, settable battery-care preservation mode + target SoC, charging-statistics history aggregator, preferred-workshop, charging-modes catalog, charging-actions PUT for runtime settings.
-- **VW NA (Group C) - 4 new endpoints**: doors + windows + lights migrated to the modern `data.exteriorStatus.*` shape (closes #322 roberttco's 2023 ID.4 US "everything-null" symptom), climate via `climateStatusReport`, odometer fallback `data.currentMileage`, GPS fallback `lastParkedLocation` for OFFLINE cars.
+Unlike portal-only integrations it also covers **Porsche** (which the EU Data Act portal excludes) and keeps **Audi two-way control**.
 
-**VW account-lock detection.** Three throttled-or-locked token responses inside a 30-minute window now surface a guided Repairs issue (`account_locked`) explaining the lock + next steps (wait, raise `scan_interval`, optionally switch to read-only Data Act portal mode). Auto-clears on next successful auth.
+---
 
-**Scout-policy enforcement.** Every silenced JSON path now MUST also be parsed into an entity, or carry an explicit T2-T5 exemption comment. The pre-existing "silence first, parse later" pattern is gone; existing silencer-only entries from v2.4.x are documented as exempt or promoted to parsed sensors (active ventilation alone closed an IOU from 2026-05-27). Wildcard rules for `.error.*` envelopes now stop Scout descending into the bff-error wrappers (closes #389, #384).
+## Current status
 
-**Provenance canaries + weekly watcher.** Five uniquely-spelled identifier strings watermark the strategic modules (auth resolver, Data Act scraper, DAG flow, Scout, watchdog). A weekly cron queries GitHub Code Search for the canaries outside the `its-me-prash` namespace and opens a triage issue if a foreign hit appears. Apache 2.0 permits the port; the canaries make stripping the LICENSE + NOTICE observable.
+In 2026 VW progressively locked down direct vehicle access for third-party tools (CARIAD BFF with device attestation, CUPRA/SEAT OLA behind Play Integrity since June 2026). This integration stays usable because it speaks **several channels** and switches automatically the moment one is blocked:
 
-**Hardening.** SPDX license headers on every Python file. Pre-commit hook enforces `ruff check`, `mypy --strict`, CHANGELOG version-match, and Bruno-collection URL drift gate. Python ↔ Bruno strict-mode CI prevents URLs from diverging from their reference recordings.
+- **Brand-native backends** — full access including control, where available (Audi, Škoda, Porsche, VW US/CA).
+- **EU Data Act portal** — read-only fallback for all brands (attestation-free, ~15 min cadence).
+- **volkswagen.de web channel (beta, opt-in)** — a second attestation-free read channel for VW.
 
-**Carried over from v2.7-v2.9** (still all live): Browser-Login (DAG) for Audi/Škoda/SEAT/CUPRA, multi-strategy auth resolver, EU Data Act portal read-only tier, MFA / email-OTP config flow, coordinator auto-reload watchdog, FCM push-channel for Audi/VW, Standheizung Auxheat entities, `vag_connect.open_app` service, brake-service sensors + preferred workshop, parser-health telemetry, per-brand capability advertisement, InvalidURL safety net, attestation gate watcher.
+Current work centres on portal robustness (timeout retry, data freshness) and resilience across the channels.
 
-Full [CHANGELOG](CHANGELOG.md#2100---2026-06-02).
+➡️ Full version history: **[CHANGELOG.md](CHANGELOG.md)**.
 
 ---
 
 ## Where we lead
 
-State as of 2026-05-31, after the 2026-05-27 VW backend change that hit the entire HA-VAG-integration community simultaneously:
+Honest picture as of mid-2026: the EU Data Act portal has by now become the de-facto standard channel, and many integrations use it. What concretely sets us apart:
 
-| Feature | Status here | Status in other HA-VAG integrations |
+| Strength | Us | Portal-only alternatives |
 |---|---|---|
-| **OAuth Device Authorization Grant (QR-Login)** for Audi/Škoda/SEAT/CUPRA | ✅ live since v2.7.0 | Nobody has it |
-| **Multi-strategy auth fallback chain** (3 tiers per brand) | ✅ live since v2.6.0 | Nobody |
-| **EU Data Act portal read-only tier** as 3rd-tier fallback | ✅ integrated since v2.6.0 | Only available as separate standalone integration |
-| **InvalidURL safety net** prevents token leakage in logs | ✅ live since v2.7.2 | Nobody |
-| **Server-side attestation gate watcher** alerts on VW backend flag flips | ✅ live since v2.7.0 | Nobody |
-| **Vehicle Data Scout** auto-detects API drift, generates 1-click bug reports | ✅ live since v1.9.0 | No comparable feature |
-| **All 7 VAG brands in one integration** (Audi+VW+Škoda+SEAT+CUPRA+Porsche+VW NA) | ✅ | Other projects ship one repo per brand |
+| **All 7 group brands incl. Porsche** in one integration | ✅ | The EU Data Act portal **structurally excludes Porsche** — portal-only tools can never cover Porsche |
+| **Audi two-way control** (lock/climate/charge, set target SoC) | ✅ | The portal is by design **read-only** |
+| **Multi-channel auth with auto-fallback** (brand backend → EU Data Act portal → opt-in vw.de web) | ✅ | mostly single-source — one portal outage = total outage |
+| **Vehicle Data Scout** — detects API drift automatically, generates 1-click bug reports | ✅ | nothing comparable |
 
 ---
 
 ## Where the limits are (honest)
 
-**VW EU is hard Play-Integrity-gated since the 2026-05-27 backend change.** This wall hits every Python-based VAG integration (ours included). It is not a temporary delay on our side, it is VW's backend policy:
+**VW EU and CUPRA/SEAT OLA have been behind device attestation since 2026.** This wall (Google Play Integrity / Firebase App Check) hits every Python-based VAG integration — ours included. It is not a delay on our side, it is VW backend policy:
 
-- The token endpoint validates an `X-Assertion` header that must be a Google Play Integrity signed JWS token
-- Python cannot generate this token because the signing key lives only inside Google's mobile-app attestation service
-- Consequence: **VW EU users do not get a real refresh_token** and are forced into a re-login every ~2 hours
+- The token / OLA endpoint demands an attestation token signed by the official app, which Python cannot produce (the signing key lives only inside the Google/Firebase attestation service).
+- Consequence: **VW EU** gets no durable `refresh_token` (the OIDC hybrid flow lasts ~2 h), and **CUPRA/SEAT** over OLA get `403 "Forbidden device detected"` since ~2026-06-08.
 
-What we still offer for VW EU:
+What we offer regardless:
 
-1. **OIDC Hybrid Flow** as primary strategy (read + write, but 2h re-login)
-2. **EU Data Act portal** as read-only fallback (15-min cadence, attestation-free, unbreakable)
-3. **Attestation gate watcher** that polls weekly and auto-opens an issue the moment VW opens the gate
+1. **EU Data Act portal** as a read-only fallback for all brands (attestation-free, ~15 min cadence) — takes over automatically when the native backend blocks.
+2. **volkswagen.de web channel (beta, opt-in)** as a second attestation-free read channel for VW.
+3. **OIDC hybrid flow** for VW EU as a read+write strategy (with the 2h re-login as the price).
 
-**EU Data Act 2026-09-12 compliance deadline.** By that date, VW must legally provide direct vehicle-data access to owners without attestation gating. Our `_data_act_portal.py` is positioned for that day.
+**EU Data Act deadline 2026-09-12.** By that date, EU regulation requires VW to offer direct, attestation-free owner-data access — portal field coverage is expected to keep growing until then.
 
-Brand status:
+Status per brand:
 
-| Brand | Auth | refresh_token? | Notes |
+| Brand | Control | Data | Note |
 |---|---|---|---|
-| **Audi** | DAG Browser-Login or email+pwd Hybrid | ✅ yes (via DAG) | Fully functional |
-| **Škoda** | DAG Browser-Login or email+pwd | ✅ yes (via DAG) | Fully functional |
-| **SEAT** | DAG Browser-Login or OLA | ✅ yes (via DAG) | Fully functional |
-| **CUPRA** | DAG Browser-Login or OLA | ✅ yes (via DAG) | Fully functional |
-| **VW EU** | OIDC Hybrid Flow or Data Act Portal | ⚠️ no, 2h re-login | Backend-gated (see above) |
-| **Porsche** | Auth0 + PPA | ✅ yes | Stable |
-| **VW US/CA** | VW NA Cloud | ✅ yes | Beta |
+| **Audi** | ✅ Two-way | ✅ full | myAudi backend, no attestation wall |
+| **Škoda** | ✅ Two-way | ✅ full | own Škoda backend |
+| **Porsche** | ✅ Two-way | ✅ full | Auth0 + PPA, stable |
+| **VW US/CA** | ✅ Two-way | ✅ full | VW NA cloud (beta) |
+| **VW EU** | ⚠️ via OIDC hybrid (~2h re-login) | ✅ read-only portal / vw.de beta | backend attestation-gated |
+| **CUPRA / SEAT** | ❌ OLA blocked (App Check) | ✅ read-only portal | since ~2026-06-08, not fixable via headers |
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -5,24 +5,24 @@
 <h1 align="center">VW Group Connect</h1>
 
 <p align="center">
-  <strong>Integración de Home Assistant para Audi · VW · Škoda · SEAT · CUPRA</strong>
+  <strong>Integración de Home Assistant para Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
+  <em>Una integración para las 7 marcas VAG, acceso directo a la API, sin middleware</em>
 </p>
 
 <p align="center">
-  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
-  <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha" alt="Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Licencia"></a>
+  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-blue" alt="Home Assistant"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://www.home-assistant.io/docs/quality_scale/"><img src="https://img.shields.io/badge/quality_scale-platinum-d4af37" alt="Quality Scale Platinum"></a>
 </p>
 
 <p align="center">
-  <a href="../README.md">Deutsch</a> ·
+  <a href="README.md">Deutsch</a> ·
   <a href="README.en.md">English</a> ·
   <a href="README.fr.md">Français</a> ·
   <a href="README.nl.md">Nederlands</a> ·
-  <a href="README.es.md">Español</a> ·
   <a href="README.pl.md">Polski</a> ·
   <a href="README.cs.md">Čeština</a> ·
   <a href="README.sv.md">Svenska</a>
@@ -31,321 +31,227 @@
 ---
 
 > ### 📛 Note on the rename
-> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
-> Turns out that abbreviation reads *quite* differently to English speakers 😅
+> Antes publicada como **`vag-connect-ha`** (VAG = Volkswagen AG, abreviatura habitual en el ámbito DACH).
+> Resultó que esa abreviatura suena *bastante distinta* para los angloparlantes 😅
 >
-> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
-> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
-> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
-> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+> **Lo que sigue funcionando igual**: todas las entidades (p. ej. `sensor.audi_q4_battery_soc`),
+> todas las llamadas de servicio (`vag_connect.lock`, `vag_connect.show_vag`, etc.), todas las automatizaciones,
+> la instalación por HACS — **nada se rompe**. Cambia el nombre de marketing/visualización,
+> las interioridades del código siguen igual. Detalles en [`MIGRATION.md`](MIGRATION.md).
 >
-> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
-> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+> Enorme agradecimiento a las comunidades **Home Assistant UK** y **HA Ideas, Projects and Solutions**
+> por el aviso — especialmente a **Si Gregory**, **Ben Johnson** y **Evets David**.
 >
-> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
-> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
+> Y un saludo especial a **Jordan Waeles**, cuyo comentario `show_vag()` es ahora un easter egg
+> oficialmente soportado en esta integración (servicio `vag_connect.show_vag`, ver CHANGELOG v2.2.3).
 
 ---
 
+## ¿Qué es esto?
 
-## Novedades en v2.10.0
+**VW Group Connect es una integración de [Home Assistant](https://www.home-assistant.io) para datos y control de coches conectados de las siete marcas del Grupo Volkswagen — Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche y VW US/Canadá — desde una única entrada de configuración, instalable a través de [HACS](https://hacs.xyz).**
 
-El release más grande de esta integración hasta la fecha. Unas 6 semanas de trabajo intensivo en un solo cut.
+Expone el estado de batería y carga, autonomía, cuentakilómetros, climatización, puertas/ventanas y ubicación y — donde el backend de la marca aún lo permite (p. ej. Audi) — envía comandos como bloquear/desbloquear, climatización y control de carga. Para seguir funcionando a través de los cambios de la API de Volkswagen de 2026, habla varios canales y cambia automáticamente cuando uno queda bloqueado: los backends nativos de marca, el portal de datos de vehículo de solo lectura de la **EU Data Act** y un canal web `volkswagen.de` opcional.
 
-- **Fix login VW EU Auth0 SPA (#388)**: VW migró la página de password a una plantilla full-SPA hacia 2026-05-31. Retry JSON Content-Type sobre `/u/login` más detección de consent endurecida desbloquea a usuarios en classic-auth.
-- **Paridad parser cross-brand**: VW EU Group A (10 campos nuevos - 12V, ventilación activa, techo solar trasero, capota, totales por viaje), SEAT/CUPRA Group B (6 endpoints OLA - warning-lights v3, battery-care configurable, estadísticas de carga, taller preferido), VW NA Group C (4 endpoints - migración `data.exteriorStatus.*`, arregla el síntoma "todo en null" del ID.4 US 2023 #322).
-- **Detección de bloqueo de cuenta VW** con issue Repairs guiada + auto-clear.
-- **Aplicación de la Scout Policy**: cada ruta JSON silenced debe también parsearse a una entidad, o llevar una exención T2-T5 explícita. Cierra #384, #389.
-- **Canaries de procedencia + watcher semanal** + hardening (SPDX, drift-gate Bruno, mypy strict).
+A diferencia de las integraciones que solo usan el portal, también cubre **Porsche** (que el portal de la EU Data Act excluye) y mantiene el **control bidireccional de Audi**.
 
-El resto de v2.7-v2.9 sigue activo: Browser-Login DAG, multi-strategy auth, Data Act Portal, MFA, push FCM, Standheizung, brake-service, parser telemetry.
+> Una integración de [Home Assistant](https://www.home-assistant.io) para datos y control de vehículos conectados de las siete marcas del Grupo VW (Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche, VW US/CA) — una integración, varios canales de datos, fallback automático, instalación por HACS.
 
-Ver el [CHANGELOG](CHANGELOG.md#2100---2026-06-02) completo.
+---
 
-## Novedades en v2.7.x
+## Estado actual
 
-**Inicio de sesión por navegador (sin contraseña en HA) para Audi, Škoda, SEAT, CUPRA.** OAuth Device Authorization Grant RFC 8628. Escanea un código QR con el móvil o abre la URL en cualquier dispositivo, confirma un código corto, hecho. refresh_token real, sin re-login cada dos horas.
+VW fue cerrando en 2026, paso a paso, el acceso directo al vehículo para herramientas de terceros (CARIAD-BFF con attestation de dispositivo, OLA de CUPRA/SEAT detrás de Play Integrity desde junio de 2026). Esta integración sigue siendo usable porque habla **varios canales** y conmuta automáticamente en cuanto uno se bloquea:
 
-**Resolutor multi-estrategia de auth.** Hasta tres estrategias de respaldo por marca (Browser-Login, OIDC Hybrid Flow, EU Data Act Portal solo lectura). Una estrategia muere, la integración sigue con la siguiente.
+- **Backends propios de marca** — acceso completo incl. control, donde está disponible (Audi, Škoda, Porsche, VW US/CA).
+- **Portal EU Data Act** — fallback de solo lectura para todas las marcas (sin attestation, cadencia ~15 min).
+- **Canal web volkswagen.de (Beta, opt-in)** — segundo canal de lectura sin attestation para VW.
 
-**Data Act Portal como respaldo solo lectura.** Implementación propia del login del portal EU Data Act, integrada como estrategia de 3er nivel. Solo lectura pero sin attestation, así que irrompible cuando VW endurece la ruta OAuth.
+El trabajo en curso gira en torno a la robustez del portal (reintento por timeout, frescura de los datos) y la resiliencia a través de los canales.
 
-**Muchos más datos.** Estadísticas de viaje (distancia de por vida, último viaje), nivel de aceite, presión por neumático, puertas / ventanas / techo / maletero por posición, temperatura exterior en MY24+, calefacción auxiliar Webasto, todas las alertas del fabricante incluso las específicas como Audi STO.
-
-Ver [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+➡️ Historial de versiones completo: **[CHANGELOG.md](CHANGELOG.md)**.
 
 ---
 
 ## Donde lideramos
 
-Estado al 2026-05-31, tras el cambio del backend VW del 2026-05-27 que golpeó a toda la comunidad de integraciones HA-VAG a la vez:
+Estado honesto a mediados de 2026: el portal EU Data Act se ha convertido entretanto en el canal estándar de facto, y muchas integraciones lo usan. Lo que nos distingue en concreto:
 
-| Funcionalidad | Estado aquí | Estado en otros |
+| Fortaleza | Nosotros | Alternativas portal-only |
 |---|---|---|
-| OAuth Device Authorization Grant (QR-Login) para Audi/Škoda/SEAT/CUPRA | ✅ desde v2.7.0 | Nadie |
-| Cadena multi-estrategia (3 niveles por marca) | ✅ desde v2.6.0 | Nadie |
-| Portal EU Data Act como 3er nivel solo lectura | ✅ desde v2.6.0 | Solo como integración separada |
-| Red de seguridad InvalidURL contra fuga de tokens | ✅ desde v2.7.2 | Nadie |
-| Watcher del gate de attestation server-side | ✅ desde v2.7.0 | Nadie |
-| Vehicle Data Scout, detección automática de drift de API | ✅ desde v1.9.0 | Nada equivalente |
-| Las 7 marcas VAG en una integración | ✅ | Otros proyectos tienen un repo por marca |
+| **Las 7 marcas del grupo incl. Porsche** en una sola integración | ✅ | El portal EU Data Act **excluye Porsche estructuralmente** — las herramientas portal-only nunca pueden cubrir Porsche |
+| **Control bidireccional de Audi** (bloqueo/clima/carga, fijar Target-SoC) | ✅ | El portal es **de solo lectura** por diseño |
+| **Auth multicanal con fallback automático** (backend de marca → portal EU Data Act → web vw.de opt-in) | ✅ | normalmente de fuente única — un fallo del portal = caída total |
+| **Vehicle Data Scout** — detecta el drift de la API automáticamente, genera reportes de bug en 1 clic | ✅ | nada equivalente |
 
 ---
 
 ## Donde están los límites (con honestidad)
 
-**VW EU está duramente bloqueado por Play Integrity desde el 2026-05-27.** Este muro afecta a toda integración VAG basada en Python (la nuestra incluida). No es un retraso por nuestra parte, es la política backend de VW:
+**VW EU y el OLA de CUPRA/SEAT están detrás de attestation de dispositivo desde 2026.** Este muro (Google Play Integrity / Firebase App Check) afecta a toda integración VAG basada en Python — la nuestra incluida. No es un retraso por nuestra parte, es la política del backend de VW:
 
-- El endpoint del token valida una cabecera `X-Assertion` que debe ser un JWS firmado por Google Play Integrity
-- Python no puede generar este token, la clave de firma vive solo en el servicio de attestation de Google
-- Consecuencia: los usuarios VW EU no obtienen un refresh_token real y son forzados a reloguearse cada ~2h
+- El endpoint de token/OLA exige un token de attestation firmado por la app oficial, que Python no puede generar (la clave de firma vive solo en el servicio de attestation de Google/Firebase).
+- Consecuencia: **VW EU** no obtiene un `refresh_token` duradero (el flujo OIDC-Hybrid aguanta ~2 h), y **CUPRA/SEAT** vía OLA reciben desde ~2026-06-08 un `403 "Forbidden device detected"`.
 
-Lo que ofrecemos para VW EU: OIDC Hybrid Flow como estrategia primaria (lectura + escritura, 2h re-login), portal EU Data Act como respaldo solo lectura (cadencia 15 min, sin attestation), watcher semanal que abre automáticamente un issue cuando VW abre la puerta.
+Lo que ofrecemos a pesar de ello:
 
-**Fecha límite EU Data Act 2026-09-12.** Para esa fecha, VW debe legalmente proveer acceso directo a los datos del vehículo a los propietarios sin attestation. Nuestro `_data_act_portal.py` está listo para ese día.
+1. **Portal EU Data Act** como fallback de solo lectura para todas las marcas (sin attestation, cadencia ~15 min) — toma el relevo automáticamente cuando el backend nativo se bloquea.
+2. **Canal web volkswagen.de (Beta, opt-in)** como segundo canal de lectura sin attestation para VW.
+3. **Flujo OIDC-Hybrid** para VW EU como estrategia de lectura+escritura (con el re-login cada 2 h como precio).
 
-## ✨ v2.0.0 Big-Bang Highlights — also available in English
+**Fecha límite EU Data Act 2026-09-12.** Para esa fecha VW debe, por reglamento de la UE, ofrecer acceso directo y sin attestation a los datos del propietario — la cobertura de campos del portal presumiblemente seguirá creciendo hasta entonces.
 
-> The detailed v2.0.0 highlights table + "What makes us unique" USP section
-> are maintained in English on the German + English READMEs. They are
-> provided here as the canonical source so non-DE/EN readers can still
-> see all v2.0 features with `` markers without waiting on
-> 6 parallel translations.
+Estado por marca:
 
-### Latest highlights — v2.0.0 Big-Bang
-
-| Feature | Status |
-|---|---|
-| **Skoda Driving-Score Sensor** | Efficiency score 0-100 + class bucket for Skoda MY24+ |
-| **Cross-brand Aux-Heating parity (Skoda)** | SkodaClient now inherits the Webasto switch from SEAT/CUPRA |
-| **Porsche TPMS sensors** | 4 tire-pressure sensors + warning binary_sensor (PPA TIRE_PRESSURE) |
-| **Long-Term Trip Aggregates** | Lifetime distance / avg fuel / avg electric (Audi + VW EU) |
-| **Departure-Timer Read-Only Binary-Sensors** | 3 pure-read enabled-sensors |
-| **Weekly Preheat (`recurring_on`)** | Service param for weekday lists (Audi + VW EU + VW NA) |
-| **Charging-Station POI Lookup** | `vag_connect.find_charging_stations` service |
-| **Vehicle Alarm sensors** | closes issue #33 |
-| **heaterSource sensor** | closes issue #163 |
-| **Push Manager Lifecycle Wiring** | Skoda MQTT + CUPRA/SEAT FCM + Audi/VW Cariad FCM (opt-in) |
-| **EU Data Act Abstraction Shim** | Architectural seam for the 2026-09-12 EUDA Art. 3 deadline |
-| **Auth Resilience One-Click Repair** | Repair button for 4 auth reasons triggers reauth flow |
-| **System Health Panel** | Drop-in `system_health.py` |
-| **Quality Scale Platinum** | Re-introduced after v1.26.x revert |
-| **DeviceInfo `configuration_url` + `suggested_area`** | Brand-aware "Open in App" button |
-
-### What makes us unique
-
-- **Native coverage of all 7 VAG brands** in a single integration
-- **Direct manufacturer-API access** without middleware / Docker / 3rd service
-- **Vehicle Data Scout** — automatic JSON-field drift detection with Repair notification + 1-click GitHub issue
-- **Capability-Filter Phase 3** — phantom entities suppressed before spawn
-- **Per-VIN wakeup cap + cooldown** — protects 12V battery
-- **Auth Resilience One-Click Repair** — reauth flow from Repairs panel
-- **System Health Panel** — at-a-glance push channel status, API quota, last poll
-- **Bruno-CI Stage 2** — strict URL-drift check
-- **Token persistence across HA updates** — no re-login after HACS updates since v1.19.2
-- **Diagnostics anonymisation by default** — VINs, GPS, tokens stripped before export
-
-
-Quería controlar mi Audi en Home Assistant — completamente. Así que construí esto.
-
-**VW Group Connect** es una integración autónoma de Home Assistant para todas las marcas VAG. Sin dependencias externas, sin Docker, sin servicios externos.
-
-Desde v0.14.1, la integración habla **directamente** con la API CARIAD — cliente async propio, completamente autónomo. Arquitectura cloud-polling, 80+ entidades en 10 plataformas, 14 servicios.
-
-> ✅ **Sucesor multi-marca mantenido activamente** de [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivado el 2025-10-29) y [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (obsoleto el 2025-03-14). Una integración para Audi, VW, Škoda, SEAT, CUPRA, Porsche y VW US/CA — sin plugin separado por marca.
-
-## Estado actual y límites honestos / Current Status & Honest Limits (v1.12.3)
-
-VW Group Connect se desarrolla activamente. Para que sepas qué funciona y qué viene:
-
-### ✅ Qué funciona AHORA (todas las 7 marcas)
-
-**🛰️ Bug-Reports y solicitudes de features en 1 clic (LIVE desde v1.9.0)**
-
-Dos sensores de diagnóstico con una pipeline reporter compartida — **primera validación live real por usuarios de la comunidad** en v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) y v1.12.3 (DnnsJp74 / Audi):
-
-- 🔬 **Vehicle Data Scout** — detecta automáticamente campos JSON desconocidos en la API de tu coche. Localizado por marca en 8 idiomas (DE: API-Beobachter, FR: Observateur d'API, etc.).
-- 🚨 **Error Reporter** — Ring-buffer de los últimos 20 errores de integración con contexto anonimizado (modelo, firmware, stack trace).
-- 🔘 **Reporter Pipeline:** ambos sensores crean automáticamente notificaciones HA Repair con un GitHub-Issue prerellenado como enlace de 1 clic. Más una descarga de diagnostics con todo enmascarado para foro/Facebook.
-- 🔒 **Promesa de privacidad:** Nada sale de tu HA sin tu clic explícito. VINs enmascarados, GPS redondeado a 1 decimal, JWTs/UUIDs/emails eliminados. Cumple GDPR.
-
-**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
-
-Sensor `connection_state` (online / standby / offline) para Audi, VW EU, Škoda, SEAT, CUPRA — primera integración VAG con estado de conexión centralizado. Helper agnóstico de marca `compute_connection_state` con recorrido recursivo `carCapturedTimestamp`.
-
-**🔋 Monitorización batería 12V + Smart-Wake (v1.12.0)**
-
-- Sensor `voltage_12v` (V) + binary `warning_12v_low` por debajo de 11.5V — evita caídas silenciosas de la API por batería de arranque vacía
-- Sensor `wake_count_today` + soft-cap a 3 wakes/día (`_WAKE_BUDGET_PER_DAY`) protege la 12V de wake-loops, lanza `wake_budget_exhausted` ANTES de la llamada API
-
-**💨 UI optimista para Lock/Climate/Charging (v1.11.1)**
-
-Los switches cambian inmediatamente al hacer clic (patrón myskoda PR #832), roundtrip API en segundo plano. En caso de fallo: revert + ServiceValidationError. 8 métodos actuator migrados.
-
-**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up en v1.11.1)**
-
-Tres sensores de autonomía explícitos: `electric_range_km`, `combustion_range_km`, `total_range_km`. El parser VW EU/Audi clasifica por tipo de motor (4 fuentes en lugar de 2). Fallback Audi diésel desde `measurements.rangeStatus.value.dieselRange`. Verificado vía evcc-io/evcc#19045 + sample Audi Q4 + logs CarConnectivity.
-
-**🔒 Modo Read-only Fase 1 (v1.12.0)**
-
-Toggle de opciones "Read-only Mode" → omite plataformas lock/switch/button(non-refresh)/climate/number para propietarios conservadores con privacidad/seguridad. Sensors + binary_sensors + device_tracker permanecen.
-
-**⚡ Number Max-Charge-Current escribible (v1.12.0)**
-
-Slider 6-32A en lugar de un sensor solo de lectura. Nuevo `command_set_max_charge_current` POST chargingSettings.
-
-**💡 Binary-Sensors por luz (v1.12.0)**
-
-Dinámicamente por tipo de luz desde el dict `lights_individual` + agregados `lights_on` + `lights_count`.
-
-**🛠️ Estabilidad defensiva (v1.8.7 + v1.10.1)**
-
-- Retry 504, retry errores de red transitorios, cache 6h + tolerancia 3 fallos
-- Protección token-refresh-storm (max 3/h) — evita bans de IP
-- Helpers `safe_int` / `safe_float` / `safe_enum` — toleran rarezas del backend
-
-**🚪 Firmware-Shapes CUPRA Born 2026 (v1.10.2 — primera validación live de Gerhard #53)**
-
-Cadena de fallback de nombres de campos: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Tolerancia enum minúsculas para `"connected"` / `"locked"`. Compatibilidad hacia atrás preservada.
-
-**🔓 Lock + Wake para Audi/VW (v1.9.1, #92 Audi S6 C8)**
-
-`command_lock` ahora envía S-PIN para Audi/VW (CARIAD BFF respondía `403 spin_error`). `command_wake` usa fallback v1→v2.
-
-**🛡️ Capability-Filter Fase 2 (v1.9.1, #56)**
-
-Body-sniffing `classify_command_failure` para marcadores `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error`. `_cariad_cmd` escribe cada resultado en FeatureState. Las entidades ligadas a comandos (Lock/Climate/Switch/Buttons) pasan automáticamente a unavailable cuando el backend dice "no" definitivo.
-
-### ⚠️ Aún en progreso / What's still in progress (sesiones planificadas)
-
-- **v1.13.0 MINOR** — Export de diagnostics anonimizado (#62) + Capability-Filter Fase 3 (`capability.active && user-enabled` PRE-creación-de-entidad, oculta botones como la app MyCupra) + Read-only Fase 2/3 (Command-Locking + separación de servicios cloud_refresh vs wake_vehicle).
-- **v1.14.0 MINOR** — Trip Statistics desde Audi `tripstatistics/v1` (#24, #35).
-- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), UI timer Climate (#26).
-- **v1.16.0 MINOR** — SoC objetivo de carga específico por ubicación + perfiles de carga (#25, #31).
-- **v1.17.0 MINOR** — Remote Start ICE (#28, patrón upstream #717).
-- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) para actualizaciones en tiempo real sin polling (#57, #27).
-- **v2.0.0 MAJOR** — HACS Default + Live-Tests todas las marcas + EU Data Act ready (pycupra `EUDAConnection` como referencia, deadline septiembre 2026) (#13, #59).
-
-### 🚫 Límites conscientes / Conscious limits
-
-- **Plataforma image:** no existe API CARIAD render-image oficial. La entidad image cambiará a URLs proporcionadas por el usuario en una futura release.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nueva arquitectura E³ 1.2, aún no reverse-engineereada públicamente (ni en upstream ni en CarConnectivity). VW Group Connect detecta estos vehículos y hace **graceful degradation** en lugar de errores 404.
-- **Ford / marcas no-VAG:** fuera de alcance — ver [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) para Ford.
-
-### 🔧 Requisito de privacidad
-
-Para que la posición GPS, el estado del vehículo y la calefacción estacionaria funcionen, **"Compartir mi posición"** debe estar activado en tu app My-VW / My-Audi / MySkoda / MyCupra — de lo contrario el backend responde con 403.
-
-### 📚 Más información / More info
-
-- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — priorización P0/P1/P2/P3 completa de todos los issues abiertos
-- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — por release: mapeos de campos + decisiones de arquitectura + refs a fuentes externas
-- 🎨 Guía Dashboards + tarjeta Lovelace BETA: [`docs/dashboards.md`](docs/dashboards.md) — solución de problemas "Añadir al panel" + tarjeta Lovelace dedicada (BETA)
-- 🤝 Session Handoff (para colaboradores y herramientas IA): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔒 Reglas de privacidad y manejo de datos: sección [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
-- 📋 FAQ Subscription / Service Plus / diagnóstico `missing-capability`: sección FAQ de [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
----
-
-## Marcas Compatibles
-
-| Brand | Auth | API | Status |
+| Marca | Control | Datos | Comentario |
 |---|---|---|---|
-| **Volkswagen EU** | IDK | emea.bff.cariad.digital | ✅ |
-| **Audi** | IDK + AZS/MBB | emea.bff.cariad.digital | ✅ |
-| **Škoda** | IDK | mysmob.api.connect.skoda-auto.cz | ✅ |
-| **SEAT** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| **CUPRA** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
-| VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
-
-> **Porsche & VW NA:** Ambas marcas están disponibles como Beta desde v1.0.0. Buscamos testers — reporta feedback como [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
+| **Audi** | ✅ Bidireccional | ✅ completo | Backend myAudi, sin muro de attestation |
+| **Škoda** | ✅ Bidireccional | ✅ completo | Backend propio de Škoda |
+| **Porsche** | ✅ Bidireccional | ✅ completo | Auth0 + PPA, estable |
+| **VW US/CA** | ✅ Bidireccional | ✅ completo | Nube VW-NA (Beta) |
+| **VW EU** | ⚠️ vía OIDC-Hybrid (~2 h re-login) | ✅ portal de solo lectura / vw.de-Beta | Backend con attestation gate |
+| **CUPRA / SEAT** | ❌ OLA bloqueado (App Check) | ✅ portal de solo lectura | desde ~2026-06-08, no arreglable por header |
 
 ---
 
-## Características
+## Lo que obtienes
 
-| Feature | Audi | VW EU | Škoda | SEAT/CUPRA |
-|---|:---:|:---:|:---:|:---:|
-| Fuel / Battery level | ✓ | ✓ | ✓ | ✓ |
-| Range | ✓ | ✓ | ✓ | ✓ |
-| Odometer | ✓ | ✓ | ✓ | ✓ |
-| GPS position | ✓ | ✓ | ✓ | ✓ |
-| Doors (total + per door) | ✓ | ✓ | ✓ | ✓ |
-| Windows | ✓ | ✓ | ✓ | ✓ |
-| Climate start/stop | ✓ | ✓ | ✓ | ✓ |
-| Target temperature | ✓ | ✓ | ✓ | ✓ |
-| Lock / Unlock | ✓ | ✓ | ✓ | ✓ |
-| Flash lights | ✓ | ✓ | ✓ | ✓ |
-| Wake vehicle | ✓ | ✓ | ✓ | ✓ |
-| Service due km/days | ✓ | ✓ | ✓ | ✓ |
-| Online status | ✓ | ✓ | ✓ | ✓ |
-| Battery SoC % | ✓ | ✓ | ✓ | ✓ |
-| Charge state | ✓ | ✓ | ✓ | ✓ |
-| Charge power kW | ✓ | ✓ | ✓ | ✓ |
-| Charge speed km/h | ✓ | ✓ | ✓ | ✓ |
-| Charge ETA | ✓ | ✓ | ✓ | ✓ |
-| Charge target % | ✓ | ✓ | ✓ | ✓ |
-| Trunk / hood / sunroof | ✓ | ✓ | ✓ | ✓ |
-| Window heating | ✓ | ✓ | ✓ | ✓ |
-| Vehicle renders | ✓ | — | — | ✓ |
-| Departure timers 1–3 | ✓ | ✓ | — | — |
-| Battery temperature | ✓ | ✓ | — | — |
-| AdBlue range | ✓ | ✓ | — | ✓ |
+Más de 100 entidades en 11 plataformas de HA, más de 20 llamadas de servicio, soporte nativo multi-vehículo por cuenta. Quality Scale Platinum.
+
+**Sensores** (por vehículo): Battery SoC, Range (eléctrica / combustión / total), Fuel Level, Odometer, Outside Temp, Battery Temp, 12V Voltage, Service Days, Oil Service Days, Charging Power / Rate / Type, Last Trip Stats, Lifetime Trip Aggregates, Charging History, Plug State, Lights Count, Equipment Count, Software Version, API Quota Remaining, Connection State, Last Seen, Skoda Driving Score, Porsche TPMS 4 esquinas, Last Alarm Timestamp, Heater Source para ID.x, Oil Level Warning, avisos del vehículo (sensor de texto con todos los warnings del backend).
+
+**Binary Sensors**: Doors Locked, Doors Open por puerta, Windows Open por ventana, Trunk / Hood / Sunroof, Plug Connected, Charging, OTA Update Available, 12V Low Warning, Lights On por luz, Vehicle Online, Departure-Timer 1-3 Enabled, Alarm Active + Siren Active, TPMS Warning.
+
+**Control**: Lock/Unlock, Climate Start/Stop, Charging Start/Stop, Window Heating, Cabin Ventilation (CUPRA/SEAT), Aux Heating (Webasto), Departure Timer 1-3 con Weekly-Preheat, Set Target SoC, Set Target Temp, Set Max Charge Current, Set Charge Mode, Honk-and-Flash, Wake Vehicle, Refresh, Find Charging Stations.
+
+**Image Platform**: 1-7 renders del vehículo por VIN (Audi/VW vía GraphQL MediaService, CUPRA/SEAT vía OLA viewPoints, Skoda vía Widget + composites multi-ángulo).
+
+**Device Tracker**: posición GPS como TrackerEntity para el mapa Lovelace de HA.
 
 ---
 
 ## Instalación
 
-### HACS
+### Opción 1: Un clic (recomendado)
+
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vwgroup-connect-ha&category=integration)
+
+### Opción 2: Repositorio personalizado de HACS
 
 1. HACS → Integraciones → ⋮ → Repositorios personalizados
-2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Categoría: Integración
-3. Instalar **VW Group Connect** → Reiniciar Home Assistant
-4. Ajustes → Integraciones → **+ Integración** → **VW Group Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha`
+3. Categoría: Integración
+4. Instalar **VW Group Connect**
+5. Reiniciar Home Assistant
 
-### Manual
+### Opción 3: Manual
 
 ```bash
-cp -r custom_components/vag_connect ~/.homeassistant/custom_components/
+cd /config/custom_components
+git clone https://github.com/its-me-prash/vwgroup-connect-ha.git
+mv vwgroup-connect-ha/custom_components/vag_connect .
+rm -rf vwgroup-connect-ha
 ```
 
-Reinicia Home Assistant.
+Después reinicia HA.
 
 ---
 
 ## Configuración
 
-| Field | Required | Description |
-|---|---|---|
-| Marca | ✓ | Audi / Volkswagen / Škoda / SEAT / CUPRA |
-| Correo | ✓ | Correo de la app del fabricante |
-| Contraseña | ✓ | Contraseña de la app |
-| S-PIN | — | Requerido para bloqueo (en Seguridad en la app) |
-| Intervalo | — | Minutos entre actualizaciones (predeterminado: 5) |
+Ajustes → Dispositivos y servicios → Añadir integración → "VW Group Connect"
 
-**¿Qué app?** Audi → myAudi · VW → WeConnect · Škoda → MyŠkoda · SEAT → My SEAT · CUPRA → MyCupra
+**En la primera configuración eliges:**
 
----
+- **Inicio de sesión por navegador** (recomendado para Audi/Škoda/SEAT/CUPRA): escanea un código QR o abre la URL, sin contraseña guardada en HA
+- **Correo + contraseña** (para VW EU, Porsche, VW US/CA): clásico con credenciales de Brand-ID
 
-## Limitaciones Conocidas
-
-- **S-PIN** necesario para bloqueo
-- **Intervalo** mínimo 5 minutos
-- **2FA** — confirmar una vez manualmente en la app
-- **Porsche / VW NA** — funcional como Beta, buscamos testers
+**Opciones** (disponibles tras la configuración):
+- Intervalo de polling (5-60 min, por defecto 10 min)
+- Modo de solo lectura para automatizaciones seguras sin comandos accidentales
+- Reverse-geocoding opt-in (envía GPS a OpenStreetMap para resolver direcciones)
+- Toggles de push (Skoda MQTT, CUPRA/SEAT FCM, Audi/VW FCM) como base, activación en vivo pendiente
 
 ---
 
+## Ejemplos de Lovelace
+
+### Map Card
+
+```yaml
+type: map
+title: Flota
+default_zoom: 12
+hours_to_show: 24
+entities:
+  - device_tracker.audi_a4_b9_position
+  - device_tracker.vw_golf_7_gte_position
+  - zone.home
+```
+
+### Picture-Entity Card con render del vehículo
+
+```yaml
+type: picture-entity
+entity: image.audi_a4_b9_render_side_lg
+camera_view: live
+show_state: false
+show_name: false
+```
+
+### Búsqueda de estaciones de carga
+
+```yaml
+action: vag_connect.find_charging_stations
+data:
+  vin: WAUZZZ...
+  latitude: 47.3769
+  longitude: 8.5417
+  radius_m: 5000
+  max_results: 25
+response_variable: result
+```
+
+Más ejemplos en [`docs/FAQ.md`](docs/FAQ.md). Las tarjetas Lovelace personalizadas se integran automáticamente vía `extra_state_attributes.image_url`.
+
+---
+
+## Preguntas frecuentes
+
+| Pregunta | Respuesta |
+|---|---|
+| ¿Cuándo se despierta mi coche? | Solo en llamadas de servicio (Lock/Climate/Wake), nunca en los polls de estado. Smart-Wake-Cap: máx. 3 wakes/día por coche, 5 min de cooldown. |
+| ¿Cuánta cuota de API? | MyCupra/MySeat: ~1500 llamadas/día. Con polling de 10 min: ~144 llamadas/día = 10 % del presupuesto. El sensor `requests_remaining_today` muestra el estado. |
+| ¿Por qué tengo que volver a iniciar sesión cada 2 h en VW EU? | VW puso el endpoint de token detrás de Google Play Integrity desde 2026-05-27. Afecta a toda integración VAG basada en Python. La EU Data Act 2026-09-12 debería solucionarlo. |
+| ¿El token se mantiene tras actualizar por HACS? | Sí, desde v1.19.2 vía persistencia en el Store de HA. |
+| ¿Cómo reporto bugs? | HA → Integración → 🔧 Reparar → Reporte de bug. Los diagnostics se anonimizan (VINs enmascarados, GPS redondeado, tokens eliminados). |
+| ¿Las etiquetas de campo muestran claves crudas (`brand`, `spin`) tras actualizar? | Recarga forzada del navegador (Ctrl+Shift+R). HA cachea las traducciones en el cliente. |
+
+FAQ completa en [`docs/FAQ.md`](docs/FAQ.md). Solución de problemas de dashboards en [`docs/dashboards.md`](docs/dashboards.md).
+
+---
+
+## Privacidad y seguridad
+
+- Sin servicios externos, todo directo entre HA y la API del fabricante
+- Caché de token local en `.storage/` de HA (por entrada de configuración, JSON, eliminado automáticamente al quitar la integración)
+- Diagnostics anonimizados: VINs enmascarados, GPS redondeado a 1 decimal, tokens y contraseñas completamente eliminados
+- Reverse-geocoding opt-in, desactivado por defecto
+- Enmascarado de VIN consistente en todos los logs
+- Las URLs de token se redactan en el log de ERROR (v2.7.2+)
+
+Detalles en [`PRIVACY.md`](PRIVACY.md) y [`SECURITY.md`](SECURITY.md).
+
+---
+
+## Contribuir
+
+PRs bienvenidos, ver [`CONTRIBUTING.md`](CONTRIBUTING.md). Reglas de estilo en [`STYLE.md`](STYLE.md) (privado en `_private/STYLE.md` para maintainers).
+
+**Vehicle Data Scout** (en vivo desde v1.9.0): cuando tu integración detecta campos JSON desconocidos, crea automáticamente una notificación de Repair en HA con un enlace a un issue de GitHub prerrellenado. Reporte de bug en 1 clic sin estudiar el código.
+
+---
 
 ## Licencia
 
-Apache License 2.0 — [LICENSE](LICENSE)
-
-**VW Group Connect™** es una marca no registrada (™, no ®). Por favor no uses este nombre en forks para evitar confusión.
-
-Esta integración es un proyecto comunitario independiente sin afiliación con Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG ni ninguna filial del Grupo Volkswagen.
-
----
-
-*Copyright 2026 [Prash Balan](https://github.com/its-me-prash) · Apache License 2.0*
+[Apache License 2.0](LICENSE) para el código de la integración. [CC BY-NC-ND 4.0](LICENSE-RESEARCH) para el contenido de `docs/research/`. Atribuciones a proyectos open-source upstream en [`NOTICE.md`](NOTICE.md).

--- a/README.fr.md
+++ b/README.fr.md
@@ -5,24 +5,24 @@
 <h1 align="center">VW Group Connect</h1>
 
 <p align="center">
-  <strong>Intégration Home Assistant pour Audi · VW · Škoda · SEAT · CUPRA</strong>
+  <strong>Intégration Home Assistant pour Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
+  <em>Une seule intégration pour les 7 marques VAG, accès direct à l'API, sans middleware</em>
 </p>
 
 <p align="center">
-  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
-  <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha" alt="Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Licence"></a>
+  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-blue" alt="Home Assistant"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://www.home-assistant.io/docs/quality_scale/"><img src="https://img.shields.io/badge/quality_scale-platinum-d4af37" alt="Quality Scale Platinum"></a>
 </p>
 
 <p align="center">
-  <a href="../README.md">Deutsch</a> ·
+  <a href="README.md">Deutsch</a> ·
   <a href="README.en.md">English</a> ·
-  <a href="README.fr.md">Français</a> ·
-  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.es.md">Español</a> ·
+  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.pl.md">Polski</a> ·
   <a href="README.cs.md">Čeština</a> ·
   <a href="README.sv.md">Svenska</a>
@@ -31,321 +31,227 @@
 ---
 
 > ### 📛 Note on the rename
-> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
-> Turns out that abbreviation reads *quite* differently to English speakers 😅
+> Auparavant publié sous le nom **`vag-connect-ha`** (VAG = Volkswagen AG, abréviation courante en zone DACH).
+> Il s'est avéré que cette abréviation sonne *nettement différemment* pour les anglophones 😅
 >
-> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
-> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
-> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
-> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+> **Ce qui continue de fonctionner à l'identique** : toutes les entités (p. ex. `sensor.audi_q4_battery_soc`),
+> tous les service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), toutes les automatisations,
+> l'installation HACS — **rien ne casse**. C'est le nom marketing/affiché qui change,
+> les internes du code restent identiques. Détails dans [`MIGRATION.md`](MIGRATION.md).
 >
-> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
-> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+> Un grand merci aux communautés **Home Assistant UK** et **HA Ideas, Projects and Solutions**
+> pour l'avoir signalé — en particulier à **Si Gregory**, **Ben Johnson** et **Evets David**.
 >
-> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
-> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
+> Et un clin d'œil spécial à **Jordan Waeles**, dont le commentaire `show_vag()` est désormais un easter egg
+> officiellement pris en charge dans cette intégration (service `vag_connect.show_vag`, voir CHANGELOG v2.2.3).
 
 ---
 
+## Qu'est-ce que c'est ?
 
-## Nouveautés en v2.10.0
+**VW Group Connect est une intégration [Home Assistant](https://www.home-assistant.io) pour les données et le contrôle des véhicules connectés sur l'ensemble des sept marques du groupe Volkswagen — Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche et VW US/Canada — depuis une seule entrée de configuration, installable via [HACS](https://hacs.xyz).**
 
-Le plus gros release de cette intégration à ce jour. Environ 6 semaines de travail intensif en un seul cut.
+Elle expose l'état de la batterie et de la charge, l'autonomie, le kilométrage, la climatisation, les portes/fenêtres et la localisation, et — lorsque le backend de la marque le permet encore (p. ex. Audi) — envoie des commandes comme verrouillage/déverrouillage, contrôle de la climatisation et de la charge. Pour rester fonctionnelle malgré les changements d'API de Volkswagen en 2026, elle parle plusieurs canaux et bascule automatiquement quand l'un d'eux est bloqué : les backends natifs des marques, le portail de données véhicule **EU Data Act** en lecture seule, et un canal web `volkswagen.de` en opt-in.
 
-- **Correctif login VW EU Auth0 SPA (#388)**: VW a migré la page de mot de passe vers un template full-SPA vers le 2026-05-31. Le retry JSON Content-Type sur `/u/login` plus la détection consent durcie débloque les utilisateurs sur classic-auth.
-- **Parité parser cross-brand**: VW EU Group A (10 nouveaux champs - 12V, ventilation active, sunroof arrière, capote, totaux par trajet), SEAT/CUPRA Group B (6 endpoints OLA - warning-lights v3, battery-care réglable, statistiques de charge, atelier préféré), VW NA Group C (4 endpoints - migration `data.exteriorStatus.*`, fix du symptôme "tout à null" sur ID.4 US 2023 #322).
-- **Détection de verrouillage de compte VW** avec issue Repairs guidée + auto-clear.
-- **Application de la Scout Policy**: chaque chemin JSON silenced doit aussi être parsé en entité, ou avoir une exemption T2-T5 explicite. Ferme #384, #389.
-- **Canaries de provenance + watcher hebdomadaire** + hardening (SPDX, drift-gate Bruno, mypy strict).
+Contrairement aux intégrations qui reposent uniquement sur le portail, elle couvre aussi **Porsche** (que le portail EU Data Act exclut) et conserve le **contrôle bidirectionnel d'Audi**.
 
-Reste de v2.7-v2.9 toujours actif: Browser-Login DAG, multi-strategy auth, Data Act Portal, MFA, push FCM, Standheizung, brake-service, parser telemetry.
-
-Voir [CHANGELOG](CHANGELOG.md#2100---2026-06-02) complet.
-
-## Nouveautés en v2.7.x
-
-**Connexion par navigateur (aucun mot de passe stocké dans HA) pour Audi, Škoda, SEAT, CUPRA.** OAuth Device Authorization Grant RFC 8628. Scanner un QR code avec le téléphone ou ouvrir l URL sur n importe quel appareil, confirmer un code court, fini. refresh_token réel, plus de re-login toutes les deux heures.
-
-**Résolveur multi-stratégie d auth.** Jusqu à trois stratégies de repli par marque (Browser-Login, OIDC Hybrid Flow, EU Data Act Portal en lecture seule). Une stratégie meurt, l intégration tourne sur la suivante.
-
-**Data Act Portal en repli lecture seule.** Implémentation maison du login portail EU Data Act, intégrée comme stratégie de 3e niveau. Lecture seule mais sans attestation, donc incassable si VW resserre la voie OAuth.
-
-**Plus de points de données.** Statistiques de trajet (distance à vie, dernier trajet), niveau d huile, pression par pneu, portes / fenêtres / toit / coffre par position, température extérieure sur MY24+, chauffage auxiliaire Webasto, toutes les alertes constructeur dont les alertes marque-spécifiques comme Audi STO.
-
-Voir [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+> Une intégration [Home Assistant](https://www.home-assistant.io) pour les données et le contrôle des véhicules connectés sur les sept marques du groupe VW (Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche, VW US/CA) — une seule intégration, plusieurs canaux de données, repli automatique, installation via HACS.
 
 ---
 
-## Où nous menons
+## Situation actuelle
 
-État au 2026-05-31, après le changement backend VW du 2026-05-27 qui a touché toute la communauté d intégrations HA-VAG simultanément :
+En 2026, VW a progressivement fermé l'accès direct au véhicule pour les outils tiers (CARIAD-BFF avec attestation d'appareil, OLA CUPRA/SEAT derrière Play Integrity depuis juin 2026). Cette intégration reste utilisable parce qu'elle parle **plusieurs canaux** et bascule automatiquement dès que l'un d'eux est bloqué :
 
-| Fonctionnalité | Statut ici | Statut chez les autres |
+- **Backends propres aux marques** — accès complet, contrôle inclus là où c'est disponible (Audi, Škoda, Porsche, VW US/CA).
+- **Portail EU Data Act** — repli en lecture seule pour toutes les marques (sans attestation, cadence ~15 min).
+- **Canal web volkswagen.de (bêta, opt-in)** — deuxième canal de lecture sans attestation pour VW.
+
+Le travail en cours porte sur la robustesse du portail (retry sur timeout, fraîcheur des données) et la résilience à travers les canaux.
+
+➡️ Historique complet des versions : **[CHANGELOG.md](CHANGELOG.md)**.
+
+---
+
+## Là où nous menons
+
+État honnête mi-2026 : le portail EU Data Act est devenu le canal standard de facto, beaucoup d'intégrations l'utilisent. Ce qui nous distingue concrètement :
+
+| Atout | Nous | Alternatives portail-only |
 |---|---|---|
-| OAuth Device Authorization Grant (QR-Login) pour Audi/Škoda/SEAT/CUPRA | ✅ depuis v2.7.0 | Personne |
-| Chaîne d auth multi-stratégie (3 niveaux par marque) | ✅ depuis v2.6.0 | Personne |
-| Portail EU Data Act en 3e niveau lecture seule | ✅ depuis v2.6.0 | Uniquement en intégration séparée |
-| Filet de sécurité InvalidURL anti fuite de token dans les logs | ✅ depuis v2.7.2 | Personne |
-| Watcher du gate d attestation server-side | ✅ depuis v2.7.0 | Personne |
-| Vehicle Data Scout, détection auto de la dérive API | ✅ depuis v1.9.0 | Rien d équivalent |
-| Les 7 marques VAG dans une intégration | ✅ | Les autres projets ont un dépôt par marque |
+| **Les 7 marques du groupe, Porsche inclus**, dans une seule intégration | ✅ | Le portail EU Data Act **exclut structurellement Porsche** — les outils portail-only ne pourront jamais couvrir Porsche |
+| **Contrôle bidirectionnel Audi** (verrouillage/climatisation/charge, réglage du SoC cible) | ✅ | Le portail est en **lecture seule** par conception |
+| **Auth multi-canal avec repli automatique** (backend de la marque → portail EU Data Act → web vw.de en opt-in) | ✅ | le plus souvent à source unique — une panne du portail = panne totale |
+| **Vehicle Data Scout** — détecte automatiquement la dérive de l'API, génère des rapports de bug en 1 clic | ✅ | rien d'équivalent |
 
 ---
 
-## Où sont les limites (en toute honnêteté)
+## Là où sont les limites (en toute honnêteté)
 
-**VW EU est durement verrouillé par Play Integrity depuis le 2026-05-27.** Ce mur touche toute intégration VAG basée sur Python (la nôtre incluse). Ce n est pas un retard de notre côté, c est la politique backend de VW :
+**VW EU et l'OLA CUPRA/SEAT sont derrière une attestation d'appareil depuis 2026.** Ce mur (Google Play Integrity / Firebase App Check) touche toute intégration VAG basée sur Python — la nôtre incluse. Ce n'est pas un retard de notre côté, c'est la politique backend de VW :
 
-- L endpoint token valide un header `X-Assertion` qui doit être un JWS signé par Google Play Integrity
-- Python ne peut pas générer ce token, la clé de signature vit uniquement dans le service d attestation Google
-- Conséquence : les utilisateurs VW EU n obtiennent pas de vrai refresh_token et sont forcés à se reconnecter toutes les ~2h
+- L'endpoint token/OLA exige un token d'attestation signé par l'app officielle, que Python ne peut pas générer (la clé de signature vit uniquement dans le service d'attestation Google/Firebase).
+- Conséquence : **VW EU** n'obtient pas de `refresh_token` durable (le flux hybride OIDC tient ~2 h), et **CUPRA/SEAT** via OLA reçoivent depuis le ~2026-06-08 un `403 "Forbidden device detected"`.
 
-Ce que nous offrons quand même pour VW EU : OIDC Hybrid Flow en stratégie primaire (lecture + écriture, 2h de re-login), portail EU Data Act en repli lecture seule (cadence 15 min, sans attestation), watcher hebdomadaire qui ouvre automatiquement un issue dès que VW lève la barrière.
+Ce que nous offrons malgré tout :
 
-**Échéance EU Data Act 2026-09-12.** D ici cette date, VW doit légalement fournir l accès direct aux données du véhicule aux propriétaires sans attestation. Notre `_data_act_portal.py` est prêt pour ce jour.
+1. **Portail EU Data Act** en repli lecture seule pour toutes les marques (sans attestation, cadence ~15 min) — prend le relais automatiquement quand le backend natif bloque.
+2. **Canal web volkswagen.de (bêta, opt-in)** comme deuxième canal de lecture sans attestation pour VW.
+3. **Flux hybride OIDC** pour VW EU comme stratégie lecture+écriture (au prix d'une reconnexion toutes les 2 h).
 
-## ✨ v2.0.0 Big-Bang Highlights — also available in English
+**Échéance EU Data Act 2026-09-12.** D'ici là, le règlement européen impose à VW de fournir un accès direct et sans attestation aux données du propriétaire — la couverture des champs du portail devrait continuer de croître d'ici cette date.
 
-> The detailed v2.0.0 highlights table + "What makes us unique" USP section
-> are maintained in English on the German + English READMEs. They are
-> provided here as the canonical source so non-DE/EN readers can still
-> see all v2.0 features with `` markers without waiting on
-> 6 parallel translations.
+Statut par marque :
 
-### Latest highlights — v2.0.0 Big-Bang
-
-| Feature | Status |
-|---|---|
-| **Skoda Driving-Score Sensor** | Efficiency score 0-100 + class bucket for Skoda MY24+ |
-| **Cross-brand Aux-Heating parity (Skoda)** | SkodaClient now inherits the Webasto switch from SEAT/CUPRA |
-| **Porsche TPMS sensors** | 4 tire-pressure sensors + warning binary_sensor (PPA TIRE_PRESSURE) |
-| **Long-Term Trip Aggregates** | Lifetime distance / avg fuel / avg electric (Audi + VW EU) |
-| **Departure-Timer Read-Only Binary-Sensors** | 3 pure-read enabled-sensors |
-| **Weekly Preheat (`recurring_on`)** | Service param for weekday lists (Audi + VW EU + VW NA) |
-| **Charging-Station POI Lookup** | `vag_connect.find_charging_stations` service |
-| **Vehicle Alarm sensors** | closes issue #33 |
-| **heaterSource sensor** | closes issue #163 |
-| **Push Manager Lifecycle Wiring** | Skoda MQTT + CUPRA/SEAT FCM + Audi/VW Cariad FCM (opt-in) |
-| **EU Data Act Abstraction Shim** | Architectural seam for the 2026-09-12 EUDA Art. 3 deadline |
-| **Auth Resilience One-Click Repair** | Repair button for 4 auth reasons triggers reauth flow |
-| **System Health Panel** | Drop-in `system_health.py` |
-| **Quality Scale Platinum** | Re-introduced after v1.26.x revert |
-| **DeviceInfo `configuration_url` + `suggested_area`** | Brand-aware "Open in App" button |
-
-### What makes us unique
-
-- **Native coverage of all 7 VAG brands** in a single integration
-- **Direct manufacturer-API access** without middleware / Docker / 3rd service
-- **Vehicle Data Scout** — automatic JSON-field drift detection with Repair notification + 1-click GitHub issue
-- **Capability-Filter Phase 3** — phantom entities suppressed before spawn
-- **Per-VIN wakeup cap + cooldown** — protects 12V battery
-- **Auth Resilience One-Click Repair** — reauth flow from Repairs panel
-- **System Health Panel** — at-a-glance push channel status, API quota, last poll
-- **Bruno-CI Stage 2** — strict URL-drift check
-- **Token persistence across HA updates** — no re-login after HACS updates since v1.19.2
-- **Diagnostics anonymisation by default** — VINs, GPS, tokens stripped before export
-
-
-Je voulais contrôler mon Audi dans Home Assistant — complètement. Alors j'ai construit ça.
-
-**VW Group Connect** est une intégration Home Assistant autonome pour toutes les marques VAG. Aucune dépendance externe, aucun Docker, aucun service externe. Installez l'intégration, entrez vos identifiants, c'est prêt.
-
-Depuis v0.14.1, l'intégration parle **directement** à l'API CARIAD — client async propre, entièrement autonome. Architecture cloud-polling, 80+ entités sur 10 plateformes, 14 services.
-
-> ✅ **Successeur multi-marque activement maintenu** de [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (archivé le 2025-10-29) et [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (déprécié le 2025-03-14). Une intégration pour Audi, VW, Škoda, SEAT, CUPRA, Porsche et VW US/CA — pas de plugin séparé par marque.
-
-## État actuel et limites honnêtes / Current Status & Honest Limits (v1.12.3)
-
-VW Group Connect évolue activement. Pour que tu saches ce qui fonctionne et ce qui arrive :
-
-### ✅ Ce qui FONCTIONNE maintenant (toutes les 7 marques)
-
-**🛰️ Rapports de bugs & demandes de fonctionnalités en 1-clic (LIVE depuis v1.9.0)**
-
-Deux capteurs de diagnostic avec une pipeline reporter commune — **première vraie validation live par des utilisateurs de la communauté** en v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) et v1.12.3 (DnnsJp74 / Audi) :
-
-- 🔬 **Vehicle Data Scout** — détecte automatiquement les champs JSON inconnus dans l'API de ta voiture. Localisé par marque dans 8 langues (DE : API-Beobachter, FR : Observateur d'API, etc.).
-- 🚨 **Error Reporter** — Ring-buffer des 20 dernières erreurs d'intégration avec contexte anonymisé (modèle, firmware, stack trace).
-- 🔘 **Reporter Pipeline :** les deux capteurs créent automatiquement des notifications HA Repair avec un GitHub-Issue pré-rempli en lien 1-clic. Plus un téléchargement de diagnostics avec tout masqué pour le forum/Facebook.
-- 🔒 **Promesse confidentialité :** Rien ne quitte ton HA sans ton clic explicite. VIN masqués, GPS arrondi à 1 décimale, JWT/UUID/emails supprimés. Conforme RGPD.
-
-**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
-
-Capteur `connection_state` (online / standby / offline) pour Audi, VW EU, Škoda, SEAT, CUPRA — première intégration VAG avec statut de connexion centralisé. Helper brand-agnostic `compute_connection_state` avec parcours récursif `carCapturedTimestamp`.
-
-**🔋 Surveillance batterie 12V + Smart-Wake (v1.12.0)**
-
-- Capteur `voltage_12v` (V) + binary `warning_12v_low` à <11.5V — empêche les pannes silencieuses de l'API dues à une batterie de démarrage vide
-- Capteur `wake_count_today` + soft-cap à 3 wakes/jour (`_WAKE_BUDGET_PER_DAY`) protège la 12V des wake-loops, lève `wake_budget_exhausted` AVANT l'appel API
-
-**💨 UI optimiste pour Lock/Climate/Charging (v1.11.1)**
-
-Les switches basculent immédiatement au clic (pattern myskoda PR #832), aller-retour API en arrière-plan. En cas d'échec : revert + ServiceValidationError. 8 méthodes actuator migrées.
-
-**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up en v1.11.1)**
-
-Trois capteurs d'autonomie explicites : `electric_range_km`, `combustion_range_km`, `total_range_km`. Le parser VW EU/Audi classifie par type de motorisation (4 sources au lieu de 2). Fallback diesel Audi depuis `measurements.rangeStatus.value.dieselRange`. Vérifié via evcc-io/evcc#19045 + sample Audi Q4 + logs CarConnectivity.
-
-**🔒 Mode Read-only Phase 1 (v1.12.0)**
-
-Toggle d'options "Read-only Mode" → ignore les plateformes lock/switch/button(non-refresh)/climate/number pour les propriétaires soucieux de confidentialité/sécurité. Sensors + binary_sensors + device_tracker restent.
-
-**⚡ Number Max-Charge-Current modifiable (v1.12.0)**
-
-Slider 6-32A au lieu d'un capteur read-only seul. Nouveau `command_set_max_charge_current` POST chargingSettings.
-
-**💡 Binary-Sensors par feu (v1.12.0)**
-
-Dynamiquement par type de feu depuis le dict `lights_individual` + agrégats `lights_on` + `lights_count`.
-
-**🛠️ Stabilité défensive (v1.8.7 + v1.10.1)**
-
-- Retry 504, retry erreurs réseau transitoires, cache 6h + tolérance 3 échecs
-- Protection token-refresh-storm (max 3/h) — empêche les bans IP
-- Helpers `safe_int` / `safe_float` / `safe_enum` — tolèrent les bizarreries du backend
-
-**🚪 Firmware-Shapes CUPRA Born 2026 (v1.10.2 — première validation live de Gerhard #53)**
-
-Chaîne de fallback de noms de champs : `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Tolérance enum lowercase pour `"connected"` / `"locked"`. Compatibilité ascendante préservée.
-
-**🔓 Lock + Wake pour Audi/VW (v1.9.1, #92 Audi S6 C8)**
-
-`command_lock` envoie maintenant le S-PIN pour Audi/VW (CARIAD BFF répondait `403 spin_error`). `command_wake` utilise le fallback v1→v2.
-
-**🛡️ Capability-Filter Phase 2 (v1.9.1, #56)**
-
-Body-sniffing `classify_command_failure` pour les marqueurs `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error`. `_cariad_cmd` écrit chaque résultat dans FeatureState. Les entités liées aux commandes (Lock/Climate/Switch/Buttons) deviennent automatiquement unavailable sur un "non" définitif du backend.
-
-### ⚠️ Encore en cours / What's still in progress (sessions planifiées)
-
-- **v1.13.0 MINOR** — Export de diagnostics anonymisés (#62) + Capability-Filter Phase 3 (`capability.active && user-enabled` PRE-création-d'entité, masque les boutons comme l'app MyCupra) + Read-only Phase 2/3 (Command-Locking + séparation des services cloud_refresh vs wake_vehicle).
-- **v1.14.0 MINOR** — Statistiques de trajets depuis Audi `tripstatistics/v1` (#24, #35).
-- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), UI minuteur Climate (#26).
-- **v1.16.0 MINOR** — SoC cible de charge spécifique au lieu + profils de charge (#25, #31).
-- **v1.17.0 MINOR** — Remote Start ICE (#28, pattern upstream #717).
-- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) pour des mises à jour en temps réel sans polling (#57, #27).
-- **v2.0.0 MAJOR** — HACS Default + Live-Tests toutes marques + EU Data Act ready (pycupra `EUDAConnection` comme référence, deadline septembre 2026) (#13, #59).
-
-### 🚫 Limites conscientes / Conscious limits
-
-- **Plateforme image :** aucune API CARIAD render-image officielle n'existe. L'entité image basculera vers des URL fournies par l'utilisateur dans une future release.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nouvelle architecture E³ 1.2, pas encore reverse-engineerée publiquement (même pas dans upstream ou CarConnectivity). VW Group Connect détecte ces véhicules et fait du **graceful degradation** au lieu d'erreurs 404.
-- **Ford / marques non-VAG :** hors périmètre — voir [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) pour Ford.
-
-### 🔧 Prérequis confidentialité
-
-Pour que la position GPS, le statut véhicule et le préchauffage fonctionnent, **"Partager ma position"** doit être activé dans ton app My-VW / My-Audi / MySkoda / MyCupra — sinon le backend répond avec 403.
-
-### 📚 Plus d'infos / More info
-
-- 🗺️ Roadmap : [`docs/ROADMAP.md`](docs/ROADMAP.md) — priorisation P0/P1/P2/P3 complète de tous les issues ouverts
-- 📜 Tech Changelog : [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — par release : mappings de champs + décisions d'architecture + refs sources externes
-- 🎨 Guide Dashboards + carte Lovelace BETA : [`docs/dashboards.md`](docs/dashboards.md) — "Ajouter au tableau de bord" troubleshooting + carte Lovelace dédiée (BETA)
-- 🤝 Session Handoff (pour contributeurs & outils IA) : [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔒 Règles de confidentialité & gestion des données : section [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
-- 📋 FAQ Subscription / Service Plus / diagnostic `missing-capability` : section FAQ de [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
----
-
-## Marques Supportées
-
-| Brand | Auth | API | Status |
+| Marque | Contrôle | Données | Remarque |
 |---|---|---|---|
-| **Volkswagen EU** | IDK | emea.bff.cariad.digital | ✅ |
-| **Audi** | IDK + AZS/MBB | emea.bff.cariad.digital | ✅ |
-| **Škoda** | IDK | mysmob.api.connect.skoda-auto.cz | ✅ |
-| **SEAT** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| **CUPRA** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
-| VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
-
-> **Porsche & VW NA :** Les deux marques sont disponibles en Beta depuis v1.0.0. Testeurs recherchés — signalez vos retours via un [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues) !
+| **Audi** | ✅ Bidirectionnel | ✅ complet | backend myAudi, pas de mur d'attestation |
+| **Škoda** | ✅ Bidirectionnel | ✅ complet | backend Škoda propre |
+| **Porsche** | ✅ Bidirectionnel | ✅ complet | Auth0 + PPA, stable |
+| **VW US/CA** | ✅ Bidirectionnel | ✅ complet | cloud VW-NA (bêta) |
+| **VW EU** | ⚠️ via hybride OIDC (reconnexion ~2 h) | ✅ portail lecture seule / bêta vw.de | backend gated par attestation |
+| **CUPRA / SEAT** | ❌ OLA bloqué (App Check) | ✅ portail lecture seule | depuis le ~2026-06-08, non corrigeable via header |
 
 ---
 
-## Fonctionnalités
+## Ce que tu obtiens
 
-| Feature | Audi | VW EU | Škoda | SEAT/CUPRA |
-|---|:---:|:---:|:---:|:---:|
-| Fuel / Battery level | ✓ | ✓ | ✓ | ✓ |
-| Range | ✓ | ✓ | ✓ | ✓ |
-| Odometer | ✓ | ✓ | ✓ | ✓ |
-| GPS position | ✓ | ✓ | ✓ | ✓ |
-| Doors (total + per door) | ✓ | ✓ | ✓ | ✓ |
-| Windows | ✓ | ✓ | ✓ | ✓ |
-| Climate start/stop | ✓ | ✓ | ✓ | ✓ |
-| Target temperature | ✓ | ✓ | ✓ | ✓ |
-| Lock / Unlock | ✓ | ✓ | ✓ | ✓ |
-| Flash lights | ✓ | ✓ | ✓ | ✓ |
-| Wake vehicle | ✓ | ✓ | ✓ | ✓ |
-| Service due km/days | ✓ | ✓ | ✓ | ✓ |
-| Online status | ✓ | ✓ | ✓ | ✓ |
-| Battery SoC % | ✓ | ✓ | ✓ | ✓ |
-| Charge state | ✓ | ✓ | ✓ | ✓ |
-| Charge power kW | ✓ | ✓ | ✓ | ✓ |
-| Charge speed km/h | ✓ | ✓ | ✓ | ✓ |
-| Charge ETA | ✓ | ✓ | ✓ | ✓ |
-| Charge target % | ✓ | ✓ | ✓ | ✓ |
-| Trunk / hood / sunroof | ✓ | ✓ | ✓ | ✓ |
-| Window heating | ✓ | ✓ | ✓ | ✓ |
-| Vehicle renders | ✓ | — | — | ✓ |
-| Departure timers 1–3 | ✓ | ✓ | — | — |
-| Battery temperature | ✓ | ✓ | — | — |
-| AdBlue range | ✓ | ✓ | — | ✓ |
+100+ entités sur 11 plateformes HA, 20+ service-calls, support multi-véhicule natif par compte. Quality-Scale Platinum.
+
+**Capteurs** (par véhicule) : Battery SoC, Range (electric / combustion / total), Fuel Level, Odometer, Outside Temp, Battery Temp, 12V Voltage, Service Days, Oil Service Days, Charging Power / Rate / Type, Last Trip Stats, Lifetime Trip Aggregates, Charging History, Plug State, Lights Count, Equipment Count, Software Version, API Quota Remaining, Connection State, Last Seen, Skoda Driving Score, Porsche TPMS 4 Corners, Last Alarm Timestamp, Heater Source pour ID.x, Oil Level Warning, alertes véhicule (capteur texte avec toutes les alertes du backend).
+
+**Binary Sensors** : Doors Locked, Doors Open par porte, Windows Open par fenêtre, Trunk / Hood / Sunroof, Plug Connected, Charging, OTA Update Available, 12V Low Warning, Lights On par feu, Vehicle Online, Departure-Timer 1-3 Enabled, Alarm Active + Siren Active, TPMS Warning.
+
+**Contrôle** : Lock/Unlock, Climate Start/Stop, Charging Start/Stop, Window Heating, Cabin Ventilation (CUPRA/SEAT), Aux Heating (Webasto), Departure Timer 1-3 avec préchauffage hebdomadaire, Set Target SoC, Set Target Temp, Set Max Charge Current, Set Charge Mode, Honk-and-Flash, Wake Vehicle, Refresh, Find Charging Stations.
+
+**Image Platform** : 1-7 rendus de véhicule par VIN (Audi/VW via GraphQL MediaService, CUPRA/SEAT via OLA viewPoints, Skoda via Widget + composites multi-angles).
+
+**Device Tracker** : position GPS comme TrackerEntity pour la carte Lovelace de HA.
 
 ---
 
 ## Installation
 
-### HACS
+### Option 1 : One-Click (recommandé)
+
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vwgroup-connect-ha&category=integration)
+
+### Option 2 : HACS Custom Repository
 
 1. HACS → Intégrations → ⋮ → Dépôts personnalisés
-2. URL : `https://github.com/its-me-prash/vwgroup-connect-ha` — Catégorie : Intégration
-3. Installer **VW Group Connect** → Redémarrer Home Assistant
-4. Paramètres → Intégrations → **+ Intégration** → **VW Group Connect**
+2. URL : `https://github.com/its-me-prash/vwgroup-connect-ha`
+3. Catégorie : Integration
+4. Installer **VW Group Connect**
+5. Redémarrer Home Assistant
 
-### Manual
+### Option 3 : Manuel
 
 ```bash
-cp -r custom_components/vag_connect ~/.homeassistant/custom_components/
+cd /config/custom_components
+git clone https://github.com/its-me-prash/vwgroup-connect-ha.git
+mv vwgroup-connect-ha/custom_components/vag_connect .
+rm -rf vwgroup-connect-ha
 ```
 
-Redémarrez Home Assistant.
+Ensuite, redémarrer HA.
 
 ---
 
 ## Configuration
 
-| Field | Required | Description |
-|---|---|---|
-| Marque | ✓ | Audi / Volkswagen / Škoda / SEAT / CUPRA |
-| E-mail | ✓ | E-mail de connexion de l'application constructeur |
-| Mot de passe | ✓ | Mot de passe de l'application |
-| S-PIN | — | Requis pour le verrouillage (dans Sécurité dans l'app) |
-| Intervalle | — | Minutes entre les mises à jour (défaut : 5) |
+Paramètres → Appareils et services → Ajouter une intégration → « VW Group Connect »
 
-**Quelle app ?** Audi → myAudi · VW → WeConnect · Škoda → MyŠkoda · SEAT → My SEAT · CUPRA → MyCupra
+**Lors du premier setup, tu choisis :**
 
----
+- **Connexion par navigateur** (recommandé pour Audi/Škoda/SEAT/CUPRA) : scanner un QR code ou ouvrir l'URL, aucun mot de passe stocké dans HA
+- **E-mail + mot de passe** (pour VW EU, Porsche, VW US/CA) : classique, avec les identifiants Brand-ID
 
-## Limitations Connues
-
-- **S-PIN** requis pour le verrouillage — à configurer dans l'app
-- **Intervalle** minimum 5 minutes — trop court entraîne un blocage temporaire
-- **2FA** — confirmer une fois manuellement dans l'app
-- **Porsche / VW NA** — fonctionnel en Beta, testeurs recherchés
+**Options** (disponibles après le setup) :
+- Intervalle de polling (5-60 min, défaut 10 min)
+- Mode lecture seule pour des automatisations sûres sans commandes involontaires
+- Reverse-geocoding en opt-in (envoie le GPS à OpenStreetMap pour la résolution d'adresse)
+- Toggles push (Skoda MQTT, CUPRA/SEAT FCM, Audi/VW FCM) en fondation, activation live à venir
 
 ---
 
+## Exemples Lovelace
+
+### Map Card
+
+```yaml
+type: map
+title: Fuhrpark
+default_zoom: 12
+hours_to_show: 24
+entities:
+  - device_tracker.audi_a4_b9_position
+  - device_tracker.vw_golf_7_gte_position
+  - zone.home
+```
+
+### Picture-Entity Card avec rendu de véhicule
+
+```yaml
+type: picture-entity
+entity: image.audi_a4_b9_render_side_lg
+camera_view: live
+show_state: false
+show_name: false
+```
+
+### Recherche de bornes de recharge
+
+```yaml
+action: vag_connect.find_charging_stations
+data:
+  vin: WAUZZZ...
+  latitude: 47.3769
+  longitude: 8.5417
+  radius_m: 5000
+  max_results: 25
+response_variable: result
+```
+
+Plus d'exemples dans [`docs/FAQ.md`](docs/FAQ.md). Les cartes Lovelace personnalisées s'intègrent automatiquement via `extra_state_attributes.image_url`.
+
+---
+
+## Questions fréquentes
+
+| Question | Réponse |
+|---|---|
+| Quand ma voiture est-elle réveillée ? | Uniquement lors des service-calls (Lock/Climate/Wake), jamais lors des status-polls. Plafond Smart-Wake : max 3 wakes/jour par voiture, cooldown 5 min. |
+| Combien de quota API ? | MyCupra/MySeat : ~1500 calls/jour. À 10 min de polling : ~144 calls/jour = 10 % du budget. Le capteur `requests_remaining_today` indique l'état. |
+| Pourquoi dois-je me reconnecter toutes les 2 h pour VW EU ? | Depuis le 2026-05-27, VW a placé l'endpoint token derrière Google Play Integrity. Cela touche toute intégration VAG basée sur Python. L'EU Data Act au 2026-09-12 devrait corriger ça. |
+| Le token reste après une mise à jour HACS ? | Oui, depuis la v1.19.2 via la persistance du Store de HA. |
+| Comment signaler des bugs ? | HA → Intégration → 🔧 Réparer → Bug-Report. Les diagnostics sont anonymisés (VIN masqués, GPS arrondi, tokens supprimés). |
+| Les libellés de champs affichent des clés brutes (`brand`, `spin`) après une mise à jour ? | Rafraîchissement forcé du navigateur (Ctrl+Shift+R). HA met les traductions en cache côté client. |
+
+FAQ complète dans [`docs/FAQ.md`](docs/FAQ.md). Dépannage des dashboards dans [`docs/dashboards.md`](docs/dashboards.md).
+
+---
+
+## Confidentialité & Sécurité
+
+- Aucun service externe, tout passe directement entre HA et l'API constructeur
+- Cache de tokens local dans le `.storage/` de HA (par config-entry, JSON, automatiquement supprimé à la suppression de l'intégration)
+- Diagnostics anonymisés : VIN masqués, GPS arrondi à 1 décimale, tokens et mots de passe entièrement supprimés
+- Reverse-geocoding en opt-in, désactivé par défaut
+- Masquage des VIN systématique dans tous les logs
+- Les URLs de token sont expurgées dans le log ERROR (v2.7.2+)
+
+Détails dans [`PRIVACY.md`](PRIVACY.md) et [`SECURITY.md`](SECURITY.md).
+
+---
+
+## Contribuer
+
+Les PR sont les bienvenues, voir [`CONTRIBUTING.md`](CONTRIBUTING.md). Règles de style dans [`STYLE.md`](STYLE.md) (en privé dans `_private/STYLE.md` pour les mainteneurs).
+
+**Vehicle Data Scout** (live depuis la v1.9.0) : quand ton intégration détecte des champs JSON inconnus, elle crée automatiquement une notification HA Repair avec un lien d'issue GitHub pré-rempli. Rapport de bug en 1 clic, sans avoir à étudier le code.
+
+---
 
 ## Licence
 
-Apache License 2.0 — [LICENSE](LICENSE)
-
-**VW Group Connect™** est une marque non déposée (™, pas ®). Veuillez ne pas utiliser ce nom dans les forks afin d'éviter toute confusion.
-
-Cette intégration est un projet communautaire indépendant sans affiliation avec Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG ou toute filiale VAG.
-
----
-
-*Copyright 2026 [Prash Balan](https://github.com/its-me-prash) · Apache License 2.0*
+[Apache License 2.0](LICENSE) pour le code de l'intégration. [CC BY-NC-ND 4.0](LICENSE-RESEARCH) pour le contenu de `docs/research/`. Pour les attributions aux projets open-source amont, voir [`NOTICE.md`](NOTICE.md).

--- a/README.md
+++ b/README.md
@@ -59,74 +59,58 @@ Unlike portal-only integrations it also covers **Porsche** (which the EU Data Ac
 
 ---
 
-## Was ist neu in v2.10.0
+## Aktuell
 
-Das grösste Release dieser Integration bisher. Etwa 6 Wochen intensive Arbeit in einem Cut.
+VW hat 2026 den direkten Fahrzeug-Zugriff für Dritt-Tools schrittweise dichtgemacht (CARIAD-BFF mit Geräte-Attestation, CUPRA/SEAT-OLA hinter Play Integrity seit Juni 2026). Diese Integration bleibt nutzbar, weil sie **mehrere Kanäle** spricht und automatisch umschaltet, sobald einer blockiert:
 
-**VW EU Auth0 SPA-Login gefixt (#388 BalooDK + swebachus).** Um den 2026-05-31 hat VW die universal-login Passwort-Seite auf ein full-SPA-Template migriert. Unser form-encoded POST kam mit 400 zurück trotz korrekter Credentials, und der Data Act Portal Fallback hat dann das `consent.js` Asset der SPA fälschlich als Consent-Wall interpretiert. Beide Beine gefixt: JSON Content-Type Retry gegen die gleiche `/u/login` URL wenn der Form-Pfad 400 wirft, und die Consent-Detection verlangt jetzt spezifische Marker (`data act`, `datenverarbeitung`, `shape the future`, `/u/consent`) statt das blosse Wort `consent`. VW EU User auf Classic-Auth sind wieder unblockiert.
+- **Marken-eigene Backends** — voller Zugriff inkl. Steuerung, wo verfügbar (Audi, Škoda, Porsche, VW US/CA).
+- **EU-Data-Act-Portal** — read-only Fallback für alle Marken (attestation-frei, ~15 min Cadence).
+- **volkswagen.de-Web-Kanal (Beta, opt-in)** — zweiter attestation-freier Lesekanal für VW.
 
-**Cross-Brand Parser-Parität.** Drei koordinierte Parser-Gap-Closures damit jede Marke das ausgibt was ihr Backend wirklich liefert:
-- **VW EU (Group A) - 10 neue Felder**: 12V Starter-Batterie Health, optimised battery use, Active Ventilation State + Restzeit, hinteres Sonnendach, Cabrio-Verdeck, per-Trip-Totals (Fuel + Elektro kWh), Reifendruck-Fallback über `measurements.tirePressureStatus` für neuere PPC-Firmware.
-- **SEAT / CUPRA (Group B) - 6 neue OLA-Endpoints**: dediziertes warning-lights v3, settable Battery-Care Preservation-Mode + Target SoC, Charging-Statistics History-Aggregator, Preferred Workshop, Charging-Modes Katalog, Charging-Actions PUT für Runtime-Settings.
-- **VW NA (Group C) - 4 neue Endpoints**: Türen + Fenster + Lichter auf das moderne `data.exteriorStatus.*` Schema migriert (löst #322 roberttco's 2023 ID.4 US "alles-null" Symptom), Klima via `climateStatusReport`, Odometer-Fallback `data.currentMileage`, GPS-Fallback `lastParkedLocation` für OFFLINE-Autos.
+Die laufende Arbeit dreht sich um Portal-Robustheit (Timeout-Retry, Daten-Freshness) und Resilienz über die Kanäle.
 
-**VW Account-Lock Detection.** Drei throttled-or-locked Token-Antworten innerhalb von 30 Minuten lösen jetzt eine geführte Repairs-Issue (`account_locked`) aus mit Erklärung + nächste Schritte (warten, `scan_interval` hochziehen, optional auf Read-only Data Act Portal umschalten). Räumt sich beim nächsten erfolgreichen Auth selbst auf.
-
-**Scout-Policy Enforcement.** Jeder silenced JSON-Pfad MUSS jetzt auch in eine Entity geparst werden, oder einen expliziten T2-T5 Exemption-Kommentar tragen. Das alte "erst silence, später parse" Pattern ist weg; vorhandene silencer-only Entries aus v2.4.x sind entweder als exempt dokumentiert oder zu echten Sensoren promoted (Active Ventilation alleine schliesst einen IOU vom 2026-05-27). Wildcard-Rules für `.error.*` Envelopes stoppen Scout's Abstieg in die BFF-error Wrapper (schliesst #389, #384).
-
-**Provenance Canaries + Weekly Watcher.** Fünf einzigartig geschriebene Identifier-Strings markieren die strategischen Module (Auth Resolver, Data Act Scraper, DAG Flow, Scout, Watchdog). Wöchentlicher Cron fragt GitHub Code Search nach den Canaries ausserhalb des `its-me-prash` Namespace und öffnet eine Triage-Issue wenn ein Fremdtreffer auftaucht. Apache 2.0 erlaubt den Port; die Canaries machen entferntes LICENSE + NOTICE observable.
-
-**Hardening.** SPDX License-Headers in jeder Python-Datei. Pre-commit Hook enforced `ruff check`, `mypy --strict`, CHANGELOG-Version-Match, und Bruno-Collection URL-Drift-Gate. Python ↔ Bruno Strict-Mode CI verhindert dass URLs von ihren Reference-Recordings driften.
-
-**Übernommen aus v2.7-v2.9** (alles weiter live): Browser-Login (DAG) für Audi/Škoda/SEAT/CUPRA, Multi-Strategy Auth Resolver, EU Data Act Portal Read-only Tier, MFA / Email-OTP Config-Flow, Coordinator Auto-Reload Watchdog, FCM Push-Channel für Audi/VW, Standheizung Auxheat Entities, `vag_connect.open_app` Service, Brake-Service Sensors + Preferred Workshop, Parser-Health Telemetrie, Per-Brand Capability Advertisement, InvalidURL Safety Net, Attestation Gate Watcher.
-
-Voll [CHANGELOG](CHANGELOG.md#2100---2026-06-02).
+➡️ Vollständige Versionshistorie: **[CHANGELOG.md](CHANGELOG.md)**.
 
 ---
 
 ## Wo wir vorne sind
 
-Stand 2026-05-31 nach dem 2026-05-27 VW Auth-Wechsel, der die ganze HA-VAG-Integration-Community gleichzeitig getroffen hat:
+Ehrlicher Stand Mitte 2026: das EU-Data-Act-Portal ist inzwischen der De-facto-Standard-Kanal, viele Integrationen nutzen ihn. Was uns konkret unterscheidet:
 
-| Feature | Status hier | Status bei anderen HA-VAG-Integrationen |
+| Stärke | Wir | Portal-only-Alternativen |
 |---|---|---|
-| **OAuth Device Authorization Grant (QR-Login)** für Audi/Škoda/SEAT/CUPRA | ✅ live in v2.7.0 | Niemand hat das |
-| **Multi-Strategy Auth-Fallback Chain** (3 Tiers pro Marke) | ✅ live in v2.6.0 | Niemand |
-| **EU Data Act Portal Read-only Tier** als 3rd-tier fallback | ✅ integriert in v2.6.0 | Nur als separate standalone-Integration verfügbar |
-| **InvalidURL Safety Net** verhindert Token-Leakage im Log | ✅ live in v2.7.2 | Niemand |
-| **Server-side Attestation Gate Watcher** alerted bei VW-Backend-Flag-Flips | ✅ live in v2.7.0 | Niemand |
-| **Vehicle Data Scout** auto-detected API-Drift, generiert 1-Klick-Bug-Reports | ✅ live seit v1.9.0 | Niemand vergleichbares |
-| **All-7-VAG-Brands in einer Integration** (Audi+VW+Škoda+SEAT+CUPRA+Porsche+VW NA) | ✅ | Andere haben pro Marke ein eigenes Repo |
+| **Alle 7 Konzernmarken inkl. Porsche** in einer Integration | ✅ | Das EU-Data-Act-Portal **schließt Porsche strukturell aus** — portal-only-Tools können Porsche nie abdecken |
+| **Audi Zwei-Wege-Steuerung** (Lock/Klima/Laden, Target-SoC setzen) | ✅ | Portal ist by-design **read-only** |
+| **Multi-Channel-Auth mit Auto-Fallback** (Marken-Backend → EU-Data-Act-Portal → opt-in vw.de-Web) | ✅ | meist single-source — ein Portal-Ausfall = Totalausfall |
+| **Vehicle Data Scout** — erkennt API-Drift automatisch, generiert 1-Klick-Bug-Reports | ✅ | nichts Vergleichbares |
 
 ---
 
 ## Wo die Grenzen liegen (ehrlich)
 
-**VW EU ist seit dem 2026-05-27 Backend-Wechsel hart Play-Integrity-gegated.** Diese Wand trifft jede Python-basierte VAG-Integration (uns inklusive). Das ist keine vorübergehende Verzögerung von uns, das ist VW's Backend-Politik:
+**VW EU und CUPRA/SEAT-OLA sind seit 2026 hinter Geräte-Attestation.** Diese Wand (Google Play Integrity / Firebase App Check) trifft jede Python-basierte VAG-Integration — uns inklusive. Sie ist keine Verzögerung unsererseits, sondern VW-Backend-Politik:
 
-- Das Token-Endpoint validiert seit der Welle einen `X-Assertion` Header, der ein von Google Play Integrity signiertes JWS Token sein muss
-- Python kann diesen Token nicht generieren, weil das Signing-Key nur in Google's mobile-app-attestation Service liegt
-- Konsequenz: **VW EU User bekommen kein echtes refresh_token** und werden alle ~2 Stunden auf einen Re-Login zurückgezwungen
+- Das Token-/OLA-Endpoint verlangt ein von der offiziellen App signiertes Attestation-Token, das Python nicht erzeugen kann (das Signing-Key liegt nur im Google/Firebase-Attestation-Service).
+- Konsequenz: **VW EU** bekommt kein dauerhaftes `refresh_token` (der OIDC-Hybrid-Flow hält ~2 h), und **CUPRA/SEAT** über OLA bekommen seit ~2026-06-08 `403 "Forbidden device detected"`.
 
-Was wir trotzdem für VW EU bieten:
+Was wir trotzdem bieten:
 
-1. **OIDC Hybrid Flow** als primäre Strategie (read+write, aber 2h Re-Login)
-2. **EU Data Act Portal** als read-only fallback (15min Cadence, attestation-frei, unkaputtbar)
-3. **Attestation-Gate Watcher** der wöchentlich pollt und automatisch ein Issue öffnet sobald VW die Gate öffnet
+1. **EU-Data-Act-Portal** als read-only Fallback für alle Marken (attestation-frei, ~15 min Cadence) — übernimmt automatisch, wenn das native Backend blockt.
+2. **volkswagen.de-Web-Kanal (Beta, opt-in)** als zweiter attestation-freier Lesekanal für VW.
+3. **OIDC-Hybrid-Flow** für VW EU als read+write-Strategie (mit dem 2h-Re-Login als Preis).
 
-**EU Data Act 2026-09-12 Compliance-Deadline.** Bis zu diesem Datum muss VW per EU-Verordnung "direkten Datenzugriff für Owner ohne Attestation" anbieten. Unsere `_data_act_portal.py` Implementation ist genau für diesen Tag positioniert.
+**EU-Data-Act-Deadline 2026-09-12.** Bis dahin muss VW per EU-Verordnung direkten, attestation-freien Owner-Datenzugriff anbieten — die Portal-Feldabdeckung wächst bis dahin voraussichtlich weiter.
 
-Status anderer Brands:
+Status pro Marke:
 
-| Marke | Auth | refresh_token? | Bemerkung |
+| Marke | Steuerung | Daten | Bemerkung |
 |---|---|---|---|
-| **Audi** | DAG Browser-Login oder Email+Pwd Hybrid | ✅ ja (via DAG) | Voll funktional |
-| **Škoda** | DAG Browser-Login oder Email+Pwd | ✅ ja (via DAG) | Voll funktional |
-| **SEAT** | DAG Browser-Login oder OLA | ✅ ja (via DAG) | Voll funktional |
-| **CUPRA** | DAG Browser-Login oder OLA | ✅ ja (via DAG) | Voll funktional |
-| **VW EU** | OIDC Hybrid Flow oder Data Act Portal | ⚠️ nein, 2h Re-Login | Backend-gegated (siehe oben) |
-| **Porsche** | Auth0 + PPA | ✅ ja | Stabil |
-| **VW US/CA** | VW NA Cloud | ✅ ja | Beta |
+| **Audi** | ✅ Zwei-Wege | ✅ voll | myAudi-Backend, keine Attestation-Wand |
+| **Škoda** | ✅ Zwei-Wege | ✅ voll | eigenes Škoda-Backend |
+| **Porsche** | ✅ Zwei-Wege | ✅ voll | Auth0 + PPA, stabil |
+| **VW US/CA** | ✅ Zwei-Wege | ✅ voll | VW-NA-Cloud (Beta) |
+| **VW EU** | ⚠️ via OIDC-Hybrid (~2h Re-Login) | ✅ read-only Portal / vw.de-Beta | Backend-attestation-gegated |
+| **CUPRA / SEAT** | ❌ OLA blockiert (App Check) | ✅ read-only Portal | seit ~2026-06-08, nicht per Header fixbar |
 
 ---
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -5,23 +5,23 @@
 <h1 align="center">VW Group Connect</h1>
 
 <p align="center">
-  <strong>Home Assistant Integratie voor Audi · VW · Škoda · SEAT · CUPRA</strong>
+  <strong>Home Assistant-integratie voor Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
+  <em>Eén integratie voor alle 7 VAG-merken, directe API-toegang, zonder middleware</em>
 </p>
 
 <p align="center">
-  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
-  <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha" alt="Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Licentie"></a>
+  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-blue" alt="Home Assistant"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://www.home-assistant.io/docs/quality_scale/"><img src="https://img.shields.io/badge/quality_scale-platinum-d4af37" alt="Quality Scale Platinum"></a>
 </p>
 
 <p align="center">
-  <a href="../README.md">Deutsch</a> ·
+  <a href="README.md">Deutsch</a> ·
   <a href="README.en.md">English</a> ·
   <a href="README.fr.md">Français</a> ·
-  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.es.md">Español</a> ·
   <a href="README.pl.md">Polski</a> ·
   <a href="README.cs.md">Čeština</a> ·
@@ -31,321 +31,227 @@
 ---
 
 > ### 📛 Note on the rename
-> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
-> Turns out that abbreviation reads *quite* differently to English speakers 😅
+> Eerder gepubliceerd als **`vag-connect-ha`** (VAG = Volkswagen AG, gangbare DACH-afkorting).
+> Bleek dat die afkorting voor Engelstaligen *behoorlijk anders* klinkt 😅
 >
-> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
-> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
-> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
-> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+> **Wat ongewijzigd blijft werken**: alle entities (bijv. `sensor.audi_q4_battery_soc`),
+> alle service-calls (`vag_connect.lock`, `vag_connect.show_vag` enz.), alle automatiseringen,
+> de HACS-installatie — **er breekt niets**. Marketing-/weergavenaam verandert,
+> code-internals blijven gelijk. Details in [`MIGRATION.md`](MIGRATION.md).
 >
-> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
-> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+> Enorme dank aan de **Home Assistant UK**- en **HA Ideas, Projects and Solutions**-
+> communities voor de tip — in het bijzonder **Si Gregory**, **Ben Johnson** en **Evets David**.
 >
-> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
-> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
+> En een speciale shoutout naar **Jordan Waeles**, wiens `show_vag()`-comment nu een officieel
+> ondersteund easter egg in deze integratie is (`vag_connect.show_vag`-service, zie CHANGELOG v2.2.3).
 
 ---
 
+## Wat is dit? / Overzicht
 
-## Wat is nieuw in v2.10.0
+**VW Group Connect is een [Home Assistant](https://www.home-assistant.io)-integratie voor connected-car-data en -besturing over alle zeven merken van de Volkswagen Group — Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche en VW US/Canada — vanuit één config entry, te installeren via [HACS](https://hacs.xyz).**
 
-De grootste release van deze integratie tot nu toe. Ongeveer 6 weken intensief werk in één cut.
+Ze toont accu- en laadstatus, actieradius, kilometerstand, klimaat, deuren/ramen en locatie, en — waar de backend van het merk het nog toestaat (bijv. Audi) — stuurt commando's zoals vergrendelen/ontgrendelen, klimaat- en laadbesturing. Om door de API-wijzigingen van Volkswagen in 2026 heen te blijven werken spreekt ze meerdere kanalen en valt automatisch terug zodra er één geblokkeerd wordt: de merk-eigen backends, het alleen-lezen **EU Data Act**-portaal voor voertuigdata en een opt-in `volkswagen.de`-webkanaal.
 
-- **VW EU Auth0 SPA login fix (#388)**: VW migreerde de password-pagina rond 2026-05-31 naar een full-SPA template. JSON Content-Type retry op `/u/login` plus aangescherpte consent-detectie deblokkeert gebruikers op classic-auth.
-- **Cross-brand parser pariteit**: VW EU Group A (10 nieuwe velden - 12V, actieve ventilatie, achterste schuifdak, cabrio-kap, per-rit totalen), SEAT/CUPRA Group B (6 OLA endpoints - warning-lights v3, instelbare battery-care, charging-statistics, voorkeurs-werkplaats), VW NA Group C (4 endpoints - migratie naar `data.exteriorStatus.*`, lost het "alles-null" symptoom op de ID.4 US 2023 #322 op).
-- **VW account-lock detectie** met geleide Repairs issue + auto-clear.
-- **Scout Policy enforcement**: elk silenced JSON pad moet ook geparsed worden tot een entity, of een expliciete T2-T5 exemption-comment dragen. Sluit #384, #389.
-- **Provenance canaries + weekly watcher** + hardening (SPDX, Bruno drift-gate, mypy strict).
+Anders dan portal-only-integraties dekt ze ook **Porsche** (dat het EU-Data-Act-portaal uitsluit) en behoudt ze **Audi tweerichtingsbesturing**.
 
-Rest van v2.7-v2.9 nog steeds live: Browser-Login DAG, multi-strategy auth, Data Act Portal, MFA, FCM push, Standheizung, brake-service, parser telemetry.
+> Een [Home Assistant](https://www.home-assistant.io)-integratie voor connected voertuigdata en -besturing over alle zeven VW-concernmerken (Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche, VW US/CA) — één integratie, meerdere datakanalen, automatische fallback, installatie via HACS.
 
-Volledige [CHANGELOG](CHANGELOG.md#2100---2026-06-02).
+---
 
-## Wat is nieuw in v2.7.x
+## Actueel
 
-**Browser-Login (geen wachtwoord opgeslagen in HA) voor Audi, Škoda, SEAT, CUPRA.** OAuth Device Authorization Grant per RFC 8628. Scan een QR-code met je telefoon of open de URL op een willekeurig apparaat, bevestig een korte code, klaar. Echt refresh_token, geen re-login elke twee uur.
+VW heeft in 2026 stapsgewijs de directe voertuigtoegang voor third-party-tools dichtgezet (CARIAD-BFF met device-attestation, CUPRA/SEAT-OLA achter Play Integrity sinds juni 2026). Deze integratie blijft bruikbaar omdat ze **meerdere kanalen** spreekt en automatisch omschakelt zodra er één blokkeert:
 
-**Multi-strategie auth resolver.** Tot drie fallback-strategieën per merk (Browser-Login, OIDC Hybrid Flow, EU Data Act Portal alleen lezen). Een strategie stopt, de integratie loopt verder op de volgende.
+- **Merk-eigen backends** — volledige toegang incl. besturing, waar beschikbaar (Audi, Škoda, Porsche, VW US/CA).
+- **EU-Data-Act-portaal** — alleen-lezen fallback voor alle merken (attestation-vrij, ~15 min cadens).
+- **volkswagen.de-webkanaal (Beta, opt-in)** — tweede attestation-vrij leeskanaal voor VW.
 
-**Data Act Portal als alleen-lezen fallback.** Eigen implementatie van de EU Data Act portal login, geïntegreerd als 3e-tier strategie. Alleen lezen maar attestation-vrij, dus onbreekbaar wanneer VW de OAuth-route verstrakt.
+Het lopende werk draait om robuustheid van het portaal (timeout-retry, data-freshness) en veerkracht over de kanalen heen.
 
-**Aanzienlijk meer datapunten.** Reisstatistieken (lifetime afstand, laatste rit), oliepeil, bandenspanning per wiel, deuren / ramen / dak / kofferbak per positie, buitentemperatuur op MY24+, Webasto extra verwarming, alle fabrikantswaarschuwingen inclusief merk-specifieke zoals Audi STO.
-
-Zie [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+➡️ Volledige versiehistorie: **[CHANGELOG.md](CHANGELOG.md)**.
 
 ---
 
 ## Waar wij voorop lopen
 
-Stand per 2026-05-31, na de VW backend-wijziging van 2026-05-27 die de hele HA-VAG-integratie-community tegelijk trof:
+Eerlijke stand medio 2026: het EU-Data-Act-portaal is inmiddels het de-facto standaardkanaal, veel integraties gebruiken het. Wat ons concreet onderscheidt:
 
-| Functie | Status hier | Status bij anderen |
+| Kracht | Wij | Portal-only-alternatieven |
 |---|---|---|
-| OAuth Device Authorization Grant (QR-Login) voor Audi/Škoda/SEAT/CUPRA | ✅ sinds v2.7.0 | Niemand |
-| Multi-strategie auth fallback-keten (3 tiers per merk) | ✅ sinds v2.6.0 | Niemand |
-| EU Data Act portal alleen-lezen tier als 3e-tier fallback | ✅ sinds v2.6.0 | Alleen als losse integratie |
-| InvalidURL veiligheidsnet tegen token-lekken in logs | ✅ sinds v2.7.2 | Niemand |
-| Server-side attestation gate watcher | ✅ sinds v2.7.0 | Niemand |
-| Vehicle Data Scout, automatische API drift-detectie | ✅ sinds v1.9.0 | Niets vergelijkbaars |
-| Alle 7 VAG-merken in één integratie | ✅ | Andere projecten hebben één repo per merk |
+| **Alle 7 concernmerken incl. Porsche** in één integratie | ✅ | Het EU-Data-Act-portaal **sluit Porsche structureel uit** — portal-only-tools kunnen Porsche nooit dekken |
+| **Audi tweerichtingsbesturing** (vergrendelen/klimaat/laden, target-SoC instellen) | ✅ | Portaal is by-design **alleen-lezen** |
+| **Multi-channel-auth met auto-fallback** (merk-backend → EU-Data-Act-portaal → opt-in vw.de-web) | ✅ | meestal single-source — één portaal-uitval = totale uitval |
+| **Vehicle Data Scout** — detecteert API-drift automatisch, genereert 1-klik-bugrapporten | ✅ | niets vergelijkbaars |
 
 ---
 
 ## Waar de grenzen liggen (eerlijk)
 
-**VW EU is hard Play-Integrity-vergrendeld sinds de 2026-05-27 backend-wijziging.** Deze muur raakt elke Python-gebaseerde VAG-integratie (onze inbegrepen). Het is geen tijdelijke vertraging aan onze kant, het is het backend-beleid van VW:
+**VW EU en CUPRA/SEAT-OLA zitten sinds 2026 achter device-attestation.** Deze muur (Google Play Integrity / Firebase App Check) raakt elke Python-gebaseerde VAG-integratie — onze inbegrepen. Het is geen vertraging aan onze kant, maar VW-backend-beleid:
 
-- Het token-endpoint valideert een `X-Assertion` header die een door Google Play Integrity ondertekende JWS-token moet zijn
-- Python kan deze token niet genereren, de signing-key zit alleen in Google's mobile-app attestation service
-- Gevolg: VW EU-gebruikers krijgen geen echt refresh_token en moeten elke ~2 uur opnieuw inloggen
+- Het token-/OLA-endpoint verlangt een door de officiële app ondertekend attestation-token dat Python niet kan genereren (de signing-key ligt alleen in de Google/Firebase-attestation-service).
+- Gevolg: **VW EU** krijgt geen blijvend `refresh_token` (de OIDC-hybrid-flow houdt ~2 u), en **CUPRA/SEAT** via OLA krijgen sinds ~2026-06-08 `403 "Forbidden device detected"`.
 
-Wat we wel bieden voor VW EU: OIDC Hybrid Flow als primaire strategie (lezen + schrijven, 2h re-login), EU Data Act portal als alleen-lezen fallback (15-min cadens, attestation-vrij), wekelijkse watcher die automatisch een issue opent zodra VW de poort opent.
+Wat we desondanks bieden:
 
-**EU Data Act 2026-09-12 compliance-deadline.** Tegen die datum moet VW wettelijk directe voertuigdata-toegang voor eigenaren bieden zonder attestation-gating. Onze `_data_act_portal.py` is gepositioneerd voor die dag.
+1. **EU-Data-Act-portaal** als alleen-lezen fallback voor alle merken (attestation-vrij, ~15 min cadens) — neemt automatisch over wanneer de native backend blokkeert.
+2. **volkswagen.de-webkanaal (Beta, opt-in)** als tweede attestation-vrij leeskanaal voor VW.
+3. **OIDC-hybrid-flow** voor VW EU als lees+schrijf-strategie (met de 2u-herlogin als prijs).
 
-## ✨ v2.0.0 Big-Bang Highlights — also available in English
+**EU-Data-Act-deadline 2026-09-12.** Tegen die datum moet VW per EU-verordening directe, attestation-vrije eigenaars-datatoegang bieden — de veldafdekking van het portaal groeit tot dan naar verwachting verder.
 
-> The detailed v2.0.0 highlights table + "What makes us unique" USP section
-> are maintained in English on the German + English READMEs. They are
-> provided here as the canonical source so non-DE/EN readers can still
-> see all v2.0 features with `` markers without waiting on
-> 6 parallel translations.
+Status per merk:
 
-### Latest highlights — v2.0.0 Big-Bang
-
-| Feature | Status |
-|---|---|
-| **Skoda Driving-Score Sensor** | Efficiency score 0-100 + class bucket for Skoda MY24+ |
-| **Cross-brand Aux-Heating parity (Skoda)** | SkodaClient now inherits the Webasto switch from SEAT/CUPRA |
-| **Porsche TPMS sensors** | 4 tire-pressure sensors + warning binary_sensor (PPA TIRE_PRESSURE) |
-| **Long-Term Trip Aggregates** | Lifetime distance / avg fuel / avg electric (Audi + VW EU) |
-| **Departure-Timer Read-Only Binary-Sensors** | 3 pure-read enabled-sensors |
-| **Weekly Preheat (`recurring_on`)** | Service param for weekday lists (Audi + VW EU + VW NA) |
-| **Charging-Station POI Lookup** | `vag_connect.find_charging_stations` service |
-| **Vehicle Alarm sensors** | closes issue #33 |
-| **heaterSource sensor** | closes issue #163 |
-| **Push Manager Lifecycle Wiring** | Skoda MQTT + CUPRA/SEAT FCM + Audi/VW Cariad FCM (opt-in) |
-| **EU Data Act Abstraction Shim** | Architectural seam for the 2026-09-12 EUDA Art. 3 deadline |
-| **Auth Resilience One-Click Repair** | Repair button for 4 auth reasons triggers reauth flow |
-| **System Health Panel** | Drop-in `system_health.py` |
-| **Quality Scale Platinum** | Re-introduced after v1.26.x revert |
-| **DeviceInfo `configuration_url` + `suggested_area`** | Brand-aware "Open in App" button |
-
-### What makes us unique
-
-- **Native coverage of all 7 VAG brands** in a single integration
-- **Direct manufacturer-API access** without middleware / Docker / 3rd service
-- **Vehicle Data Scout** — automatic JSON-field drift detection with Repair notification + 1-click GitHub issue
-- **Capability-Filter Phase 3** — phantom entities suppressed before spawn
-- **Per-VIN wakeup cap + cooldown** — protects 12V battery
-- **Auth Resilience One-Click Repair** — reauth flow from Repairs panel
-- **System Health Panel** — at-a-glance push channel status, API quota, last poll
-- **Bruno-CI Stage 2** — strict URL-drift check
-- **Token persistence across HA updates** — no re-login after HACS updates since v1.19.2
-- **Diagnostics anonymisation by default** — VINs, GPS, tokens stripped before export
-
-
-Ik wilde mijn Audi volledig in Home Assistant besturen. Dus bouwde ik dit.
-
-**VW Group Connect** is een zelfstandige Home Assistant integratie voor alle VAG-merken. Geen externe afhankelijkheden, geen Docker, geen externe diensten.
-
-Vanaf v0.14.1 communiceert de integratie **rechtstreeks** met de CARIAD API — eigen async-client, volledig zelfstandig. Cloud-polling architectuur, 80+ entities over 10 platforms, 14 services.
-
-> ✅ **Actief onderhouden multi-merk opvolger** van [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (gearchiveerd op 2025-10-29) en [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated op 2025-03-14). Eén integratie voor Audi, VW, Škoda, SEAT, CUPRA, Porsche en VW US/CA — geen aparte plugin per merk.
-
-## Huidige status & eerlijke beperkingen / Current Status & Honest Limits (v1.12.3)
-
-VW Group Connect ontwikkelt zich actief verder. Zodat je weet wat werkt en wat eraan komt:
-
-### ✅ Wat NU werkt (alle 7 merken)
-
-**🛰️ 1-klik bug reports & feature requests (LIVE sinds v1.9.0)**
-
-Twee diagnose-sensoren met een gedeelde reporter-pipeline — **eerste echte live-validatie door community-gebruikers** in v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) en v1.12.3 (DnnsJp74 / Audi):
-
-- 🔬 **Vehicle Data Scout** — detecteert automatisch onbekende JSON-velden in de API van je auto. Per merk gelokaliseerd in 8 talen (DE: API-Beobachter, FR: Observateur d'API, etc.).
-- 🚨 **Error Reporter** — Ring-buffer van de laatste 20 integratie-fouten met geanonimiseerde context (model, firmware, stack trace).
-- 🔘 **Reporter Pipeline:** beide sensoren maken automatisch HA Repair-notificaties met een vooringevuld GitHub-Issue als 1-klik link. Plus een diagnostics-download met alles gemaskeerd voor forum/Facebook.
-- 🔒 **Privacy-belofte:** Niets verlaat je HA zonder jouw expliciete klik. VINs gemaskeerd, GPS afgerond op 1 decimaal, JWT's/UUID's/e-mails verwijderd. AVG/GDPR-compliant.
-
-**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
-
-Sensor `connection_state` (online / standby / offline) voor Audi, VW EU, Škoda, SEAT, CUPRA — eerste VAG-integratie met gecentraliseerde verbindingsstatus. Brand-agnostische helper `compute_connection_state` met recursieve `carCapturedTimestamp` walk.
-
-**🔋 12V-Accu monitoring + Smart-Wake (v1.12.0)**
-
-- `voltage_12v` sensor (V) + `warning_12v_low` binary bij <11.5V — voorkomt stille API-uitval door lege startaccu
-- `wake_count_today` sensor + soft-cap op 3 wakes/dag (`_WAKE_BUDGET_PER_DAY`) beschermt 12V tegen wake-loops, raised `wake_budget_exhausted` VOOR de API-call
-
-**💨 Optimistische UI voor Lock/Climate/Charging (v1.11.1)**
-
-Switches schakelen direct bij klik (myskoda PR #832 patroon), API-roundtrip op de achtergrond. Bij failure: revert + ServiceValidationError. 8 actuator-methodes overgezet.
-
-**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up in v1.11.1)**
-
-Drie expliciete range-sensoren: `electric_range_km`, `combustion_range_km`, `total_range_km`. VW EU/Audi parser classificeert op motortype (4 bronnen in plaats van 2). Audi-diesel-fallback uit `measurements.rangeStatus.value.dieselRange`. Geverifieerd via evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity logs.
-
-**🔒 Read-only Modus Fase 1 (v1.12.0)**
-
-Options-toggle "Read-only Mode" → skip lock/switch/button(non-refresh)/climate/number platformen voor privacy/safety-conservatieve eigenaren. Sensors + binary_sensors + device_tracker blijven.
-
-**⚡ Schrijfbare Max-Charge-Current Number (v1.12.0)**
-
-Slider 6-32A in plaats van alleen een read-only sensor. Nieuwe `command_set_max_charge_current` POST chargingSettings.
-
-**💡 Per-Light Binary-Sensors (v1.12.0)**
-
-Dynamisch per lichttype uit `lights_individual` dict + aggregaten `lights_on` + `lights_count`.
-
-**🛠️ Defensieve stabiliteit (v1.8.7 + v1.10.1)**
-
-- 504-retry, transient-network-error retry, 6h stale-cache + 3-failure tolerance
-- Token-refresh-storm bescherming (max 3/h) — voorkomt IP-bans
-- `safe_int` / `safe_float` / `safe_enum` helpers — toleranter voor backend-quirks
-
-**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhard's #53 eerste live-validatie)**
-
-Field-name fallback-keten: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerantie voor `"connected"` / `"locked"`. Backwards-compat behouden.
-
-**🔓 Lock + Wake voor Audi/VW (v1.9.1, #92 Audi S6 C8)**
-
-`command_lock` stuurt nu S-PIN voor Audi/VW (CARIAD BFF antwoordde `403 spin_error`). `command_wake` gebruikt v1→v2 fallback.
-
-**🛡️ Capability-Filter Fase 2 (v1.9.1, #56)**
-
-`classify_command_failure` body-sniffing voor `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error` markers. `_cariad_cmd` schrijft elke uitkomst naar FeatureState. Command-gebonden entities (Lock/Climate/Switch/Buttons) gaan automatisch unavailable bij definitieve backend-"nee".
-
-### ⚠️ Nog in uitvoering / What's still in progress (geplande sessies)
-
-- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Fase 3 (`capability.active && user-enabled` PRE-entity-creation, verbergt knoppen zoals de MyCupra-app) + Read-only Fase 2/3 (Command-Locking + cloud_refresh vs wake_vehicle service-scheiding).
-- **v1.14.0 MINOR** — Trip Statistics uit Audi `tripstatistics/v1` (#24, #35).
-- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26).
-- **v1.16.0 MINOR** — Locatie-specifieke laaddoel-SoC + laadprofielen (#25, #31).
-- **v1.17.0 MINOR** — Remote Start ICE (#28, upstream #717 patroon).
-- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) voor real-time updates zonder polling (#57, #27).
-- **v2.0.0 MAJOR** — HACS Default + Live-Tests alle merken + EU Data Act ready (pycupra `EUDAConnection` als referentie, deadline september 2026) (#13, #59).
-
-### 🚫 Bewuste beperkingen / Conscious limits
-
-- **Image-platform:** geen officiële CARIAD render-image API. De image-entity zal in een toekomstige release overgaan naar door gebruiker geleverde URLs.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nieuwe E³ 1.2 architectuur, nog niet publiek reverse-engineered (ook niet in upstream of CarConnectivity). VW Group Connect detecteert deze voertuigen en doet **graceful degradation** in plaats van 404-fouten.
-- **Ford / niet-VAG merken:** buiten scope — zie [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) voor Ford.
-
-### 🔧 Privacy-vereiste
-
-Voor GPS-positie, voertuigstatus en standkachel moet **"Locatie delen"** ingeschakeld zijn in je My-VW / My-Audi / MySkoda / MyCupra app — anders antwoordt de backend met 403.
-
-### 📚 Meer info / More info
-
-- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — volledige P0/P1/P2/P3 prioritisering van alle openstaande issues
-- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + architectuur-beslissingen + externe source-refs
-- 🎨 Dashboards-gids + Lovelace-kaart BETA: [`docs/dashboards.md`](docs/dashboards.md) — "Toevoegen aan dashboard" troubleshooting + dedicated Lovelace-kaart (BETA)
-- 🤝 Session Handoff (voor bijdragers & AI-tools): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔒 Privacy & data handling regels: [`CONTRIBUTING.md`](CONTRIBUTING.md) sectie (post-#53 third-party review)
-- 📋 FAQ Subscription / Service Plus / `missing-capability` diagnose: [`CONTRIBUTING.md`](CONTRIBUTING.md) FAQ-sectie
-
----
-
-## Ondersteunde Merken
-
-| Brand | Auth | API | Status |
+| Merk | Besturing | Data | Opmerking |
 |---|---|---|---|
-| **Volkswagen EU** | IDK | emea.bff.cariad.digital | ✅ |
-| **Audi** | IDK + AZS/MBB | emea.bff.cariad.digital | ✅ |
-| **Škoda** | IDK | mysmob.api.connect.skoda-auto.cz | ✅ |
-| **SEAT** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| **CUPRA** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
-| VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
-
-> **Porsche & VW NA:** Beide merken zijn sinds v1.0.0 beschikbaar als Beta. Testers gezocht — meld feedback als [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
+| **Audi** | ✅ Tweerichting | ✅ volledig | myAudi-backend, geen attestation-muur |
+| **Škoda** | ✅ Tweerichting | ✅ volledig | eigen Škoda-backend |
+| **Porsche** | ✅ Tweerichting | ✅ volledig | Auth0 + PPA, stabiel |
+| **VW US/CA** | ✅ Tweerichting | ✅ volledig | VW-NA-cloud (Beta) |
+| **VW EU** | ⚠️ via OIDC-hybrid (~2u herlogin) | ✅ alleen-lezen portaal / vw.de-Beta | backend-attestation-gegated |
+| **CUPRA / SEAT** | ❌ OLA geblokkeerd (App Check) | ✅ alleen-lezen portaal | sinds ~2026-06-08, niet via header fixbaar |
 
 ---
 
-## Functies
+## Wat je krijgt
 
-| Feature | Audi | VW EU | Škoda | SEAT/CUPRA |
-|---|:---:|:---:|:---:|:---:|
-| Fuel / Battery level | ✓ | ✓ | ✓ | ✓ |
-| Range | ✓ | ✓ | ✓ | ✓ |
-| Odometer | ✓ | ✓ | ✓ | ✓ |
-| GPS position | ✓ | ✓ | ✓ | ✓ |
-| Doors (total + per door) | ✓ | ✓ | ✓ | ✓ |
-| Windows | ✓ | ✓ | ✓ | ✓ |
-| Climate start/stop | ✓ | ✓ | ✓ | ✓ |
-| Target temperature | ✓ | ✓ | ✓ | ✓ |
-| Lock / Unlock | ✓ | ✓ | ✓ | ✓ |
-| Flash lights | ✓ | ✓ | ✓ | ✓ |
-| Wake vehicle | ✓ | ✓ | ✓ | ✓ |
-| Service due km/days | ✓ | ✓ | ✓ | ✓ |
-| Online status | ✓ | ✓ | ✓ | ✓ |
-| Battery SoC % | ✓ | ✓ | ✓ | ✓ |
-| Charge state | ✓ | ✓ | ✓ | ✓ |
-| Charge power kW | ✓ | ✓ | ✓ | ✓ |
-| Charge speed km/h | ✓ | ✓ | ✓ | ✓ |
-| Charge ETA | ✓ | ✓ | ✓ | ✓ |
-| Charge target % | ✓ | ✓ | ✓ | ✓ |
-| Trunk / hood / sunroof | ✓ | ✓ | ✓ | ✓ |
-| Window heating | ✓ | ✓ | ✓ | ✓ |
-| Vehicle renders | ✓ | — | — | ✓ |
-| Departure timers 1–3 | ✓ | ✓ | — | — |
-| Battery temperature | ✓ | ✓ | — | — |
-| AdBlue range | ✓ | ✓ | — | ✓ |
+100+ entities over 11 HA-platforms, 20+ service-calls, native multi-vehicle-support per account. Quality-Scale Platinum.
+
+**Sensoren** (per voertuig): Battery SoC, Range (electric / combustion / total), Fuel Level, Odometer, Outside Temp, Battery Temp, 12V Voltage, Service Days, Oil Service Days, Charging Power / Rate / Type, Last Trip Stats, Lifetime Trip Aggregates, Charging History, Plug State, Lights Count, Equipment Count, Software Version, API Quota Remaining, Connection State, Last Seen, Skoda Driving Score, Porsche TPMS 4 Corners, Last Alarm Timestamp, Heater Source voor ID.x, Oil Level Warning, voertuigwaarschuwingen (tekst-sensor met alle backend-warnings).
+
+**Binary Sensors**: Doors Locked, Doors Open per deur, Windows Open per raam, Trunk / Hood / Sunroof, Plug Connected, Charging, OTA Update Available, 12V Low Warning, Lights On per light, Vehicle Online, Departure-Timer 1-3 Enabled, Alarm Active + Siren Active, TPMS Warning.
+
+**Besturing**: Lock/Unlock, Climate Start/Stop, Charging Start/Stop, Window Heating, Cabin Ventilation (CUPRA/SEAT), Aux Heating (Webasto), Departure Timer 1-3 met Weekly-Preheat, Set Target SoC, Set Target Temp, Set Max Charge Current, Set Charge Mode, Honk-and-Flash, Wake Vehicle, Refresh, Find Charging Stations.
+
+**Image Platform**: 1-7 vehicle-renders per VIN (Audi/VW via GraphQL MediaService, CUPRA/SEAT via OLA viewPoints, Skoda via Widget + Multi-Angle Composites).
+
+**Device Tracker**: GPS-positie als TrackerEntity voor de HA Lovelace-map.
 
 ---
 
 ## Installatie
 
-### HACS
+### Optie 1: One-Click (aanbevolen)
+
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vwgroup-connect-ha&category=integration)
+
+### Optie 2: HACS Custom Repository
 
 1. HACS → Integraties → ⋮ → Aangepaste opslagplaatsen
-2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Categorie: Integratie
-3. **VW Group Connect** installeren → Home Assistant opnieuw opstarten
-4. Instellingen → Integraties → **+ Integratie** → **VW Group Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha`
+3. Categorie: Integratie
+4. **VW Group Connect** installeren
+5. Home Assistant opnieuw opstarten
 
-### Manual
+### Optie 3: Handmatig
 
 ```bash
-cp -r custom_components/vag_connect ~/.homeassistant/custom_components/
+cd /config/custom_components
+git clone https://github.com/its-me-prash/vwgroup-connect-ha.git
+mv vwgroup-connect-ha/custom_components/vag_connect .
+rm -rf vwgroup-connect-ha
 ```
 
-Herstart Home Assistant.
+Daarna HA opnieuw opstarten.
 
 ---
 
 ## Configuratie
 
-| Field | Required | Description |
-|---|---|---|
-| Merk | ✓ | Audi / Volkswagen / Škoda / SEAT / CUPRA |
-| E-mail | ✓ | Aanmeldings-e-mail van de fabrikants-app |
-| Wachtwoord | ✓ | Wachtwoord van de app |
-| S-PIN | — | Vereist voor vergrendeling (onder Beveiliging in de app) |
-| Poll-interval | — | Minuten tussen updates (standaard: 5) |
+Instellingen → Apparaten en diensten → Integratie toevoegen → "VW Group Connect"
 
-**Welke app?** Audi → myAudi · VW → WeConnect · Škoda → MyŠkoda · SEAT → My SEAT · CUPRA → MyCupra
+**Bij de eerste setup kies je:**
 
----
+- **Browser-Login** (aanbevolen voor Audi/Škoda/SEAT/CUPRA): QR-code scannen of URL openen, geen wachtwoord opgeslagen in HA
+- **E-mail + wachtwoord** (voor VW EU, Porsche, VW US/CA): klassiek met Brand-ID-credentials
 
-## Bekende Beperkingen
-
-- **S-PIN** vereist voor vergrendeling
-- **Poll-interval** minimaal 5 minuten
-- **2FA** — eenmalig handmatig bevestigen in de app
-- **Porsche / VW NA** — functioneel als Beta, testers gezocht
+**Opties** (beschikbaar na setup):
+- Polling-interval (5-60 min, standaard 10 min)
+- Alleen-lezen modus voor veilige automatiseringen zonder ongewilde commando's
+- Reverse-geocoding opt-in (stuurt GPS naar OpenStreetMap voor adres-resolutie)
+- Push-toggles (Skoda MQTT, CUPRA/SEAT FCM, Audi/VW FCM) als basis, live-activering pending
 
 ---
 
+## Lovelace-voorbeelden
+
+### Map Card
+
+```yaml
+type: map
+title: Wagenpark
+default_zoom: 12
+hours_to_show: 24
+entities:
+  - device_tracker.audi_a4_b9_position
+  - device_tracker.vw_golf_7_gte_position
+  - zone.home
+```
+
+### Picture-Entity Card met vehicle-render
+
+```yaml
+type: picture-entity
+entity: image.audi_a4_b9_render_side_lg
+camera_view: live
+show_state: false
+show_name: false
+```
+
+### Charging-Station-Lookup
+
+```yaml
+action: vag_connect.find_charging_stations
+data:
+  vin: WAUZZZ...
+  latitude: 47.3769
+  longitude: 8.5417
+  radius_m: 5000
+  max_results: 25
+response_variable: result
+```
+
+Meer voorbeelden in [`docs/FAQ.md`](docs/FAQ.md). Custom Lovelace-kaarten integreren automatisch via `extra_state_attributes.image_url`.
+
+---
+
+## Veelgestelde vragen
+
+| Vraag | Antwoord |
+|---|---|
+| Wanneer wordt mijn auto gewekt? | Alleen bij service-calls (Lock/Climate/Wake), nooit bij status-polls. Smart-Wake-cap: max 3 wakes/dag per auto, 5min cooldown. |
+| Hoeveel API-quota? | MyCupra/MySeat: ~1500 calls/dag. Bij 10min polling: ~144 calls/dag = 10% budget. Sensor `requests_remaining_today` toont de stand. |
+| Waarom moet ik bij VW EU elke 2u opnieuw inloggen? | VW heeft sinds 2026-05-27 het token-endpoint achter Google Play Integrity gezet. Dat raakt elke Python-gebaseerde VAG-integratie. EU Data Act 2026-09-12 zou dit moeten oplossen. |
+| Blijft het token na een HACS-update? | Ja, sinds v1.19.2 via HA Store-persistentie. |
+| Hoe meld ik bugs? | HA → Integratie → 🔧 Repareren → Bug-Report. Diagnostics worden geanonimiseerd (VINs gemaskeerd, GPS afgerond, tokens gestript). |
+| Veldlabels tonen raw keys (`brand`, `spin`) na een update? | Hard browser refresh (Ctrl+Shift+R). HA cachet vertalingen client-side. |
+
+Volledige FAQ in [`docs/FAQ.md`](docs/FAQ.md). Dashboard-troubleshooting in [`docs/dashboards.md`](docs/dashboards.md).
+
+---
+
+## Privacy & beveiliging
+
+- Geen externe diensten, alles rechtstreeks tussen HA en de manufacturer-API
+- Token-cache lokaal in HA's `.storage/` (per-config-entry, JSON, automatisch verwijderd bij integratie-removal)
+- Diagnostics geanonimiseerd: VINs gemaskeerd, GPS afgerond op 1 decimaal, tokens en wachtwoorden volledig gestript
+- Reverse-geocoding opt-in, standaard uitgeschakeld
+- VIN-masking doorlopend in alle logs
+- Token-URLs worden in de ERROR-log geredacteerd (v2.7.2+)
+
+Details in [`PRIVACY.md`](PRIVACY.md) en [`SECURITY.md`](SECURITY.md).
+
+---
+
+## Contributing
+
+PRs welkom, zie [`CONTRIBUTING.md`](CONTRIBUTING.md). Style-regels in [`STYLE.md`](STYLE.md) (privé in `_private/STYLE.md` voor maintainers).
+
+**Vehicle Data Scout** (live sinds v1.9.0): wanneer je integratie onbekende JSON-velden detecteert, maakt ze automatisch een HA Repair-notificatie aan met een vooringevulde GitHub-issue-link. 1-klik bug-report zonder code te bestuderen.
+
+---
 
 ## Licentie
 
-Apache License 2.0 — [LICENSE](LICENSE)
-
-**VW Group Connect™** is een niet-geregistreerd handelsmerk (™, niet ®). Gebruik deze naam niet in forks om verwarring te voorkomen.
-
-Deze integratie is een onafhankelijk communityproject zonder enige verbinding met Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG of andere VAG-dochterondernemingen.
-
----
-
-*Copyright 2026 [Prash Balan](https://github.com/its-me-prash) · Apache License 2.0*
+[Apache License 2.0](LICENSE) voor de integratie-code. [CC BY-NC-ND 4.0](LICENSE-RESEARCH) voor de inhoud van `docs/research/`. Attributies aan upstream open-source projecten zie [`NOTICE.md`](NOTICE.md).

--- a/README.pl.md
+++ b/README.pl.md
@@ -5,25 +5,25 @@
 <h1 align="center">VW Group Connect</h1>
 
 <p align="center">
-  <strong>Integracja Home Assistant dla Audi · VW · Škoda · SEAT · CUPRA</strong>
+  <strong>Integracja Home Assistant dla Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
+  <em>Jedna integracja dla wszystkich 7 marek VAG, bezpośredni dostęp do API, bez middleware</em>
 </p>
 
 <p align="center">
-  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
-  <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha" alt="Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Licencja"></a>
+  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-blue" alt="Home Assistant"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://www.home-assistant.io/docs/quality_scale/"><img src="https://img.shields.io/badge/quality_scale-platinum-d4af37" alt="Quality Scale Platinum"></a>
 </p>
 
 <p align="center">
-  <a href="../README.md">Deutsch</a> ·
+  <a href="README.md">Deutsch</a> ·
   <a href="README.en.md">English</a> ·
   <a href="README.fr.md">Français</a> ·
-  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.es.md">Español</a> ·
-  <a href="README.pl.md">Polski</a> ·
+  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.cs.md">Čeština</a> ·
   <a href="README.sv.md">Svenska</a>
 </p>
@@ -31,321 +31,227 @@
 ---
 
 > ### 📛 Note on the rename
-> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
-> Turns out that abbreviation reads *quite* differently to English speakers 😅
+> Wcześniej publikowane jako **`vag-connect-ha`** (VAG = Volkswagen AG, popularny skrót w regionie DACH).
+> Okazało się, że ten skrót brzmi *znacząco inaczej* dla osób anglojęzycznych 😅
 >
-> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
-> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
-> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
-> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+> **Co działa dalej bez zmian**: wszystkie encje (np. `sensor.audi_q4_battery_soc`),
+> wszystkie wywołania usług (`vag_connect.lock`, `vag_connect.show_vag` itd.), wszystkie automatyzacje,
+> instalacja przez HACS — **nic się nie psuje**. Zmienia się nazwa marketingowa / wyświetlana,
+> wnętrze kodu pozostaje takie samo. Szczegóły w [`MIGRATION.md`](MIGRATION.md).
 >
-> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
-> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+> Ogromne podziękowania dla społeczności **Home Assistant UK** oraz **HA Ideas, Projects and Solutions**
+> za zwrócenie uwagi — szczególnie dla **Si Gregory**, **Ben Johnson** i **Evets David**.
 >
-> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
-> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
+> I specjalne pozdrowienia dla **Jordana Waelesa**, którego komentarz `show_vag()` jest teraz oficjalnie
+> wspieranym easter eggiem w tej integracji (usługa `vag_connect.show_vag`, patrz CHANGELOG v2.2.3).
 
 ---
 
+## Co to jest?
 
-## Co nowego w v2.10.0
+**VW Group Connect to integracja [Home Assistant](https://www.home-assistant.io) do odczytu danych i sterowania samochodami połączonymi we wszystkich siedmiu markach Grupy Volkswagen — Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche oraz VW US/Kanada — z jednego wpisu konfiguracyjnego, instalowana przez [HACS](https://hacs.xyz).**
 
-Największy release tej integracji do tej pory. Około 6 tygodni intensywnej pracy w jednym cut.
+Pokazuje stan akumulatora i ładowania, zasięg, przebieg, klimatyzację, drzwi/okna oraz lokalizację, a tam, gdzie backend marki nadal na to pozwala (np. Audi) — wysyła komendy takie jak zamykanie/otwieranie, sterowanie klimatyzacją i ładowaniem. Aby działać mimo zmian w API Volkswagena z 2026 roku, korzysta z kilku kanałów i automatycznie przełącza się na kolejny, gdy jeden zostanie zablokowany: natywne backendy marek, portal danych pojazdu **EU Data Act** (tylko do odczytu) oraz opcjonalny kanał webowy `volkswagen.de`.
 
-- **Fix loginu VW EU Auth0 SPA (#388)**: VW zmigrował stronę hasła do full-SPA template około 2026-05-31. Retry JSON Content-Type na `/u/login` plus zaostrzona detekcja consent odblokowuje użytkowników na classic-auth.
-- **Cross-brand parser parity**: VW EU Group A (10 nowych pól - 12V, aktywna wentylacja, tylny szyberdach, dach kabrio, sumy per-trip), SEAT/CUPRA Group B (6 endpointów OLA - warning-lights v3, konfigurowalny battery-care, charging-statistics, preferowany warsztat), VW NA Group C (4 endpointy - migracja do `data.exteriorStatus.*`, naprawia objaw "wszystko null" na ID.4 US 2023 #322).
-- **Detekcja blokady konta VW** z prowadzoną Repairs issue + auto-clear.
-- **Egzekwowanie Scout Policy**: każda silenced ścieżka JSON musi też być parsowana do entity, lub mieć jawny komentarz T2-T5 exemption. Zamyka #384, #389.
-- **Provenance canaries + weekly watcher** + hardening (SPDX, Bruno drift-gate, mypy strict).
+W odróżnieniu od integracji opartych wyłącznie na portalu, obejmuje też **Porsche** (którego portal EU Data Act nie udostępnia) i zachowuje **dwukierunkowe sterowanie Audi**.
 
-Reszta z v2.7-v2.9 nadal działa: Browser-Login DAG, multi-strategy auth, Data Act Portal, MFA, FCM push, Standheizung, brake-service, parser telemetry.
+> Integracja [Home Assistant](https://www.home-assistant.io) do odczytu danych i sterowania samochodami połączonymi we wszystkich siedmiu markach koncernu VW (Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche, VW US/CA) — jedna integracja, wiele kanałów danych, automatyczny fallback, instalacja przez HACS.
 
-Pełny [CHANGELOG](CHANGELOG.md#2100---2026-06-02).
+---
 
-## Co nowego w v2.7.x
+## Bieżący stan
 
-**Logowanie przez przeglądarkę (bez hasła w HA) dla Audi, Škoda, SEAT, CUPRA.** OAuth Device Authorization Grant zgodnie z RFC 8628. Zeskanuj kod QR telefonem lub otwórz URL na dowolnym urządzeniu, potwierdź krótki kod, gotowe. Prawdziwy refresh_token, bez re-loginu co dwie godziny.
+W 2026 roku VW stopniowo zamykał bezpośredni dostęp do pojazdów dla narzędzi firm trzecich (CARIAD-BFF z atestacją urządzenia, OLA dla CUPRA/SEAT za Play Integrity od czerwca 2026). Ta integracja pozostaje używalna, ponieważ obsługuje **wiele kanałów** i automatycznie przełącza się, gdy tylko jeden zostanie zablokowany:
 
-**Wieloskładnikowy resolver auth.** Do trzech strategii zapasowych na markę (Browser-Login, OIDC Hybrid Flow, EU Data Act Portal tylko do odczytu). Jedna strategia umiera, integracja działa dalej na następnej.
+- **Natywne backendy marek** — pełny dostęp wraz ze sterowaniem, tam gdzie jest dostępne (Audi, Škoda, Porsche, VW US/CA).
+- **Portal EU Data Act** — fallback tylko do odczytu dla wszystkich marek (bez atestacji, cadence ~15 min).
+- **Kanał webowy volkswagen.de (Beta, opt-in)** — drugi kanał odczytu dla VW bez atestacji.
 
-**Portal Data Act jako fallback tylko do odczytu.** Własna implementacja loginu portalu EU Data Act, zintegrowana jako strategia 3-go poziomu. Tylko do odczytu ale bez attestation, więc niezniszczalna gdy VW zaostrza ścieżkę OAuth.
+Bieżąca praca skupia się na odporności portalu (retry przy timeoutach, świeżość danych) i odporności między kanałami.
 
-**Znacznie więcej danych.** Statystyki podróży (przebieg życiowy, ostatnia trasa), poziom oleju, ciśnienie w każdej oponie, drzwi / okna / szyberdach / bagażnik per pozycja, temperatura zewnętrzna na MY24+, ogrzewanie postojowe Webasto, wszystkie ostrzeżenia producenta w tym markowo-specyficzne jak Audi STO.
-
-Zobacz [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+➡️ Pełna historia wersji: **[CHANGELOG.md](CHANGELOG.md)**.
 
 ---
 
 ## Gdzie prowadzimy
 
-Stan na 2026-05-31, po zmianie backendu VW z 2026-05-27 która uderzyła całą społeczność integracji HA-VAG jednocześnie:
+Uczciwy stan na połowę 2026: portal EU Data Act stał się de facto standardowym kanałem, korzysta z niego wiele integracji. Co konkretnie nas wyróżnia:
 
-| Funkcja | Status tutaj | Status u innych |
+| Mocna strona | My | Alternatywy oparte tylko na portalu |
 |---|---|---|
-| OAuth Device Authorization Grant (QR-Login) dla Audi/Škoda/SEAT/CUPRA | ✅ od v2.7.0 | Nikt |
-| Wieloskładnikowy łańcuch auth (3 poziomy na markę) | ✅ od v2.6.0 | Nikt |
-| Portal EU Data Act jako 3-ci poziom tylko do odczytu | ✅ od v2.6.0 | Tylko jako osobna integracja |
-| Siatka bezpieczeństwa InvalidURL przeciw wyciekowi tokenów | ✅ od v2.7.2 | Nikt |
-| Watcher gate'u attestation server-side | ✅ od v2.7.0 | Nikt |
-| Vehicle Data Scout, auto-detekcja driftu API | ✅ od v1.9.0 | Nic porównywalnego |
-| Wszystkie 7 marek VAG w jednej integracji | ✅ | Inne projekty mają repo per marka |
+| **Wszystkie 7 marek koncernu wraz z Porsche** w jednej integracji | ✅ | Portal EU Data Act **strukturalnie wyklucza Porsche** — narzędzia oparte tylko na portalu nigdy nie obejmą Porsche |
+| **Dwukierunkowe sterowanie Audi** (Lock/Klima/Ładowanie, ustawianie docelowego SoC) | ✅ | Portal jest z założenia **tylko do odczytu** |
+| **Multi-channel auth z auto-fallbackiem** (backend marki → portal EU Data Act → opcjonalny web vw.de) | ✅ | zwykle pojedyncze źródło — awaria portalu = całkowita awaria |
+| **Vehicle Data Scout** — automatycznie wykrywa drift API, generuje raporty błędów jednym kliknięciem | ✅ | nic porównywalnego |
 
 ---
 
 ## Gdzie są granice (uczciwie)
 
-**VW EU jest twardo zablokowane przez Play Integrity od zmiany backendu 2026-05-27.** Ten mur uderza w każdą integrację VAG opartą o Python (naszą włącznie). To nie jest nasze opóźnienie, to polityka backendu VW:
+**VW EU oraz OLA dla CUPRA/SEAT są od 2026 za atestacją urządzenia.** Ten mur (Google Play Integrity / Firebase App Check) uderza w każdą integrację VAG opartą o Python — w nas włącznie. To nie jest opóźnienie po naszej stronie, lecz polityka backendu VW:
 
-- Endpoint tokenu waliduje nagłówek `X-Assertion` który musi być JWS-em podpisanym przez Google Play Integrity
-- Python nie może wygenerować tego tokenu, klucz podpisujący leży tylko w usłudze attestation Google
-- Konsekwencja: użytkownicy VW EU nie dostają prawdziwego refresh_tokenu i muszą logować się ponownie co ~2 godziny
+- Endpoint tokenu/OLA wymaga tokenu atestacji podpisanego przez oficjalną aplikację, którego Python nie potrafi wygenerować (klucz podpisujący leży wyłącznie w usłudze atestacji Google/Firebase).
+- Konsekwencja: **VW EU** nie dostaje trwałego `refresh_token` (hybrydowy flow OIDC trzyma ~2 h), a **CUPRA/SEAT** przez OLA dostają od ~2026-06-08 `403 "Forbidden device detected"`.
 
-Co oferujemy dla VW EU: OIDC Hybrid Flow jako strategia podstawowa (odczyt + zapis, 2h re-login), portal EU Data Act jako fallback tylko do odczytu (cadence 15 min, bez attestation), cotygodniowy watcher który automatycznie otwiera issue gdy VW otworzy bramę.
+Co mimo to oferujemy:
 
-**Termin EU Data Act 2026-09-12.** Do tej daty VW musi prawnie zapewnić właścicielom bezpośredni dostęp do danych pojazdu bez attestation. Nasze `_data_act_portal.py` jest gotowe na ten dzień.
+1. **Portal EU Data Act** jako fallback tylko do odczytu dla wszystkich marek (bez atestacji, cadence ~15 min) — przejmuje automatycznie, gdy natywny backend blokuje.
+2. **Kanał webowy volkswagen.de (Beta, opt-in)** jako drugi kanał odczytu dla VW bez atestacji.
+3. **Hybrydowy flow OIDC** dla VW EU jako strategia odczyt+zapis (z ceną ponownego logowania co 2 h).
 
-## ✨ v2.0.0 Big-Bang Highlights — also available in English
+**Termin EU Data Act 2026-09-12.** Do tej daty VW musi na mocy rozporządzenia UE zapewnić bezpośredni dostęp do danych właściciela bez atestacji — pokrycie pól w portalu do tego czasu prawdopodobnie będzie rosło.
 
-> The detailed v2.0.0 highlights table + "What makes us unique" USP section
-> are maintained in English on the German + English READMEs. They are
-> provided here as the canonical source so non-DE/EN readers can still
-> see all v2.0 features with `` markers without waiting on
-> 6 parallel translations.
+Status per marka:
 
-### Latest highlights — v2.0.0 Big-Bang
-
-| Feature | Status |
-|---|---|
-| **Skoda Driving-Score Sensor** | Efficiency score 0-100 + class bucket for Skoda MY24+ |
-| **Cross-brand Aux-Heating parity (Skoda)** | SkodaClient now inherits the Webasto switch from SEAT/CUPRA |
-| **Porsche TPMS sensors** | 4 tire-pressure sensors + warning binary_sensor (PPA TIRE_PRESSURE) |
-| **Long-Term Trip Aggregates** | Lifetime distance / avg fuel / avg electric (Audi + VW EU) |
-| **Departure-Timer Read-Only Binary-Sensors** | 3 pure-read enabled-sensors |
-| **Weekly Preheat (`recurring_on`)** | Service param for weekday lists (Audi + VW EU + VW NA) |
-| **Charging-Station POI Lookup** | `vag_connect.find_charging_stations` service |
-| **Vehicle Alarm sensors** | closes issue #33 |
-| **heaterSource sensor** | closes issue #163 |
-| **Push Manager Lifecycle Wiring** | Skoda MQTT + CUPRA/SEAT FCM + Audi/VW Cariad FCM (opt-in) |
-| **EU Data Act Abstraction Shim** | Architectural seam for the 2026-09-12 EUDA Art. 3 deadline |
-| **Auth Resilience One-Click Repair** | Repair button for 4 auth reasons triggers reauth flow |
-| **System Health Panel** | Drop-in `system_health.py` |
-| **Quality Scale Platinum** | Re-introduced after v1.26.x revert |
-| **DeviceInfo `configuration_url` + `suggested_area`** | Brand-aware "Open in App" button |
-
-### What makes us unique
-
-- **Native coverage of all 7 VAG brands** in a single integration
-- **Direct manufacturer-API access** without middleware / Docker / 3rd service
-- **Vehicle Data Scout** — automatic JSON-field drift detection with Repair notification + 1-click GitHub issue
-- **Capability-Filter Phase 3** — phantom entities suppressed before spawn
-- **Per-VIN wakeup cap + cooldown** — protects 12V battery
-- **Auth Resilience One-Click Repair** — reauth flow from Repairs panel
-- **System Health Panel** — at-a-glance push channel status, API quota, last poll
-- **Bruno-CI Stage 2** — strict URL-drift check
-- **Token persistence across HA updates** — no re-login after HACS updates since v1.19.2
-- **Diagnostics anonymisation by default** — VINs, GPS, tokens stripped before export
-
-
-Chciałem w pełni sterować moim Audi z poziomu Home Assistant. Więc to zbudowałem.
-
-**VW Group Connect** to samodzielna integracja Home Assistant dla wszystkich marek VAG. Bez zewnętrznych zależności, bez Dockera, bez zewnętrznych usług.
-
-Od v0.14.1 integracja **bezpośrednio** komunikuje się z API CARIAD — własny klient async, w pełni autonomiczny. Architektura cloud-polling, 80+ encji w 10 platformach, 14 usług.
-
-> ✅ **Aktywnie utrzymywany wieloprodukcyjny następca** projektów [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (zarchiwizowany 2025-10-29) i [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). Jedna integracja dla Audi, VW, Škoda, SEAT, CUPRA, Porsche i VW US/CA — bez osobnej wtyczki dla każdej marki.
-
-## Bieżący stan i uczciwe ograniczenia / Current Status & Honest Limits (v1.12.3)
-
-VW Group Connect aktywnie się rozwija. Abyś wiedział, co działa i co nadchodzi:
-
-### ✅ Co działa TERAZ (wszystkie 7 marek)
-
-**🛰️ Bug reporty i prośby o funkcje 1-kliknięciem (LIVE od v1.9.0)**
-
-Dwa sensory diagnostyczne ze wspólną pipeline reportera — **pierwsza prawdziwa walidacja live przez użytkowników społeczności** w v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) i v1.12.3 (DnnsJp74 / Audi):
-
-- 🔬 **Vehicle Data Scout** — wykrywa automatycznie nieznane pola JSON w API twojego auta. Lokalizowany per marka w 8 językach (DE: API-Beobachter, FR: Observateur d'API, etc.).
-- 🚨 **Error Reporter** — Ring-buffer ostatnich 20 błędów integracji z anonimizowanym kontekstem (model, firmware, stack trace).
-- 🔘 **Reporter Pipeline:** oba sensory tworzą automatycznie powiadomienia HA Repair z prefilled GitHub-Issue jako linkiem 1-kliknięciem. Plus pobranie diagnostics ze wszystkim zamaskowanym dla forum/Facebooka.
-- 🔒 **Obietnica prywatności:** Nic nie opuszcza twojego HA bez twojego wyraźnego kliknięcia. VIN-y zamaskowane, GPS zaokrąglone do 1 miejsca po przecinku, JWT/UUID/e-maile usunięte. Zgodne z RODO/GDPR.
-
-**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
-
-Sensor `connection_state` (online / standby / offline) dla Audi, VW EU, Škoda, SEAT, CUPRA — pierwsza integracja VAG ze scentralizowanym statusem połączenia. Brand-agnostyczny helper `compute_connection_state` z rekursywnym przejściem `carCapturedTimestamp`.
-
-**🔋 Monitoring akumulatora 12V + Smart-Wake (v1.12.0)**
-
-- Sensor `voltage_12v` (V) + binary `warning_12v_low` przy <11.5V — zapobiega cichym awariom API spowodowanym pustym akumulatorem rozruchowym
-- Sensor `wake_count_today` + soft-cap na 3 wakes/dzień (`_WAKE_BUDGET_PER_DAY`) chroni 12V przed wake-loops, podnosi `wake_budget_exhausted` PRZED wywołaniem API
-
-**💨 Optymistyczne UI dla Lock/Climate/Charging (v1.11.1)**
-
-Switche przełączają się natychmiast po kliknięciu (wzorzec myskoda PR #832), roundtrip API w tle. Przy niepowodzeniu: revert + ServiceValidationError. 8 metod actuator przeniesionych.
-
-**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up w v1.11.1)**
-
-Trzy jawne sensory zasięgu: `electric_range_km`, `combustion_range_km`, `total_range_km`. Parser VW EU/Audi klasyfikuje wg typu silnika (4 źródła zamiast 2). Fallback diesel Audi z `measurements.rangeStatus.value.dieselRange`. Zweryfikowany przez evcc-io/evcc#19045 + sample Audi Q4 + logi CarConnectivity.
-
-**🔒 Tryb Read-only Faza 1 (v1.12.0)**
-
-Toggle opcji "Read-only Mode" → pomija platformy lock/switch/button(non-refresh)/climate/number dla właścicieli ostrożnych w kwestii prywatności/bezpieczeństwa. Sensors + binary_sensors + device_tracker pozostają.
-
-**⚡ Zapisywalny Number Max-Charge-Current (v1.12.0)**
-
-Slider 6-32A zamiast tylko sensora read-only. Nowy `command_set_max_charge_current` POST chargingSettings.
-
-**💡 Per-Light Binary-Sensors (v1.12.0)**
-
-Dynamicznie per typ światła z dict `lights_individual` + agregaty `lights_on` + `lights_count`.
-
-**🛠️ Defensywna stabilność (v1.8.7 + v1.10.1)**
-
-- Retry 504, retry przejściowych błędów sieci, cache 6h + tolerancja 3 błędów
-- Ochrona przed token-refresh-storm (max 3/h) — zapobiega banom IP
-- Helpery `safe_int` / `safe_float` / `safe_enum` — tolerują dziwactwa backendu
-
-**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — pierwsza walidacja live Gerharda #53)**
-
-Łańcuch fallback nazw pól: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Tolerancja enum lowercase dla `"connected"` / `"locked"`. Wsteczna kompatybilność zachowana.
-
-**🔓 Lock + Wake dla Audi/VW (v1.9.1, #92 Audi S6 C8)**
-
-`command_lock` wysyła teraz S-PIN dla Audi/VW (CARIAD BFF odpowiadał `403 spin_error`). `command_wake` używa fallback v1→v2.
-
-**🛡️ Capability-Filter Faza 2 (v1.9.1, #56)**
-
-Body-sniffing `classify_command_failure` dla markerów `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error`. `_cariad_cmd` zapisuje każdy wynik do FeatureState. Encje powiązane z komendami (Lock/Climate/Switch/Buttons) automatycznie stają się unavailable przy ostatecznym "nie" backendu.
-
-### ⚠️ Jeszcze w toku / What's still in progress (zaplanowane sesje)
-
-- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Faza 3 (`capability.active && user-enabled` PRE-tworzenie-encji, ukrywa przyciski jak aplikacja MyCupra) + Read-only Faza 2/3 (Command-Locking + rozdzielenie usług cloud_refresh vs wake_vehicle).
-- **v1.14.0 MINOR** — Trip Statistics z Audi `tripstatistics/v1` (#24, #35).
-- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), UI timera Climate (#26).
-- **v1.16.0 MINOR** — Specyficzne dla lokalizacji SoC docelowy ładowania + profile ładowania (#25, #31).
-- **v1.17.0 MINOR** — Remote Start ICE (#28, wzorzec upstream #717).
-- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) dla aktualizacji w czasie rzeczywistym bez pollingu (#57, #27).
-- **v2.0.0 MAJOR** — HACS Default + Live-Tests wszystkich marek + EU Data Act ready (pycupra `EUDAConnection` jako referencja, deadline wrzesień 2026) (#13, #59).
-
-### 🚫 Świadome ograniczenia / Conscious limits
-
-- **Platforma image:** nie istnieje oficjalne API CARIAD render-image. Encja image przejdzie na URL-e dostarczone przez użytkownika w przyszłej release.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — nowa architektura E³ 1.2, jeszcze nie zreverse-engineered publicznie (nawet w upstream ani CarConnectivity). VW Group Connect wykrywa te pojazdy i robi **graceful degradation** zamiast błędów 404.
-- **Ford / marki spoza VAG:** poza zakresem — patrz [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) dla Forda.
-
-### 🔧 Wymóg prywatności
-
-Aby pozycja GPS, status pojazdu i ogrzewanie postojowe działały, **"Udostępnij moją lokalizację"** musi być włączone w twojej aplikacji My-VW / My-Audi / MySkoda / MyCupra — inaczej backend odpowiada 403.
-
-### 📚 Więcej informacji / More info
-
-- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — pełna priorytyzacja P0/P1/P2/P3 wszystkich otwartych issues
-- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: mapowania pól + decyzje architektoniczne + refy do zewnętrznych źródeł
-- 🎨 Przewodnik Dashboards + karta Lovelace BETA: [`docs/dashboards.md`](docs/dashboards.md) — rozwiązywanie problemów "Dodaj do panelu" + dedykowana karta Lovelace (BETA)
-- 🤝 Session Handoff (dla współtwórców i narzędzi AI): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔒 Zasady prywatności i obsługi danych: sekcja [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
-- 📋 FAQ Subscription / Service Plus / diagnoza `missing-capability`: sekcja FAQ w [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
----
-
-## Obsługiwane Marki
-
-| Brand | Auth | API | Status |
+| Marka | Sterowanie | Dane | Uwaga |
 |---|---|---|---|
-| **Volkswagen EU** | IDK | emea.bff.cariad.digital | ✅ |
-| **Audi** | IDK + AZS/MBB | emea.bff.cariad.digital | ✅ |
-| **Škoda** | IDK | mysmob.api.connect.skoda-auto.cz | ✅ |
-| **SEAT** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| **CUPRA** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
-| VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
-
-> **Porsche & VW NA:** Obie marki są dostępne jako Beta od v1.0.0. Szukamy testerów — zgłoś opinię jako [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
+| **Audi** | ✅ Dwukierunkowe | ✅ pełne | backend myAudi, bez muru atestacji |
+| **Škoda** | ✅ Dwukierunkowe | ✅ pełne | własny backend Škody |
+| **Porsche** | ✅ Dwukierunkowe | ✅ pełne | Auth0 + PPA, stabilne |
+| **VW US/CA** | ✅ Dwukierunkowe | ✅ pełne | VW-NA-Cloud (Beta) |
+| **VW EU** | ⚠️ przez hybrydowy OIDC (~2h re-login) | ✅ portal tylko do odczytu / vw.de-Beta | backend za atestacją |
+| **CUPRA / SEAT** | ❌ OLA zablokowane (App Check) | ✅ portal tylko do odczytu | od ~2026-06-08, nie do naprawienia nagłówkiem |
 
 ---
 
-## Funkcje
+## Co dostajesz
 
-| Feature | Audi | VW EU | Škoda | SEAT/CUPRA |
-|---|:---:|:---:|:---:|:---:|
-| Fuel / Battery level | ✓ | ✓ | ✓ | ✓ |
-| Range | ✓ | ✓ | ✓ | ✓ |
-| Odometer | ✓ | ✓ | ✓ | ✓ |
-| GPS position | ✓ | ✓ | ✓ | ✓ |
-| Doors (total + per door) | ✓ | ✓ | ✓ | ✓ |
-| Windows | ✓ | ✓ | ✓ | ✓ |
-| Climate start/stop | ✓ | ✓ | ✓ | ✓ |
-| Target temperature | ✓ | ✓ | ✓ | ✓ |
-| Lock / Unlock | ✓ | ✓ | ✓ | ✓ |
-| Flash lights | ✓ | ✓ | ✓ | ✓ |
-| Wake vehicle | ✓ | ✓ | ✓ | ✓ |
-| Service due km/days | ✓ | ✓ | ✓ | ✓ |
-| Online status | ✓ | ✓ | ✓ | ✓ |
-| Battery SoC % | ✓ | ✓ | ✓ | ✓ |
-| Charge state | ✓ | ✓ | ✓ | ✓ |
-| Charge power kW | ✓ | ✓ | ✓ | ✓ |
-| Charge speed km/h | ✓ | ✓ | ✓ | ✓ |
-| Charge ETA | ✓ | ✓ | ✓ | ✓ |
-| Charge target % | ✓ | ✓ | ✓ | ✓ |
-| Trunk / hood / sunroof | ✓ | ✓ | ✓ | ✓ |
-| Window heating | ✓ | ✓ | ✓ | ✓ |
-| Vehicle renders | ✓ | — | — | ✓ |
-| Departure timers 1–3 | ✓ | ✓ | — | — |
-| Battery temperature | ✓ | ✓ | — | — |
-| AdBlue range | ✓ | ✓ | — | ✓ |
+100+ encji w 11 platformach HA, 20+ wywołań usług, natywne wsparcie wielu pojazdów na konto. Quality-Scale Platinum.
+
+**Sensory** (per pojazd): Battery SoC, Range (electric / combustion / total), Fuel Level, Odometer, Outside Temp, Battery Temp, 12V Voltage, Service Days, Oil Service Days, Charging Power / Rate / Type, Last Trip Stats, Lifetime Trip Aggregates, Charging History, Plug State, Lights Count, Equipment Count, Software Version, API Quota Remaining, Connection State, Last Seen, Skoda Driving Score, Porsche TPMS 4 Corners, Last Alarm Timestamp, Heater Source dla ID.x, Oil Level Warning, ostrzeżenia pojazdu (sensor tekstowy ze wszystkimi ostrzeżeniami backendu).
+
+**Binary Sensors**: Doors Locked, Doors Open per drzwi, Windows Open per okno, Trunk / Hood / Sunroof, Plug Connected, Charging, OTA Update Available, 12V Low Warning, Lights On per światło, Vehicle Online, Departure-Timer 1-3 Enabled, Alarm Active + Siren Active, TPMS Warning.
+
+**Sterowanie**: Lock/Unlock, Climate Start/Stop, Charging Start/Stop, Window Heating, Cabin Ventilation (CUPRA/SEAT), Aux Heating (Webasto), Departure Timer 1-3 z Weekly-Preheat, Set Target SoC, Set Target Temp, Set Max Charge Current, Set Charge Mode, Honk-and-Flash, Wake Vehicle, Refresh, Find Charging Stations.
+
+**Image Platform**: 1-7 renderów pojazdu per VIN (Audi/VW przez GraphQL MediaService, CUPRA/SEAT przez OLA viewPoints, Skoda przez Widget + Multi-Angle Composites).
+
+**Device Tracker**: pozycja GPS jako TrackerEntity dla mapy HA Lovelace.
 
 ---
 
 ## Instalacja
 
-### HACS
+### Opcja 1: One-Click (zalecane)
+
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vwgroup-connect-ha&category=integration)
+
+### Opcja 2: HACS Custom Repository
 
 1. HACS → Integracje → ⋮ → Niestandardowe repozytoria
-2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Kategoria: Integracja
-3. Zainstaluj **VW Group Connect** → Uruchom ponownie Home Assistant
-4. Ustawienia → Integracje → **+ Integracja** → **VW Group Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha`
+3. Kategoria: Integration
+4. Zainstaluj **VW Group Connect**
+5. Uruchom ponownie Home Assistant
 
-### Manual
+### Opcja 3: Ręcznie
 
 ```bash
-cp -r custom_components/vag_connect ~/.homeassistant/custom_components/
+cd /config/custom_components
+git clone https://github.com/its-me-prash/vwgroup-connect-ha.git
+mv vwgroup-connect-ha/custom_components/vag_connect .
+rm -rf vwgroup-connect-ha
 ```
 
-Uruchom ponownie Home Assistant.
+Następnie uruchom ponownie HA.
 
 ---
 
 ## Konfiguracja
 
-| Field | Required | Description |
-|---|---|---|
-| Marka | ✓ | Audi / Volkswagen / Škoda / SEAT / CUPRA |
-| E-mail | ✓ | E-mail logowania z aplikacji producenta |
-| Hasło | ✓ | Hasło z aplikacji |
-| S-PIN | — | Wymagany do blokowania (w Bezpieczeństwo w aplikacji) |
-| Interwał | — | Minuty między aktualizacjami (domyślnie: 5) |
+Ustawienia → Urządzenia i usługi → Dodaj integrację → "VW Group Connect"
 
-**Która aplikacja?** Audi → myAudi · VW → WeConnect · Škoda → MyŠkoda · SEAT → My SEAT · CUPRA → MyCupra
+**Przy pierwszej konfiguracji wybierasz:**
 
----
+- **Logowanie przez przeglądarkę** (zalecane dla Audi/Škoda/SEAT/CUPRA): zeskanuj kod QR lub otwórz URL, hasło nie jest zapisywane w HA
+- **E-mail + hasło** (dla VW EU, Porsche, VW US/CA): klasycznie z danymi Brand-ID
 
-## Znane Ograniczenia
-
-- **S-PIN** wymagany do blokowania
-- **Interwał** minimum 5 minut
-- **2FA** — potwierdzić raz ręcznie w aplikacji
-- **Porsche / VW NA** — działające jako Beta, szukamy testerów
+**Opcje** (dostępne po konfiguracji):
+- Interwał odpytywania (5-60 min, domyślnie 10 min)
+- Tryb read-only dla bezpiecznych automatyzacji bez przypadkowych komend
+- Reverse-geocoding opt-in (wysyła GPS do OpenStreetMap w celu rozwiązania adresu)
+- Push-Toggles (Skoda MQTT, CUPRA/SEAT FCM, Audi/VW FCM) jako fundament, aktywacja live w toku
 
 ---
 
+## Przykłady Lovelace
+
+### Map Card
+
+```yaml
+type: map
+title: Fuhrpark
+default_zoom: 12
+hours_to_show: 24
+entities:
+  - device_tracker.audi_a4_b9_position
+  - device_tracker.vw_golf_7_gte_position
+  - zone.home
+```
+
+### Picture-Entity Card z renderem pojazdu
+
+```yaml
+type: picture-entity
+entity: image.audi_a4_b9_render_side_lg
+camera_view: live
+show_state: false
+show_name: false
+```
+
+### Wyszukiwanie stacji ładowania
+
+```yaml
+action: vag_connect.find_charging_stations
+data:
+  vin: WAUZZZ...
+  latitude: 47.3769
+  longitude: 8.5417
+  radius_m: 5000
+  max_results: 25
+response_variable: result
+```
+
+Więcej przykładów w [`docs/FAQ.md`](docs/FAQ.md). Niestandardowe karty Lovelace integrują się automatycznie przez `extra_state_attributes.image_url`.
+
+---
+
+## Najczęstsze pytania
+
+| Pytanie | Odpowiedź |
+|---|---|
+| Kiedy moje auto jest budzone? | Tylko przy wywołaniach usług (Lock/Climate/Wake), nigdy przy odpytywaniu statusu. Smart-Wake-Cap: maks. 3 wybudzenia/dzień na auto, cooldown 5 min. |
+| Ile API-Quota? | MyCupra/MySeat: ~1500 wywołań/dzień. Przy odpytywaniu co 10 min: ~144 wywołań/dzień = 10% budżetu. Sensor `requests_remaining_today` pokazuje stan. |
+| Dlaczego przy VW EU muszę logować się ponownie co 2 h? | VW od 2026-05-27 umieścił endpoint tokenu za Google Play Integrity. Dotyczy to każdej integracji VAG opartej o Python. EU Data Act 2026-09-12 powinno to naprawić. |
+| Czy token przetrwa aktualizację HACS? | Tak, od v1.19.2 dzięki persystencji w HA Store. |
+| Jak zgłaszać błędy? | HA → Integracja → 🔧 Napraw → Bug-Report. Diagnostyka jest anonimizowana (VIN-y zamaskowane, GPS zaokrąglony, tokeny usunięte). |
+| Etykiety pól pokazują surowe klucze (`brand`, `spin`) po aktualizacji? | Twarde odświeżenie przeglądarki (Ctrl+Shift+R). HA cache'uje tłumaczenia po stronie klienta. |
+
+Pełne FAQ w [`docs/FAQ.md`](docs/FAQ.md). Rozwiązywanie problemów z dashboardami w [`docs/dashboards.md`](docs/dashboards.md).
+
+---
+
+## Prywatność i bezpieczeństwo
+
+- Brak zewnętrznych usług, wszystko bezpośrednio między HA a API producenta
+- Token-Cache lokalnie w `.storage/` HA (per-config-entry, JSON, automatycznie usuwany przy usunięciu integracji)
+- Diagnostyka anonimizowana: VIN-y zamaskowane, GPS zaokrąglony do 1 miejsca po przecinku, tokeny i hasła całkowicie usunięte
+- Reverse-geocoding opt-in, domyślnie wyłączony
+- Maskowanie VIN konsekwentnie we wszystkich logach
+- URL-e z tokenami są redagowane w logu ERROR (v2.7.2+)
+
+Szczegóły w [`PRIVACY.md`](PRIVACY.md) i [`SECURITY.md`](SECURITY.md).
+
+---
+
+## Contributing
+
+PR-y mile widziane, patrz [`CONTRIBUTING.md`](CONTRIBUTING.md). Reguły stylu w [`STYLE.md`](STYLE.md) (prywatne w `_private/STYLE.md` dla maintainerów).
+
+**Vehicle Data Scout** (live od v1.9.0): gdy twoja integracja wykryje nieznane pola JSON, automatycznie tworzy powiadomienie HA Repair z gotowym linkiem do issue na GitHubie. Bug-Report jednym kliknięciem, bez studiowania kodu.
+
+---
 
 ## Licencja
 
-Apache License 2.0 — [LICENSE](LICENSE)
-
-**VW Group Connect™** jest niezastrzeżonym znakiem towarowym (™, nie ®). Prosimy nie używać tej nazwy w forkach, aby uniknąć nieporozumień.
-
-Ta integracja jest niezależnym projektem społecznościowym bez powiązania z Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG ani żadną filią Grupy Volkswagen.
-
----
-
-*Copyright 2026 [Prash Balan](https://github.com/its-me-prash) · Apache License 2.0*
+[Apache License 2.0](LICENSE) dla kodu integracji. [CC BY-NC-ND 4.0](LICENSE-RESEARCH) dla treści `docs/research/`. Atrybucje do upstreamowych projektów open-source w [`NOTICE.md`](NOTICE.md).

--- a/README.sv.md
+++ b/README.sv.md
@@ -5,347 +5,253 @@
 <h1 align="center">VW Group Connect</h1>
 
 <p align="center">
-  <strong>Home Assistant Integration för Audi · VW · Škoda · SEAT · CUPRA</strong>
+  <strong>Home Assistant-integration för Audi · VW · Škoda · SEAT · CUPRA · Porsche · VW US/CA</strong><br>
+  <em>En integration för alla 7 VAG-märken, direkt API-åtkomst, utan mellanlager</em>
 </p>
 
 <p align="center">
-  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha?style=for-the-badge"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"></a>
-  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/downloads/its-me-prash/vwgroup-connect-ha/total?style=for-the-badge&label=Downloads" alt="Downloads"></a>
-  <a href="../custom_components/vag_connect/quality_scale.yaml"><img src="https://img.shields.io/badge/Quality%20Scale-Platinum%20%F0%9F%8F%86-gold?style=for-the-badge"></a>
+  <a href="https://hacs.xyz"><img src="https://img.shields.io/badge/HACS-Custom-orange.svg" alt="HACS"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/releases"><img src="https://img.shields.io/github/v/release/its-me-prash/vwgroup-connect-ha" alt="Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="Licens"></a>
+  <a href="https://www.home-assistant.io"><img src="https://img.shields.io/badge/Home%20Assistant-2025.1%2B-blue" alt="Home Assistant"></a>
+  <a href="https://github.com/its-me-prash/vwgroup-connect-ha/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/its-me-prash/vwgroup-connect-ha/ci.yml?branch=main&label=CI" alt="CI"></a>
+  <a href="https://www.home-assistant.io/docs/quality_scale/"><img src="https://img.shields.io/badge/quality_scale-platinum-d4af37" alt="Quality Scale Platinum"></a>
 </p>
 
 <p align="center">
-  <a href="../README.md">Deutsch</a> ·
+  <a href="README.md">Deutsch</a> ·
   <a href="README.en.md">English</a> ·
   <a href="README.fr.md">Français</a> ·
-  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.es.md">Español</a> ·
+  <a href="README.nl.md">Nederlands</a> ·
   <a href="README.pl.md">Polski</a> ·
-  <a href="README.cs.md">Čeština</a> ·
-  <a href="README.sv.md">Svenska</a>
+  <a href="README.cs.md">Čeština</a>
 </p>
 
 ---
 
 > ### 📛 Note on the rename
-> Previously published as **`vag-connect-ha`** (VAG = Volkswagen AG, standard DACH abbreviation).
-> Turns out that abbreviation reads *quite* differently to English speakers 😅
+> Tidigare publicerad som **`vag-connect-ha`** (VAG = Volkswagen AG, vanlig DACH-förkortning).
+> Det visade sig att förkortningen låter *rätt så annorlunda* för engelsktalande 😅
 >
-> **What keeps working as before**: all entities (e.g. `sensor.audi_q4_battery_soc`),
-> all service-calls (`vag_connect.lock`, `vag_connect.show_vag` etc.), all automations,
-> the HACS install — **nothing breaks**. Marketing/display name changes, code internals
-> stay unchanged. See [`MIGRATION.md`](MIGRATION.md).
+> **Det som rullar vidare oförändrat**: alla entiteter (t.ex. `sensor.audi_q4_battery_soc`),
+> alla service-anrop (`vag_connect.lock`, `vag_connect.show_vag` osv.), alla automationer,
+> HACS-installationen — **inget går sönder**. Marknadsförings-/visningsnamnet ändras,
+> kodens interna delar är desamma. Detaljer i [`MIGRATION.md`](MIGRATION.md).
 >
-> Huge thanks to the **Home Assistant UK** and **HA Ideas, Projects and Solutions**
-> communities for the heads-up — especially **Si Gregory**, **Ben Johnson**, and **Evets David**.
+> Stort tack till communityn **Home Assistant UK** och **HA Ideas, Projects and Solutions**
+> för tipset — särskilt **Si Gregory**, **Ben Johnson** och **Evets David**.
 >
-> And a special shoutout to **Jordan Waeles**, whose `show_vag()` comment is now an officially
-> supported easter egg in this integration (`vag_connect.show_vag` service, see CHANGELOG v2.2.3).
+> Och en särskild hälsning till **Jordan Waeles**, vars `show_vag()`-kommentar nu är ett officiellt
+> stött easter egg i den här integrationen (`vag_connect.show_vag`-service, se CHANGELOG v2.2.3).
 
 ---
 
+## Vad är det här?
 
-## Nytt i v2.10.0
+**VW Group Connect är en [Home Assistant](https://www.home-assistant.io)-integration för uppkopplad fordonsdata och styrning över alla sju märkena i Volkswagen-koncernen — Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche och VW US/Canada — från en enda config-entry, installerbar via [HACS](https://hacs.xyz).**
 
-Den största releasen av denna integration hittills. Runt 6 veckors intensivt arbete i en enda cut.
+Den visar batteri- och laddningsstatus, räckvidd, vägmätare, klimat, dörrar/fönster och position, och — där märkets backend fortfarande tillåter det (t.ex. Audi) — skickar kommandon som lås/lås upp, klimat- och laddningsstyrning. För att fortsätta fungera genom Volkswagens API-ändringar 2026 talar den flera kanaler och faller automatiskt tillbaka när en blockeras: de märkesegna backendarna, den läs-bara fordonsdata-portalen enligt **EU Data Act**, och en opt-in-webbkanal via `volkswagen.de`.
 
-- **Fix för VW EU Auth0 SPA-login (#388)**: VW migrerade lösenordssidan till en full-SPA-mall runt 2026-05-31. JSON Content-Type retry mot `/u/login` plus skärpt consent-detektion låser upp användare på classic-auth.
-- **Parser-paritet över varumärken**: VW EU Group A (10 nya fält - 12V, aktiv ventilation, bakre takfönster, cabriolet-suff, totaler per-resa), SEAT/CUPRA Group B (6 OLA-endpoints - warning-lights v3, inställbar battery-care, charging-statistics, föredragen verkstad), VW NA Group C (4 endpoints - migration till `data.exteriorStatus.*`, fixar "allt-null"-symptomet på ID.4 US 2023 #322).
-- **VW kontolås-detektion** med guidad Repairs issue + auto-clear.
-- **Scout Policy-tvång**: varje silenced JSON-väg måste också parsas till en entity, eller bära ett explicit T2-T5 exemption-kommentar. Stänger #384, #389.
-- **Provenance canaries + veckovis watcher** + härdning (SPDX, Bruno drift-gate, mypy strict).
+Till skillnad från portal-bara integrationer täcker den dessutom **Porsche** (som EU Data Act-portalen utesluter) och behåller **tvåvägsstyrning för Audi**.
 
-Resten från v2.7-v2.9 fortfarande live: Browser-Login DAG, multi-strategy auth, Data Act Portal, MFA, FCM push, Standheizung, brake-service, parser telemetry.
+> En [Home Assistant](https://www.home-assistant.io)-integration för uppkopplad fordonsdata och -styrning över alla sju VW-koncernmärken (Volkswagen, Audi, Škoda, SEAT, CUPRA, Porsche, VW US/CA) — en integration, flera datakanaler, automatisk fallback, installation via HACS.
 
-Full [CHANGELOG](CHANGELOG.md#2100---2026-06-02).
+---
 
-## Nytt i v2.7.x
+## Aktuellt
 
-**Browser-inloggning (inget lösenord lagras i HA) för Audi, Škoda, SEAT, CUPRA.** OAuth Device Authorization Grant enligt RFC 8628. Skanna en QR-kod med telefonen eller öppna URL:en på vilken enhet som helst, bekräfta en kort kod, klar. Riktig refresh_token, ingen om-inloggning varannan timme.
+VW har under 2026 steg för steg stängt direktåtkomsten för tredjepartsverktyg (CARIAD-BFF med enhets-attestation, CUPRA/SEAT-OLA bakom Play Integrity sedan juni 2026). Den här integrationen förblir användbar eftersom den talar **flera kanaler** och växlar automatiskt så fort en blockeras:
 
-**Multi-strategi auth-resolver.** Upp till tre fallback-strategier per märke (Browser-Login, OIDC Hybrid Flow, EU Data Act Portal endast läs). En strategi dör, integrationen kör vidare på nästa.
+- **Märkesegna backendar** — full åtkomst inkl. styrning, där det är möjligt (Audi, Škoda, Porsche, VW US/CA).
+- **EU Data Act-portal** — läs-bar fallback för alla märken (attestationsfri, ~15 min kadens).
+- **volkswagen.de-webbkanal (Beta, opt-in)** — andra attestationsfria läskanal för VW.
 
-**Data Act Portal som fallback endast läs.** Egen implementation av EU Data Act portal-login, integrerad som 3:e-tiers-strategi. Endast läs men utan attestation, alltså obrytbar när VW skärper OAuth-vägen.
+Det pågående arbetet handlar om portal-robusthet (timeout-retry, dataaktualitet) och resiliens över kanalerna.
 
-**Många fler datapunkter.** Resstatistik (livstidsavstånd, sista resan), oljenivå, däcktryck per hjul, dörrar / fönster / soltak / baklucka per position, utomhustemperatur på MY24+, Webasto motorvärmare, alla tillverkarvarningar inklusive märkesspecifika som Audi STO.
-
-Se [CHANGELOG](CHANGELOG.md#270---2026-05-31).
+➡️ Fullständig versionshistorik: **[CHANGELOG.md](CHANGELOG.md)**.
 
 ---
 
 ## Var vi leder
 
-Status per 2026-05-31, efter VW backend-ändringen 2026-05-27 som drabbade hela HA-VAG-integrations-communityt samtidigt:
+Ärligt läge i mitten av 2026: EU Data Act-portalen har nu blivit den de facto standardkanalen, och många integrationer använder den. Det som konkret skiljer oss:
 
-| Funktion | Status här | Status hos andra |
+| Styrka | Vi | Portal-bara alternativ |
 |---|---|---|
-| OAuth Device Authorization Grant (QR-Login) för Audi/Škoda/SEAT/CUPRA | ✅ sedan v2.7.0 | Ingen |
-| Multi-strategi auth-fallback-kedja (3 tiers per märke) | ✅ sedan v2.6.0 | Ingen |
-| EU Data Act-portal endast läs som 3:e-tiers fallback | ✅ sedan v2.6.0 | Endast som separat integration |
-| InvalidURL säkerhetsnät mot token-läckage i loggar | ✅ sedan v2.7.2 | Ingen |
-| Server-side attestation gate watcher | ✅ sedan v2.7.0 | Ingen |
-| Vehicle Data Scout, auto-detektion av API-drift | ✅ sedan v1.9.0 | Inget jämförbart |
-| Alla 7 VAG-märken i en integration | ✅ | Andra projekt har en repo per märke |
+| **Alla 7 koncernmärken inkl. Porsche** i en integration | ✅ | EU Data Act-portalen **utesluter Porsche strukturellt** — portal-bara verktyg kan aldrig täcka Porsche |
+| **Tvåvägsstyrning för Audi** (lås/klimat/laddning, sätta target-SoC) | ✅ | Portalen är by-design **läs-bar** |
+| **Multi-channel-auth med auto-fallback** (märkes-backend → EU Data Act-portal → opt-in vw.de-webb) | ✅ | oftast single-source — ett portalavbrott = totalavbrott |
+| **Vehicle Data Scout** — upptäcker API-drift automatiskt, genererar 1-klicks bug-rapporter | ✅ | inget jämförbart |
 
 ---
 
 ## Var gränserna går (ärligt)
 
-**VW EU är hårt Play-Integrity-låst sedan backend-ändringen 2026-05-27.** Denna mur drabbar varje Python-baserad VAG-integration (vår inräknad). Det är inte en tillfällig fördröjning från vår sida, det är VW:s backend-politik:
+**VW EU och CUPRA/SEAT-OLA ligger sedan 2026 bakom enhets-attestation.** Den här muren (Google Play Integrity / Firebase App Check) drabbar varje Python-baserad VAG-integration — vår inräknad. Det är ingen fördröjning från vår sida, utan VW:s backend-politik:
 
-- Token-endpoint validerar en `X-Assertion` header som måste vara en JWS-token signerad av Google Play Integrity
-- Python kan inte generera den här token, signeringsnyckeln finns endast i Googles mobile-app attestation-tjänst
-- Konsekvens: VW EU-användare får ingen riktig refresh_token och tvingas in i om-inloggning var ~2:e timme
+- Token-/OLA-endpointen kräver en attestation-token signerad av den officiella appen, som Python inte kan generera (signeringsnyckeln finns endast i Googles/Firebases attestation-tjänst).
+- Konsekvens: **VW EU** får ingen varaktig `refresh_token` (OIDC-hybrid-flödet håller ~2 h), och **CUPRA/SEAT** via OLA får sedan ~2026-06-08 `403 "Forbidden device detected"`.
 
-Vad vi ändå erbjuder för VW EU: OIDC Hybrid Flow som primär strategi (läs + skriv, 2h re-login), EU Data Act-portal som fallback endast läs (15-min kadens, utan attestation), veckovis watcher som automatiskt öppnar ett ärende när VW öppnar grinden.
+Vad vi ändå erbjuder:
 
-**EU Data Act 2026-09-12 compliance-deadline.** Vid det datumet måste VW lagligen erbjuda direkt fordonsdata-åtkomst till ägare utan attestation-gating. Vår `_data_act_portal.py` är positionerad för den dagen.
+1. **EU Data Act-portal** som läs-bar fallback för alla märken (attestationsfri, ~15 min kadens) — tar automatiskt över när den nativa backenden blockerar.
+2. **volkswagen.de-webbkanal (Beta, opt-in)** som andra attestationsfria läskanal för VW.
+3. **OIDC-hybrid-flöde** för VW EU som läs+skriv-strategi (med 2h-ominloggningen som pris).
 
-## ✨ v2.0.0 Big-Bang Highlights — also available in English
+**EU Data Act-deadline 2026-09-12.** Senast då måste VW enligt EU-förordning erbjuda direkt, attestationsfri ägardataåtkomst — portalens fälttäckning väntas växa vidare fram till dess.
 
-> The detailed v2.0.0 highlights table + "What makes us unique" USP section
-> are maintained in English on the German + English READMEs. They are
-> provided here as the canonical source so non-DE/EN readers can still
-> see all v2.0 features with `` markers without waiting on
-> 6 parallel translations.
+Status per märke:
 
-### Latest highlights — v2.0.0 Big-Bang
-
-| Feature | Status |
-|---|---|
-| **Skoda Driving-Score Sensor** | Efficiency score 0-100 + class bucket for Skoda MY24+ |
-| **Cross-brand Aux-Heating parity (Skoda)** | SkodaClient now inherits the Webasto switch from SEAT/CUPRA |
-| **Porsche TPMS sensors** | 4 tire-pressure sensors + warning binary_sensor (PPA TIRE_PRESSURE) |
-| **Long-Term Trip Aggregates** | Lifetime distance / avg fuel / avg electric (Audi + VW EU) |
-| **Departure-Timer Read-Only Binary-Sensors** | 3 pure-read enabled-sensors |
-| **Weekly Preheat (`recurring_on`)** | Service param for weekday lists (Audi + VW EU + VW NA) |
-| **Charging-Station POI Lookup** | `vag_connect.find_charging_stations` service |
-| **Vehicle Alarm sensors** | closes issue #33 |
-| **heaterSource sensor** | closes issue #163 |
-| **Push Manager Lifecycle Wiring** | Skoda MQTT + CUPRA/SEAT FCM + Audi/VW Cariad FCM (opt-in) |
-| **EU Data Act Abstraction Shim** | Architectural seam for the 2026-09-12 EUDA Art. 3 deadline |
-| **Auth Resilience One-Click Repair** | Repair button for 4 auth reasons triggers reauth flow |
-| **System Health Panel** | Drop-in `system_health.py` |
-| **Quality Scale Platinum** | Re-introduced after v1.26.x revert |
-| **DeviceInfo `configuration_url` + `suggested_area`** | Brand-aware "Open in App" button |
-
-### What makes us unique
-
-- **Native coverage of all 7 VAG brands** in a single integration
-- **Direct manufacturer-API access** without middleware / Docker / 3rd service
-- **Vehicle Data Scout** — automatic JSON-field drift detection with Repair notification + 1-click GitHub issue
-- **Capability-Filter Phase 3** — phantom entities suppressed before spawn
-- **Per-VIN wakeup cap + cooldown** — protects 12V battery
-- **Auth Resilience One-Click Repair** — reauth flow from Repairs panel
-- **System Health Panel** — at-a-glance push channel status, API quota, last poll
-- **Bruno-CI Stage 2** — strict URL-drift check
-- **Token persistence across HA updates** — no re-login after HACS updates since v1.19.2
-- **Diagnostics anonymisation by default** — VINs, GPS, tokens stripped before export
-
-
-Jag ville styra min Audi i Home Assistant — fullständigt. Så jag byggde detta.
-
-**VW Group Connect** är en fristående Home Assistant-integration för alla VAG-märken. Inga externa beroenden, ingen Docker, inga externa tjänster.
-
-Från v0.14.1 kommunicerar integrationen **direkt** med CARIAD API — egen async-klient, helt fristående. Cloud-polling-arkitektur, 80+ entiteter över 10 plattformar, 14 tjänster.
-
-> ✅ **Aktivt underhållen multi-märkes-efterträdare** till [`mitch-dc/volkswagen_we_connect_id`](https://github.com/mitch-dc/volkswagen_we_connect_id) (arkiverat 2025-10-29) och [`skodaconnect/homeassistant-skodaconnect`](https://github.com/skodaconnect/homeassistant-skodaconnect) (deprecated 2025-03-14). En integration för Audi, VW, Škoda, SEAT, CUPRA, Porsche och VW US/CA — ingen separat plugin per märke.
-
-## Nuvarande status och ärliga begränsningar / Current Status & Honest Limits (v1.12.3)
-
-VW Group Connect utvecklas aktivt vidare. Så att du vet vad som fungerar och vad som kommer:
-
-### ✅ Vad som fungerar NU (alla 7 märken)
-
-**🛰️ 1-klick bug rapporter & feature-önskemål (LIVE sedan v1.9.0)**
-
-Två diagnostiska sensorer med en gemensam reporter pipeline — **första riktiga live-validering av community-användare** i v1.10.2 (Gerhard / CUPRA Born), v1.12.2 (tritanium73 / Skoda) och v1.12.3 (DnnsJp74 / Audi):
-
-- 🔬 **Vehicle Data Scout** — upptäcker automatiskt okända JSON-fält i din bils API. Märkes-lokaliserad på 8 språk (DE: API-Beobachter, FR: Observateur d'API, etc.).
-- 🚨 **Error Reporter** — Ring-buffer av de senaste 20 integrationsfelen med anonymiserad kontext (modell, firmware, stack trace).
-- 🔘 **Reporter Pipeline:** båda sensorerna skapar automatiskt HA Repair-notifikationer med ett förifyllt GitHub-Issue som 1-klicks länk. Plus en diagnostics-nedladdning med allt maskerat för forum/Facebook.
-- 🔒 **Integritetslöfte:** Inget lämnar din HA utan din explicita klick. VIN maskerade, GPS avrundad till 1 decimal, JWT/UUID/e-post borttagna. GDPR-compliant.
-
-**🟢🟡⚫ Multi-Brand Connection-State (v1.8.12)**
-
-Sensor `connection_state` (online / standby / offline) för Audi, VW EU, Škoda, SEAT, CUPRA — första VAG-integration med centraliserad anslutningsstatus. Brand-agnostisk helper `compute_connection_state` med rekursiv `carCapturedTimestamp` walk.
-
-**🔋 12V-batteri-övervakning + Smart-Wake (v1.12.0)**
-
-- Sensor `voltage_12v` (V) + binary `warning_12v_low` vid <11.5V — förhindrar tysta API-avbrott orsakade av tomt startbatteri
-- Sensor `wake_count_today` + soft-cap på 3 wakes/dag (`_WAKE_BUDGET_PER_DAY`) skyddar 12V mot wake-loops, höjer `wake_budget_exhausted` INNAN API-anrop
-
-**💨 Optimistisk UI för Lock/Climate/Charging (v1.11.1)**
-
-Switches växlar omedelbart vid klick (myskoda PR #832 mönster), API-roundtrip i bakgrunden. Vid misslyckande: revert + ServiceValidationError. 8 actuator-metoder migrerade.
-
-**🔋 PHEV-Range-Triple (v1.10.0 + #94 + #96 follow-up i v1.11.1)**
-
-Tre explicita räckviddssensorer: `electric_range_km`, `combustion_range_km`, `total_range_km`. VW EU/Audi-parser klassificerar efter motortyp (4 källor istället för 2). Audi-diesel-fallback från `measurements.rangeStatus.value.dieselRange`. Verifierat via evcc-io/evcc#19045 + Audi Q4 sample + CarConnectivity-loggar.
-
-**🔒 Read-only-läge Fas 1 (v1.12.0)**
-
-Options-toggle "Read-only Mode" → hoppa över lock/switch/button(non-refresh)/climate/number-plattformar för privacy/safety-konservativa ägare. Sensors + binary_sensors + device_tracker stannar.
-
-**⚡ Skrivbar Max-Charge-Current Number (v1.12.0)**
-
-Slider 6-32A istället för bara en read-only-sensor. Ny `command_set_max_charge_current` POST chargingSettings.
-
-**💡 Per-Light Binary-Sensors (v1.12.0)**
-
-Dynamiskt per ljustyp från `lights_individual` dict + aggregat `lights_on` + `lights_count`.
-
-**🛠️ Defensiv stabilitet (v1.8.7 + v1.10.1)**
-
-- 504-retry, transient-network-error retry, 6h stale-cache + 3-failure tolerance
-- Token-refresh-storm-skydd (max 3/h) — förhindrar IP-bans
-- Helpers `safe_int` / `safe_float` / `safe_enum` — tolererar backend-quirks
-
-**🚪 CUPRA Born 2026 Firmware-Shapes (v1.10.2 — Gerhards #53 första live-validering)**
-
-Field-name fallback-kedja: `battery.currentSocPercentage` (Born 2026) → `currentPct` (Rainer #109) → `currentSOC_pct` (legacy). Lowercase enum tolerance för `"connected"` / `"locked"`. Bakåtkompatibilitet bevarad.
-
-**🔓 Lock + Wake för Audi/VW (v1.9.1, #92 Audi S6 C8)**
-
-`command_lock` skickar nu S-PIN för Audi/VW (CARIAD BFF svarade `403 spin_error`). `command_wake` använder v1→v2 fallback.
-
-**🛡️ Capability-Filter Fas 2 (v1.9.1, #56)**
-
-Body-sniffing `classify_command_failure` för `missing-capability` / `subscription_expired` / `not_entitled` / `spin_error` markörer. `_cariad_cmd` skriver varje resultat till FeatureState. Command-bundna entiteter (Lock/Climate/Switch/Buttons) går automatiskt unavailable vid definitivt "nej" från backend.
-
-### ⚠️ Fortfarande pågår / What's still in progress (planerade sessioner)
-
-- **v1.13.0 MINOR** — Anonymized Diagnostics-Export (#62) + Capability-Filter Fas 3 (`capability.active && user-enabled` PRE-entity-creation, döljer knappar som MyCupra-appen) + Read-only Fas 2/3 (Command-Locking + cloud_refresh vs wake_vehicle service-separation).
-- **v1.14.0 MINOR** — Trip Statistics från Audi `tripstatistics/v1` (#24, #35).
-- **v1.15.0+ MINOR** — PPC Climate Body conditional shape (#29, #51), Theft/Alarm Binary (#33), Climate-Timer UI (#26).
-- **v1.16.0 MINOR** — Platsspecifik laddmål-SoC + laddprofiler (#25, #31).
-- **v1.17.0 MINOR** — Remote Start ICE (#28, upstream #717-mönster).
-- **v1.18.0 MINOR** — Push CUPRA/SEAT (Firebase FCM) + Push Skoda (mysmob MQTT) för realtidsuppdateringar utan polling (#57, #27).
-- **v2.0.0 MAJOR** — HACS Default + Live-tester alla märken + EU Data Act ready (pycupra `EUDAConnection` som referens, deadline september 2026) (#13, #59).
-
-### 🚫 Medvetna begränsningar / Conscious limits
-
-- **Image-plattform:** inget officiellt CARIAD render-image API existerar. Image-entiteten kommer i en framtida release att gå över till användar-tillhandahållna URL:er.
-- **PPC/PPE Audi 2025+** (Q5, A5/S5, A6 e-tron, Q6 e-tron, RS e-tron GT Facelift) — ny E³ 1.2-arkitektur, ännu inte offentligt reverse-engineered (varken i upstream eller CarConnectivity). VW Group Connect upptäcker dessa fordon och gör **graceful degradation** istället för 404-fel.
-- **Ford / icke-VAG-märken:** utanför scope — se [`marq24/ha-fordpass`](https://github.com/marq24/ha-fordpass) för Ford.
-
-### 🔧 Integritetskrav
-
-För att GPS-position, fordonsstatus och kupévärmare ska fungera måste **"Dela min position"** vara aktiverat i din My-VW / My-Audi / MySkoda / MyCupra-app — annars svarar backend med 403.
-
-### 📚 Mer info / More info
-
-- 🗺️ Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) — komplett P0/P1/P2/P3-prioritering av alla öppna issues
-- 📜 Tech Changelog: [`docs/CHANGELOG_TECHNICAL.md`](docs/CHANGELOG_TECHNICAL.md) — per release: field-mappings + arkitekturbeslut + externa source-refs
-- 🎨 Dashboards-guide + Lovelace-kort BETA: [`docs/dashboards.md`](docs/dashboards.md) — "Lägg till på instrumentpanel" felsökning + dedikerat Lovelace-kort (BETA)
-- 🤝 Session Handoff (för bidragsgivare och AI-verktyg): [`docs/SESSION_HANDOFF.md`](docs/SESSION_HANDOFF.md)
-- 🔒 Integritets- och datahanteringsregler: sektion [`CONTRIBUTING.md`](CONTRIBUTING.md) (post-#53 third-party review)
-- 📋 FAQ Subscription / Service Plus / `missing-capability` diagnos: FAQ-sektion i [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
----
-
-## Stödda Märken
-
-| Brand | Auth | API | Status |
+| Märke | Styrning | Data | Anmärkning |
 |---|---|---|---|
-| **Volkswagen EU** | IDK | emea.bff.cariad.digital | ✅ |
-| **Audi** | IDK + AZS/MBB | emea.bff.cariad.digital | ✅ |
-| **Škoda** | IDK | mysmob.api.connect.skoda-auto.cz | ✅ |
-| **SEAT** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| **CUPRA** | IDK | ola.prod.code.seat.cloud.vwgroup.com | ✅ |
-| Porsche | Auth0 | api.ppa.porsche.com | ✅ Beta |
-| VW NA (US/CA) | VW NA Auth | b-h-s.spr.*.p.con-veh.net | ✅ Beta |
-
-> **Porsche & VW NA:** Båda märkena har varit tillgängliga som Beta sedan v1.0.0. Testare sökes — rapportera feedback som [Issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)!
+| **Audi** | ✅ Tvåvägs | ✅ full | myAudi-backend, ingen attestation-mur |
+| **Škoda** | ✅ Tvåvägs | ✅ full | egen Škoda-backend |
+| **Porsche** | ✅ Tvåvägs | ✅ full | Auth0 + PPA, stabil |
+| **VW US/CA** | ✅ Tvåvägs | ✅ full | VW-NA-cloud (Beta) |
+| **VW EU** | ⚠️ via OIDC-hybrid (~2h ominloggning) | ✅ läs-bar portal / vw.de-beta | Backend-attestations-gateat |
+| **CUPRA / SEAT** | ❌ OLA blockerad (App Check) | ✅ läs-bar portal | sedan ~2026-06-08, inte fixbart via header |
 
 ---
 
-## Funktioner
+## Vad du får
 
-| Feature | Audi | VW EU | Škoda | SEAT/CUPRA |
-|---|:---:|:---:|:---:|:---:|
-| Fuel / Battery level | ✓ | ✓ | ✓ | ✓ |
-| Range | ✓ | ✓ | ✓ | ✓ |
-| Odometer | ✓ | ✓ | ✓ | ✓ |
-| GPS position | ✓ | ✓ | ✓ | ✓ |
-| Doors (total + per door) | ✓ | ✓ | ✓ | ✓ |
-| Windows | ✓ | ✓ | ✓ | ✓ |
-| Climate start/stop | ✓ | ✓ | ✓ | ✓ |
-| Target temperature | ✓ | ✓ | ✓ | ✓ |
-| Lock / Unlock | ✓ | ✓ | ✓ | ✓ |
-| Flash lights | ✓ | ✓ | ✓ | ✓ |
-| Wake vehicle | ✓ | ✓ | ✓ | ✓ |
-| Service due km/days | ✓ | ✓ | ✓ | ✓ |
-| Online status | ✓ | ✓ | ✓ | ✓ |
-| Battery SoC % | ✓ | ✓ | ✓ | ✓ |
-| Charge state | ✓ | ✓ | ✓ | ✓ |
-| Charge power kW | ✓ | ✓ | ✓ | ✓ |
-| Charge speed km/h | ✓ | ✓ | ✓ | ✓ |
-| Charge ETA | ✓ | ✓ | ✓ | ✓ |
-| Charge target % | ✓ | ✓ | ✓ | ✓ |
-| Trunk / hood / sunroof | ✓ | ✓ | ✓ | ✓ |
-| Window heating | ✓ | ✓ | ✓ | ✓ |
-| Vehicle renders | ✓ | — | — | ✓ |
-| Departure timers 1–3 | ✓ | ✓ | — | — |
-| Battery temperature | ✓ | ✓ | — | — |
-| AdBlue range | ✓ | ✓ | — | ✓ |
+100+ entiteter över 11 HA-plattformar, 20+ service-anrop, native multi-vehicle-stöd per konto. Quality-Scale Platinum.
+
+**Sensorer** (per fordon): Battery SoC, Range (electric / combustion / total), Fuel Level, Odometer, Outside Temp, Battery Temp, 12V Voltage, Service Days, Oil Service Days, Charging Power / Rate / Type, Last Trip Stats, Lifetime Trip Aggregates, Charging History, Plug State, Lights Count, Equipment Count, Software Version, API Quota Remaining, Connection State, Last Seen, Skoda Driving Score, Porsche TPMS 4 Corners, Last Alarm Timestamp, Heater Source för ID.x, Oil Level Warning, fordonsvarningar (textsensor med alla backend-warnings).
+
+**Binary Sensors**: Doors Locked, Doors Open per dörr, Windows Open per fönster, Trunk / Hood / Sunroof, Plug Connected, Charging, OTA Update Available, 12V Low Warning, Lights On per light, Vehicle Online, Departure-Timer 1-3 Enabled, Alarm Active + Siren Active, TPMS Warning.
+
+**Styrning**: Lock/Unlock, Climate Start/Stop, Charging Start/Stop, Window Heating, Cabin Ventilation (CUPRA/SEAT), Aux Heating (Webasto), Departure Timer 1-3 med Weekly-Preheat, Set Target SoC, Set Target Temp, Set Max Charge Current, Set Charge Mode, Honk-and-Flash, Wake Vehicle, Refresh, Find Charging Stations.
+
+**Image Platform**: 1-7 fordonsrenders per VIN (Audi/VW via GraphQL MediaService, CUPRA/SEAT via OLA viewPoints, Skoda via Widget + Multi-Angle-kompositer).
+
+**Device Tracker**: GPS-position som TrackerEntity för HA Lovelace-kartan.
 
 ---
 
 ## Installation
 
-### HACS
+### Alternativ 1: One-Click (rekommenderas)
+
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=its-me-prash&repository=vwgroup-connect-ha&category=integration)
+
+### Alternativ 2: HACS Custom Repository
 
 1. HACS → Integrationer → ⋮ → Anpassade förråd
-2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha` — Kategori: Integration
-3. Installera **VW Group Connect** → Starta om Home Assistant
-4. Inställningar → Integrationer → **+ Integration** → **VW Group Connect**
+2. URL: `https://github.com/its-me-prash/vwgroup-connect-ha`
+3. Kategori: Integration
+4. Installera **VW Group Connect**
+5. Starta om Home Assistant
 
-### Manual
+### Alternativ 3: Manuellt
 
 ```bash
-cp -r custom_components/vag_connect ~/.homeassistant/custom_components/
+cd /config/custom_components
+git clone https://github.com/its-me-prash/vwgroup-connect-ha.git
+mv vwgroup-connect-ha/custom_components/vag_connect .
+rm -rf vwgroup-connect-ha
 ```
 
-Starta om Home Assistant.
+Starta sedan om HA.
 
 ---
 
 ## Konfiguration
 
-| Field | Required | Description |
-|---|---|---|
-| Märke | ✓ | Audi / Volkswagen / Škoda / SEAT / CUPRA |
-| E-post | ✓ | Inloggnings-e-post från tillverkarens app |
-| Lösenord | ✓ | Lösenord från appen |
-| S-PIN | — | Krävs för låsning (under Säkerhet i appen) |
-| Intervall | — | Minuter mellan uppdateringar (standard: 5) |
+Inställningar → Enheter & Tjänster → Lägg till integration → "VW Group Connect"
 
-**Vilken app?** Audi → myAudi · VW → WeConnect · Škoda → MyŠkoda · SEAT → My SEAT · CUPRA → MyCupra
+**Vid första setup väljer du:**
 
----
+- **Browser-Login** (rekommenderas för Audi/Škoda/SEAT/CUPRA): skanna QR-kod eller öppna URL, inget lösenord sparas i HA
+- **E-post + lösenord** (för VW EU, Porsche, VW US/CA): klassiskt med Brand-ID-credentials
 
-## Kända Begränsningar
-
-- **S-PIN** krävs för låsning
-- **Intervall** minst 5 minuter
-- **2FA** — bekräfta en gång manuellt i appen
-- **Porsche / VW NA** — fungerar som Beta, testare sökes
+**Alternativ** (tillgängliga efter setup):
+- Polling-intervall (5-60 min, standard 10 min)
+- Read-only-läge för säkra automationer utan oavsiktliga kommandon
+- Reverse-geocoding opt-in (skickar GPS till OpenStreetMap för adressuppslag)
+- Push-toggles (Skoda MQTT, CUPRA/SEAT FCM, Audi/VW FCM) som grund, live-aktivering pending
 
 ---
 
+## Lovelace-exempel
+
+### Map Card
+
+```yaml
+type: map
+title: Fuhrpark
+default_zoom: 12
+hours_to_show: 24
+entities:
+  - device_tracker.audi_a4_b9_position
+  - device_tracker.vw_golf_7_gte_position
+  - zone.home
+```
+
+### Picture-Entity-kort med fordonsrender
+
+```yaml
+type: picture-entity
+entity: image.audi_a4_b9_render_side_lg
+camera_view: live
+show_state: false
+show_name: false
+```
+
+### Charging-Station-Lookup
+
+```yaml
+action: vag_connect.find_charging_stations
+data:
+  vin: WAUZZZ...
+  latitude: 47.3769
+  longitude: 8.5417
+  radius_m: 5000
+  max_results: 25
+response_variable: result
+```
+
+Fler exempel i [`docs/FAQ.md`](docs/FAQ.md). Egna Lovelace-kort integreras automatiskt via `extra_state_attributes.image_url`.
+
+---
+
+## Vanliga frågor
+
+| Fråga | Svar |
+|---|---|
+| När väcks min bil? | Bara vid service-anrop (Lock/Climate/Wake), aldrig vid status-polls. Smart-Wake-cap: max 3 wakes/dag per bil, 5 min cooldown. |
+| Hur mycket API-quota? | MyCupra/MySeat: ~1500 calls/dag. Vid 10 min polling: ~144 calls/dag = 10% av budgeten. Sensorn `requests_remaining_today` visar läget. |
+| Varför måste jag logga in på nytt var 2:e timme för VW EU? | VW har sedan 2026-05-27 lagt token-endpointen bakom Google Play Integrity. Det drabbar varje Python-baserad VAG-integration. EU Data Act 2026-09-12 bör åtgärda det. |
+| Behålls token efter HACS-uppdatering? | Ja, sedan v1.19.2 via HA Store-persistens. |
+| Hur rapporterar jag buggar? | HA → Integration → 🔧 Reparera → Bug-Report. Diagnostics anonymiseras (VIN maskeras, GPS avrundas, tokens stripas). |
+| Fältetiketter visar raw-keys (`brand`, `spin`) efter uppdatering? | Hård browser-refresh (Ctrl+Shift+R). HA cachar översättningar client-side. |
+
+Fullständig FAQ i [`docs/FAQ.md`](docs/FAQ.md). Dashboard-felsökning i [`docs/dashboards.md`](docs/dashboards.md).
+
+---
+
+## Integritet & säkerhet
+
+- Inga externa tjänster, allt direkt mellan HA och tillverkar-API
+- Token-cache lokalt i HA:s `.storage/` (per config-entry, JSON, tas automatiskt bort när integrationen avlägsnas)
+- Diagnostics anonymiseras: VIN maskeras, GPS avrundas till 1 decimal, tokens och lösenord stripas helt
+- Reverse-geocoding opt-in, avstängt som standard
+- VIN-maskering genomgående i alla loggar
+- Token-URL:er redactas i ERROR-loggen (v2.7.2+)
+
+Detaljer i [`PRIVACY.md`](PRIVACY.md) och [`SECURITY.md`](SECURITY.md).
+
+---
+
+## Contributing
+
+PR:er välkomnas, se [`CONTRIBUTING.md`](CONTRIBUTING.md). Style-regler i [`STYLE.md`](STYLE.md) (privat i `_private/STYLE.md` för maintainers).
+
+**Vehicle Data Scout** (live sedan v1.9.0): När din integration upptäcker okända JSON-fält skapar den automatiskt en HA Repair-notifikation med en förifylld GitHub-issue-länk. 1-klicks bug-rapport utan att studera kod.
+
+---
 
 ## Licens
 
-Apache License 2.0 — [LICENSE](LICENSE)
-
-**VW Group Connect™** är ett oregistrerat varumärke (™, inte ®). Använd inte detta namn i forks för att undvika förvirring.
-
-Denna integration är ett oberoende gemenskapsprojekt utan koppling till Volkswagen AG, Audi AG, Škoda Auto, SEAT S.A., CUPRA, Porsche AG eller något VAG-dotterbolag.
-
----
-
-*Copyright 2026 [Prash Balan](https://github.com/its-me-prash) · Apache License 2.0*
+[Apache License 2.0](LICENSE) för integrationskoden. [CC BY-NC-ND 4.0](LICENSE-RESEARCH) för innehållet i `docs/research/`. Attributioner till upstream open source-projekt, se [`NOTICE.md`](NOTICE.md).


### PR DESCRIPTION
Brings the README and all 7 language variants to the current state, translated consistently from the rewritten canonical German README.md.

**What changed (all 8 languages):**
- Replaced the stale **"What is new in v2.10.0"** changelog dump (4 versions old) with a concise current multi-channel status + a pointer to CHANGELOG.md.
- Corrected the now-false **"nobody has this"** competitive claims — the EU Data Act portal is the de-facto standard now and QR/device-code was pulled — to the real differentiators: **7 brands incl. Porsche** (portal excludes Porsche), **Audi two-way**, **multi-channel auto-fallback**, Vehicle Data Scout.
- Updated the per-brand limits table to **2026 attestation reality**: CUPRA/SEAT OLA blocked (App Check, ~2026-06-08) → read-only portal; Audi/Škoda/Porsche/VW US-CA two-way; VW EU hybrid (~2h) or portal/vw.de-beta.
- Added the **"What is this?"** elevator pitch to every language.

Docs-only — no code, no version bump, no tag (per the bundle-releases discipline).