### PR TITLE
Fix vw.de authproxy for MBB cars: per-platform gdc + stop 412/optional reads forcing a re-login loop

### DIFF
--- a/custom_components/vag_connect/cariad/_authproxy.py
+++ b/custom_components/vag_connect/cariad/_authproxy.py
@@ -42,7 +42,21 @@ _HOST_VILMA = "myvw-vilma-proxy-prod"
 # VCF host than the static vehicle-file reads use above. Cross-checked against
 # rafaelhutter website_portal.py:328,391,417 (MIT); our own builders below.
 _HOST_VCF_LIVE = "myvw-vcf-prod"
-_GDC_WCAR = "myvw-wcar-prod"
+_GDC_WCAR = "myvw-wcar-prod"  # WeConnect / MEB (ID.x) global-data-centre
+_GDC_MBB = "myvw-mbb-prod"  # legacy MBB / Car-Net global-data-centre
+
+
+def gdc_for_backend(mod_backend: str | None) -> str:
+    """Map a vehicle's ``modBackend`` (from relations) to its live-status gdc.
+
+    The myVolkswagen web app sends ``gdc=myvw-mbb-prod`` for legacy MBB/Car-Net
+    cars and ``gdc=myvw-wcar-prod`` for WeConnect (MEB/ID.x) cars. Sending the
+    WeConnect gdc to an MBB car makes every live-status read return HTTP 412
+    Precondition Failed (verified live 2026-07-12 on an MBB Golf GTE — the web
+    app itself calls ``…/tripdata/cyclic/last?gdc=myvw-mbb-prod``). Unknown /
+    missing backend falls back to the WeConnect gdc (the historical default).
+    """
+    return _GDC_MBB if (mod_backend or "").strip().upper() == "MBB" else _GDC_WCAR
 
 
 def build_authproxy_url(
@@ -68,26 +82,32 @@ def build_authproxy_url(
     return url
 
 
-def build_warninglights_url(vin: str) -> str:
+def build_warninglights_url(vin: str, gdc: str | None = None) -> str:
     """Active dashboard warning-lights list (``warninglights/last``).
 
     Realm is the WeConnect vehicle backend, NOT ``vw-de``. Carries both
-    ``gdc`` + the live VCF host, matching the myVolkswagen web app.
+    ``gdc`` + the live VCF host, matching the myVolkswagen web app. ``gdc``
+    selects the global-data-centre per car platform (see
+    :func:`gdc_for_backend`); None keeps the historical WeConnect default.
     """
     return build_authproxy_url(
         f"vehicles/{vin}/warninglights/last",
         realm=_REALM_WECONNECT,
         resource_host=_HOST_VCF_LIVE,
-        gdc=_GDC_WCAR,
+        gdc=gdc or _GDC_WCAR,
     )
 
 
-def build_transactionhistory_url(vin: str) -> str:
-    """Remote-command history (lock/unlock lives here). Realm ``vw-de``."""
+def build_transactionhistory_url(vin: str, gdc: str | None = None) -> str:
+    """Remote-command history (lock/unlock lives here). Realm ``vw-de``.
+
+    ``gdc`` selects the global-data-centre per car platform (see
+    :func:`gdc_for_backend`); None keeps the historical WeConnect default.
+    """
     return build_authproxy_url(
         f"vehicles/{vin}/transactionhistory",
         resource_host=_HOST_VCF_LIVE,
-        gdc=_GDC_WCAR,
+        gdc=gdc or _GDC_WCAR,
     )
 
 
@@ -127,7 +147,7 @@ def build_vehicle_images_url(vin: str) -> str:
     )
 
 
-def build_usercapabilities_url(vin: str) -> str:
+def build_usercapabilities_url(vin: str, gdc: str | None = None) -> str:
     """Per-vehicle capability list (``usercapabilities``). Realm ``vw-de``.
 
     v2.16.2 (rafaelhutter v0.5.20 parity — GAP 4.1) — the myVolkswagen web app
@@ -143,7 +163,7 @@ def build_usercapabilities_url(vin: str) -> str:
         f"vehicles/{vin}/usercapabilities",
         realm=_REALM_WECONNECT,
         resource_host=_HOST_VCF_LIVE,
-        gdc=_GDC_WCAR,
+        gdc=gdc or _GDC_WCAR,
     )
 
 

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -114,10 +114,16 @@ _TIMEOUT_S = 60
 _RETRIABLE_STATUSES = frozenset({500, 502, 503, 504})
 _RETRY_DELAYS = (3.0, 6.0)
 
-# A stale authproxy session answers data calls with 401/403, but ALSO with
-# 412 Precondition Failed / 428 Precondition Required (the proxy's own
-# "your session is no longer valid" signal). Treat all four as "re-login".
-_AUTH_FAIL_STATUSES = frozenset({401, 403, 412, 428})
+# A stale authproxy session answers data calls with 401/403 (and 428
+# Precondition Required) — treat those as "re-login". NOT 412 Precondition
+# Failed: verified live 2026-07-12 that 412 is a per-VEHICLE precondition — an
+# MBB/Car-Net car queried with the WeConnect ``gdc`` 412s while the session is
+# still fully valid (relations returns 200). Treating 412 as an auth failure
+# re-logged in on every poll → email-OTP thrash + silent no-data for MBB cars.
+# 412 now degrades to "no data this poll" (see ``_get_json``), and the optional
+# live-status reads pass ``optional=True`` so a car that simply doesn't serve a
+# given read (401/403) can't force a re-login loop either.
+_AUTH_FAIL_STATUSES = frozenset({401, 403, 428})
 
 # v2.15.13 — PROACTIVE session-roll debounce. The vw.de authproxy session's
 # downstream tokens expire ~30 min after the last login (our own
@@ -334,6 +340,12 @@ class WebsiteAuthProxyConnector:
         # so 0.0 would wrongly debounce the very first roll — CI caught this on a
         # fresh runner where the tests passed on a long-uptime dev box.)
         self._last_roll: float = float("-inf")
+        # Per-VIN platform backend ("MBB"/"MEB"/…) learned from the relations
+        # parse, so the live-status reads pick the right ``gdc`` — an MBB car
+        # uses a different global-data-centre than a WeConnect car, and the
+        # wrong gdc makes every read 412. Empty string = "known, no backend
+        # field" (→ WeConnect default) so it isn't re-probed every read.
+        self._vin_backend: dict[str, str] = {}
 
     # ── login ──────────────────────────────────────────────────────────────
 
@@ -854,6 +866,7 @@ class WebsiteAuthProxyConnector:
         *,
         accept: str = "application/json",
         soft: bool = False,
+        optional: bool = False,
     ) -> Any:
         """GET a reverse-proxy endpoint and parse JSON.
 
@@ -861,9 +874,16 @@ class WebsiteAuthProxyConnector:
         ``user-id: __userId__`` placeholder the authproxy substitutes for the
         signed-in user's real id. On ``soft=True`` a transient 5xx returns
         ``None`` (after a short backoff) instead of raising — so a flaky
-        backend just means "no data this poll" rather than a dead session. A
-        401/403 always raises ``AuthenticationError`` so the caller can
-        re-login. (Backoff pattern mirrors the EU Data Act connector.)
+        backend just means "no data this poll" rather than a dead session.
+
+        A 401/403 normally raises ``AuthenticationError`` so the caller can
+        re-login — EXCEPT on an ``optional=True`` read, where a 4xx means "this
+        car doesn't serve this endpoint" (not a dead session) and returns
+        ``None``. 412 Precondition Failed always degrades to ``None`` (it is a
+        per-vehicle precondition, e.g. the wrong-platform gdc, never a dead
+        session). Session validity is decided by the core reads (relations /
+        charging / maintenance), which keep raising on a genuine 401/403.
+        (Backoff pattern mirrors the EU Data Act connector.)
         """
         headers = self._headers({
             "Accept": accept,
@@ -876,7 +896,22 @@ class WebsiteAuthProxyConnector:
                 headers=headers,
                 timeout=ClientTimeout(total=_TIMEOUT_S),
             ) as resp:
+                if resp.status == 412:
+                    # Per-vehicle precondition (e.g. an MBB car queried with the
+                    # WeConnect gdc) — never a dead session → no data this poll.
+                    _LOGGER.debug(
+                        "Website authproxy GET %s → 412 precondition "
+                        "(no data this poll)", url,
+                    )
+                    return None
                 if resp.status in _AUTH_FAIL_STATUSES:
+                    if optional:
+                        _LOGGER.debug(
+                            "Website authproxy GET %s → HTTP %s (optional read "
+                            "unavailable for this car — not a session failure)",
+                            url, resp.status,
+                        )
+                        return None
                     raise AuthenticationError(
                         f"Website authproxy GET {url} → HTTP {resp.status}"
                     )
@@ -889,6 +924,10 @@ class WebsiteAuthProxyConnector:
                         await asyncio.sleep(_RETRY_DELAYS[attempt])
                         continue
                     if soft:
+                        _LOGGER.debug(
+                            "Website authproxy GET %s → HTTP %s "
+                            "(soft; no data this poll)", url, resp.status,
+                        )
                         return None
                     raise AuthenticationError(
                         f"Website authproxy GET {url} → HTTP {resp.status}"
@@ -936,11 +975,45 @@ class WebsiteAuthProxyConnector:
         ``modBackend`` (MBB vs MEB) so a future combined entry can self-discover
         VINs + user-id from the portal session instead of hard-coding them.
         Returns ``None`` on a transient backend hiccup (401/403 still raises).
+        Also caches each VIN's platform backend for the live-status gdc pick.
         """
         from .._authproxy import parse_relations  # noqa: PLC0415
 
         body = await self._get_json(f"{_SITE_BASE}{_RELATIONS_PATH}", soft=True)
-        return parse_relations(body) if body is not None else None
+        rels = parse_relations(body) if body is not None else None
+        if rels is not None:
+            for v in rels.vehicles:
+                # Empty string = "seen, no backend field" → WeConnect default,
+                # and marks the VIN cached so _ensure_backend won't re-probe.
+                self._vin_backend[v.vin] = v.mod_backend or ""
+        return rels
+
+    def _gdc(self, vin: str) -> str:
+        """The live-status ``gdc`` for *vin* from its cached platform backend."""
+        from .._authproxy import gdc_for_backend  # noqa: PLC0415
+
+        return gdc_for_backend(self._vin_backend.get(vin))
+
+    async def _ensure_backend(self, vin: str) -> None:
+        """Resolve *vin*'s platform (MBB/MEB) once so ``_gdc`` picks right.
+
+        The live-status reads need the correct global-data-centre id (an MBB car
+        uses a different gdc than a WeConnect car — the wrong one 412s). We learn
+        the platform from the relations parse; fetch it once and cache it. A
+        genuine 401/403 still propagates (dead session → re-login); any other
+        hiccup is swallowed and leaves the WeConnect default in place.
+        """
+        if vin in self._vin_backend:
+            return
+        try:
+            await self.get_relations()
+        except AuthenticationError:
+            raise
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Website authproxy: platform probe skipped for %s", vin[-6:],
+                exc_info=True,
+            )
 
     async def get_master_data(self, vin: str) -> AuthproxyVehicleInfo:
         """Market model name / engine / year / colour (text + code) for *vin*."""
