### PR TITLE
fix(vw-website): submit OTP into the form's real code field (v2.14.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.14.10] - 2026-06-18
+
+### Fixed
+
+- **volkswagen.de website login (beta): the email code is finally accepted instead of looping with a new code every time.** Entering the emailed code kept failing as a "credential issue", and a fresh code was sent after each attempt. The login page's code box isn't always named the same thing internally, and the integration was filling in the wrong one — so the identity service saw an empty code, rejected it, and emailed a new one, over and over. It now fills whichever code box the page actually shows (and ticks "remember this browser" when offered, so the saved session lasts longer). (Opt-in beta channel only.)
+
 ## [2.14.9] - 2026-06-17
 
 ### Fixed

--- a/README.pl.md
+++ b/README.pl.md
@@ -42,7 +42,7 @@
 > Ogromne podziękowania dla społeczności **Home Assistant UK** oraz **HA Ideas, Projects and Solutions**
 > za zwrócenie uwagi — szczególnie dla **Si Gregory**, **Ben Johnson** i **Evets David**.
 >
-> I specjalne pozdrowienia dla **Jordana Waelesa**, którego komentarz `show_vag()` jest teraz oficjalnie
+> I specjalne pozdrowienia dla **Jordan Waeles**, którego komentarz `show_vag()` jest teraz oficjalnie
 > wspieranym easter eggiem w tej integracji (usługa `vag_connect.show_vag`, patrz CHANGELOG v2.2.3).
 
 ---

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -455,13 +455,33 @@ class WebsiteAuthProxyConnector:
                 "Website authproxy: no pending OTP challenge — call "
                 "begin_login() first"
             )
-        # The Auth0 email-challenge page is a form carrying hidden fields
-        # (_csrf / relayState / hmac); a hardcoded {code, state} POST omits
-        # them, which is what made the OTP "not transmit cleanly". Parse the
-        # challenge form exactly like the password step (begin_login) and merge
-        # the code into the real fields before POSTing to the form's action.
+        # The Auth0 email-challenge form carries hidden fields (_csrf /
+        # relayState / hmac) AND a code input whose name is NOT always "code" —
+        # it can be otp / mfa-code / token / passcode. Our form parser surfaces
+        # value-less inputs, so the real field is present in ``fields``; set the
+        # code into whichever the form actually carries. A hardcoded "code" left
+        # the real field empty, so the IDP treated it as "no code entered",
+        # re-issued a FRESH challenge (= a new email) and we bounced on
+        # "email-challenge" forever — the "credential issue + new code every
+        # attempt" loop. Also opt into any "remember" field so the SSO cookie
+        # lives longer (helps the silent resume). Fall back to "code" only if the
+        # form exposes no recognisable code field. (Mirrors the working
+        # rafaelhutter authproxy flow.)
         fields, action = _login_fields(self._otp_html or "")
-        fields["code"] = str(code).strip()
+        code_clean = str(code).strip()
+        matched = False
+        for key in list(fields):
+            kl = key.lower()
+            if kl in (
+                "code", "otp", "mfa-code", "mfa_code",
+                "email-code", "passcode", "token",
+            ):
+                fields[key] = code_clean
+                matched = True
+            elif "remember" in kl:
+                fields[key] = "true"
+        if not matched:
+            fields["code"] = code_clean
         if self._otp_state:
             fields.setdefault("state", self._otp_state)
         post_url = _resolve_action(self._otp_url, action)

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.14.9"
+  "version": "2.14.10"
 }

