### PR TITLE
fix: closed windows/roof show as 'open' on Audi/VW-EU (windows_individual convention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased]
+
+### Fixed
+
+- **Closed windows and roof no longer show as "open" on Audi / VW-EU cars.** Every window read over the CARIAD channel — plus the rear sunroof and roof cover — reported *open* while the car was shut, even though the aggregate "windows open" sensor correctly said closed. Two causes, both in the CARIAD parser: (1) `windows_individual` stored `True == open`, the lone violation of the `True == closed` convention that the EU-Data-Act portal parser and `VagWindowSensor` (which inverts) already follow — so every closed window was flipped to open; (2) option-dependent roof parts on a car without an opening roof report a non-open/closed sentinel status, which was written as `False` ("not closed → open") instead of leaving the descriptor `None`, defeating the phantom-entity guard. The parser now follows the documented `True == closed` convention and skips sentinel statuses, so shut windows read *closed* and non-existent roofs don't surface at all. Verified on a real PPE Audi Q6. Note for maintainer: `doors_individual` carries the opposite convention (`True == open`, per `VagDoorSensor`), and `seat_cupra.py` stores doors as `True == closed` — a likely-latent SEAT/CUPRA door inversion, left untouched here as it can't be verified on hardware.
+
 ## [2.18.0] - 2026-07-17
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -3265,7 +3265,16 @@ class VWEUClient(CariadBaseClient):
                     status_raw = status_raw.get("value") or status_raw.get("status")
                 if not isinstance(status_raw, str):
                     continue
-                is_closed = status_raw.lower() == "closed"
+                # Only a real open/closed status is meaningful. Option-dependent
+                # roof parts on a car without one report a non-open/closed
+                # sentinel (e.g. "unsupported"/"invalid"); treating that as
+                # "not closed" wrote False and rendered the entity as 'open'.
+                # Leave the descriptor None so the phantom-entity guard
+                # (_DATA_PRESENT_REQUIRED) suppresses it instead.
+                status_l = status_raw.lower()
+                if status_l not in ("open", "closed"):
+                    continue
+                is_closed = status_l == "closed"
                 if "sunroofrear" in name_l.replace("_", "") or name_l == "sun_roof_rear":
                     if d.sunroof_rear_closed is None:
                         d.sunroof_rear_closed = is_closed
@@ -3425,11 +3434,24 @@ class VWEUClient(CariadBaseClient):
             d.windows_open = any(
                 safe_get(w, "status[0].value") == "open" for w in windows
             )
-            d.windows_individual = {
-                str(name): safe_get(w, "status[0].value") == "open"
-                for w in windows
-                if (name := w.get("name")) is not None
-            }
+            # windows_individual follows the documented ``True == closed``
+            # convention — the same one the EU-Data-Act portal parser and
+            # ``VagWindowSensor`` (which inverts) already use. Storing
+            # ``status == "open"`` here (True == open) was the lone outlier and
+            # made every *closed* window render as *open* on Audi / VW-EU cars.
+            # Only entries with a real open/closed status are stored; a
+            # non-open/closed sentinel (an option-dependent roof on a car
+            # without one) is skipped so it can't surface as a phantom window.
+            windows_individual: dict[str, bool] = {}
+            for w in windows:
+                name = w.get("name")
+                if name is None:
+                    continue
+                st = safe_get(w, "status[0].value")
+                if not isinstance(st, str) or st.lower() not in ("open", "closed"):
+                    continue
+                windows_individual[str(name)] = st.lower() == "closed"
+            d.windows_individual = windows_individual
         elif overall == "SAFE":
             d.windows_open = False
 