@@ -964,10 +1037,12 @@ class WebsiteAuthProxyConnector:
     async def get_warning_lights(self, vin: str) -> int | None:
         """Count of currently-active dashboard warning lights for *vin*.
 
-        BETA, fail-soft: any 4xx / parse-miss / empty body returns None (a
-        transient 5xx is retried inside ``_get_json(soft=True)``). An empty
-        ``warningLights`` list is a valid "all OK ⇒ 0" reading (not None). A
-        genuine 401/403/412/428 still propagates so the caller re-logs in.
+        BETA, fail-soft + OPTIONAL: any 4xx (incl. 401/403/412 — e.g. a car that
+        doesn't serve this read) / parse-miss / empty body returns None; a
+        transient 5xx is retried inside ``_get_json``. An empty ``warningLights``
+        list is a valid "all OK ⇒ 0" reading (not None). This read never forces a
+        re-login (see ``optional`` in ``_get_json``) — session validity is gated
+        by the core reads. Uses the car's platform ``gdc`` (MBB vs WeConnect).
         ``Accept-Language: de-DE`` is load-bearing here (the endpoint 400s
         without a language) — sent by ``_headers()`` on every read.
         """
@@ -976,8 +1051,10 @@ class WebsiteAuthProxyConnector:
             parse_warning_lights,
         )
 
