### PR TITLE
Fix EU-Data-Act portal feed for all VW EU users: kickoff needs Duration + traceId (#465, #709)

### DIFF
--- a/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
@@ -77,6 +77,7 @@ import io
 import json
 import logging
 import time
+import uuid
 import zipfile
 from typing import TYPE_CHECKING, Any
 
@@ -896,7 +897,14 @@ class DataActScraper:
             async with self._session.get(
                 url,
                 timeout=ClientTimeout(total=20),
-                headers={"Accept": "application/json"},
+                headers={
+                    "Accept": "application/json",
+                    # v2.17.x — the euda-apim layer now rejects requests without
+                    # a traceId (the portal's newer API contract; verified live
+                    # 2026-07-12 — the sibling relations endpoint 400s
+                    # "Required request header 'traceId' not present" without it).
+                    "traceId": uuid.uuid4().hex,
+                },
             ) as resp:
                 if resp.status == 401:
                     raise DataActSessionExpiredError(
@@ -977,6 +985,12 @@ class DataActScraper:
             "Name": name,
             "Identifier": identifier,
             "Frequency": "15mins",
+            # v2.17.x — the portal now REQUIRES a Duration field; without it the
+            # POST 400s "Invalid Duration: None. Allowed values are
+            # ['No Expiry', 'One Month'] or upcoming dates …" (verified live
+            # 2026-07-12). "One Month" matches the 31-day StartDate/EndDate
+            # window below; the coordinator re-adopts/re-kicks each cycle.
+            "Duration": "One Month",
             "StartDate": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "EndDate": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
             "DataClusters": clusters,
@@ -994,6 +1008,9 @@ class DataActScraper:
                     "Content-Type": "application/json",
                     "CSRF-Token": csrf,
                     "X-CSRF-Token": csrf,  # belt and braces
+                    # Required by the euda-apim layer (see metadata GET above);
+                    # without it the POST 503s at the AEM edge.
+                    "traceId": uuid.uuid4().hex,
                 },
             ) as resp:
                 if resp.status == 401:
@@ -1002,9 +1019,14 @@ class DataActScraper:
                     )
                 if resp.status not in (200, 201, 202):
                     body_text = await resp.text(errors="replace")
