### PR TITLE
fix: use Mapping, not dict, when reading the S-PIN from the config entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased]
+
+### Fixed
+
+- **Your S-PIN is used again.** Every S-PIN-gated action (lock/unlock, auxiliary heating, …) failed with "configure your S-PIN" even when the S-PIN was configured correctly — on every install, whether the PIN was set during setup or later under Configure. The stored PIN was read back through a type check that never matched, so the integration behaved as if no PIN had been set. Storing the PIN was never the problem; reading it back was. Thanks **@torstentosh** for the original report (#666).
+
 ## [2.17.5] - 2026-07-13
 
 ### Fixed

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -12,6 +12,7 @@ Thread safety:
 """
 
 import asyncio
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
@@ -3917,20 +3918,25 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         v2.17.5 (#759) — when *vin* is given and a per-VIN override exists in
         ``CONF_SPIN_BY_VIN``, that wins; otherwise the shared per-entry S-PIN is
         returned (so single-S-PIN setups behave exactly as before).
+
+        The mapping checks below test against ``Mapping``, not ``dict``: HA hands
+        out ``ConfigEntry.data``/``.options`` as ``MappingProxyType``, which is a
+        ``Mapping`` but *not* a ``dict`` subclass. Testing for ``dict`` silently
+        discarded every configured S-PIN.
         """
         options = getattr(self.entry, "options", None) or {}
         data = getattr(self.entry, "data", None) or {}
-        if vin and isinstance(options, dict):
+        if vin and isinstance(options, Mapping):
             by_vin = options.get(CONF_SPIN_BY_VIN)
-            if isinstance(by_vin, dict):
+            if isinstance(by_vin, Mapping):
                 per = str(by_vin.get(vin) or "")
                 if per:
                     return per
-        if isinstance(options, dict):
+        if isinstance(options, Mapping):
             spin = str(options.get(CONF_SPIN) or "")
             if spin:
                 return spin
-        if isinstance(data, dict):
+        if isinstance(data, Mapping):
             return str(data.get(CONF_SPIN) or "")
         return ""
 

--- a/tests/test_v2171_spin_plumbing_666.py
+++ b/tests/test_v2171_spin_plumbing_666.py
@@ -10,6 +10,7 @@ arm resolves options-first, and an Options edit refreshes the live connector.
 """
 from __future__ import annotations
 
+from types import MappingProxyType
 from unittest.mock import MagicMock
 
 from custom_components.vag_connect.const import CONF_SPIN, CONF_SPIN_BY_VIN
@@ -19,8 +20,11 @@ def _coord(options=None, data=None):
     from custom_components.vag_connect.coordinator import VagConnectCoordinator
     c = VagConnectCoordinator.__new__(VagConnectCoordinator)
     c.entry = MagicMock()
-    c.entry.options = options if options is not None else {}
-    c.entry.data = data if data is not None else {}
+    # HA exposes ConfigEntry.data/.options as MappingProxyType, never as a plain
+    # dict. Faking them as dicts here hid a bug where the lookup tested
+    # `isinstance(..., dict)` and silently dropped every configured S-PIN.
+    c.entry.options = MappingProxyType(options if options is not None else {})
+    c.entry.data = MappingProxyType(data if data is not None else {})
     return c
 
 
@@ -53,6 +57,43 @@ class TestSpinFromEntry:
         assert c._spin_from_entry("ANYVIN") == "1111"
         c2 = _coord(options={}, data={CONF_SPIN: "3333"})
         assert c2._spin_from_entry("ANYVIN") == "3333"
+
+
+class TestSpinMappingProxyRegression:
+    """The config entry hands out MappingProxyType, not dict.
+
+    `isinstance(MappingProxyType({...}), dict)` is False, so a lookup gated on
+    `isinstance(..., dict)` returns "" for every real-world entry and the user
+    gets `spin_required` despite a correctly stored S-PIN. These tests pin the
+    runtime type explicitly so the guard cannot regress to `dict`.
+    """
+
+    def test_spin_in_data_survives_mappingproxy(self):
+        c = _coord(options={}, data={CONF_SPIN: "1111", "username": "a@b.c"})
+        assert isinstance(c.entry.data, MappingProxyType)
+        assert not isinstance(c.entry.data, dict)  # the trap
+        assert c._spin_from_entry() == "1111"
+
+    def test_spin_in_nonempty_options_survives_mappingproxy(self):
+        # a non-empty options mapping stays a MappingProxyType (an empty one is
+        # falsy and gets replaced by a real dict via `or {}`, masking the bug)
+        c = _coord(options={CONF_SPIN: "9999", "scan_interval": 300},
+                   data={CONF_SPIN: "1111"})
+        assert c._spin_from_entry() == "9999"
+
+    def test_per_vin_override_survives_mappingproxy(self):
+        c = _coord(options={CONF_SPIN: "1111", CONF_SPIN_BY_VIN: {"VINA": "2222"}})
+        assert c._spin_from_entry("VINA") == "2222"
+
+    def test_refresh_mbb_pushes_real_spin_not_empty(self):
+        c = _coord(options={}, data={CONF_SPIN: "1234"})
+        cmd = MagicMock()
+        cmd._spin = "0000"
+        client = MagicMock()
+        client._mbb_command_target = lambda: cmd
+        c._cariad_client = client
+        c._refresh_mbb_command_spin()
+        assert cmd._spin == "1234"  # not "" — #666's symptom
 
 
 class TestRefreshMbbSpin:


### PR DESCRIPTION
## The bug

`ConfigEntry.data` and `.options` are handed out by Home Assistant as
`types.MappingProxyType`, which is **not** a `dict` subclass:

```python
>>> isinstance(MappingProxyType({"spin": "1234"}), dict)
False
```

`_spin_from_entry()` gated every lookup behind `isinstance(..., dict)`, so the check
never passed on a real config entry and the method returned `""`. Every S-PIN-gated
command then failed with `spin_required` ("configure your S-PIN") even though the S-PIN
was stored correctly. Saving the S-PIN was never broken — reading it back was.

There is no configuration in which the current code can return a non-empty S-PIN on a
real HA instance:

| entry | value | result |
|---|---|---|
| `options` empty | falsy → `or {}` → real `dict` | check passes, finds nothing, falls through |
| `data` non-empty | `MappingProxyType` | check **fails** → skipped |
| return | | `""` |

Putting the S-PIN in `options` instead does not help: a non-empty `options` is also a
proxy and fails the same way. The `or {}` fallback is what made this look configuration-
dependent — it only ever rescues *empty* mappings.

`_refresh_mbb_command_spin()` (#666) inherits this and pushes `""` into the armed MBB
connector.

This is not a 2.17.5 regression — the same guard is in 2.17.4 and 2.17.3.

## The fix

Test against `collections.abc.Mapping` instead of `dict`. `MappingProxyType` is
registered as a `Mapping`, so this accepts both the runtime type and a plain dict, and
keeps the original defensive intent. Behaviour is otherwise unchanged: options still win
over data, per-VIN still wins over shared.

## Why this shipped: the tests faked the wrong type

`tests/test_v2171_spin_plumbing_666.py` built the entry with plain dicts:

```python
c.entry.options = options if options is not None else {}   # plain dict
c.entry.data    = data if data is not None else {}         # plain dict
```

Plain dicts pass `isinstance(..., dict)`, so the suite exercised a type that never occurs
at runtime and stayed green while the feature was fully broken in the field.

This PR changes that helper to wrap both in `MappingProxyType` — the real runtime type —
so the existing tests now cover the real contract, and adds a
`TestSpinMappingProxyRegression` class that pins the type explicitly (including one
assertion of the trap itself, `not isinstance(entry.data, dict)`) so the guard cannot
regress to `dict`.

**Red/green:** with the test change but *without* the coordinator fix, **11 tests fail** —
including the six pre-existing ones. With the fix: all green.

```
11 failed, 3 passed      # tests fixed, coordinator reverted
14 passed                # this PR
3601 passed, 15 skipped  # full suite
All checks passed!       # ruff check custom_components/
```

## Possibly the root cause of #666

The docstring of the #666 test describes exactly this symptom — torstentosh getting
"configure your S-PIN" on his Q4 with a correct PIN. That fix reshuffled options-vs-data
precedence, but the `dict` guard would have discarded the PIN regardless of where it was
stored. **[Inference]** — I cannot verify this against his setup, but it would explain why
the report persisted through a fix that looked correct.

## Verified on

- VW Group Connect 2.17.5, HA 2026.5.4, Audi Q6 e-tron (PPE), region DE, S-PIN configured
  during initial setup (lands in `entry.data`, `options == {}`)
- Before: S-PIN-gated commands fail with `spin_required`; after: they execute

## Scope

Deliberately limited to the S-PIN path (one PR = one concern). The same
`isinstance(<entry data/options>, dict)` pattern appears elsewhere and looks wrong for the
same reason — these fail *silently* into defaults rather than erroring, so they may have
gone unnoticed:

- `coordinator.py:3599, 3601` — PPE mode detection
- `coordinator.py:3868, 3874` — `auxheat_duration` / `auxheat_target_temp`
- `coordinator.py:4079, 4081` — `CONF_READ_ONLY`
- `number.py:210` — options-backed number values

`4079/4081` is worth a look first: if `read_only_mode` sits in a non-empty `data`, the
guard fails and read-only mode is silently **not** honoured — that one fails open. Happy
to file a separate issue or PR for those if you want them fixed the same way.
