### PR TITLE
Release triage: charge-power scale (#717), PII redaction (#718), VW NA data-forbidden (#659)

### DIFF
--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -742,15 +742,21 @@ class VWNAClient:
         # PRIVACY: every value below is a fixed label, a class name, or a
         # numeric HTTP status. No UUID / VIN / body fragment / token is ever
         # built into these strings (matches the shape-only log above).
+        # #659 — the entitlement/forbidden verdict keys ONLY off the primary RVS
+        # read (vehicle_raw). On a COMBUSTION VW NA car the EV-only charge +
+        # climate summaries legitimately 403 (USER_NOT_AUTHORIZED) while RVS 200s
+        # — counting those as data-403s falsely tripped the "renew subscription"
+        # Repair. RVS 200 already proves entitlement; RVS 403 is the real signal.
         data_403s = [
-            r for r in (vehicle_raw, charge, climate)
+            r for r in (vehicle_raw,)
             if isinstance(r, APIError) and getattr(r, "status", None) == 403
         ]
         if data_403s:
             data_class = _classify_data_403(data_403s[0])
             _LOGGER.debug(
-                "VW NA data 403 classified as %s (%d/3 reads 403)",
-                data_class, len(data_403s),
+                "VW NA data 403 classified as %s (primary RVS read forbidden; "
+                "benign EV-summary 403s on combustion cars are ignored)",
+                data_class,
             )
             # Privileges shape/status as the entitlement discriminator —
             # value-safe: only the dict-ness, an active bool, a count int, or

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -2197,8 +2197,17 @@ def map_dataset_to_vehicle_data(
         # unmapped fields + their REAL values so the user can see everything the
         # backend sent, on one disabled diagnostic sensor. Capped to keep the
         # attribute payload sane; the debug log above already records the count.
+        # PRIVACY (#718 et al.): the portal dataset carries the account UUID
+        # (user_id) and the VIN as data fields. They are NOT suppressed from
+        # discovery — the field NAMES stay so the Scout still surfaces them — but
+        # their VALUES are redacted here, because this diagnostic attribute
+        # otherwise exposes the REAL account UUID + full VIN (the Scout issue
+        # itself already masks both). Match on the leaf name so both the bare
+        # (`vin`) and container-qualified (`eu_data_act.vin`) spellings redact.
         d.raw_unmapped_fields = {
-            k: str(fields[k]) for k in unmapped[:_RAW_FIELD_CAP]
+            k: ("<redacted>" if k.rsplit(".", 1)[-1] in ("user_id", "vin")
+                else str(fields[k]))
+            for k in unmapped[:_RAW_FIELD_CAP]
         }
         if len(unmapped) > _RAW_FIELD_CAP:
             _LOGGER.debug(

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1072,20 +1072,20 @@ def map_dataset_to_vehicle_data(
         if d.electric_range_km is None:
             d.electric_range_km = rng
 
-    cp = _to_float(first("battery_state_report.charge_power", "charge_power",
-                        "chargePower_kW",
-                        # v2.15.3 (#518) — EU-Data-Act dialect alias. Dict
-                        # defines charging_power (UUID 978be4ed) as "Power of
-                        # charging" (type=number, unit=null). Treating it as kW
-                        # is a CONVENTION for a charging-power field (typical
-                        # magnitudes are kW), NOT substantiated by the dict —
-                        # the sibling charge_rate_unit is a distance/time RATE
-                        # unit enum ("Unit of charge rate"), never a power unit.
-                        # LAST fallback only — canonical charge_power keys win
-                        # when a car reports both.
-                        "charging_power"))
-    if cp is not None:
-        d.charging_power_kw = cp
+    # #717 — battery_state_report.charge_power / charge_power are RAW
+    # 0.1-kW-resolution portal values (EU data dict UUID 44ed0d61: "actual charge
+    # power … range 0..500 with a resolution of 0,1 kW"; the reporter saw 65 →
+    # 6.5 kW), so they scale /10 — the same deci-unit handling the temps + kWh
+    # fields below already get. The chargePower_kW / charging_power aliases carry
+    # kW already (chargePower_kW by name; charging_power UUID 978be4ed treated as
+    # kW by convention — #518), so they stay UNSCALED.
+    cp_deci = _to_float(first("battery_state_report.charge_power", "charge_power"))
+    if cp_deci is not None:
+        d.charging_power_kw = round(cp_deci / 10.0, 1)
+    else:
+        cp_kw = _to_float(first("chargePower_kW", "charging_power"))
+        if cp_kw is not None:
+            d.charging_power_kw = cp_kw
 
     # 2.15.1 — the charger dialect reports charged energy
     # (battery_state_report.charge_energy). The EU data dictionary defines this
@@ -1147,11 +1147,19 @@ def map_dataset_to_vehicle_data(
     # the canonical `Charge Rate` entry (dict UUID 732b602c, unit=kmPerHour)
     # already represents — i.e. the km/h rate charging_rate_kmh maps. Added as
     # the LAST alias so canonical/report-shaped keys still win when both appear.
-    crate = _to_int(first("battery_state_report.charge_rate", "charge_rate",
-                          "chargeRate_kmph", "charging_rate_kmh",
-                          "actual_charge_rate"))
-    if crate is not None:
-        d.charging_rate_kmh = crate
+    # #717 — battery_state_report.charge_rate / charge_rate are RAW
+    # 0.1-resolution portal values (dict UUID 0c60a14f: "actual rate … range
+    # 0..3000 with a resolution of 0,1"; reporter saw 149 → 14.9), so /10. The
+    # chargeRate_kmph / charging_rate_kmh / actual_charge_rate aliases already
+    # carry the real km/h value and stay UNSCALED.
+    crate_deci = _to_float(first("battery_state_report.charge_rate", "charge_rate"))
+    if crate_deci is not None:
+        d.charging_rate_kmh = round(crate_deci / 10.0, 1)
+    else:
+        crate = _to_int(first("chargeRate_kmph", "charging_rate_kmh",
+                              "actual_charge_rate"))
+        if crate is not None:
+            d.charging_rate_kmh = crate
 
     plug = first("charging_plug1_connectionstate", "plug_connection_state",
                  "plugConnectionState", "plug_state")

--- a/tests/test_717_charge_power_scale.py
+++ b/tests/test_717_charge_power_scale.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#717 — charge power + charge rate 10x unit bug (Golf GTE mk8.5 2025, UK).
+
+`battery_state_report.charge_power` (EU data dict UUID 44ed0d61: "resolution of
+0,1 kW") and `battery_state_report.charge_rate` (0c60a14f: "resolution of 0,1")
+are reported in 0.1-resolution units. The EU-Data-Act mapper passed them
+through 1:1, so a 6.5 kW charge surfaced as 65 kW and a 14.9 km/h rate as 149
+(reporter-confirmed against the official app). The mapper now divides both by
+10 — the same deci-unit handling the temps + battery-kWh fields already get. The
+already-unit aliases (chargePower_kW / chargeRate_kmph) must stay UNSCALED so a
+canonical-key car (ID.7 / CUPRA) can never regress.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(fields: dict[str, str]) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_717_charge_power_deci_scaled_to_kw() -> None:
+    # raw 65 (0.1-kW) → 6.5 kW.
+    assert _map({"battery_state_report.charge_power": "65"}).charging_power_kw == 6.5
+
+
+def test_717_charge_rate_deci_scaled() -> None:
+    # raw 149 (0.1) → 14.9.
+    assert _map({"battery_state_report.charge_rate": "149"}).charging_rate_kmh == 14.9
+
+
+def test_717_kw_alias_not_double_scaled() -> None:
+    # chargePower_kW already carries kW → must NOT be divided (no regression).
+    assert _map({"chargePower_kW": "6.5"}).charging_power_kw == 6.5
+
+
+def test_717_kmph_alias_not_scaled() -> None:
+    # chargeRate_kmph already carries km/h → unscaled.
+    assert _map({"chargeRate_kmph": "15"}).charging_rate_kmh == 15

--- a/tests/test_718_pii_redaction.py
+++ b/tests/test_718_pii_redaction.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#718 — redact user_id + VIN VALUES in raw_unmapped_fields (PII leak).
+
+The EU-Data-Act dataset carries the account UUID (``user_id``) and the ``vin`` as
+data fields. Being unmapped, they landed in the ``raw_unmapped_fields`` diagnostic
+attribute with their REAL values — a PII leak. They are now value-redacted while
+the field NAMES stay (so the Vehicle Data Scout still surfaces them — no
+suppression, per the scout no-suppress policy).
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(fields: dict[str, str]) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_718_user_id_and_vin_values_redacted_names_kept() -> None:
+    d = _map(
+        {
+            "user_id": "00000000-1111-2222-3333-444455556666",
+            "eu_data_act.vin": "WVWZZZTEST0000718",
+            "some_new_telemetry_field": "42",
+        }
+    )
+    raw = d.raw_unmapped_fields or {}
+    # NAMES stay (not suppressed → the Scout still surfaces them)
+    assert "user_id" in raw and "eu_data_act.vin" in raw
+    # ...but the real account UUID + VIN values are redacted
+    assert raw["user_id"] == "<redacted>"
+    assert raw["eu_data_act.vin"] == "<redacted>"
+    # a genuine unmapped telemetry field keeps its real value for discovery
+    assert raw["some_new_telemetry_field"] == "42"

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -156,7 +156,7 @@ def test_curated_mapping_populates_high_value_fields() -> None:
         "battery_state_report.soc": "82",
         "mileage.value": "18842",
         "range": "54",
-        "battery_state_report.charge_power": "7.4",
+        "battery_state_report.charge_power": "74",  # 0.1-kW units (#717) → 7.4 kW
         "settings.target_soc": "80",
         "charging_state_report.current_charge_state": "charging",
         "charging_state_report.charge_mode": "manual",

--- a/tests/test_v2150a12_mapping.py
+++ b/tests/test_v2150a12_mapping.py
@@ -16,7 +16,8 @@ def _map(fields: dict[str, str]) -> VehicleData:
 
 class TestNewMappings:
     def test_charge_rate(self) -> None:
-        assert _map({"battery_state_report.charge_rate": "12"}).charging_rate_kmh == 12
+        # 0.1-resolution portal value (#717) → /10: raw 120 → 12 km/h.
+        assert _map({"battery_state_report.charge_rate": "120"}).charging_rate_kmh == 12
 
     def test_plug_state_connected(self) -> None:
         d = _map({"charging_plug1_connectionstate": "connected"})

--- a/tests/test_v2154_mapping.py
+++ b/tests/test_v2154_mapping.py
@@ -334,7 +334,9 @@ def test_alias_actual_charge_rate_to_charging_rate_kmh() -> None:
 
 
 def test_alias_canonical_charge_rate_wins_over_actual() -> None:
-    d = _map({"battery_state_report.charge_rate": "7", "actual_charge_rate": "11"})
+    # canonical battery_state_report.charge_rate is 0.1-resolution (#717) → /10;
+    # raw 70 → 7 km/h. It still WINS over the (unscaled) actual_charge_rate alias.
+    d = _map({"battery_state_report.charge_rate": "70", "actual_charge_rate": "11"})
     assert d.charging_rate_kmh == 7
 
 

--- a/tests/test_v2154_vw_na_data_403_triage.py
+++ b/tests/test_v2154_vw_na_data_403_triage.py
@@ -175,3 +175,24 @@ class TestGetStatusTriage:
 
         assert client.vw_na_data_forbidden is False
         assert client.vw_na_data_forbidden_reason == ""
+
+    @pytest.mark.asyncio
+    async def test_659_combustion_ev_403_with_rvs_ok_not_forbidden(self, caplog):
+        """#659 — a COMBUSTION VW NA car: RVS 200 (entitled) but the EV-only
+        charge/climate summaries 403. The verdict keys off RVS only, so this must
+        NOT surface the entitlement Repair (previously the EV 403s falsely did)."""
+        client = _client()
+
+        async def _get_side(url: str, *a, **k):  # noqa: ANN002, ANN003
+            if "/rvs/" in url:
+                return {"powerStatus": {}}  # primary read entitled
+            raise _api_error(403, _ENTITLEMENT_BODY)  # EV summaries forbidden
+
+        client._get = AsyncMock(side_effect=_get_side)  # type: ignore[method-assign]
+        client.get_subscription_privileges = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        await client.get_status(_SECRET_VIN)
+
+        assert client.vw_na_data_forbidden is False
+        assert client.vw_na_data_forbidden_reason == ""
+        _assert_no_secret_leak(caplog)


### PR DESCRIPTION
Three verified, low-risk fixes for the next release (each with regression tests; ruff + mypy strict + full suite green).

### #717 — EU-Data-Act charge power + rate reported 10× too large
`battery_state_report.charge_power` (dict: *"resolution of 0,1 kW"*) and `battery_state_report.charge_rate` (*"resolution of 0,1"*) are 0.1-resolution portal values, but the mapper passed them through 1:1 — a 6.5 kW charge surfaced as 65 kW, a 14.9 km/h rate as 149 (reporter-confirmed vs the official app). Now scaled `/10`, the same deci-unit handling the temps + battery-kWh already get (cf. #534). **Key-aware:** only the 0.1-resolution keys are scaled; the already-unit aliases (`chargePower_kW` / `chargeRate_kmph` / `charging_power` / `actual_charge_rate`) stay unscaled so a canonical-key car (ID.7 / CUPRA) can't regress.

### #718 — account UUID + VIN leaked into `raw_unmapped_fields`
The portal dataset carries `user_id` (account UUID) and `vin` as fields; unmapped, they exposed their **real** values in the `raw_unmapped_fields` diagnostic attribute. Their VALUES are now redacted while the field NAMES stay — the Vehicle Data Scout still surfaces them (no suppression) and no PII leaks.

### #659 — false "renew subscription" Repair on combustion VW NA cars
On a gasoline VW NA car the EV-only `/ev/v1` charge + climate summaries legitimately 403 while the primary RVS read 200s. Counting those EV 403s as data-forbidden falsely tripped the entitlement Repair. The verdict now keys **only** off the RVS read (RVS 200 already proves entitlement); a genuine RVS 403 still classifies as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)