### PR TITLE
2.17.5: fix the Scout UUID flood + full portal-coverage sweep + per-vehicle S-PIN

### DIFF
--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -749,6 +749,48 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
+    # v2.17.5 — LIVE 'active' status twins (state_*_active) of the enabled
+    # settings above. Diagnostic, disabled-by-default.
+    VagBinarySensorDescription(
+        key="mirror_heating_active",
+        translation_key="mirror_heating_active",
+        data_key="mirror_heating_active",
+        icon="mdi:mirror",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    VagBinarySensorDescription(
+        key="climate_zone_active_front_left",
+        translation_key="climate_zone_active_front_left",
+        data_key="climate_zone_active_front_left",
+        icon="mdi:thermostat",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    VagBinarySensorDescription(
+        key="climate_zone_active_front_right",
+        translation_key="climate_zone_active_front_right",
+        data_key="climate_zone_active_front_right",
+        icon="mdi:thermostat",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    VagBinarySensorDescription(
+        key="climate_zone_active_rear_left",
+        translation_key="climate_zone_active_rear_left",
+        data_key="climate_zone_active_rear_left",
+        icon="mdi:thermostat",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    VagBinarySensorDescription(
+        key="climate_zone_active_rear_right",
+        translation_key="climate_zone_active_rear_right",
+        data_key="climate_zone_active_rear_right",
+        icon="mdi:thermostat",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
 )
 BINARY_DESCRIPTIONS = BINARY_DESCRIPTIONS + _NEW_BINARY
 

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -2660,6 +2660,16 @@ class VWEUClient(CariadBaseClient):
         if isinstance(mode_pending, list):
             d.charging_mode_pending = len(mode_pending)
 
+        # v2.17.5 — fourth *.requests sibling: batteryChargingCare.
+        # chargingCareSettings.requests counts queued battery-care changes
+        # (we already parse batteryCareMode/batteryCareTargetSoc from this
+        # container). Same [N items] count diagnostic; None when leaf absent.
+        care_pending = v(
+            raw, "batteryChargingCare", "chargingCareSettings", "requests"
+        )
+        if isinstance(care_pending, list):
+            d.charging_care_pending = len(care_pending)
+
         # v2.3.0 — scout #264 (Audi moltke69 2026-05-19) — route-aware
         # smart charging fields. The Cariad-BFF backend ships a
         # navigation-aware SoC target (e.g. "charge until you have

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -2775,10 +2775,20 @@ class VWEUClient(CariadBaseClient):
         # than expanded.
 
         plug_state = v(raw, "charging", "plugStatus", "value", "plugConnectionState")
-        d.plug_state = plug_state
         # v2.0.1 (#131 follow-up) — defensive parsing.
         if isinstance(plug_state, str):
             d.plug_connected = plug_state.upper() == "CONNECTED"
+            # v2.17.5 (#770) — don't surface the CARIAD 'invalid'/'unsupported'
+            # sentinel as a raw plug-state text sensor (the boolean above is
+            # already safe via the positive == CONNECTED test). Mirror the
+            # climatisation 'invalid' handling and keep the text state unknown.
+            d.plug_state = (
+                None
+                if plug_state.upper() in ("INVALID", "UNSUPPORTED")
+                else plug_state
+            )
+        else:
+            d.plug_state = plug_state
         # v2.0.1 (#131 follow-up) — defensive parsing.
         plug_lock = v(raw, "charging", "plugStatus", "value", "plugLockState")
         if isinstance(plug_lock, str):

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -547,12 +547,18 @@ _CAPTURED_NAME_HINTS: tuple[str, ...] = (
 # disambiguates. Four dict entries share the name "value", so name-keying
 # collapses them onto one last-wins field and the range is lost on ID.3/4/5/7.
 # The flattener additionally keys such points by their ``key`` UUID so first()
-# can resolve them by UUID. Generic set mirrors the reference impl's own list.
+# can resolve them by UUID.
 _GENERIC_FIELD_NAMES: frozenset[str] = frozenset(
     {"value", "unit", "state", "timestamp", "is_set", "type"}
 )
-_UUID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+# v2.17.5 — ONLY alias the UUIDs we actually MAP. The 2.17.4 blanket alias
+# emitted an ``eu_data_act.<uuid>`` key for EVERY generic-named point, which
+# flooded the Vehicle Data Scout with dozens of unmapped timestamp/state UUID
+# names per car ("46 new fields"). We now alias solely these known-mapped UUIDs;
+# every other generic point keeps only its bare name + value (still Scout-visible,
+# so discovery is unaffected) and no longer spams unmapped UUID rows.
+_MAPPED_UUIDS: frozenset[str] = frozenset(
+    {"0ca40e18-0564-3eda-bcc0-7aee9ef44f04"}  # primary range (electric on BEV / combustion on PHEV)
 )
 
 
@@ -752,17 +758,19 @@ def _walk_fields(
             fname = node.get("dataFieldName") or node.get("name")
             if fname is not None and "value" in node:
                 add(fname, node.get("value"), ts, ts_real)
-                # v2.17.4 — when the leaf name is a GENERIC token, also key by the
-                # per-point ``key`` UUID so points that collide on a bare name
-                # (many "value" points on MEB/ID.x) don't collapse and first()
-                # can resolve them by UUID (e.g. 0ca40e18 → primary range). The
-                # UUID key is lowercased to match the dictionary + mapping forms.
+                # v2.17.4/v2.17.5 — when the leaf name is a GENERIC token, also key
+                # by the per-point ``key`` UUID so points that collide on a bare
+                # name (many "value" points on MEB/ID.x) don't collapse and first()
+                # can resolve them by UUID (e.g. 0ca40e18 → primary range). Only
+                # UUIDs we actually MAP are aliased (_MAPPED_UUIDS) — aliasing every
+                # generic point flooded the Scout with unmapped UUID rows (2.17.4
+                # regression). Lowercased to match the dictionary + mapping forms.
                 pkey = node.get("key")
                 if (
                     isinstance(fname, str)
                     and fname.strip().lower() in _GENERIC_FIELD_NAMES
                     and isinstance(pkey, str)
-                    and _UUID_RE.match(pkey.strip())
+                    and pkey.strip().lower() in _MAPPED_UUIDS
                 ):
                     add(pkey.strip().lower(), node.get("value"), ts, ts_real)
                 # v2.15.4 overreport fix: a data-point node reached through a

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1942,7 +1942,12 @@ def map_dataset_to_vehicle_data(
     # v2.15.5 (#544) — sunroof motor hood 1 POSITION (%; 0=closed). Distinct
     # from the open/closed STATE above. Dict type=number, unit "%". first()
     # drops the uint16 65535 "no reading" sentinel; valid 0-100 survives.
-    _sunroof_pos = _to_int(first("position_sunroof_motor_hood_1"))
+    # v2.17.5 — hood_3 is the same sunroof-position % on cars that report only
+    # that slot (we already merge hood_3 STATE into sunroof_open above), so fold
+    # it in as a fallback rather than leaving the position sensor empty.
+    _sunroof_pos = _to_int(first(
+        "position_sunroof_motor_hood_1", "position_sunroof_motor_hood_3",
+    ))
     if _sunroof_pos is not None and d.sunroof_position_pct is None:
         d.sunroof_position_pct = _sunroof_pos
     _svc_hatch = _to_int(first("state_service_hatch"))
@@ -1980,6 +1985,13 @@ def map_dataset_to_vehicle_data(
     _oil_dip = _to_int(first("oil_level_dipstick_indicator_function"))
     if _oil_dip is not None:
         d.oil_dipstick_active = _oil_dip == 1
+    # v2.17.5 — oil_level_min_warning (dict 6933): a boolean LOW-oil-level lamp
+    # (0=OK, 1=low). Distinct from the oil-CHANGE service lamp (warning_oil).
+    # Feeds the existing oil_level_warning binary_sensor, until now only BFF-fed,
+    # so VW combustion cars on the portal get oil-level-warning coverage too.
+    _oil_w = first("oil_level_min_warning")
+    if _oil_w is not None and d.oil_level_warning is None:
+        d.oil_level_warning = str(_oil_w).strip().lower() in ("1", "true")
     # scr_range — AdBlue/SCR range (km). Empty string guarded by _to_int.
     _scr = _to_int(first("scr_range"))
     if _scr is not None and d.adblue_range_km is None:
@@ -2204,6 +2216,15 @@ def map_dataset_to_vehicle_data(
     _zfr = _setting_bool(first("setting_zone_enabled_front_right"))
     if _zfr is not None and d.climate_zone_front_right_enabled is None:
         d.climate_zone_front_right_enabled = _zfr
+    # v2.17.5 — the portal ships rear zones too (setting_zone_enabled_rear_*) but
+    # only the front pair was aliased. Rear targets the BFF-shared
+    # climate_zone_rear_left/right attrs (there is no _enabled twin for rear).
+    _zrl = _setting_bool(first("setting_zone_enabled_rear_left"))
+    if _zrl is not None and d.climate_zone_rear_left is None:
+        d.climate_zone_rear_left = _zrl
+    _zrr = _setting_bool(first("setting_zone_enabled_rear_right"))
+    if _zrr is not None and d.climate_zone_rear_right is None:
+        d.climate_zone_rear_right = _zrr
 
     # start_stop_action — dict type=string, "Indicates the action related to
     # charging". No dict-listed enum values → no confirmed prefix; _shorten_enum

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1174,7 +1174,10 @@ def map_dataset_to_vehicle_data(
     if tmax is not None:
         d.hv_battery_max_temperature_c = tmax
 
-    locked = first("locked", "doors_locked", "doorLockStatus")
+    # v2.17.5 — qualified door-lock fields win over the bare ``locked`` leaf: a
+    # ``trunk.locked`` container ALSO emits a bare ``locked`` (cross-container
+    # collision) that would otherwise mis-set doors_locked from the trunk state.
+    locked = first("doors_locked", "doorLockStatus", "locked")
     if locked is not None:
         d.doors_locked = str(locked).lower() in ("true", "locked", "1")
 
@@ -1366,6 +1369,11 @@ def map_dataset_to_vehicle_data(
         d.doors_locked = all(v == 2 for v in _lock_vals)  # any unlocked → False
     if _tail_lock in (2, 3) and d.trunk_locked is None:
         d.trunk_locked = _tail_lock == 2
+    # v2.17.5 — the boolean ``trunk.locked`` dialect (dotted spelling so it never
+    # collides with the door's bare ``locked``). "true" = trunk locked.
+    _trunk_l = first("trunk.locked", "trunk_locked")
+    if _trunk_l is not None and d.trunk_locked is None:
+        d.trunk_locked = str(_trunk_l).strip().lower() in ("true", "locked", "1")
 
     # open-state → doors_individual (True == OPEN, matching the vw_eu polarity)
     for _slot, _name in (
@@ -1685,6 +1693,12 @@ def map_dataset_to_vehicle_data(
         d.parking_light_left = _pll_b
     if _plr_b is not None:
         d.parking_light_right = _plr_b
+    # v2.17.5 — parkinglightstate.is_set: some dialects send only this flag and
+    # not the per-side lights above (mirrors the parking_brake.is_set precedent).
+    # "true"/"set" = a parking light is on.
+    _pls = first("parkinglightstate.is_set", "parkinglightstate_is_set")
+    if _pls is not None and d.parking_light is None:
+        d.parking_light = str(_pls).strip().lower() in ("true", "1", "set")
     if (_pll_b is not None or _plr_b is not None) and d.parking_light is None:
         d.parking_light = bool(_pll_b) or bool(_plr_b)
 
@@ -2225,6 +2239,23 @@ def map_dataset_to_vehicle_data(
     _zrr = _setting_bool(first("setting_zone_enabled_rear_right"))
     if _zrr is not None and d.climate_zone_rear_right is None:
         d.climate_zone_rear_right = _zrr
+    # v2.17.5 — LIVE 'active' status twins of the *_enabled settings above
+    # (state_mirror_heating_active / state_zone_active_*). active != enabled.
+    _mha = _setting_bool(first("state_mirror_heating_active"))
+    if _mha is not None and d.mirror_heating_active is None:
+        d.mirror_heating_active = _mha
+    _zafl = _setting_bool(first("state_zone_active_front_left"))
+    if _zafl is not None and d.climate_zone_active_front_left is None:
+        d.climate_zone_active_front_left = _zafl
+    _zafr = _setting_bool(first("state_zone_active_front_right"))
+    if _zafr is not None and d.climate_zone_active_front_right is None:
+        d.climate_zone_active_front_right = _zafr
+    _zarl = _setting_bool(first("state_zone_active_rear_left"))
+    if _zarl is not None and d.climate_zone_active_rear_left is None:
+        d.climate_zone_active_rear_left = _zarl
+    _zarr = _setting_bool(first("state_zone_active_rear_right"))
+    if _zarr is not None and d.climate_zone_active_rear_right is None:
+        d.climate_zone_active_rear_right = _zarr
 
     # start_stop_action — dict type=string, "Indicates the action related to
     # charging". No dict-listed enum values → no confirmed prefix; _shorten_enum

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -437,6 +437,10 @@ class VehicleData:
     # (i.e. queued ``start_charging`` / ``stop_charging`` commands).
     # Same int-count diagnostic, same None semantics.
     charging_status_pending: int | None = None
+    # v2.17.5 — fourth *.requests sibling: ``batteryChargingCare
+    # .chargingCareSettings.requests`` counts queued battery-care changes.
+    # Same int-count diagnostic, same None semantics. sensor, diagnostic.
+    charging_care_pending: int | None = None
     # v2.15.8 — Cariad scout #583 (Audi): third charging-side *.requests
     # sibling — ``charging.chargeMode.requests`` counts queued chargeMode
     # change requests (e.g. a putChargeMode POST switching preferred mode
@@ -1650,6 +1654,15 @@ class VehicleData:
     # front_left / _front_right). binary_sensor, diagnostic.
     climate_zone_front_left_enabled: bool | None = None
     climate_zone_front_right_enabled: bool | None = None
+    # v2.17.5 — glass/mirror heating currently ACTIVE (state_mirror_heating_
+    # active) — distinct from the *enabled* setting above. binary_sensor, diag.
+    mirror_heating_active: bool | None = None
+    # v2.17.5 — extended conditioning currently ACTIVE per zone (state_zone_
+    # active_*) — the live status twin of the *_enabled settings. binary, diag.
+    climate_zone_active_front_left: bool | None = None
+    climate_zone_active_front_right: bool | None = None
+    climate_zone_active_rear_left: bool | None = None
+    climate_zone_active_rear_right: bool | None = None
     # Charging-related action (start_stop_action — dict type=string, no enum
     # list; _shorten_enum passes unprefixed values through). LOW —
     # disabled-by-default. sensor, diagnostic.

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -56,6 +56,7 @@ from .const import (
     CONF_READ_ONLY,
     CONF_SCAN_INTERVAL,
     CONF_SPIN,
+    CONF_SPIN_BY_VIN,
     CONF_HIDE_EMPTY_ENTITIES,
     CONF_SUPPLEMENTARY_AUTHPROXY,
     CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES,
@@ -1605,6 +1606,17 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
         # Only persist / branch when the submit validated cleanly. On an
         # error we fall through to re-show the form (with ``errors``) below.
         if user_input is not None and not errors:
+            # v2.17.5 (#759) — fold the per-VIN S-PIN fields into one
+            # CONF_SPIN_BY_VIN dict and drop the transient per-field keys so they
+            # never persist as standalone options. Empty fields = shared S-PIN.
+            _by_vin: dict[str, str] = {}
+            for _k in list(user_input.keys()):
+                if _k.startswith(f"{CONF_SPIN_BY_VIN}_"):
+                    _val = str(user_input.pop(_k) or "").strip()
+                    if _val:
+                        _by_vin[_k[len(CONF_SPIN_BY_VIN) + 1:]] = _val
+            if _by_vin:
+                user_input[CONF_SPIN_BY_VIN] = _by_vin
             # b1/C1 — if the user ticked "add vw.de read channel", branch into
             # the login sub-flow; the remaining options are saved when it
             # completes. Default-False so untouched submits behave exactly as
@@ -1882,6 +1894,21 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
             schema[vol.Optional(
                 "remove_supplementary_eu_portal", default=False,
             )] = _BOOL_SELECTOR
+        # v2.17.5 (#759) — one optional S-PIN field per known VIN, shown only
+        # when the account has more than one vehicle (each may carry its own
+        # S-PIN). Empty leaves that vehicle on the shared CONF_SPIN above; values
+        # are folded into CONF_SPIN_BY_VIN on submit.
+        _coord = getattr(self._config_entry, "runtime_data", None)
+        _vehicles = getattr(_coord, "vehicles", None)
+        _cur_by_vin = current_options.get(CONF_SPIN_BY_VIN)
+        if not isinstance(_cur_by_vin, dict):
+            _cur_by_vin = {}
+        if isinstance(_vehicles, dict) and len(_vehicles) > 1:
+            for _vin in _vehicles:
+                schema[vol.Optional(
+                    f"{CONF_SPIN_BY_VIN}_{_vin}",
+                    default=str(_cur_by_vin.get(_vin, "")),
+                )] = _SPIN_SELECTOR
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(schema),

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -9,6 +9,10 @@ CONF_BRAND                    = "brand"
 CONF_USERNAME                 = "username"
 CONF_PASSWORD                 = "password"
 CONF_SPIN                     = "spin"
+# v2.17.5 (#759) — optional per-VIN S-PIN overrides: {vin: spin}. When a
+# vehicle has no entry here the shared CONF_SPIN is used, so existing
+# single-S-PIN setups are unchanged. Set via the Options flow.
+CONF_SPIN_BY_VIN              = "spin_by_vin"
 # v2.15.1 (#503) — Volkswagen US/Canada region selector. VWNorthAmericaClient
 # picks the right MYVW client_id + b-h-s.spr.{us|ca}00 host from this value.
 # Only consumed by the volkswagen_na brand; every other brand ignores it.

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_READ_ONLY,
     CONF_SCAN_INTERVAL,
     CONF_SPIN,
+    CONF_SPIN_BY_VIN,
     CONF_USERNAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -3548,13 +3549,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # hit the 403 with ``spinState=DEFINED`` — that's then a clear
         # signal to configure the S-PIN, not an integration bug.
         brand = self.entry.data.get(CONF_BRAND, "").lower()
-        options = getattr(self.entry, "options", None) or {}
-        data = getattr(self.entry, "data", None) or {}
-        spin = ""
-        if isinstance(options, dict):
-            spin = str(options.get(CONF_SPIN) or "")
-        if not spin and isinstance(data, dict):
-            spin = str(data.get(CONF_SPIN) or "")
+        spin = self._spin_from_entry(vin)  # #759 — per-VIN override, else shared
         if brand in ("seat", "cupra") and not spin:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -3570,16 +3565,9 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         )
 
     async def async_unlock(self, vin: str) -> None:
-        # Prefer options (Options Flow) over data (initial config). Use real
-        # dict semantics so MagicMock values in tests don't accidentally pass
-        # the truthiness check.
-        options = getattr(self.entry, "options", None) or {}
-        data = getattr(self.entry, "data", None) or {}
-        spin = ""
-        if isinstance(options, dict):
-            spin = str(options.get(CONF_SPIN) or "")
-        if not spin and isinstance(data, dict):
-            spin = str(data.get(CONF_SPIN) or "")
+        # v2.17.5 (#759) — per-VIN S-PIN override, else the shared per-entry
+        # S-PIN (Options over Data). Same result as before for single-S-PIN setups.
+        spin = self._spin_from_entry(vin)
         if not spin:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -3866,7 +3854,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # the SEAT/CUPRA path so VW/Audi users without S-PIN configured
         # can still use the engine pre-heater.
         if not cariad_brand:
-            spin = self._spin_from_entry()
+            spin = self._spin_from_entry(vin)  # #759 per-VIN
             if not spin:
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
@@ -3923,10 +3911,21 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             **address_fields,
         )
 
-    def _spin_from_entry(self) -> str:
-        """Return the configured S-PIN preferring Options over Data."""
+    def _spin_from_entry(self, vin: str | None = None) -> str:
+        """Return the configured S-PIN, preferring Options over Data.
+
+        v2.17.5 (#759) — when *vin* is given and a per-VIN override exists in
+        ``CONF_SPIN_BY_VIN``, that wins; otherwise the shared per-entry S-PIN is
+        returned (so single-S-PIN setups behave exactly as before).
+        """
         options = getattr(self.entry, "options", None) or {}
         data = getattr(self.entry, "data", None) or {}
+        if vin and isinstance(options, dict):
+            by_vin = options.get(CONF_SPIN_BY_VIN)
+            if isinstance(by_vin, dict):
+                per = str(by_vin.get(vin) or "")
+                if per:
+                    return per
         if isinstance(options, dict):
             spin = str(options.get(CONF_SPIN) or "")
             if spin:

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -259,6 +259,20 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
+    # v2.17.5 — fourth charging-side *_pending sibling — counts queued
+    # battery-care setting changes (``batteryChargingCare
+    # .chargingCareSettings.requests``). 0 = idle, >0 = queued at the gateway.
+    # Disabled by default — power-user opt-in. None when leaf absent.
+    VagSensorDescription(
+        key="charging_care_pending",
+        translation_key="charging_care_pending",
+        data_key="charging_care_pending",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery-heart-variant",
+        condition="electric",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
     # v2.2.3 — Cariad scout #272 (VW EU arvcer 2026-05-23): third
     # *_pending sibling — counts queued start/stop_climatisation
     # commands. No ``condition`` filter (every brand with climatisation

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -299,6 +299,9 @@
       "charging_mode_pending": {
         "name": "Charge Mode Changes Pending"
       },
+      "charging_care_pending": {
+        "name": "Battery Care Changes Pending"
+      },
       "climatisation_status_pending": {
         "name": "Climate Commands Pending"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Climate zone front-right"
+      },
+      "mirror_heating_active": {
+        "name": "Mirror heating active"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Climate zone front-left active"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Climate zone front-right active"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Climate zone rear-left active"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Climate zone rear-right active"
       },
       "abrp_data_changed": {
         "name": "ABRP Data Changed"

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Změny režimu nabíjení čekají"
       },
+      "charging_care_pending": {
+        "name": "Změny péče o baterii čekají"
+      },
       "climate_remaining_time_min": {
         "name": "Klimatizace – zbývající čas"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Klimatická zóna vpředu vpravo"
+      },
+      "mirror_heating_active": {
+        "name": "Vyhřívání zrcátek aktivní"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Klimatická zóna vpředu vlevo aktivní"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Klimatická zóna vpředu vpravo aktivní"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Klimatická zóna vzadu vlevo aktivní"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Klimatická zóna vzadu vpravo aktivní"
       },
       "abrp_data_changed": {
         "name": "Data ABRP změněna"

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Ladetilstandsændringer afventende"
       },
+      "charging_care_pending": {
+        "name": "Batteriplejeændringer afventende"
+      },
       "climate_remaining_time_min": {
         "name": "Klima forventet tid"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Klimazone for højre"
+      },
+      "mirror_heating_active": {
+        "name": "Sidespejlsvarme aktiv"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Klimazone for venstre aktiv"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Klimazone for højre aktiv"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Klimazone bag venstre aktiv"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Klimazone bag højre aktiv"
       },
       "abrp_data_changed": {
         "name": "ABRP-data ændret"

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Lademodus-Änderungen ausstehend"
       },
+      "charging_care_pending": {
+        "name": "Batterie-Schutz-Änderungen ausstehend"
+      },
       "climate_remaining_time_min": {
         "name": "Klima-Restzeit"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Klimazone vorne rechts"
+      },
+      "mirror_heating_active": {
+        "name": "Spiegelheizung aktiv"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Klimazone vorne links aktiv"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Klimazone vorne rechts aktiv"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Klimazone hinten links aktiv"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Klimazone hinten rechts aktiv"
       },
       "abrp_data_changed": {
         "name": "ABRP-Daten geändert"

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Charge Mode Changes Pending"
       },
+      "charging_care_pending": {
+        "name": "Battery Care Changes Pending"
+      },
       "climate_remaining_time_min": {
         "name": "Climate ETA"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Climate zone front-right"
+      },
+      "mirror_heating_active": {
+        "name": "Mirror heating active"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Climate zone front-left active"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Climate zone front-right active"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Climate zone rear-left active"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Climate zone rear-right active"
       },
       "abrp_data_changed": {
         "name": "ABRP Data Changed"

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Cambios de modo de carga pendientes"
       },
+      "charging_care_pending": {
+        "name": "Cambios de cuidado de batería pendientes"
+      },
       "climate_remaining_time_min": {
         "name": "Climatización – tiempo restante"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Zona climática delantera derecha"
+      },
+      "mirror_heating_active": {
+        "name": "Calefacción de espejos activa"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Zona climática delantera izquierda activa"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Zona climática delantera derecha activa"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Zona climática trasera izquierda activa"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Zona climática trasera derecha activa"
       },
       "abrp_data_changed": {
         "name": "Datos de ABRP cambiados"

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Lataustavan muutokset odottamassa"
       },
+      "charging_care_pending": {
+        "name": "Akkusuojan muutokset odottamassa"
+      },
       "climate_remaining_time_min": {
         "name": "Ilmastoinnin arvioitu valmistuminen"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Ilmastointivyöhyke oikea etu"
+      },
+      "mirror_heating_active": {
+        "name": "Peililämmitys aktiivinen"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Ilmastointivyöhyke vasen etu aktiivinen"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Ilmastointivyöhyke oikea etu aktiivinen"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Ilmastointivyöhyke vasen taka aktiivinen"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Ilmastointivyöhyke oikea taka aktiivinen"
       },
       "abrp_data_changed": {
         "name": "ABRP-tiedot muuttuivat"

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Changements de mode de charge en attente"
       },
+      "charging_care_pending": {
+        "name": "Changements d'entretien de la batterie en attente"
+      },
       "climate_remaining_time_min": {
         "name": "Climatisation – temps restant"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Zone climatique avant droite"
+      },
+      "mirror_heating_active": {
+        "name": "Chauffage des rétroviseurs actif"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Zone climatique avant gauche active"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Zone climatique avant droite active"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Zone climatique arrière gauche active"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Zone climatique arrière droite active"
       },
       "abrp_data_changed": {
         "name": "Données ABRP modifiées"

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Modifiche modalità di ricarica in sospeso"
       },
+      "charging_care_pending": {
+        "name": "Modifiche protezione batteria in sospeso"
+      },
       "climate_remaining_time_min": {
         "name": "Tempo clima rimanente"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Zona clima anteriore destra"
+      },
+      "mirror_heating_active": {
+        "name": "Riscaldamento specchietti attivo"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Zona clima anteriore sinistra attiva"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Zona clima anteriore destra attiva"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Zona clima posteriore sinistra attiva"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Zona clima posteriore destra attiva"
       },
       "abrp_data_changed": {
         "name": "Dati ABRP cambiati"

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Endringer av lademodus ventende"
       },
+      "charging_care_pending": {
+        "name": "Endringer av batteripleie ventende"
+      },
       "climate_remaining_time_min": {
         "name": "Klima gjenstår"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Klimasone foran høyre"
+      },
+      "mirror_heating_active": {
+        "name": "Speilvarme aktiv"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Klimasone foran venstre aktiv"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Klimasone foran høyre aktiv"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Klimasone bak venstre aktiv"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Klimasone bak høyre aktiv"
       },
       "abrp_data_changed": {
         "name": "ABRP-data endret"

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Laadmoduswijzigingen in behandeling"
       },
+      "charging_care_pending": {
+        "name": "Batterij-Zorg wijzigingen in behandeling"
+      },
       "climate_remaining_time_min": {
         "name": "Klimaat resterende tijd"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Klimaatzone rechtsvoor"
+      },
+      "mirror_heating_active": {
+        "name": "Spiegelverwarming actief"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Klimaatzone linksvoor actief"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Klimaatzone rechtsvoor actief"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Klimaatzone linksachter actief"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Klimaatzone rechtsachter actief"
       },
       "abrp_data_changed": {
         "name": "ABRP-gegevens gewijzigd"

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Zmiany trybu ładowania oczekują"
       },
+      "charging_care_pending": {
+        "name": "Zmiany ochrony baterii oczekują"
+      },
       "climate_remaining_time_min": {
         "name": "Klimatyzacja – pozostały czas"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Strefa klimatyczna przód prawa"
+      },
+      "mirror_heating_active": {
+        "name": "Podgrzewanie lusterek aktywne"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Strefa klimatyczna przód lewa aktywna"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Strefa klimatyczna przód prawa aktywna"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Strefa klimatyczna tył lewa aktywna"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Strefa klimatyczna tył prawa aktywna"
       },
       "abrp_data_changed": {
         "name": "Dane ABRP zmienione"

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -674,6 +674,9 @@
       "charging_mode_pending": {
         "name": "Laddlägesändringar väntar"
       },
+      "charging_care_pending": {
+        "name": "Batterivårdsändringar väntar"
+      },
       "climate_remaining_time_min": {
         "name": "Klimat – återstående tid"
       },
@@ -1290,6 +1293,21 @@
       },
       "climate_zone_front_right_enabled": {
         "name": "Klimatzon fram höger"
+      },
+      "mirror_heating_active": {
+        "name": "Spegelvärme aktiv"
+      },
+      "climate_zone_active_front_left": {
+        "name": "Klimatzon fram vänster aktiv"
+      },
+      "climate_zone_active_front_right": {
+        "name": "Klimatzon fram höger aktiv"
+      },
+      "climate_zone_active_rear_left": {
+        "name": "Klimatzon bak vänster aktiv"
+      },
+      "climate_zone_active_rear_right": {
+        "name": "Klimatzon bak höger aktiv"
       },
       "abrp_data_changed": {
         "name": "ABRP-data ändrad"

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -622,6 +622,16 @@ class TestVWEUStatusParsing:
         assert result.plug_state == "CONNECTED"
         assert result.connector_locked is True
 
+    def test_ev_plug_invalid_sentinel_stripped(self):
+        # v2.17.5 (#770) — a CARIAD 'invalid' plugConnectionState must NOT surface
+        # as a raw text state; the boolean stays safely False (positive test).
+        client = self._client()
+        payload = self._ev_payload()
+        payload["charging"]["plugStatus"]["value"]["plugConnectionState"] = "invalid"
+        result = client._parse_status("VIN1", payload, {})
+        assert result.plug_connected is False
+        assert result.plug_state is None
+
     def test_ev_doors_locked(self):
         client = self._client()
         result = client._parse_status("VIN1", self._ev_payload(), {})

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -632,6 +632,16 @@ class TestVWEUStatusParsing:
         assert result.plug_connected is False
         assert result.plug_state is None
 
+    def test_ev_battery_care_pending_count(self):
+        # v2.17.5 — batteryChargingCare.chargingCareSettings.requests → count
+        client = self._client()
+        payload = self._ev_payload()
+        payload["batteryChargingCare"] = {
+            "chargingCareSettings": {"requests": [{"id": "a"}, {"id": "b"}]}
+        }
+        result = client._parse_status("VIN1", payload, {})
+        assert result.charging_care_pending == 2
+
     def test_ev_doors_locked(self):
         client = self._client()
         result = client._parse_status("VIN1", self._ev_payload(), {})

--- a/tests/test_v2171_spin_plumbing_666.py
+++ b/tests/test_v2171_spin_plumbing_666.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from custom_components.vag_connect.const import CONF_SPIN
+from custom_components.vag_connect.const import CONF_SPIN, CONF_SPIN_BY_VIN
 
 
 def _coord(options=None, data=None):
@@ -35,6 +35,24 @@ class TestSpinFromEntry:
 
     def test_empty(self):
         assert _coord()._spin_from_entry() == ""
+
+    # ── v2.17.5 (#759) per-VIN S-PIN overrides ──────────────────────────────
+    def test_per_vin_override_wins(self):
+        c = _coord(options={CONF_SPIN: "1111", CONF_SPIN_BY_VIN: {"VINA": "2222"}})
+        assert c._spin_from_entry("VINA") == "2222"  # per-VIN override wins
+        assert c._spin_from_entry("VINB") == "1111"  # unlisted VIN → shared
+        assert c._spin_from_entry() == "1111"         # no VIN → shared
+
+    def test_per_vin_empty_falls_back_to_shared(self):
+        c = _coord(options={CONF_SPIN: "1111", CONF_SPIN_BY_VIN: {"VINA": ""}})
+        assert c._spin_from_entry("VINA") == "1111"
+
+    def test_no_by_vin_setup_unchanged_with_vin_arg(self):
+        # existing single-S-PIN setups: passing a VIN must not change the result
+        c = _coord(options={CONF_SPIN: "1111"})
+        assert c._spin_from_entry("ANYVIN") == "1111"
+        c2 = _coord(options={}, data={CONF_SPIN: "3333"})
+        assert c2._spin_from_entry("ANYVIN") == "3333"
 
 
 class TestRefreshMbbSpin:

--- a/tests/test_v2174_competitor_sweep_fixes.py
+++ b/tests/test_v2174_competitor_sweep_fixes.py
@@ -147,3 +147,34 @@ def test_400_429_not_aggressively_retried() -> None:
     assert 400 not in _RETRIABLE_STATUSES
     assert 429 not in _RETRIABLE_STATUSES
     assert 500 in _RETRIABLE_STATUSES  # 5xx still backs off + retries
+
+
+# ── v2.17.5 portal-coverage aliases (verified-real gaps from the full sweep) ──
+
+def test_v2175_oil_low_level_warning_alias() -> None:
+    # oil_level_min_warning (0=OK, 1=low) → existing oil_level_warning sensor
+    assert map_dataset_to_vehicle_data(
+        {"oil_level_min_warning": "1"}, VehicleData(vin="X")
+    ).oil_level_warning is True
+    assert map_dataset_to_vehicle_data(
+        {"oil_level_min_warning": "0"}, VehicleData(vin="X")
+    ).oil_level_warning is False
+
+
+def test_v2175_sunroof_hood3_position_fallback() -> None:
+    d = map_dataset_to_vehicle_data(
+        {"position_sunroof_motor_hood_3": "40"}, VehicleData(vin="X")
+    )
+    assert d.sunroof_position_pct == 40
+
+
+def test_v2175_rear_climate_zones_aliased() -> None:
+    d = map_dataset_to_vehicle_data(
+        {
+            "setting_zone_enabled_rear_left": "true",
+            "setting_zone_enabled_rear_right": "false",
+        },
+        VehicleData(vin="X"),
+    )
+    assert d.climate_zone_rear_left is True
+    assert d.climate_zone_rear_right is False

--- a/tests/test_v2174_competitor_sweep_fixes.py
+++ b/tests/test_v2174_competitor_sweep_fixes.py
@@ -88,6 +88,30 @@ def test_well_named_field_with_uuid_key_gets_no_alias() -> None:
     assert _RANGE_UUID not in fields
 
 
+def test_unmapped_generic_uuid_emits_no_alias_no_scout_flood() -> None:
+    """v2.17.5 regression guard: the 2.17.4 blanket alias emitted an
+    ``eu_data_act.<uuid>`` key for EVERY generic-named point, flooding the
+    Vehicle Data Scout with dozens of unmapped timestamp/state UUID rows per car.
+    Only UUIDs we actually MAP are aliased now; every other generic point keeps
+    only its bare name (still Scout-visible) and emits NO UUID row."""
+    fields = _walk_fields(
+        {
+            "data": [
+                # unmapped generic "timestamp"/"state" points carrying real UUIDs
+                {"dataFieldName": "timestamp", "key": "067f539c-85fe-3067-9c29-d63e177e3712", "value": "2026-07-15T10:42:52Z"},
+                {"dataFieldName": "state", "key": "0718582b-7259-3c9a-818a-ea848a7365a8", "value": "VALID"},
+                # the ONE mapped UUID still gets its alias
+                {"dataFieldName": "value", "key": _RANGE_UUID, "value": "300"},
+            ]
+        }
+    )
+    # only the mapped range UUID surfaced — no unmapped-UUID flood
+    uuid_keys = [k for k in fields if k.count("-") == 4 and len(k) == 36]
+    assert uuid_keys == [_RANGE_UUID]
+    # the bare generic names stay Scout-visible (no suppression)
+    assert "state" in fields
+
+
 # ── #3 INT32_MIN sentinel ────────────────────────────────────────────────────
 
 def test_int32_min_is_a_global_sentinel() -> None:

--- a/tests/test_v2174_competitor_sweep_fixes.py
+++ b/tests/test_v2174_competitor_sweep_fixes.py
@@ -178,3 +178,38 @@ def test_v2175_rear_climate_zones_aliased() -> None:
     )
     assert d.climate_zone_rear_left is True
     assert d.climate_zone_rear_right is False
+
+
+def test_v2175_live_active_climate_and_mirror() -> None:
+    d = map_dataset_to_vehicle_data(
+        {
+            "state_mirror_heating_active": "true",
+            "state_zone_active_front_left": "true",
+            "state_zone_active_front_right": "false",
+            "state_zone_active_rear_left": "true",
+            "state_zone_active_rear_right": "false",
+        },
+        VehicleData(vin="X"),
+    )
+    assert d.mirror_heating_active is True
+    assert d.climate_zone_active_front_left is True
+    assert d.climate_zone_active_front_right is False
+    assert d.climate_zone_active_rear_left is True
+    assert d.climate_zone_active_rear_right is False
+
+
+def test_v2175_parkinglightstate_is_set() -> None:
+    assert map_dataset_to_vehicle_data(
+        {"parkinglightstate.is_set": "true"}, VehicleData(vin="X")
+    ).parking_light is True
+
+
+def test_v2175_trunk_locked_dotted_and_no_doors_collision() -> None:
+    # trunk.locked → trunk_locked; and a QUALIFIED door field wins over the
+    # trunk's bare 'locked' leaf (the cross-container collision fix).
+    d = map_dataset_to_vehicle_data(
+        {"trunk.locked": "true", "doorLockStatus": "unlocked", "locked": "true"},
+        VehicleData(vin="X"),
+    )
+    assert d.trunk_locked is True
+    assert d.doors_locked is False


### PR DESCRIPTION
### Fixes a 2.17.4 regression
The 2.17.4 generic-point UUID aliasing emitted an `eu_data_act.<uuid>` key for **every** generic-named data-point, so cars started filing "30/46/55 new field(s)" Scout issues full of unmapped UUID rows. Now only the UUIDs we actually map are aliased — the bare generic names stay Scout-visible, no flood.

### Portal-coverage sweep (verified-real gaps that were hidden behind the flood)
- **oil low-level warning**, **rear climate zones**, **sunroof hood_3** → existing sensors (no new entities).
- **5 live "active" binary sensors** — mirror heating + 4 climate-zone actives (the live-status twins of the existing *enabled* settings).
- **Battery Care Changes Pending** sensor (the 4th charging-side `*.requests` sibling).
- **parking-light** `is_set` dialect → existing parking_light sensor.
- **trunk.locked** → trunk_locked, plus a real cross-container bug fix: the door-lock reader preferred the bare `locked` leaf that a `trunk.locked` container also emits, which could mis-set doors_locked from the trunk state. Qualified door fields now win.
- All new entities translated in **12 languages**.

### Feature
- **Per-vehicle S-PIN (#759)** — accounts whose vehicles each have their own S-PIN can set a per-VIN S-PIN in the Options flow. Fully backward-compatible: the shared S-PIN stays the default.

### Also
- `#770` — the plug `invalid`/`unsupported` sentinel no longer surfaces as a raw text state.

Full suite **3597 passed / 15 skipped**.