### PR TITLE
fix(atlas): make local Phase A.2 runnable + guard against decoy APKs

### DIFF
--- a/scripts/app_atlas/apk_extractor.py
+++ b/scripts/app_atlas/apk_extractor.py
@@ -118,6 +118,37 @@ def resolve_apkcombo_download(slug: str) -> str | None:
     return f"https://apkcombo.com{relative}"
 
 
+# Uptodown embeds a per-download token in the download button's data-url;
+# the file is served from dw.uptodown.net/dwn/<token>.
+_UPTODOWN_TOKEN_RE = re.compile(
+    r'id="detail-download-button"[^>]*data-url="([^"]+)"'
+)
+
+
+def resolve_uptodown_download(subdomain: str) -> str | None:
+    """Resolve the direct APK/XAPK URL from an Uptodown app subdomain.
+
+    Fallback for brands not served by APKCombo (e.g. Škoda). ``subdomain``
+    is e.g. ``"cz-skodaauto-myskoda"``. The ``/android/download`` page carries
+    a token in the ``#detail-download-button`` ``data-url``; the file lives at
+    ``https://dw.uptodown.net/dwn/<token>``. Returns the URL or None.
+    """
+    page_url = f"https://{subdomain}.en.uptodown.com/android/download"
+    try:
+        body = fetch_text(page_url)
+    except urllib.error.HTTPError as exc:
+        _LOGGER.warning("Uptodown %s → HTTP %s", page_url, exc.code)
+        return None
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("Uptodown %s → %s", page_url, exc)
+        return None
+    m = _UPTODOWN_TOKEN_RE.search(body)
+    if not m:
+        _LOGGER.warning("Uptodown %s: no download token found", page_url)
+        return None
+    return f"https://dw.uptodown.net/dwn/{m.group(1)}"
+
+
 def download_to(url: str, dest: Path) -> bool:
     """Download a URL to ``dest`` using browser-like headers.
 
@@ -188,19 +219,41 @@ def unpack_xapk(xapk_path: Path, dest_dir: Path) -> Path | None:
         return target
 
 
+def _apk_declares_package(base_apk: Path, expected_pkg: str) -> bool:
+    """True if the APK's AndroidManifest contains the expected package name.
+
+    Guard against decoy downloads: some mirrors (Uptodown) gate the real file
+    and serve their own client app instead. Binary AXML stores strings as
+    UTF-16LE, so a substring scan of AndroidManifest.xml reliably confirms the
+    declared package is present.
+    """
+    try:
+        with zipfile.ZipFile(base_apk) as z:
+            manifest = z.read("AndroidManifest.xml")
+    except (KeyError, zipfile.BadZipFile, OSError) as exc:
+        _LOGGER.warning("Could not read AndroidManifest from %s: %s", base_apk, exc)
+        return False
+    return expected_pkg in manifest.decode("utf-16-le", errors="ignore")
+
+
 def apktool_decode(apk_path: Path, dest_dir: Path) -> bool:
     """Run ``apktool d <apk> -o <dest>``. Returns True on success."""
+    import shutil
     if dest_dir.exists():
         # apktool refuses to overwrite by default.
-        import shutil
         shutil.rmtree(dest_dir)
+    # Windows: apktool ships as a .BAT/.cmd wrapper — a bare ["apktool", ...] is NOT
+    # resolved by CreateProcess (which only finds .exe, not PATHEXT scripts), so it raised
+    # FileNotFoundError on local Windows runs. shutil.which() honours PATHEXT and returns the
+    # full path to apktool.BAT, which subprocess can execute. On Linux it returns the binary.
+    apktool_bin = shutil.which("apktool") or "apktool"
     try:
         result = subprocess.run(
-            ["apktool", "d", "--force-manifest", "-o", str(dest_dir), str(apk_path)],
+            [apktool_bin, "d", "--force-manifest", "-o", str(dest_dir), str(apk_path)],
             check=False,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=600,
         )
         if result.returncode != 0:
             _LOGGER.error("apktool failed (rc=%d):\n%s\n%s",
@@ -211,7 +264,7 @@ def apktool_decode(apk_path: Path, dest_dir: Path) -> bool:
         _LOGGER.error("apktool not on PATH — workflow needs `apt-get install apktool`")
         return False
     except subprocess.TimeoutExpired:
-        _LOGGER.error("apktool timed out after 120s for %s", apk_path)
+        _LOGGER.error("apktool timed out after 600s for %s", apk_path)
         return False
 
 
@@ -357,14 +410,22 @@ def extract_brand_apk(brand: str, brand_cfg: dict[str, Any],
     """
     sources = brand_cfg.get("sources", {})
     apkcombo_slug = sources.get("apkcombo_slug")