--- a/tests/test_vw_eu_window_invert.py
+++ b/tests/test_vw_eu_window_invert.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""vw_eu CARIAD parser: ``windows_individual`` must follow the documented
+``True == closed`` convention — the same one the EU-Data-Act portal parser
+and ``VagWindowSensor`` already use. The CARIAD ``_parse_status`` path was the
+lone outlier storing ``True == open``, so ``VagWindowSensor`` (which inverts)
+rendered every *closed* window as *open* on Audi / VW-EU cars.
+
+Also: option-dependent roof parts (rear sunroof / roof cover) that report a
+non-open/closed sentinel status on a car without an opening roof must not
+create a phantom 'open' entity — the descriptor stays None (phantom-guarded)
+and no window entry is emitted.
+"""
+from __future__ import annotations
+
+
+def _vw_client():
+    from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+    client = VWEUClient.__new__(VWEUClient)
+    client._vehicle_metadata = {}
+    return client
+
+
+def _windows_raw(*entries):
+    return {"access": {"accessStatus": {"value": {"windows": list(entries)}}}}
+
+
+def test_windows_individual_uses_true_equals_closed():
+    """Documented convention: windows_individual stores True == closed."""
+    client = _vw_client()
+    raw = _windows_raw(
+        {"name": "frontLeft", "status": [{"value": "closed"}]},
+        {"name": "frontRight", "status": [{"value": "open"}]},
+    )
+    data = client._parse_status("VINX", raw, parking={})
+    assert data.windows_individual["frontLeft"] is True    # closed
+    assert data.windows_individual["frontRight"] is False   # open
+
+
+def test_sentinel_roof_status_not_added_as_window():
+    """A non-open/closed sentinel (SUV without an opening roof) is skipped,
+    not stored as a phantom 'open' window."""
+    client = _vw_client()
+    raw = _windows_raw(
+        {"name": "frontLeft", "status": [{"value": "closed"}]},
+        {"name": "roofCover", "status": [{"value": "unsupported"}]},
+        {"name": "sunRoofRear", "status": [{"value": "invalid"}]},
+    )
+    data = client._parse_status("VINX", raw, parking={})
+    assert data.windows_individual["frontLeft"] is True
+    assert "roofCover" not in data.windows_individual
+    assert "sunRoofRear" not in data.windows_individual
+
+
+def test_sentinel_roof_status_leaves_descriptor_none():
+    """A sentinel roof status leaves the *_closed descriptor None so the
+    phantom-entity guard suppresses it (instead of False → 'open')."""
+    client = _vw_client()
+    raw = _windows_raw(
+        {"name": "roofCover", "status": [{"value": "unsupported"}]},
+        {"name": "sunRoofRear", "status": [{"value": "invalid"}]},
+    )
+    data = client._parse_status("VINX", raw, parking={})
+    assert data.roof_cover_closed is None
+    assert data.sunroof_rear_closed is None
+
+
+def test_real_open_closed_roof_still_parsed():
+    """Regression guard: a car that genuinely reports open/closed roof parts
+    must still populate the descriptors (sentinel skip must not drop real data)."""
+    client = _vw_client()
+    raw = _windows_raw(
+        {"name": "sunRoofRear", "status": [{"value": "closed"}]},
+        {"name": "roofCover", "status": [{"value": "open"}]},
+    )
+    data = client._parse_status("VINX", raw, parking={})
+    assert data.sunroof_rear_closed is True
+    assert data.roof_cover_closed is False


### PR DESCRIPTION
## Problem

On Audi / VW-EU cars every window read over the CARIAD channel — plus the rear sunroof and roof cover — shows **open** while the car is shut, even though the aggregate "windows open" sensor correctly reports closed. On my PPE Q6 that was 9 phantom "open" sensors (4 windows + `roofCover`/`sunRoof`/`sunRoofRear` + the `Verdeck`/`Schiebedach hinten` descriptors).

## Root cause (both in `vw_eu._parse_status`)

1. **`windows_individual` stored `True == open`.** That's the lone violation of the documented **`True == closed`** convention — the EU-Data-Act portal parser stores `True == closed` (see `test_v2150b10_portal_long_tail.py`: *"windows_individual True=closed"*) and `VagWindowSensor.is_on` inverts (`not val`) on that assumption. So the CARIAD path fed the sensor the wrong polarity and every **closed** window was flipped to **open**.

2. **Sentinel roof status written as `False` instead of `None`.** Option-dependent roof parts (rear sunroof / roof cover) on a car without an opening roof report a non-open/closed sentinel status. The roof fallback did `is_closed = status == "closed"` → `False` ("not closed → open") and assigned it, so the `_DATA_PRESENT_REQUIRED` phantom guard (which only suppresses `None`) couldn't hide the entity. The same sentinel entries were also added to `windows_individual`, spawning junk "window" sensors for `roofCover`/`sunRoof`/`sunRoofRear`.

## Fix

`windows_individual` now follows the documented `True == closed` convention and **skips** entries whose status isn't a real `open`/`closed` value; the roof descriptors are only assigned for a real `open`/`closed` status (sentinel → stays `None` → phantom-guarded). `windows_open` is unchanged.

**Scope is intentionally limited to the CARIAD parser.** `VagWindowSensor` and `seat_cupra.py` are untouched, so there's **no effect on SEAT/CUPRA** (which I can't verify on hardware).

## Note for you (separate, out of scope)

While tracing this I noticed `doors_individual` carries the **opposite** convention: `VagDoorSensor.is_on` is `bool(val)` (`True == open`), but `seat_cupra.py` stores doors as `True == closed`. That looks like a latent SEAT/CUPRA **door** inversion. I left it alone since it's a different field, a different brand, and not verifiable on my car — flagging it in case it's worth a look.

## Tests

New `tests/test_vw_eu_window_invert.py` pins: the `True == closed` convention, the sentinel skip in `windows_individual`, the descriptor-`None` behaviour, and a regression guard that a genuinely open/closed roof is still parsed. Existing `test_sunroof_rear_and_roof_cover_closed_via_windows_list` (real open/closed) stays green.

```
3755 passed, 15 skipped
ruff check custom_components/ — clean
```

## Verification

Confirmed on a real PPE **Audi Q6** (v2.18.0 + equivalent patch): all 9 phantom "open" sensors now read *closed* or are suppressed; aggregates unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
