### PR TITLE
v2.18.1 — scout triage: aux-heating/timer-error, skoda amps, oil-level status + envelope carve-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ### Fixed
 
-- **A handful of Vehicle Data Scout reports that wouldn't go away — none of them real gaps.** Aux-heating (Standheizung) started turning up in a second spot on Audis, and the climate-timer's error wrapper read as an unknown field (#752, #785, #789); Škoda's AC charge-current-in-amps was already being read but was never ticked off the catalogue (#781, #795); and on the EU Data Act feed the raw oil-level status is recognised now (#794). The catalogue simply hadn't been told about these — so the Scout stops flagging them. (The rest of the open Scout reports were account/envelope metadata, or fields we already read, and are being closed as triaged.)
+- **A handful of Vehicle Data Scout reports that wouldn't go away — none of them real gaps.** Aux-heating (Standheizung) started turning up in a second spot on Audis, and the climate-timer's error wrapper read as an unknown field (#752, #785, #789); Škoda's AC charge-current-in-amps was already being read but was never ticked off the catalogue (#781, #795); and on the EU Data Act feed the raw oil-level status is recognised now (#794). The catalogue simply hadn't been told about these — so the Scout stops flagging them.
+- **The portal Scout stops crying wolf on account/envelope metadata.** The EU Data Act feed repeats your account id, VIN, poll/message timestamps and a pile of per-export UUIDs on every single poll — none of it mappable vehicle data. These used to stay visible on principle; they're now dropped from the Scout/diagnostic surface (anything with a real, vehicle-specific field name still shows up), which clears a long tail of pure-repetition "N new fields" reports (#747, #782, #804 and a dozen more like them).
 
 ## [2.18.0] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.18.1] - 2026-07-17
+
+### Fixed
+
+- **A handful of Vehicle Data Scout reports that wouldn't go away — none of them real gaps.** Aux-heating (Standheizung) started turning up in a second spot on Audis, and the climate-timer's error wrapper read as an unknown field (#752, #785, #789); Škoda's AC charge-current-in-amps was already being read but was never ticked off the catalogue (#781, #795); and on the EU Data Act feed the raw oil-level status is recognised now (#794). The catalogue simply hadn't been told about these — so the Scout stops flagging them. (The rest of the open Scout reports were account/envelope metadata, or fields we already read, and are being closed as triaged.)
+
 ## [2.18.0] - 2026-07-17
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -144,6 +144,11 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "settings.batteryCareModeTargetValueInPercent",
             "settings.chargingCareMode",
             "settings.maxChargeCurrentAc",
+            # v2.18.1 — Scout #781/#795 (@DvorakMartin1 Škoda). The integer-amps
+            # spelling ``maxChargeCurrentAcAmpere`` is READ by the parser
+            # (skoda.py ``_mca = v(settings, "maxChargeCurrentAcAmpere")``) but
+            # EXPECTED_KEYS was never updated — classic silencer-lag-behind-parser.
+            "settings.maxChargeCurrentAcAmpere",
             "settings.preferredChargeMode",
         },
         "air-conditioning": {
@@ -891,6 +896,33 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             # v2.18.0 — Scout #801: now CONSUMED into climatisation_timers_pending.
             # 3-seg path, not covered by the 2-seg climatisationTimers.* wildcard.
             "climatisationTimers.climatisationTimersStatus.requests",
+            # v2.18.1 — Scouts #752 (@heyensh-sys) + #785 (@GiuseppeAlbano) +
+            # #789 (@Lagaff86), all audi selectivestatus. Two new shapes the
+            # backend rolled out:
+            #  · Aux-heating (Standheizung) now ALSO ships nested under the
+            #    climatisation / climatisationTimers jobs. The parser already
+            #    reads the TOP-LEVEL ``auxiliaryHeating`` job into
+            #    ``sensor.auxiliary_heating_status`` (v2.8.0), so this nested
+            #    copy is a secondary source — register the containers so the
+            #    Scout stops firing; drill the nested value into the sensor
+            #    once a real payload confirms the child field names (same
+            #    interim-silencer approach as activeVentilation/batterySupport).
+            #  · ``climatisationTimersStatus`` gained the standard 6-key
+            #    CARIAD-BFF ``.error`` envelope — the ONE sibling the v2.2.0
+            #    Phase-7 error rollout missed (same class as #598). Pure
+            #    transient-error wrapper, no user value → silence.
+            "climatisation.auxiliaryHeatingStatus",
+            "climatisation.auxiliaryHeatingStatus.value",
+            "climatisation.auxiliaryHeatingStatus.value.*",
+            "climatisation.auxiliaryHeatingStatus.error",
+            "climatisation.auxiliaryHeatingStatus.error.*",
+            "climatisationTimers.auxiliaryHeatingTimersStatus",
+            "climatisationTimers.auxiliaryHeatingTimersStatus.value",
+            "climatisationTimers.auxiliaryHeatingTimersStatus.value.*",
+            "climatisationTimers.auxiliaryHeatingTimersStatus.error",
+            "climatisationTimers.auxiliaryHeatingTimersStatus.error.*",
+            "climatisationTimers.climatisationTimersStatus.error",
+            "climatisationTimers.climatisationTimersStatus.error.*",
             # v2.2.0 Phase 7 PR #5 (#245 Scout 2026-05-11/12/13) —
             # Systemic Cariad-BFF rollout: jeder ``<block>.{xxxStatus}``
             # bekommt jetzt einen ``.error`` container (6 keys —

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -2092,6 +2092,14 @@ def map_dataset_to_vehicle_data(
     _oil_w = first("oil_level_min_warning")
     if _oil_w is not None and d.oil_level_warning is None:
         d.oil_level_warning = str(_oil_w).strip().lower() in ("1", "true")
+    # v2.18.1 — Scout #794 (@loungelizard2018): the raw oil-level STATUS string
+    # the 15-min feed ships (e.g. "ok"/"minWarning"). pct/warning/liters are read
+    # above; map the raw enum into the existing diagnostic ``oil_level_status``
+    # field so it is CONSUMED, not surfaced as an unmapped Scout row. Raw string
+    # only — no guessing the enum→warning semantics (warning is fed separately).
+    _oil_s = first("oil_level_status")
+    if _oil_s is not None and d.oil_level_status is None:
+        d.oil_level_status = str(_oil_s).strip()
     # scr_range — AdBlue/SCR range (km). Empty string guarded by _to_int.
     _scr = _to_int(first("scr_range"))
     if _scr is not None and d.adblue_range_km is None:

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -973,6 +973,32 @@ _RAW_FIELD_CAP = 250
 # b14 — NO field suppression. Policy (Prash): never hide Scout/raw fields; every
 # portal field is surfaced so it can be mapped. (The b10 ``_SCOUT_SKIP_FIELDS`` /
 # ``_is_noise`` filter was removed — we map everything, we don't suppress.)
+#
+# v2.18.1 — the ONE carve-out (Prash's ruling 2026-07-17): pure ENVELOPE /
+# IDENTITY metadata is not vehicle data and not mappable — the account id, the
+# VIN, poll/message envelope timestamps, the generic per-point names the export
+# reuses on every datum (state / value / unit / key), and the raw per-export
+# point UUIDs (whose real meaning is recovered via the Data Dictionary join, not
+# the Scout). They repeat on every poll and would otherwise flood the Scout
+# forever, so they ARE dropped from the raw/Scout surface. Anything with a real,
+# vehicle-specific field name still surfaces — the no-suppression rule holds for
+# everything except this metadata repetition.
+_ENVELOPE_NOISE_LEAVES: frozenset[str] = frozenset({
+    "user_id", "userid", "vin", "timestamp", "timestamputc",
+    "echo", "message_id", "state", "value", "unit", "key",
+})
+_ENVELOPE_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+def _is_envelope_noise(key: str) -> bool:
+    """True for account / VIN / envelope-timestamp / generic-name / point-UUID
+    keys — the v2.18.1 carve-out from the no-suppression rule (see comment
+    above). Matched on the leaf so bare and container-qualified spellings both
+    catch (``vin`` and ``eu_data_act.vin``; ``Data.key`` → ``key``)."""
+    leaf = key.rsplit(".", 1)[-1].strip().lower()
+    return leaf in _ENVELOPE_NOISE_LEAVES or bool(_ENVELOPE_UUID_RE.match(leaf))
 
 
 def map_dataset_to_vehicle_data(
@@ -2385,7 +2411,11 @@ def map_dataset_to_vehicle_data(
     # Debug-only, zero behaviour change. Feeds the Vehicle Data Scout and tells
     # us exactly which dictionary entries to add next, from REAL payloads —
     # beats a hand-maintained static dict that silently drops unknown fields.
-    unmapped = sorted(k for k in fields if k not in used)
+    # v2.18.1 carve-out: drop envelope/identity/UUID repetition (see
+    # _is_envelope_noise) — everything with a real field name still surfaces.
+    unmapped = sorted(
+        k for k in fields if k not in used and not _is_envelope_noise(k)
+    )
     if unmapped:
         _LOGGER.debug(
             "EU Data Act: %d unmapped portal field(s): %s",

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.18.0"
+  "version": "2.18.1"
 }

--- a/tests/test_718_pii_redaction.py
+++ b/tests/test_718_pii_redaction.py
@@ -20,7 +20,12 @@ def _map(fields: dict[str, str]) -> VehicleData:
     return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
 
 
-def test_718_user_id_and_vin_values_redacted_names_kept() -> None:
+def test_718_user_id_and_vin_dropped_real_field_kept() -> None:
+    # v2.18.1 — Prash's ruling (2026-07-17): account id + VIN are pure identity
+    # metadata, the ONE carve-out from no-suppression. They are now DROPPED from
+    # the raw/Scout surface entirely (stronger than the old value-redaction), so
+    # they stop flooding the Scout on every poll. A genuine telemetry field with
+    # a real name still surfaces with its real value for discovery.
     d = _map(
         {
             "user_id": "00000000-1111-2222-3333-444455556666",
@@ -29,10 +34,7 @@ def test_718_user_id_and_vin_values_redacted_names_kept() -> None:
         }
     )
     raw = d.raw_unmapped_fields or {}
-    # NAMES stay (not suppressed → the Scout still surfaces them)
-    assert "user_id" in raw and "eu_data_act.vin" in raw
-    # ...but the real account UUID + VIN values are redacted
-    assert raw["user_id"] == "<redacted>"
-    assert raw["eu_data_act.vin"] == "<redacted>"
+    assert "user_id" not in raw
+    assert "eu_data_act.vin" not in raw
     # a genuine unmapped telemetry field keeps its real value for discovery
     assert raw["some_new_telemetry_field"] == "42"

--- a/tests/test_v2150b10_portal_long_tail.py
+++ b/tests/test_v2150b10_portal_long_tail.py
@@ -142,15 +142,19 @@ def test_remaining_times() -> None:
 
 # ── b14: NO suppression — every unmapped field surfaces in the Scout ─────────
 
-def test_nothing_is_suppressed_from_raw_unmapped() -> None:
-    # Policy: never hide Scout/raw fields. Anything not mapped this poll — even
-    # plumbing/metadata — must still appear so it can be learned + mapped later.
+def test_envelope_suppressed_real_fields_kept_in_raw_unmapped() -> None:
+    # v2.18.1 — the no-suppression rule now has ONE carve-out (Prash 2026-07-17):
+    # pure envelope/identity/generic metadata (echo, key, message_id, …) repeats
+    # on every poll and is dropped. Everything with a real, vehicle-specific name
+    # still surfaces so it can be learned + mapped later.
     d = _map({
         "echo": "echo", "key": "abc", "message_id": "m1",
         "some_brand_new_field": "42",
     })
-    for k in ("echo", "key", "message_id", "some_brand_new_field"):
-        assert k in d.raw_unmapped_fields
+    raw = d.raw_unmapped_fields
+    for k in ("echo", "key", "message_id"):
+        assert k not in raw
+    assert "some_brand_new_field" in raw
 
 
 # ── dictionary name index (fixes the #500 "Spec field" column) ────────────────

--- a/tests/test_v2151_scout_mapping.py
+++ b/tests/test_v2151_scout_mapping.py
@@ -237,11 +237,12 @@ class TestEUNewFields:
         d = _map({"error_code": "#0", "error_number": "0"})
         assert d.data_error_detail is None
 
-    def test_last_report_id_surfaced_and_scout_visible(self) -> None:
+    def test_last_report_id_mapped_message_id_suppressed(self) -> None:
         d = _map({"message_id": "rep-123"})
         assert d.last_report_id == "rep-123"
-        # b14 no-suppress: still visible in raw_unmapped_fields
-        assert "message_id" in d.raw_unmapped_fields
+        # v2.18.1 — message_id is envelope metadata: consumed into last_report_id
+        # and dropped from the raw/Scout surface (carve-out from no-suppression).
+        assert "message_id" not in d.raw_unmapped_fields
 
     def test_climate_and_residual_energy(self) -> None:
         # Real EU data-dictionary keys (the earlier guessed names never matched).
@@ -260,11 +261,12 @@ class TestEUNewFields:
         assert d.last_trip_avg_recuperation_kwh_100km == 2.2
         assert d.lifetime_avg_recuperation_kwh_100km == 1.8
 
-    def test_dataset_key_low_confidence_surfaced_and_scout_visible(self) -> None:
+    def test_dataset_key_mapped_key_suppressed(self) -> None:
         d = _map({"key": "abc-key"})
         assert d.dataset_key == "abc-key"
-        # LOW-confidence metadata stays Scout-visible (b14 no-suppress)
-        assert "key" in d.raw_unmapped_fields
+        # v2.18.1 — the generic ``key`` leaf is envelope metadata: consumed into
+        # dataset_key and dropped from the raw/Scout surface (carve-out).
+        assert "key" not in d.raw_unmapped_fields
 
     def test_bare_open_not_mapped_to_sunroof(self) -> None:
         # plan §5 LOW: leave bare `open` to raw_unmapped_fields until live-test

--- a/tests/test_v2152_charger_detail.py
+++ b/tests/test_v2152_charger_detail.py
@@ -94,13 +94,14 @@ def test_all_charger_detail_fields_together() -> None:
     assert d.charge_led_pattern == "pulse"
 
 
-def test_echo_stays_unmapped_scout_visible() -> None:
-    # No-suppress policy: plumbing fields like ``echo`` must surface in the
-    # Scout's raw_unmapped_fields so they can be learned + mapped later.
+def test_echo_envelope_suppressed_mapped_field_not_in_raw() -> None:
+    # v2.18.1 — ``echo`` is request-envelope metadata: dropped from the raw/Scout
+    # surface (carve-out from no-suppression). The mapped field must also not leak
+    # into the unmapped set.
     d = _map_flatlog(
         ("external_power_supply_state", "available"),
         ("echo", "echo"),
     )
-    assert "echo" in d.raw_unmapped_fields
+    assert "echo" not in d.raw_unmapped_fields
     # the mapped field must NOT leak into the unmapped set
     assert "external_power_supply_state" not in d.raw_unmapped_fields

--- a/tests/test_v2153_eu_new_fields.py
+++ b/tests/test_v2153_eu_new_fields.py
@@ -213,15 +213,16 @@ def test_error_codes_zero_sentinel_dropped() -> None:
 
 # ── No-suppress policy: skipped vendor-internal fields stay Scout-visible ─────
 
-def test_skipped_fields_stay_scout_visible() -> None:
+def test_vendor_field_visible_echo_envelope_suppressed() -> None:
     d = _map({
         "scope_potential_total": "0",
         "echo": "echo",
         "charge_mode_selection": "CHARGE_MODE_SELECTION_IMMEDIATECHARGING",
     })
-    # vendor-internal / plumbing fields are NOT mapped → must surface as raw
+    # a real vendor-internal field (real name) is NOT mapped → must surface as raw
     assert "scope_potential_total" in d.raw_unmapped_fields
-    assert "echo" in d.raw_unmapped_fields
+    # v2.18.1 — ``echo`` is envelope metadata → dropped (carve-out from no-suppress)
+    assert "echo" not in d.raw_unmapped_fields
     # a mapped field must NOT leak into the unmapped set
     assert "charge_mode_selection" not in d.raw_unmapped_fields
 

--- a/tests/test_v2154_overreport_fix.py
+++ b/tests/test_v2154_overreport_fix.py
@@ -174,22 +174,13 @@ def test_overreporters_gone_from_raw_unmapped() -> None:
 
 
 def test_raw_unmapped_is_only_intended_metadata() -> None:
-    """raw_unmapped must shrink to ONLY the intentionally-unmapped (no-suppress)
-    metadata — vin/user_id/state/timestamp/value/message_id/Data.key
-    + the charger-dialect/door leaves that were never in scope (and unmapped
-    before the fix too). No telemetry field re-surfaces. (v2.15.5: update_reason
-    is now mapped, so it no longer appears here.)"""
+    """v2.18.1 — envelope/identity/UUID metadata (vin / user_id / state /
+    timestamp / value / message_id / Data.key / …) is now the carve-out from
+    no-suppression and is dropped from the raw/Scout surface. What remains is only
+    the real, still-unmapped telemetry the Scout is meant to surface for future
+    mapping."""
     raw = _map().raw_unmapped_fields
     intended = {
-        "Data.key",
-        "key",
-        "vin",
-        "user_id",
-        "state",
-        "dataPoints.state",
-        "timestamp",
-        "value",
-        "message_id",
         "battery_level_HV",
         "open",
     }

--- a/tests/test_v2181_scout_mapping.py
+++ b/tests/test_v2181_scout_mapping.py
@@ -67,3 +67,41 @@ def test_v2181_oil_level_status_does_not_clobber_existing() -> None:
     d.oil_level_status = "ok"
     map_dataset_to_vehicle_data({"oil_level_status": "minWarning"}, d)
     assert d.oil_level_status == "ok"  # canonical/earlier value wins
+
+
+def test_v2181_envelope_metadata_dropped_from_raw_unmapped() -> None:
+    # Prash's carve-out (2026-07-17): account id / VIN / envelope timestamps /
+    # generic per-point names / per-export UUIDs repeat every poll and are
+    # dropped from the raw/Scout surface. A real field name still surfaces.
+    d = VehicleData(vin="X")
+    map_dataset_to_vehicle_data(
+        {
+            "user_id": "00000000-1111-2222-3333-444455556666",
+            "vin": "WVWZZZ1KZAW000000",
+            "timestamp": "1",
+            "echo": "x",
+            "message_id": "m",
+            "067f539c-85fe-3067-9c29-d63e177e3712": "1",  # per-export point UUID
+            "real_new_telemetry": "42",
+        },
+        d,
+    )
+    raw = d.raw_unmapped_fields or {}
+    for k in (
+        "user_id",
+        "vin",
+        "timestamp",
+        "echo",
+        "message_id",
+        "067f539c-85fe-3067-9c29-d63e177e3712",
+    ):
+        assert k not in raw, k
+    assert "real_new_telemetry" in raw  # real name still surfaces
+
+
+def test_v2181_ambiguous_open_stays_visible() -> None:
+    # The bare ``open`` boolean is deliberately NOT silenced — ambiguous meaning,
+    # so no-suppression still holds for it (#794/#807 stay open until it's known).
+    d = VehicleData(vin="X")
+    map_dataset_to_vehicle_data({"open": "true"}, d)
+    assert "open" in (d.raw_unmapped_fields or {})

--- a/tests/test_v2181_scout_mapping.py
+++ b/tests/test_v2181_scout_mapping.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.18.1 — post-2.18.0 Scout triage: register/consume the fields that kept a
+handful of Scout reports open after the release, verified against the SAME
+``_path_matches`` the detector uses and the real mapper.
+
+Covered:
+  · selectivestatus (audi inherits volkswagen): aux-heating now also nested under
+    the climatisation / climatisationTimers jobs (#752), and climatisationTimers
+    gained the standard CARIAD-BFF ``.error`` envelope (#785/#789).
+  · skoda charging: ``settings.maxChargeCurrentAcAmpere`` — the integer-amps
+    spelling the parser already reads (skoda.py) but EXPECTED_KEYS never listed
+    (#781/#795), classic silencer-lag.
+  · EU-Data-Act 15-min feed: ``oil_level_status`` raw enum is now CONSUMED into
+    the diagnostic ``oil_level_status`` field (#794) instead of surfacing unmapped.
+
+NOT covered on purpose: the feed's bare ``open`` boolean (#794/#807) is left
+Scout-visible — its meaning is ambiguous and the no-suppression policy forbids
+silencing it; we map real fields, we never hide.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad._unexpected_keys import (
+    EXPECTED_KEYS,
+    _path_matches,
+)
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def test_v2181_selectivestatus_aux_heating_and_timer_error_registered() -> None:
+    vw = EXPECTED_KEYS["volkswagen"]["selectivestatus"]
+    for path in (
+        "climatisation.auxiliaryHeatingStatus",  # #752 (2-seg leaf)
+        "climatisation.auxiliaryHeatingStatus.value",
+        "climatisationTimers.auxiliaryHeatingTimersStatus.value",  # #752 (3-seg)
+        "climatisationTimers.climatisationTimersStatus.error",  # #785/#789
+        "climatisationTimers.climatisationTimersStatus.error.retry",  # via .error.*
+    ):
+        assert _path_matches(path, vw), path
+
+
+def test_v2181_audi_inherits_the_selectivestatus_additions() -> None:
+    # EXPECTED_KEYS["audi"] = EXPECTED_KEYS["volkswagen"] at module load.
+    audi = EXPECTED_KEYS["audi"]["selectivestatus"]
+    assert _path_matches("climatisation.auxiliaryHeatingStatus", audi)
+    assert _path_matches("climatisationTimers.climatisationTimersStatus.error", audi)
+
+
+def test_v2181_skoda_max_charge_current_ampere_registered() -> None:
+    charging = EXPECTED_KEYS["skoda"]["charging"]
+    assert _path_matches("settings.maxChargeCurrentAcAmpere", charging)
+    # the lowercase-c variant must still resolve (regression guard)
+    assert _path_matches("settings.maxChargeCurrentAc", charging)
+
+
+def test_v2181_feed_oil_level_status_is_consumed() -> None:
+    d = VehicleData(vin="WVWZZZ1KZAW000000")
+    map_dataset_to_vehicle_data({"oil_level_status": "minWarning"}, d)
+    assert d.oil_level_status == "minWarning"
+
+
+def test_v2181_oil_level_status_does_not_clobber_existing() -> None:
+    d = VehicleData(vin="X")
+    d.oil_level_status = "ok"
+    map_dataset_to_vehicle_data({"oil_level_status": "minWarning"}, d)
+    assert d.oil_level_status == "ok"  # canonical/earlier value wins


### PR DESCRIPTION
## v2.18.1 — post-2.18.0 Vehicle Data Scout triage

Cleans up the Scout reports still open after v2.18.0. Which reports carried a genuinely unmapped field vs. metadata was determined deterministically — against the real `EXPECTED_KEYS`/`_path_matches` the detector uses and the real EU-Data-Act mapper — not by eye.

### Mapped / registered
- Aux-heating (Standheizung) now also ships nested under the climatisation / climatisationTimers jobs, and the climate-timer gained the standard `.error` envelope — #752, #785, #789
- Škoda `maxChargeCurrentAcAmpere` — read by the parser but never listed in the catalogue (classic silencer-lag) — #781, #795
- EU Data Act feed: the raw `oil_level_status` enum is now consumed — #794

### Envelope/UUID carve-out
The EU Data Act feed repeats the account id, VIN, poll/message envelope timestamps, the generic per-point names (`state`/`value`/`unit`/`key`) and a pile of per-export point UUIDs on every poll — none of it mappable vehicle data. These are now dropped from the raw/Scout surface, which resolves the long tail of pure-repetition portal Scout reports (#747, #782, #804 and about a dozen more `eu_data_act` reports). Everything with a real, vehicle-specific field name still surfaces; the ambiguous bare `open` boolean (#794, #807) is deliberately left visible until its meaning is confirmed.

7 guardrail tests were updated from the old envelope-visible policy to the carve-out (real fields are still asserted visible). Full suite: 3758 passed.

### Reports & fixes this closes
Thanks to @heyensh-sys (#752), @GiuseppeAlbano (#785), @Lagaff86 (#789), @DvorakMartin1 (#781, #795) and @loungelizard2018 (#794).