-    if not apkcombo_slug:
-        _LOGGER.warning("Brand %s: no apkcombo_slug — skipping APK extraction "
-                       "(Phase A.2 currently only supports APKCombo CDN)", brand)
+    uptodown_sub = sources.get("uptodown_subdomain")
+    if not apkcombo_slug and not uptodown_sub:
+        _LOGGER.warning("Brand %s: no apkcombo_slug or uptodown_subdomain — "
+                       "skipping APK extraction", brand)
         return None
 
-    # 1. Resolve download URL.
-    download_url = resolve_apkcombo_download(apkcombo_slug)
+    # 1. Resolve download URL — APKCombo first (XAPK, fast CDN), then fall
+    #    back to Uptodown for brands APKCombo doesn't serve (e.g. Škoda).
+    download_url = None
+    if apkcombo_slug:
+        download_url = resolve_apkcombo_download(apkcombo_slug)
+    if not download_url and uptodown_sub:
+        _LOGGER.info("Brand %s: APKCombo unavailable — trying Uptodown", brand)
+        download_url = resolve_uptodown_download(uptodown_sub)
     if not download_url:
+        _LOGGER.warning("Brand %s: no download URL via APKCombo or Uptodown", brand)
         return None
     _LOGGER.info("Brand %s: APK download URL resolved", brand)
 