--- a/tests/test_v21410_otp_field_name.py
+++ b/tests/test_v21410_otp_field_name.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+"""v2.14.10 — website-authproxy: submit the OTP into the form's REAL code field.
+
+Live symptom: entering the email code kept failing with a "credential issue",
+and a NEW code was emailed after every attempt. Root cause: the Auth0
+email-challenge form's code input is not always named ``code`` — it can be
+``mfa-code`` / ``otp`` / ``token``. ``submit_otp`` hardcoded ``fields["code"]``,
+so the real field stayed empty → the IDP treated it as "no code entered",
+re-issued a fresh challenge (a new email) and the flow bounced on
+"email-challenge" forever.
+
+v2.14.10 sets the code into whichever recognised field the parsed form actually
+carries (the form parser surfaces value-less inputs), falling back to ``code``
+only if none is present. Mirrors the working rafaelhutter authproxy flow.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+)
+
+_LANDED_OK = "https://www.volkswagen.de/de/besitzer-und-nutzer/myvolkswagen.html"
+
+
+class _Resp:
+    def __init__(self, url: str, status: int = 200, text: str = "") -> None:
+        self.url = url
+        self.status = status
+        self._text = text
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def text(self, errors: str | None = None) -> str:
+        return self._text
+
+
+class _CaptureSession:
+    """Captures the POST body and lands the OTP submit back on volkswagen.de."""
+
+    def __init__(self) -> None:
+        self.posted: dict[str, Any] = {}
+
+    def post(self, url: str, **kw: Any) -> _Resp:
+        self.posted = dict(kw.get("data") or {})
+        return _Resp(_LANDED_OK, status=200, text="<html>welcome</html>")
+
+
+def _armed_conn(html: str) -> tuple[WebsiteAuthProxyConnector, _CaptureSession]:
+    sess = _CaptureSession()
+    conn = WebsiteAuthProxyConnector(sess, "u@x.z", "pw")  # type: ignore[arg-type]
+    conn._otp_url = "https://identity.vwgroup.io/u/mfa-email-challenge?state=ST"
+    conn._otp_html = html
+    conn._otp_state = "ST"
+    return conn, sess
+
+
+@pytest.mark.asyncio
+async def test_code_goes_into_mfa_code_field() -> None:
+    """A form whose code input is named 'mfa-code' (value-less) gets the code —
+    not left empty with the code misfiled under 'code'."""
+    html = (
+        '<form action="/u/mfa-email-challenge?state=ST">'
+        '<input name="state" value="ST">'
+        '<input name="mfa-code">'
+        '<input name="hmac" value="h">'
+        '</form>'
+    )
+    conn, sess = _armed_conn(html)
+    ok = await conn.submit_otp("123456")
+    assert ok is True
+    assert sess.posted["mfa-code"] == "123456"
+
+
+@pytest.mark.asyncio
+async def test_code_goes_into_otp_field_and_remember_opt_in() -> None:
+    """Field named 'otp' gets the code; a 'remember' checkbox is set true."""
+    html = (
+        '<form action="/u/mfa-email-challenge?state=ST">'
+        '<input name="state" value="ST">'
+        '<input name="otp">'
+        '<input name="rememberBrowser">'
+        '</form>'
+    )
+    conn, sess = _armed_conn(html)
+    assert await conn.submit_otp("654321") is True
+    assert sess.posted["otp"] == "654321"
+    assert sess.posted["rememberBrowser"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_standard_code_field_still_works() -> None:
+    """Regression: a form that DOES name it 'code' still works."""
+    html = (
+        '<form action="/u/mfa-email-challenge?state=ST">'
+        '<input name="state" value="ST">'
+        '<input name="code">'
+        '</form>'
+    )
+    conn, sess = _armed_conn(html)
+    assert await conn.submit_otp("111222") is True
+    assert sess.posted["code"] == "111222"
+
+
+@pytest.mark.asyncio
+async def test_no_recognisable_field_falls_back_to_code() -> None:
+    """If the form exposes no recognisable code input, fall back to 'code'."""
+    html = (
+        '<form action="/u/mfa-email-challenge?state=ST">'
+        '<input name="state" value="ST">'
+        '</form>'
+    )
+    conn, sess = _armed_conn(html)
+    assert await conn.submit_otp("999000") is True
+    assert sess.posted["code"] == "999000"


### PR DESCRIPTION
## Live symptom
On the vw.de beta channel, entering the emailed code kept failing as a **credential issue**, and a **new code was emailed after every attempt**.

## Root cause
The Auth0 email-challenge form's code input is **not always named `code`** — it can be `mfa-code` / `otp` / `token`. `submit_otp` hardcoded `fields["code"]`, leaving the real field empty → the IDP read it as "no code entered", re-issued a fresh challenge (a new email), and the flow bounced on `email-challenge` forever.

## Fix
Set the code into whichever recognised field the parsed form actually carries (our `_FormParser` surfaces value-less inputs, so the real field is present in the parsed dict), opt into any `remember` field for a longer-lived SSO cookie, and fall back to `code` only if none is present.

**Verified against the working rafaelhutter authproxy flow** (which does the same multi-field-name submit — that's the reference that confirmed the diagnosis).

## Scope / tests
- Opt-in **beta channel only**. New `test_v21410`: code lands in `mfa-code` / `otp` (+ remember=true) / `code` / fallback.
- ruff + mypy-strict green.

**Note:** a separate latent bug exists — the reauth flow (`async_step_reauth_confirm`) routes website entries through `_validate_credentials` instead of the authproxy+OTP path; it only bites after the saved cookies fully expire. Tracked as a follow-up. **Hypothesis confidence:** strong (verified vs working reference + matches symptom exactly), but the field-name fix is strictly more robust than before regardless.