### PR TITLE
chore: add .mailmap to canonicalize historical commit identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Canonicalize historical commit identities to the maintainer.
+# Maps early-history commits (made under a tooling identity) onto the
+# canonical author so `git shortlog`, the contributor graph and any
+# mailmap-aware view show a single, consistent maintainer.
+Prash <pirabhu.balan@gmail.com> <noreply@anthropic.com>


### PR DESCRIPTION
Adds a `.mailmap` that maps early-history commits onto the canonical maintainer name/email, so `git shortlog`, the GitHub contributor graph, and any mailmap-aware view show one consistent author.

Display-only — **no history rewrite, zero SHA changes, no force-push**. Individual historical commits keep their original SHAs (tags, PR refs, HACS releases all unaffected); only the aggregate/contributor views are canonicalized.