@@ -378,6 +439,19 @@ def extract_brand_apk(brand: str, brand_cfg: dict[str, Any],
     unpack_dir = tmp_dir / f"{brand}_unpacked"
     base_apk = unpack_xapk(apk_path, unpack_dir)
     if not base_apk:
+        return None
+
+    # 3b. Identity guard — confirm the APK actually IS the brand app. Some
+    #     mirrors (notably Uptodown) gate downloads and serve their OWN client
+    #     app (com.uptodown.*) instead of the requested one. Without this check
+    #     we'd silently analyse the wrong app and report bogus findings. The
+    #     expected package is the second segment of the apkcombo slug.
+    expected_pkg = (apkcombo_slug.split("/")[-1]
+                    if apkcombo_slug and "/" in apkcombo_slug else None)
+    if expected_pkg and not _apk_declares_package(base_apk, expected_pkg):
+        _LOGGER.error("Brand %s: downloaded APK does not declare expected package "
+                      "%r — likely a decoy/wrong download (e.g. Uptodown's own "
+                      "app). Rejecting.", brand, expected_pkg)
         return None
 
     # 4. apktool decode.

--- a/scripts/app_atlas/apk_extractor.py
+++ b/scripts/app_atlas/apk_extractor.py
@@ -444,10 +444,10 @@ def extract_brand_apk(brand: str, brand_cfg: dict[str, Any],
     # 3b. Identity guard — confirm the APK actually IS the brand app. Some
     #     mirrors (notably Uptodown) gate downloads and serve their OWN client
     #     app (com.uptodown.*) instead of the requested one. Without this check
-    #     we'd silently analyse the wrong app and report bogus findings. The
-    #     expected package is the second segment of the apkcombo slug.
-    expected_pkg = (apkcombo_slug.split("/")[-1]
-                    if apkcombo_slug and "/" in apkcombo_slug else None)
+    #     we'd silently analyse the wrong app and report bogus findings. Uses
+    #     the canonical per-brand package_id from config.json so the guard also
+    #     applies to brands fetched via a non-APKCombo source.
+    expected_pkg = brand_cfg.get("package_id")
     if expected_pkg and not _apk_declares_package(base_apk, expected_pkg):
         _LOGGER.error("Brand %s: downloaded APK does not declare expected package "
                       "%r — likely a decoy/wrong download (e.g. Uptodown's own "

--- a/tests/test_app_atlas.py
+++ b/tests/test_app_atlas.py
@@ -251,6 +251,61 @@ class TestApkExtractorModule:
         assert "Cleanup" in src or "cleanup" in src
 
 
+class TestPhaseA2Robustness:
+    """Phase A.2 hardening: Windows apktool resolution, Uptodown fallback,
+    and the package-identity guard that rejects decoy downloads."""
+
+    def _extractor(self):
+        import importlib
+        import sys
+        sys.path.insert(0, str(_REPO_ROOT / "scripts" / "app_atlas"))
+        return importlib.import_module("apk_extractor")
+
+    def _fake_apk(self, tmp_path, package: str):
+        import zipfile
+        apk = tmp_path / "x.apk"
+        with zipfile.ZipFile(apk, "w") as z:
+            # Binary AXML stores strings as UTF-16LE; emulate the package string.
+            z.writestr("AndroidManifest.xml", package.encode("utf-16-le"))
+            z.writestr("classes.dex", b"dex\n035\x00")
+        return apk
+
+    def test_apktool_resolved_via_which(self) -> None:
+        """Windows ships apktool as a .BAT wrapper that a bare subprocess call
+        cannot resolve — it must go through shutil.which."""
+        src = _EXTRACTOR_PATH.read_text(encoding="utf-8")
+        assert 'shutil.which("apktool")' in src
+
+    def test_uptodown_fallback_present(self) -> None:
+        src = _EXTRACTOR_PATH.read_text(encoding="utf-8")
+        assert "def resolve_uptodown_download(" in src
+        assert "resolve_uptodown_download(uptodown_sub)" in src
+
+    def test_package_guard_wired(self) -> None:
+        src = _EXTRACTOR_PATH.read_text(encoding="utf-8")
+        assert "def _apk_declares_package(" in src
+        assert "_apk_declares_package(base_apk, expected_pkg)" in src
+
+    def test_guard_accepts_matching_package(self, tmp_path) -> None:
+        mod = self._extractor()
+        apk = self._fake_apk(tmp_path, "de.myaudi.mobile.assistant")
+        assert mod._apk_declares_package(apk, "de.myaudi.mobile.assistant") is True
+
+    def test_guard_rejects_decoy(self, tmp_path) -> None:
+        """Uptodown serves its own com.uptodown app for gated downloads — the
+        guard must reject it when a brand package was requested."""
+        mod = self._extractor()
+        apk = self._fake_apk(tmp_path, "com.uptodown.activities")
+        assert mod._apk_declares_package(apk, "cz.skodaauto.myskoda") is False
+
+    def test_uptodown_token_regex(self) -> None:
+        mod = self._extractor()
+        html = ('<button id="detail-download-button" class="button" '
+                'data-url="AbC123_tok-en">Download</button>')
+        m = mod._UPTODOWN_TOKEN_RE.search(html)
+        assert m is not None and m.group(1) == "AbC123_tok-en"
+
+
 class TestPhaseA2Integration:
     """build_atlas.py wires the apk_extractor in when --with-apk-extraction."""
 


### PR DESCRIPTION
Makes App Atlas Phase A.2 (APK download + extract) actually runnable locally, and harder to fool.

**What changed**
- apktool is invoked via `shutil.which`, so it resolves on Windows (it ships as a `.BAT` wrapper there that a bare subprocess call can't find) — not just on the CI Linux runner. Decode timeout raised for large apps.
- Added an Uptodown fallback for brands APKCombo doesn't list (e.g. Škoda).
- Added a package-identity guard: the downloaded APK must declare the expected package, otherwise it's rejected.

**Why the guard matters**
Some mirrors gate the real file and return their own client app instead. Hit exactly that on one brand — the mirror handed back `com.uptodown.*` for the gated download. Without the guard we'd silently analyse the wrong app and report bogus findings; now it fails loudly.

**Validation**
Ran Phase A.2 end-to-end against a current brand app — the OAuth client_ids it carries are all already known in source, no new backends. One brand still needs a non-gated source (the guard rejects the decoy; APKCombo doesn't list it).

Tests: +6, all green. ruff + mypy strict clean.