+        await self._ensure_backend(vin)
         body = await self._get_json(
-            build_warninglights_url(vin), accept="*/*", soft=True
+            build_warninglights_url(vin, self._gdc(vin)),
+            accept="*/*", soft=True, optional=True,
         )
         if body is None:
             return None
@@ -992,17 +1069,20 @@ class WebsiteAuthProxyConnector:
 
         Returns ``(action, iso_timestamp_or_None)`` where action is
         ``"lock"``/``"unlock"`` — the newest ``actionSuccess`` command, else
-        the newest overall. BETA, fail-soft: any 4xx / parse-miss / no lock
-        message returns None (401/403/412/428 still propagates). This is the
-        command HISTORY, not a live lock state (that's attestation-gated).
+        the newest overall. BETA, fail-soft + OPTIONAL: any 4xx / parse-miss / no
+        lock message returns None and never forces a re-login (an MBB car
+        401/403s here). This is the command HISTORY, not a live lock state
+        (that's attestation-gated). Uses the car's platform ``gdc``.
         """
         from .._authproxy import (  # noqa: PLC0415
             build_transactionhistory_url,
             parse_lock_history,
         )
 
+        await self._ensure_backend(vin)
         body = await self._get_json(
-            build_transactionhistory_url(vin), accept="*/*", soft=True
+            build_transactionhistory_url(vin, self._gdc(vin)),
+            accept="*/*", soft=True, optional=True,
         )
         if body is None:
             return None
@@ -1033,8 +1113,9 @@ class WebsiteAuthProxyConnector:
 
         v2.16.2 (rafaelhutter v0.5.20 parity — GAP 4.1). Additive, read-only,
         fail-soft: any 4xx / parse-miss returns an empty set (a transient 5xx is
-        retried inside ``_get_json(soft=True)``); a genuine 401/403/412/428 still
-        propagates so the caller re-logs in. Sends the versioned
+        retried inside ``_get_json``); OPTIONAL — never forces a re-login (an MBB
+        car 401/403s here), session validity is gated by the core reads. Sends
+        the car's platform ``gdc`` and the versioned
         ``application/json;version=3`` Accept the endpoint requires. Deliberately
         NOT called from ``get_vehicle_data``/the poll path: our capability filter
         is best-effort metadata, and auto-gating a sole-vw.de entry on it could
@@ -1047,10 +1128,11 @@ class WebsiteAuthProxyConnector:
             parse_usercapabilities,
         )
 
+        await self._ensure_backend(vin)
         body = await self._get_json(
-            build_usercapabilities_url(vin),
+            build_usercapabilities_url(vin, self._gdc(vin)),
             accept=build_usercapabilities_accept(),
-            soft=True,
+            soft=True, optional=True,
         )
         if body is None:
             return set()
@@ -1071,8 +1153,10 @@ class WebsiteAuthProxyConnector:
 
         Every read is ``soft`` / fail-soft — a transient backend hiccup or a
         parse-miss on any one leaves the corresponding fields unset instead of
-        failing the whole poll. A real 401/403/412/428 propagates so the caller
-        re-logs in. The vehicle is marked online once any data block parsed
+        failing the whole poll. A real 401/403 on the CORE reads (the relations
+        preflight / charging / maintenance) propagates so the caller re-logs in;
+        the optional live-status reads and any 412 precondition degrade to
+        no-data instead. The vehicle is marked online once any data block parsed
         successfully.
 
         v2.16.0 (BETA, opt-in) — three additive read-path fields, all
@@ -1084,6 +1168,21 @@ class WebsiteAuthProxyConnector:
         """
         d = VehicleData(vin=vin)
         got_data = False
+
+        # Resolve the car's platform (MBB/MEB) up front so the live-status reads
+        # below pick the correct gdc, and reuse the parsed relations for the
+        # nickname/plate enrich at the end (one relations fetch, not two). A
+        # genuine 401/403 here propagates (dead session → re-login).
+        rels: AuthproxyRelations | None = None
+        try:
+            rels = await self.get_relations()  # also populates self._vin_backend
+        except AuthenticationError:
+            raise
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Website authproxy relations preflight skipped for %s", vin[-6:],
+                exc_info=True,
+            )
 
         charging = await self._get_json(
             f"{_SITE_BASE}{_CHARGING_PATH.format(vin=vin)}",
@@ -1132,11 +1231,10 @@ class WebsiteAuthProxyConnector:
             )
 
         # v2.16.0 — nickname + licence plate from the relations LIST parse
-        # (already parsed in _authproxy.py). Best-effort: a miss leaves both
-        # fields None. Falls back to the singular per-VIN relation detail only
-        # if the list omits this VIN.
+        # (fetched up front above — reused here, no second round-trip). A miss
+        # leaves both fields None; falls back to the singular per-VIN relation
+        # detail only if the list omits this VIN.
         try:
-            rels = await self.get_relations()
             match = None
             if rels is not None:
                 match = next(

--- a/tests/test_authproxy_mbb_gdc.py
+++ b/tests/test_authproxy_mbb_gdc.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Per-platform gdc + precondition/optional-read handling for the vw.de authproxy.
+
+Regression cover for the 2026-07-12 fix. The myVolkswagen web app sends
+``gdc=myvw-mbb-prod`` for legacy MBB/Car-Net cars and ``gdc=myvw-wcar-prod`` for
+WeConnect cars; sending the WeConnect gdc to an MBB car 412s every live-status
+read. The old code treated 412 (and the optional reads' 401/403) as a dead
+session and re-logged in on every poll → email-OTP thrash + silent no-data. Now:
+
+  * the live-status builders take a per-car ``gdc`` (default = WeConnect);
+  * the connector resolves each VIN's platform from the relations parse and
+    threads the matching gdc into the reads;
+  * 412 and the optional live-status reads degrade to "no data this poll"
+    instead of forcing a re-login — session validity stays on the CORE reads.
+
+Verified live against an MBB Golf GTE: relations 200 (session valid) but every
+vehicle read 412 with the WeConnect gdc.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad._authproxy import (
+    _GDC_MBB,
+    _GDC_WCAR,
+    build_transactionhistory_url,
+    build_usercapabilities_url,
+    build_warninglights_url,
+    gdc_for_backend,
+)
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+)
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+
+
+# ── pure: gdc_for_backend + builder gdc threading ──────────────────────────
+
+@pytest.mark.parametrize(
+    "backend, expected",
+    [
+        ("MBB", _GDC_MBB),
+        ("mbb", _GDC_MBB),
+        (" Mbb ", _GDC_MBB),
+        ("MEB", _GDC_WCAR),
+        ("WCAR", _GDC_WCAR),
+        ("", _GDC_WCAR),
+        (None, _GDC_WCAR),
+    ],
+)
+def test_gdc_for_backend(backend: str | None, expected: str) -> None:
+    """MBB (any case) → the MBB gdc; everything else → the WeConnect default."""
+    assert gdc_for_backend(backend) == expected
+
+
+def test_builders_default_to_wcar_gdc() -> None:
+    """No gdc arg keeps the historical WeConnect gdc (back-compat)."""
+    vin = "WVWZZZTESTVHN0001"
+    assert f"gdc={_GDC_WCAR}" in build_warninglights_url(vin)
+    assert f"gdc={_GDC_WCAR}" in build_transactionhistory_url(vin)
+    assert f"gdc={_GDC_WCAR}" in build_usercapabilities_url(vin)
+
+
+def test_builders_accept_mbb_gdc() -> None:
+    """An MBB gdc is threaded into every live-status builder URL."""
+    vin = "WVWZZZTESTVHN0001"
+    assert f"gdc={_GDC_MBB}" in build_warninglights_url(vin, _GDC_MBB)
+    assert f"gdc={_GDC_MBB}" in build_transactionhistory_url(vin, _GDC_MBB)
+    assert f"gdc={_GDC_MBB}" in build_usercapabilities_url(vin, _GDC_MBB)
+
+
+# ── connector: precondition + optional-read handling ───────────────────────
+
+class _FakeResp:
+    def __init__(
+        self, url: str, *, status: int = 200, text: str = "", json_data: Any = None
+    ) -> None:
+        self.url = url
+        self.status = status
+        self._text = text
+        self._json = json_data
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def text(self, errors: str | None = None) -> str:
+        return self._text
+
+    async def json(self, content_type: Any = None) -> Any:
+        return self._json
+
+
+_VIN = "WVWZZZTESTVHN0001"
+_CHARGING_JSON = {"data": {"batteryStatus": {"currentSOC_pct": 42}}}
+_WL_JSON = {"data": {"warningLights": []}}
+# get_relations() reads the relations body as JSON (resp.json()), so the mock
+# must return a parsed dict via json_data — not text.
+_REL_MBB = {"relations": [{"vehicle": {"vin": _VIN, "modBackend": "MBB"}}]}
+_REL_PLAIN = {"relations": [{"vehicle": {"vin": _VIN}}]}
+
+
+@pytest.mark.asyncio
+async def test_412_on_live_read_does_not_relogin() -> None:
+    """A 412 (wrong-gdc symptom on MBB cars) degrades to no-data, never raises."""
+    class _412Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "relations" in url:
+                return _FakeResp(url, json_data=_REL_MBB)
+            if "charging/status" in url:
+                return _FakeResp(url, json_data=_CHARGING_JSON)
+            if "maintenance/status" in url:
+                return _FakeResp(url, status=404)
+            return _FakeResp(url, status=412)  # every live-status read 412s
+
+    conn = WebsiteAuthProxyConnector(_412Session(), "u@x.z", "pw")  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data(_VIN)  # must NOT raise
+    assert d.battery_soc == 42
+    assert d.connection_state == "online"
+
+
+@pytest.mark.asyncio
+async def test_403_optional_read_swallowed() -> None:
+    """403 on an OPTIONAL live-status read is swallowed (no re-login)."""
+    class _WL403Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "relations" in url:
+                return _FakeResp(url, json_data=_REL_PLAIN)
+            if "charging/status" in url:
+                return _FakeResp(url, json_data=_CHARGING_JSON)
+            if "maintenance/status" in url:
+                return _FakeResp(url, status=404)
+            return _FakeResp(url, status=403)  # warninglights + transactionhistory
+
+    conn = WebsiteAuthProxyConnector(_WL403Session(), "u@x.z", "pw")  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data(_VIN)  # must NOT raise
+    assert d.battery_soc == 42
+
+
+@pytest.mark.asyncio
+async def test_403_on_core_read_still_relogins() -> None:
+    """403 on a CORE read (charging) still propagates so the caller re-logins."""
+    class _Charging403Session:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "relations" in url:
+                return _FakeResp(url, json_data=_REL_PLAIN)
+            if "charging/status" in url:
+                return _FakeResp(url, status=403)
+            return _FakeResp(url, status=404)
+
+    conn = WebsiteAuthProxyConnector(_Charging403Session(), "u@x.z", "pw")  # type: ignore[arg-type]
+    with pytest.raises(AuthenticationError):
+        await conn.get_vehicle_data(_VIN)
+
+
+@pytest.mark.asyncio
+async def test_mbb_car_uses_mbb_gdc_on_live_reads() -> None:
+    """An MBB ``modBackend`` makes the live-status reads use the MBB gdc."""
+    class _RecordingSession:
+        def __init__(self) -> None:
+            self.gets: list[str] = []
+
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            self.gets.append(url)
+            if "relations" in url:
+                return _FakeResp(url, json_data=_REL_MBB)
+            if "warninglights" in url:
+                return _FakeResp(url, json_data=_WL_JSON)
+            return _FakeResp(url, status=404)
+
+    session = _RecordingSession()
+    conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
+    await conn.get_warning_lights(_VIN)
+    wl = [u for u in session.gets if "warninglights" in u]
+    assert wl, "warninglights endpoint was never called"
+    assert f"gdc={_GDC_MBB}" in wl[0]
+
+
+@pytest.mark.asyncio
+async def test_weconnect_car_keeps_wcar_gdc() -> None:
+    """A non-MBB (or backend-less) car keeps the WeConnect gdc default."""
+    class _RecordingSession:
+        def __init__(self) -> None:
+            self.gets: list[str] = []
+
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            self.gets.append(url)
+            if "relations" in url:
+                return _FakeResp(url, json_data=_REL_PLAIN)
+            if "warninglights" in url:
+                return _FakeResp(url, json_data=_WL_JSON)
+            return _FakeResp(url, status=404)
+
+    session = _RecordingSession()
+    conn = WebsiteAuthProxyConnector(session, "u@x.z", "pw")  # type: ignore[arg-type]
+    await conn.get_warning_lights(_VIN)
+    wl = [u for u in session.gets if "warninglights" in u]
+    assert wl and f"gdc={_GDC_WCAR}" in wl[0]

--- a/tests/test_v2149_website_cookie_broadcast.py
+++ b/tests/test_v2149_website_cookie_broadcast.py
@@ -163,12 +163,27 @@ class _StatusResp:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status", [412, 428])
-async def test_get_json_412_428_raise_auth_error(status: int) -> None:
-    """A stale authproxy session answers 412/428 (not 401) — treat as re-login."""
+async def test_get_json_428_raises_auth_error() -> None:
+    """A stale authproxy session answers 428 Precondition Required → re-login."""
     class _S:
         def get(self, *_a: Any, **_k: Any) -> _StatusResp:
-            return _StatusResp(status)
+            return _StatusResp(428)
 
     with pytest.raises(AuthenticationError):
         await _conn(_S())._get_json("https://www.volkswagen.de/app/authproxy/x")
+
+
+@pytest.mark.asyncio
+async def test_get_json_412_degrades_to_none_not_relogin() -> None:
+    """412 is a per-VEHICLE precondition (e.g. the wrong-platform gdc on an MBB
+    car), NOT a dead session — verified live 2026-07-12 (relations 200 while
+    every read 412'd). It now degrades to None instead of raising, so it can't
+    force a re-login / email-OTP loop while the session is still valid. This
+    holds even in the non-soft path (412 is never a session signal).
+    """
+    class _S:
+        def get(self, *_a: Any, **_k: Any) -> _StatusResp:
+            return _StatusResp(412)
+
+    result = await _conn(_S())._get_json("https://www.volkswagen.de/app/authproxy/x")
+    assert result is None


### PR DESCRIPTION
The vw.de website authproxy read channel hardcoded the WeConnect global-data-centre (`gdc=myvw-wcar-prod`) on the live-status read builders. For **MBB/Car-Net** cars the correct gdc is `myvw-mbb-prod`; the wrong one makes every read `412` while the session is still valid (relations 200). `412` was treated as a dead session → an MBB-car user on the beta channel re-logged in every poll → **email-OTP thrash + silent no-data**.

- `_authproxy.py`: `gdc_for_backend()` + a `gdc` param on the live-status builders (default = WeConnect, back-compat); the connector resolves each VIN's platform from the relations parse and threads the right gdc.
- `_website_authproxy.py`: `412` (a per-vehicle precondition, not a dead session) degrades to "no data this poll"; the optional live-status reads (warninglights / lock-history / capabilities) return None on 401/403 instead of raising — the **core** reads (relations / charging / maintenance) still re-login on a genuine 401/403; every soft-4xx read is logged at DEBUG for diagnostics.

Verified live against an MBB Golf GTE: platform detected → `gdc=myvw-mbb-prod`, `get_vehicle_data` completes without re-login. (Note: this stops the loop; the vw.de channel exposes no live vehicle state for MBB cars regardless of gdc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)