### PR TITLE
Fix MBB command errors: route flash off the BFF + honest, correctly-classified lock/wake failures (#709)

### DIFF
--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -874,6 +874,23 @@ class VWEUClient(CariadBaseClient):
         (vs. only the honk variant) is the one detail not provable from the
         static strings. The bare-body-then-position retry covers both cases.
         """
+        # v2.17.3 — MBB gate (the footgun this fixes): command_flash was the
+        # ONE write command missing the ``_mbb_command_target()`` guard that
+        # command_lock/unlock/wake/start_climate all have. On a legacy Car-Net
+        # (MBB) car the read-only primary bearer was POSTed to the CARIAD BFF
+        # honkandflash endpoint, which answered ``400 {"info":"missing or
+        # invalid auth header"}`` — and the retry branch below then masked it
+        # as a bogus "requires userPosition / no GPS" message. There is no MBB
+        # remote-honk-flash service wired, so surface an honest, actionable
+        # error instead of leaking the bearer to the dead BFF host.
+        if self._mbb_command_target() is not None:
+            raise VehicleCommandError(
+                "flash",
+                "Honk & Flash isn't available on the MBB command channel — it "
+                "needs the CARIAD BFF, which legacy Car-Net (MBB) cars don't "
+                "have. Lock, unlock, climate and charge commands still work "
+                "over MBB.",
+            )
         body: dict[str, Any] = {"mode": "FLASH_ONLY", "duration": 10}
         try:
             await self._post_command(vin, "honkandflash", json=body)
@@ -1024,7 +1041,28 @@ class VWEUClient(CariadBaseClient):
         # wrapper-404 fallback path (non-mbb entries on older MIB3 cars) keeps
         # its original ``self._post`` behaviour.
         if self._tokens and self._tokens.strategy == "mbb":
-            await self._mbb_post_json(url, {})
+            try:
+                await self._mbb_post_json(url, {})
+            except APIError as exc:
+                # v2.17.3 — the durable-MBB grant carries commands (RLU /
+                # climate / charge via SecToken) but NOT the VSR data-refresh
+                # plane: the VSR ``requests`` POST 403s with
+                # ``VSR.security.9007 / systemId 'XID_APP_VW'``. That's a
+                # structural scope gap for this token, not a transient error and
+                # not a subscription lapse — surface it honestly instead of a
+                # raw 403 traceback that reads as "unexpected exception".
+                b = (exc.body or "").lower()
+                if exc.status == 403 and (
+                    "xid_app_vw" in b or "security.9007" in b
+                ):
+                    raise VehicleCommandError(
+                        "wake",
+                        "Remote wake isn't permitted for this car's MBB grant — "
+                        "VW's status-refresh plane (VSR) is closed to this "
+                        "token. The car still updates on its normal poll / push "
+                        "cycle.",
+                    ) from exc
+                raise
         else:
             await self._post(url, json={})
 
@@ -1687,11 +1725,25 @@ class VWEUClient(CariadBaseClient):
 
         # Leg 2 — submit hashed SPIN, get the level-2 security token
         spin_hash = compute_spin_hash(pin, challenge)
-        comp_resp = await self._mbb_post_json(
-            build_mbb_spin_completed_url(setter),
-            build_mbb_completed_body(level1, challenge, spin_hash),
-            for_command=True,
-        )
+        try:
+            comp_resp = await self._mbb_post_json(
+                build_mbb_spin_completed_url(setter),
+                build_mbb_completed_body(level1, challenge, spin_hash),
+                for_command=True,
+            )
+        except APIError as exc:
+            # v2.17.3 — the backend rejected the S-PIN hash. Legs 1-2 of the
+            # rolesrights handshake DID run (so the MBB grant permits the
+            # operation), the PIN VALUE is simply wrong. Surface an actionable
+            # SpinError instead of a raw 403 traceback — and note the lockout so
+            # the user doesn't keep burning their remaining tries.
+            if exc.status == 403 and "invalidsecuritypin" in (exc.body or "").lower():
+                raise SpinError(
+                    "The Security PIN was rejected by VW — double-check your "
+                    "S-PIN in the We Connect / Car-Net app. After 3 wrong "
+                    "attempts the PIN locks for a while."
+                ) from exc
+            raise
         sec_token = parse_mbb_completed_token(comp_resp)
         if not sec_token:
             raise VehicleCommandError(verb, "MBB SPIN completion returned no token")

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -129,6 +129,13 @@ def classify_command_failure(exc: BaseException) -> CommandFailureReason:
         return CommandFailureReason.MISSING_CAPABILITY
     if "spin_error" in body or "spinstate" in body:
         return CommandFailureReason.SPIN_REQUIRED
+    # v2.17.3 — the classic Car-Net MBB rolesrights reply for a wrong S-PIN
+    # (``mbbc.rolesandrights.invalidSecurityPin``). Without this marker it fell
+    # through to the bare ``status == 403`` → NOT_ENTITLED branch, which wrongly
+    # flags the account as unentitled and sends the user chasing a phantom
+    # subscription renewal. It's just a wrong PIN — actionable, non-hiding.
+    if "invalidsecuritypin" in body or "invalid security pin" in body:
+        return CommandFailureReason.SPIN_REQUIRED
     if "subscription" in body and ("expired" in body or "lapsed" in body):
         return CommandFailureReason.SUBSCRIPTION_EXPIRED
     if (

--- a/tests/test_v2173_mbb_command_errors.py
+++ b/tests/test_v2173_mbb_command_errors.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.17.3 — MBB command failures surface as clean, correctly-classified errors.
+
+Grounded in a live GTE (Golf GTE, the repo's standard MBB test car) diagnostic
+where all three write commands failed with raw ``APIError`` tracebacks:
+
+1. **honk/flash** — ``command_flash`` was the ONE write command missing the
+   ``_mbb_command_target()`` gate, so on an MBB car it POSTed the read-only
+   bearer to the CARIAD BFF (``400 missing or invalid auth header``) and then
+   masked it as a bogus "requires userPosition / no GPS" message.
+2. **lock (RLU)** — leg-2 rejected the S-PIN hash with
+   ``mbbc.rolesandrights.invalidSecurityPin``; it bubbled as a raw 403 and
+   ``classify_command_failure`` mislabeled it ``NOT_ENTITLED`` (phantom renewal).
+3. **wake (VSR)** — the durable-MBB grant does not carry the VSR data-refresh
+   plane, so ``requests`` 403s with ``VSR.security.9007 / XID_APP_VW``. It
+   bubbled as a raw 403 mislabeled ``NOT_ENTITLED`` too.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+from custom_components.vag_connect.cariad.exceptions import (
+    APIError,
+    CommandFailureReason,
+    SpinError,
+    VehicleCommandError,
+    classify_command_failure,
+)
+from custom_components.vag_connect.cariad.models import TokenSet
+
+_VIN = "WVWZZZAUZFW805377"  # repo-standard MBB test VIN (Golf GTE)
+
+_INVALID_SPIN_BODY = (
+    '{"error":{"errorCode":"mbbc.rolesandrights.invalidSecurityPin",'
+    '"description":"The Security PIN is invalid."}}'
+)
+_VSR_9007_BODY = (
+    '{"error":{"errorCode":"VSR.security.9007","description":"Did not find '
+    "permission for systemId 'XID_APP_VW', therefore denying access\"}}"
+)
+_CHALLENGE = {
+    "securityPinAuthInfo": {
+        "securityToken": "LEVEL1TOKEN",
+        "securityPinTransmission": {
+            "challenge": "abcdef0123456789",  # valid, even-length hex
+            "remainingTries": 3,
+        },
+    },
+}
+
+
+def _mbb_client() -> VWEUClient:
+    c = VWEUClient(MagicMock(), "u@t.de", "pw")
+    c._tokens = TokenSet(
+        access_token="a", refresh_token="r", id_token="i", strategy="mbb",
+    )
+    return c
+
+
+def _bff_client() -> VWEUClient:
+    # No tokens → _mbb_command_target() is None → command_flash uses the BFF.
+    return VWEUClient(MagicMock(), "u@t.de", "pw")
+
+
+def _patch_home_region(monkeypatch) -> None:
+    import custom_components.vag_connect.cariad._home_region as _hr
+
+    monkeypatch.setattr(
+        _hr, "resolve_home_region",
+        AsyncMock(return_value="https://msg.volkswagen.de"),
+    )
+
+
+# ── Fix 1: command_flash MBB gate ────────────────────────────────────────────
+
+def test_flash_on_mbb_raises_clean_error_and_never_touches_bff() -> None:
+    c = _mbb_client()  # strategy mbb → _mbb_command_target() is self
+    c._post_command = AsyncMock()  # type: ignore[method-assign]
+    with pytest.raises(VehicleCommandError) as ei:
+        asyncio.run(c.command_flash(_VIN))
+    # honest message, and the read-only bearer never reached the dead BFF
+    assert "mbb" in str(ei.value).lower()
+    c._post_command.assert_not_awaited()
+
+
+def test_flash_on_bff_car_still_posts() -> None:
+    # regression guard: a non-MBB car keeps hitting the BFF honkandflash path.
+    c = _bff_client()
+    c._post_command = AsyncMock()  # type: ignore[method-assign]
+    asyncio.run(c.command_flash("WVWZZZ7AZRE000001"))
+    c._post_command.assert_awaited()
+
+
+# ── Fix 2: RLU invalidSecurityPin → SpinError ────────────────────────────────
+
+def test_rlu_invalid_spin_raises_spinerror(monkeypatch) -> None:
+    c = _mbb_client()
+    _patch_home_region(monkeypatch)
+    c._mbb_country_from_id_token = MagicMock(return_value="DE")  # type: ignore[method-assign]
+    c._mbb_get = AsyncMock(return_value=_CHALLENGE)  # leg 1  # type: ignore[method-assign]
+    # leg 2 rejects the S-PIN hash
+    c._mbb_post_json = AsyncMock(  # type: ignore[method-assign]
+        side_effect=APIError(
+            403,
+            "https://x/api/rolesrights/authorization/v2/security-pin-auth-completed",
+            _INVALID_SPIN_BODY,
+        )
+    )
+    with pytest.raises(SpinError) as ei:
+        asyncio.run(c._command_rlu_mbb(_VIN, spin="1234", lock=True))
+    assert "security pin" in str(ei.value).lower()
+
+
+def test_rlu_other_403_still_propagates_raw(monkeypatch) -> None:
+    # a DIFFERENT 403 (not invalidSecurityPin) must NOT be swallowed as SpinError
+    c = _mbb_client()
+    _patch_home_region(monkeypatch)
+    c._mbb_country_from_id_token = MagicMock(return_value="DE")  # type: ignore[method-assign]
+    c._mbb_get = AsyncMock(return_value=_CHALLENGE)  # type: ignore[method-assign]
+    c._mbb_post_json = AsyncMock(  # type: ignore[method-assign]
+        side_effect=APIError(403, "https://x/completed", '{"error":"forbidden"}')
+    )
+    with pytest.raises(APIError):
+        asyncio.run(c._command_rlu_mbb(_VIN, spin="1234", lock=True))
+
+
+# ── Fix 3: wake VSR 9007 / XID_APP_VW → VehicleCommandError ───────────────────
+
+def test_wake_vsr_9007_raises_clean_command_error(monkeypatch) -> None:
+    c = _mbb_client()
+    _patch_home_region(monkeypatch)
+    c._mbb_country_from_id_token = MagicMock(return_value="DE")  # type: ignore[method-assign]
+    c._mbb_post_json = AsyncMock(  # type: ignore[method-assign]
+        side_effect=APIError(
+            403,
+            "https://msg.volkswagen.de/fs-car/bs/vsr/v1/VW/DE/vehicles/"
+            f"{_VIN}/requests",
+            _VSR_9007_BODY,
+        )
+    )
+    with pytest.raises(VehicleCommandError) as ei:
+        asyncio.run(c._command_wake_mbb(_VIN))
+    assert "wake" in str(ei.value).lower()
+
+
+def test_wake_other_403_still_propagates_raw(monkeypatch) -> None:
+    c = _mbb_client()
+    _patch_home_region(monkeypatch)
+    c._mbb_country_from_id_token = MagicMock(return_value="DE")  # type: ignore[method-assign]
+    c._mbb_post_json = AsyncMock(  # type: ignore[method-assign]
+        side_effect=APIError(403, "https://x/requests", '{"error":"nope"}')
+    )
+    with pytest.raises(APIError):
+        asyncio.run(c._command_wake_mbb(_VIN))
+
+
+# ── Fix 4: classify_command_failure marker ───────────────────────────────────
+
+class TestClassifyInvalidSpin:
+    def test_invalid_security_pin_is_spin_required_not_entitled(self) -> None:
+        exc = APIError(403, "/x", _INVALID_SPIN_BODY)
+        # was NOT_ENTITLED (bare-403 fallthrough) → now the actionable reason
+        assert classify_command_failure(exc) is CommandFailureReason.SPIN_REQUIRED
+
+    def test_bare_403_still_not_entitled(self) -> None:
+        # guard: the fix must not swallow genuine entitlement 403s
+        assert (
+            classify_command_failure(APIError(403, "/x", "forbidden"))
+            is CommandFailureReason.NOT_ENTITLED
+        )


### PR DESCRIPTION
On a legacy Car-Net (MBB) car, all three remote write commands failed with raw `APIError` tracebacks in the log (`Unexpected exception` at the websocket layer) instead of clean, actionable errors. This surfaces them honestly and fixes one genuine routing bug.

### honk / flash — routing bug (fixed)
`command_flash` was the **only** write command missing the `_mbb_command_target()` gate that `command_lock` / `command_unlock` / `command_wake` / `command_start_climate` all have. On an MBB car it POSTed the read-only primary bearer to the CARIAD BFF `honkandflash` endpoint, which answered `400 {"info":"missing or invalid auth header"}` — and the retry branch then masked it as a bogus *"requires userPosition / no GPS"* message, sending users to chase a phantom location problem.

There is no MBB remote-honk-flash service wired, so MBB cars now get a clear "not available on the MBB command channel" error and the bearer never touches the dead BFF host. Non-MBB (BFF) cars are unchanged.

### lock (RLU) — clean S-PIN error + correct classification
Leg-2 of the S-PIN handshake rejected the hash with `mbbc.rolesandrights.invalidSecurityPin`. Legs 1-2 ran (so the MBB grant permits the operation) — the PIN value itself was wrong. It bubbled as a raw 403, and `classify_command_failure` mislabeled it `NOT_ENTITLED` (which flags the account as unentitled and points the user at a subscription renewal that doesn't exist).

Now → clean `SpinError` ("verify your S-PIN in the app; 3 wrong tries locks it") + a classifier marker → `SPIN_REQUIRED` (actionable, non-hiding). The S-PIN hash algorithm is **unchanged** — this is purely error surfacing.

### wake (VSR) — honest structural message
The durable-MBB grant carries commands (RLU / climate / charge via SecToken) but not the VSR data-refresh plane, so the `requests` POST 403s with `VSR.security.9007 / systemId 'XID_APP_VW'`. Same `NOT_ENTITLED` mislabel. Now → clean `VehicleCommandError` explaining the VSR plane is closed to this token (status still updates on the normal poll / push cycle).

### Tests
- 8 new tests in `tests/test_v2173_mbb_command_errors.py` covering all four changes + regression guards (a non-invalidSecurityPin 403 still propagates raw; a bare 403 still classifies `NOT_ENTITLED`; a non-MBB car still posts to the BFF).
- Full suite: 3558 passed / 15 skipped. ruff + mypy strict clean.

Grounded in a live Golf GTE diagnostic (the repo's standard MBB test VIN). Related: #709.