-                    _LOGGER.info(
-                        "kickoff_custom_data_request HTTP %s for VIN %s: %s",
-                        resp.status, _mask_vin(vin), body_text[:200],
+                    # WARNING, not INFO: a non-2xx here means the portal rejected
+                    # the request (e.g. a changed request format) → the car gets
+                    # NO data feed, silently. It must be visible so the next
+                    # portal-side format change doesn't go unnoticed for months.
+                    _LOGGER.warning(
+                        "kickoff_custom_data_request HTTP %s for VIN %s — no data "
+                        "feed will start until this is resolved: %s",
+                        resp.status, _mask_vin(vin), body_text[:300],
                     )
                     return None
         except DataActSessionExpiredError:

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -1794,15 +1794,19 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                 # BFF strategies exhausted). When True, the coordinator
                 # checks at startup whether an active 15-min Custom
                 # Request exists for each VIN and creates one when
-                # none does. The portal kickoff implies a 1-month
-                # subscription on the user's account, so this is
-                # opt-in - the user has to flip it explicitly.
+                # none does — without it a VW EU car shows NO data.
+                # DEFAULT ON, matching the runtime default in
+                # coordinator._ensure_data_act_custom_request_kickoff
+                # (v2.17.1). It MUST stay True here: rendering the toggle
+                # default-False meant a user who merely opened + saved
+                # Configure (e.g. to set the S-PIN) silently persisted
+                # auto_kickoff=False and killed their own portal feed.
                 vol.Optional(
                     CONF_EU_DATA_ACT_AUTO_KICKOFF,
                     default=current_options.get(
                         CONF_EU_DATA_ACT_AUTO_KICKOFF,
                         current_data.get(
-                            CONF_EU_DATA_ACT_AUTO_KICKOFF, False,
+                            CONF_EU_DATA_ACT_AUTO_KICKOFF, True,
                         ),
                     ),
                 ): _BOOL_SELECTOR,

--- a/tests/test_portal_kickoff_format.py
+++ b/tests/test_portal_kickoff_format.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Regression: the EU-Data-Act portal kickoff must send Duration + traceId.
+
+VW changed the Custom-Data-Request format (mid-2026). The create POST now
+REQUIRES a ``Duration`` field — without it the portal 400s
+``"Invalid Duration: None. Allowed values are ['No Expiry', 'One Month'] …"`` —
+and the euda-apim edge rejects any request without a ``traceId`` header (503).
+Verified live 2026-07-12: with both, the create POST returns 201 and the car's
+15-min portal feed starts; without them the kickoff silently failed for EVERY
+VW EU portal user, so no car got a data feed (issues #465, #709). These tests
+pin both so a future portal-format change can't silently regress the feed again.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._data_act_scraper import (
+    DataActScraper,
+)
+
+_VIN = "WVWZZZAUZFW805377"
+
+
+class _Resp:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def text(self, errors: str | None = None) -> str:
+        return "{}"
+
+    async def json(self, content_type: Any = None) -> Any:
+        return {}
+
+
+class _CaptureSession:
+    """Records the url + kwargs of each GET/POST so headers/body are assertable."""
+
+    def __init__(self, *, get_status: int = 404, post_status: int = 201) -> None:
+        self.get_calls: list[tuple[str, dict]] = []
+        self.post_calls: list[tuple[str, dict]] = []
+        self._get_status = get_status
+        self._post_status = post_status
+
+    def get(self, url: str, **kw: Any) -> _Resp:
+        self.get_calls.append((url, kw))
+        return _Resp(self._get_status)
+
+    def post(self, url: str, **kw: Any) -> _Resp:
+        self.post_calls.append((url, kw))
+        return _Resp(self._post_status)
+
+
+def _scraper(sess: Any) -> DataActScraper:
+    return DataActScraper(sess, brand_name="volkswagen")
+
+
+@pytest.mark.asyncio
+async def test_kickoff_body_includes_duration() -> None:
+    """The kickoff POST body carries the now-required ``Duration`` field."""
+    sess = _CaptureSession(post_status=201)
+    scraper = _scraper(sess)
+    scraper._fetch_csrf_token = AsyncMock(return_value="csrf")  # type: ignore[method-assign]
+    ident = await scraper.kickoff_custom_data_request(_VIN)
+    assert ident  # 201 → returns the new Identifier
+    assert sess.post_calls, "no POST was made"
+    body = sess.post_calls[-1][1]["json"]
+    assert body["Duration"] == "One Month"
+    assert body["Frequency"] == "15mins"  # legacy fields still present (echoed live)
+
+
+@pytest.mark.asyncio
+async def test_kickoff_post_sends_traceid() -> None:
+    """The kickoff POST carries a non-empty ``traceId`` header (euda-apim edge)."""
+    sess = _CaptureSession(post_status=201)
+    scraper = _scraper(sess)
+    scraper._fetch_csrf_token = AsyncMock(return_value="csrf")  # type: ignore[method-assign]
+    await scraper.kickoff_custom_data_request(_VIN)
+    headers = sess.post_calls[-1][1]["headers"]
+    assert headers.get("traceId")
+
+
+@pytest.mark.asyncio
+async def test_metadata_probe_sends_traceid() -> None:
+    """``get_active_custom_request_identifier`` sends a traceId on its GET, and a
+    404 (no request) resolves to None (not an error)."""
+    sess = _CaptureSession(get_status=404)
+    scraper = _scraper(sess)
+    result = await scraper.get_active_custom_request_identifier(_VIN)
+    assert result is None
+    assert sess.get_calls, "no GET was made"
+    headers = sess.get_calls[-1][1]["headers"]
+    assert headers.get("traceId")


### PR DESCRIPTION
The auto-kickoff that creates the continuous 15-min Custom Data Request a VW EU car needs for **any** portal data had gone stale and silently failed for every user — so portal-enrolled cars showed "no data" (#465, #709).

VW changed the Custom-Data-Request API:
- the POST body was missing the now-required **`Duration`** field → `400 "Invalid Duration: None. Allowed values are ['No Expiry','One Month']…"`
- the euda-apim edge now rejects requests without a **`traceId`** header → `503`
- both failures were logged at INFO and swallowed, so the broken feed was invisible for months.

**Verified live** against a portal-enrolled MBB car: with `Duration:"One Month"` + a `traceId` header the create POST returns **201** and the metadata probe returns the active Identifier; without either it fails.

- `_data_act_scraper.py`: add `Duration` to the kickoff body; add `traceId` to the kickoff POST + the metadata GET; raise the swallowed non-2xx from INFO → **WARNING** with the body so the next format change is visible.
- `config_flow.py`: the OptionsFlow rendered the auto-kickoff toggle default-False while the runtime default is True — a user who merely opened + saved Configure silently persisted `auto_kickoff=False` and killed their own feed. Aligned the default to True.

🤖 Generated with [Claude Code](https://claude.com/claude-code)