### PR TITLE
Release v2.20.1 — Škoda charge controls (#866) + MBB command visibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.20.1] - 2026-07-21
+
+### Fixed
+
+- **Škoda charge controls work again (#866).** Setting the charge limit — plus the battery-care, charging-current and auto-unlock controls alongside it — failed with a server error even though the official app worked. They were being sent as an *action* rather than a *settings change*, so Škoda's backend rejected them. All four now use the exact request the app sends, checked against the actively-maintained Škoda library.
+- **Two-way controls no longer vanish on older Car-Net cars.** On some legacy Car-Net vehicles the integration couldn't read the car's service directory (it came back "unauthorised"), and a v2.20.0 change then hid *every* lock / climate / charging control for the rest of the session. Now, when that directory simply can't be read, the controls stay available (a failed command is reported when you use it) instead of disappearing — while a car that genuinely proves it lacks a service still correctly hides it. That directory read is now also retried once after refreshing the login.
+
+### Changed
+
+- Internal tidy-up of some out-of-date code comments left by the v2.20.0 command-routing change. No behaviour change.
+
+### Thanks
+
+Thanks to **@tader** for the clean Škoda charge-limit report (#866). The full roll of reporters and testers is in [CONTRIBUTORS.md](CONTRIBUTORS.md). 🙏
+
 ## [2.20.0] - 2026-07-20
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -1585,7 +1585,11 @@ class SkodaClient(CariadBaseClient):
         # request DTO (ChargeLimitDto, MyŠkoda 8.14.0) uses ``targetSOCInPercent``,
         # not the read-side ``targetStateOfChargeInPercent`` — the old key was
         # silently ignored so the target was never applied.
-        await self._post(
+        # v2.20.1 (#866) — the mysmob charging-SETTINGS routes are PUT, not POST
+        # (actions like start/stop stay POST). A POST here 500s server-side
+        # (@tader, Elroq) even with the correct field. Confirmed against the
+        # upstream myskoda rest_api (set_charge_limit → PUT).
+        await self._put(
             f"{_BASE}/api/v1/charging/{vin}/set-charge-limit",
             json={"targetSOCInPercent": target},
         )
@@ -1604,9 +1608,11 @@ class SkodaClient(CariadBaseClient):
         dispatches (see SeatCupraClient for the OLA sibling). Only the
         ``max_charge_current`` field is wired for Skoda here; the endpoint
         and the ``MAXIMUM``/``REDUCED`` enum are grounded in the mysmob
-        contract (POST /api/v1/charging/{vin}/set-charging-current) and the
+        contract (PUT /api/v1/charging/{vin}/set-charging-current) and the
         read-side ``settings.maxChargingCurrent`` shape used by
-        ``get_charging_profiles``.
+        ``get_charging_profiles``. v2.20.1 (#866) — the write DTO field is
+        ``chargingCurrent`` (not the read-side ``maxChargingCurrent``) and the
+        verb is PUT, confirmed against upstream myskoda (set_reduced_current_limit).
 
         ``target_soc`` is intentionally routed through the dedicated
         ``set-charge-limit`` endpoint (``command_set_target_soc``) — the
@@ -1619,9 +1625,9 @@ class SkodaClient(CariadBaseClient):
         if target_soc is not None:
             await self.command_set_target_soc(vin, int(target_soc))
         if max_charge_current is not None:
-            await self._post(
+            await self._put(
                 f"{_BASE}/api/v1/charging/{vin}/set-charging-current",
-                json={"maxChargingCurrent": str(max_charge_current)},
+                json={"chargingCurrent": str(max_charge_current)},
             )
 
     async def command_set_climate_temperature(self, vin: str, temp_c: float) -> None:
@@ -1667,10 +1673,10 @@ class SkodaClient(CariadBaseClient):
     # the decoded MyŠkoda 8.14.0 app: the route paths and the DTO wrappers
     # ``ChargingCareModeDto(chargingCareMode=…)``, ``AutoUnlockPlugDto(
     # autoUnlockPlug=…)`` and the ActiveVentilation ``durationInSeconds`` field.
-    # Value TYPES are the best inference (bool for the care toggle, matching the
-    # read-side bool ``isBatteryCareMode``); the auto-unlock value is passed
-    # through from the caller because its enum could not be cleanly isolated
-    # from the DEX string table — so we ground the field, never guess the value.
+    # v2.20.1 (#866) — the charging-SETTINGS routes are PUT (not POST) and their
+    # value shapes were confirmed against upstream myskoda: care-mode is the
+    # string enum ``ACTIVATED``/``DEACTIVATED`` (not a bool), auto-unlock is
+    # ``PERMANENT``/``OFF``. Actions (start/stop/window-heating) stay POST.
     #
     # WIRING STATUS:
     # - ``command_set_battery_care`` OVERRIDES the base (which raises
@@ -1691,25 +1697,26 @@ class SkodaClient(CariadBaseClient):
         Overrides ``CariadBaseClient.command_set_battery_care`` (which raises
         NotImplementedError) so the existing ``VagBatteryCareSwitch`` works for
         Skoda. Route + DTO field ``chargingCareMode`` are grounded in MyŠkoda
-        8.14.0 (``ChargingCareModeDto``); the VALUE TYPE is unverified — we send
-        a JSON bool as the most likely shape for an on/off toggle, but the app
-        may serialise it as an enum string. LIVE-GATED (no tester); if a real
-        Skoda rejects the bool, the enum form is the first thing to try.
+        8.14.0 (``ChargingCareModeDto``). v2.20.1 (#866) — verb is PUT (a
+        charging-SETTINGS route, not an action) and the value is the string
+        enum ``ACTIVATED``/``DEACTIVATED``, NOT a JSON bool — confirmed against
+        upstream myskoda (set_battery_care_mode). The old POST+bool 500'd.
         """
-        await self._post(
+        await self._put(
             f"{_BASE}/api/v1/charging/{vin}/set-care-mode",
-            json={"chargingCareMode": bool(enabled)},
+            json={"chargingCareMode": "ACTIVATED" if enabled else "DEACTIVATED"},
         )
 
     async def command_set_auto_unlock_plug(self, vin: str, mode: str) -> None:
         """Set auto-unlock-plug-when-charged behaviour.
 
         Route + DTO field ``autoUnlockPlug`` grounded in MyŠkoda 8.14.0
-        (``AutoUnlockPlugDto``). ``mode`` is passed through verbatim — the
-        app's enum values were not cleanly recoverable from the DEX strings, so
-        the caller supplies the exact token rather than us guessing. LIVE-GATED.
+        (``AutoUnlockPlugDto``). v2.20.1 (#866) — verb is PUT (charging-SETTINGS
+        route) and the enum is ``PERMANENT``/``OFF``, confirmed against upstream
+        myskoda (set_auto_unlock_charging). ``mode`` is still passed through so
+        the caller supplies the exact token; no HA entity is wired yet.
         """
-        await self._post(
+        await self._put(
             f"{_BASE}/api/v1/charging/{vin}/set-auto-unlock-plug",
             json={"autoUnlockPlug": str(mode)},
         )

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1549,7 +1549,7 @@ class VWEUClient(CariadBaseClient):
         return []
 
     async def _get_mbb_operationlist(
-        self, vin: str, *, for_command: bool = False,
+        self, vin: str, *, for_command: bool = False, _refreshed: bool = False,
     ) -> "MbbOperationList | None":
         """Fetch + cache the per-VIN MBB operationList (service directory).
 
@@ -1589,9 +1589,37 @@ class VWEUClient(CariadBaseClient):
                 url, _retry=False, for_command=for_command
             )
         except APIError as err:
+            body = str(err.body)
+            # v2.20.1 (#584) — distinguish a TOKEN-AUTH 401 from the systemId
+            # ACL. ``gw.error.authentication`` means the gateway rejected the
+            # bearer as unauthenticated (Mattheisen87's Passat: 26× on v2.20.0 —
+            # the token exchange succeeds but the FIRST call with it 401s),
+            # unlike the data-plane ACL (``mbbc.rolesandrights.unauthorized`` /
+            # ``*.security.9007``) which no refresh can fix. A real token-auth
+            # failure IS recoverable by refreshing the bearer once — mirror
+            # audi_connect_ha #782 (keep the session token fresh on auth
+            # failure). Guarded to EXACTLY ONE retry so we never storm the
+            # refresh endpoint (the original _retry=False concern).
+            if (
+                err.status == 401
+                and "gw.error.authentication" in body
+                and not _refreshed
+            ):
+                _LOGGER.info(
+                    "MBB operationList ***%s → 401 gw.error.authentication — "
+                    "refreshing the MBB bearer and retrying once (#584).",
+                    vin[-6:],
+                )
+                try:
+                    await self._refresh_tokens(for_command=for_command)
+                except Exception:  # noqa: BLE001
+                    pass
+                return await self._get_mbb_operationlist(
+                    vin, for_command=for_command, _refreshed=True,
+                )
             _LOGGER.warning(
                 "MBB operationList ***%s → HTTP %s: %s",
-                vin[-6:], err.status, str(err.body)[:160],
+                vin[-6:], err.status, body[:160],
             )
             return None
         except Exception as err:  # noqa: BLE001

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -681,8 +681,8 @@ class VWEUClient(CariadBaseClient):
             return False
 
     async def command_lock(self, vin: str, spin: str = "") -> None:
-        """Lock vehicle — combined endpoint with separate-endpoint fallback,
-        each tried on both /vehicle/v1/ and /vehicle/v2/ paths.
+        """Lock vehicle — separate endpoint (primary) with combined endpoint as
+        404-fallback, each tried on both /vehicle/v1/ and /vehicle/v2/ paths.
 
         v1.8.8 (Session 3B): HTTP-404-only fallback via
         ``_post_command_with_fallback_paths``. Auth failures, rate limits
@@ -723,10 +723,10 @@ class VWEUClient(CariadBaseClient):
     async def command_unlock(self, vin: str, spin: str = "") -> None:
         """Unlock vehicle — S-PIN required if set.
 
-        Same v1/v2 + combined/separate dispatch as ``command_lock``.
-        S-PIN, when present, is included in *both* the combined-endpoint
-        payload and the separate-endpoint fallback payload (the legacy
-        unlock endpoint accepts the PIN in the body, the same way the
+        Same v1/v2 + separate/combined dispatch as ``command_lock``.
+        S-PIN, when present, is included in *both* the separate-endpoint
+        (primary) payload and the combined-endpoint 404-fallback payload (the
+        legacy unlock endpoint accepts the PIN in the body, the same way the
         SecToken-using SEAT/CUPRA flow does in v1.8.4).
         """
         # v2.15.0 — durable MBB strategy uses the classic Car-Net RLU flow.
@@ -751,8 +751,8 @@ class VWEUClient(CariadBaseClient):
     async def command_start_climate(
         self, vin: str, ppe_mode: bool = False
     ) -> None:
-        """Start pre-conditioning — combined endpoint with separate fallback,
-        each on v1/v2.
+        """Start pre-conditioning — separate endpoint (primary) with combined
+        404-fallback, each on v1/v2.
 
         Default target temperature 21°C and window heating enabled match
         the previous separate-endpoint payload — kept so behaviour does
@@ -774,7 +774,7 @@ class VWEUClient(CariadBaseClient):
             await _tgt._command_mbb_op(vin, "climate_start")
             return
         if ppe_mode:
-            fallback_payload = {
+            start_body = {
                 "climatisationMode": "comfort",
                 "climatisationWithoutExternalPower": True,
                 "windowHeatingEnabled": True,
@@ -782,7 +782,7 @@ class VWEUClient(CariadBaseClient):
                 # rejects it on Q6/A6 e-tron / PPC vehicles.
             }
         else:
-            fallback_payload = {
+            start_body = {
                 "targetTemperature": 21.0,
                 "targetTemperatureUnit": "celsius",
                 "climatisationWithoutExternalPower": True,
@@ -792,7 +792,7 @@ class VWEUClient(CariadBaseClient):
         await self._post_command_with_fallback_paths(
             vin,
             primary_suffix="climatisation/start",
-            primary_payload=fallback_payload,
+            primary_payload=start_body,
             fallback_suffix="climatisation/start-stop",
             fallback_payload={"action": "start"},
         )
@@ -862,7 +862,7 @@ class VWEUClient(CariadBaseClient):
         await self._post(url, json=body)
 
     async def command_stop_climate(self, vin: str) -> None:
-        """Stop pre-conditioning — combined endpoint with separate fallback."""
+        """Stop pre-conditioning — separate endpoint (primary), combined 404-fallback."""
         _tgt = self._mbb_command_target()
         if _tgt is not None:
             await _tgt._command_mbb_op(vin, "climate_stop")
@@ -877,7 +877,7 @@ class VWEUClient(CariadBaseClient):
         )
 
     async def command_start_charging(self, vin: str) -> None:
-        """Start charging — combined endpoint with separate fallback."""
+        """Start charging — separate endpoint (primary), combined 404-fallback."""
         _tgt = self._mbb_command_target()
         if _tgt is not None:
             await _tgt._command_mbb_op(vin, "charge_start")
@@ -892,7 +892,7 @@ class VWEUClient(CariadBaseClient):
         )
 
     async def command_stop_charging(self, vin: str) -> None:
-        """Stop charging — combined endpoint with separate fallback."""
+        """Stop charging — separate endpoint (primary), combined 404-fallback."""
         _tgt = self._mbb_command_target()
         if _tgt is not None:
             await _tgt._command_mbb_op(vin, "charge_stop")

--- a/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
@@ -354,7 +354,7 @@ class DataActScraper:
         external evidence for is the leading one in
         ``_API_DATA_CANDIDATE_PATHS``, and that path is documented as
         returning a metadata JSON, not the customised-data zip itself.
-        Live-credential testing (TODO v2.8.1, requires real VW EU
+        Live-credential testing (TODO — requires a credentialed VW EU
         account) is what will tell us:
           1. whether one of the candidate paths returns the zip
              directly under the session cookie, or
@@ -443,7 +443,7 @@ class DataActScraper:
                 )
                 continue
 
-        # TODO v2.8.1 - live route A discovery requires real
+        # TODO (credentialed tester) - live route A discovery requires real
         # credentials, see _private/research-archive/old-docs/
         # RESEARCH_NOTES_2026-04-29.md section 9 for the only
         # confirmed endpoint shape we have so far.
@@ -520,7 +520,7 @@ class DataActScraper:
                     wait_until="domcontentloaded",
                 )
 
-                # TODO v2.8.1 - real selectors require a recorded DOM
+                # TODO (credentialed tester) - real selectors require a recorded DOM
                 # snapshot from a credentialed tester. Until then the
                 # method bails out cleanly and the coordinator falls
                 # back to "no data this cycle". Suggested selector

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1002,6 +1002,14 @@ _RAW_FIELD_CAP = 250
 # forever, so they ARE dropped from the raw/Scout surface. Anything with a real,
 # vehicle-specific field name still surfaces — the no-suppression rule holds for
 # everything except this metadata repetition.
+# NOTE (v2.20.1): do NOT union this with ``_GENERIC_FIELD_NAMES``. The two sets
+# serve different purposes and are intentionally NOT identical: the generic set
+# drives the flattener's UUID-aliasing, whereas this set silences pure envelope
+# noise for the Vehicle Data Scout. The generic-but-ambiguous leaves ``open`` /
+# ``type`` / ``is_set`` are DELIBERATELY left Scout-visible under the
+# no-suppression policy (see test_v2181_ambiguous_open_stays_visible, #794/#807)
+# until their meaning is known — carving them would suppress an unidentified
+# real field, which the mapping policy forbids.
 _ENVELOPE_NOISE_LEAVES: frozenset[str] = frozenset({
     "user_id", "userid", "vin", "timestamp", "timestamputc",
     "echo", "message_id", "state", "value", "unit", "key",

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -223,12 +223,14 @@ def _mbb_command_capability(
     falls through to the CARIAD-BFF capability gate for non-MBB cars).
 
     Policy (user choice 2026-07-19: *maximal streng*): a command entity is
-    created ONLY on positive operationList proof that the car currently grants
-    that command's Car-Net service. No proof — service absent or Disabled, or
-    the operationList not yet fetched for this VIN — hides the entity (never
-    invent a two-way control the car can't run). The operationList is fetched
-    by ``_refresh_mbb_command_capabilities`` and cached 12 h per VIN on the
-    command client.
+    hidden when the operationList was FETCHED and positively shows the service
+    absent or Disabled (never invent a two-way control the car proved it can't
+    run) → returns False. But when the operationList could NOT be fetched for
+    this VIN (not yet cached, or the read 401'd / failed — an expected
+    condition) there is no proof either way, so v2.20.1 returns None and defers
+    to the BFF gate rather than hiding a control that worked pre-v2.20.0. The
+    operationList is fetched by ``_refresh_mbb_command_capabilities`` and cached
+    12 h per VIN on the command client.
     """
     cmd = _mbb_command_channel_client(coord)
     if cmd is None:
@@ -245,7 +247,18 @@ def _mbb_command_capability(
     entry = cache.get(vin) if isinstance(cache, dict) else None
     oplist = entry[0] if entry else None
     if oplist is None:
-        return False  # STRICT: no operationList proof → hide
+        # v2.20.1 — the operationList was NOT fetched for this VIN (never
+        # cached, or the fetch 401'd / failed — an EXPECTED condition, see
+        # vw_eu._get_mbb_operationlist which treats a 401 here as the data-plane
+        # ACL and deliberately does not retry). "No proof EITHER way" must not
+        # remove a control that worked pre-v2.20.0: return None so
+        # command_capability_supported falls through to the BFF gate (permissive
+        # on an empty cache) instead of hiding. The strict "never invent a
+        # control the car proved it can't run" intent is preserved below — we
+        # still return False when the operationList WAS fetched and positively
+        # lacks or Disables the service. The spawner re-evaluates every refresh,
+        # so an entity re-appears the moment a later operationList fetch succeeds.
+        return None
     svc = oplist.service(service_id)
     return bool(svc is not None and svc.enabled)
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.20.0"
+  "version": "2.20.1"
 }

--- a/scripts/check_bruno_url_drift.py
+++ b/scripts/check_bruno_url_drift.py
@@ -106,6 +106,13 @@ _BRAND_DIRS: dict[str, tuple[list[str], str]] = {
         ["custom_components/vag_connect/cariad/api/vw_na.py"],
         "tests/bruno/vw_na",
     ),
+    # NOTE: tests/bruno/mbb_legacy/ is INTENTIONALLY not registered here. The
+    # durable-MBB specs use different host variables ({{mbb_oauth_url}},
+    # {{home_region}}) than the {{base_url}} convention this checker parses
+    # (_BRU_URL_RE), and the MBB client builds URLs from host constants in
+    # cariad/_mbb.py rather than a single {_BASE}. Adding a row without also
+    # teaching the regex + Python patterns would emit spurious Python-only
+    # drift. Left out on purpose — not an oversight.
 }
 
 

--- a/tests/bruno/skoda/08_PUT_set_charge_limit.bru
+++ b/tests/bruno/skoda/08_PUT_set_charge_limit.bru
@@ -1,10 +1,10 @@
 meta {
-  name: POST set charge limit (target SoC)
+  name: PUT set charge limit (target SoC)
   type: http
   seq: 8
 }
 
-post {
+put {
   url: {{base_url}}/api/v1/charging/{{vin}}/set-charge-limit
   body: json
   auth: bearer
@@ -21,7 +21,7 @@ headers {
 
 body:json {
   {
-    "targetStateOfChargeInPercent": 80
+    "targetSOCInPercent": 80
   }
 }
 

--- a/tests/bruno/skoda/35_PUT_set_charging_current.bru
+++ b/tests/bruno/skoda/35_PUT_set_charging_current.bru
@@ -4,7 +4,7 @@ meta {
   seq: 35
 }
 
-post {
+put {
   url: {{base_url}}/api/v1/charging/{{vin}}/set-charging-current
   body: json
   auth: bearer
@@ -21,7 +21,7 @@ headers {
 
 body:json {
   {
-    "maxChargingCurrent": "REDUCED"
+    "chargingCurrent": "REDUCED"
   }
 }
 

--- a/tests/bruno/skoda/36_PUT_set_care_mode.bru
+++ b/tests/bruno/skoda/36_PUT_set_care_mode.bru
@@ -4,7 +4,7 @@ meta {
   seq: 36
 }
 
-post {
+put {
   url: {{base_url}}/api/v1/charging/{{vin}}/set-care-mode
   body: json
   auth: bearer
@@ -21,7 +21,7 @@ headers {
 
 body:json {
   {
-    "chargingCareMode": true
+    "chargingCareMode": "ACTIVATED"
   }
 }
 

--- a/tests/bruno/skoda/37_PUT_set_auto_unlock_plug.bru
+++ b/tests/bruno/skoda/37_PUT_set_auto_unlock_plug.bru
@@ -4,7 +4,7 @@ meta {
   seq: 37
 }
 
-post {
+put {
   url: {{base_url}}/api/v1/charging/{{vin}}/set-auto-unlock-plug
   body: json
   auth: bearer

--- a/tests/test_v21510_skoda_charge_current.py
+++ b/tests/test_v21510_skoda_charge_current.py
@@ -88,19 +88,24 @@ class TestSkodaCommandUpdateChargingSettings:
         from custom_components.vag_connect.cariad.api.skoda import SkodaClient
         client = SkodaClient.__new__(SkodaClient)
         client._post = AsyncMock(return_value={})
+        client._put = AsyncMock(return_value={})
         return client
 
-    def test_max_current_posts_grounded_url_and_body(self):
+    def test_max_current_puts_grounded_url_and_body(self):
+        # v2.20.1 (#866) — charging-SETTINGS routes are PUT (not POST) and the
+        # write DTO field is chargingCurrent (upstream myskoda), not the
+        # read-side maxChargingCurrent.
         client = self._client()
         asyncio.run(
             client.command_update_charging_settings(
                 "VINX", max_charge_current="REDUCED"
             )
         )
-        client._post.assert_awaited_once_with(
+        client._put.assert_awaited_once_with(
             "https://mysmob.api.connect.skoda-auto.cz/api/v1/charging/VINX/set-charging-current",
-            json={"maxChargingCurrent": "REDUCED"},
+            json={"chargingCurrent": "REDUCED"},
         )
+        client._post.assert_not_awaited()
 
     def test_maximum_enum_passthrough(self):
         client = self._client()
@@ -109,8 +114,8 @@ class TestSkodaCommandUpdateChargingSettings:
                 "VINX", max_charge_current="MAXIMUM"
             )
         )
-        _, kwargs = client._post.await_args
-        assert kwargs["json"] == {"maxChargingCurrent": "MAXIMUM"}
+        _, kwargs = client._put.await_args
+        assert kwargs["json"] == {"chargingCurrent": "MAXIMUM"}
 
     def test_target_soc_forwarded_to_set_charge_limit(self):
         # target_soc must route through the dedicated grounded endpoint,

--- a/tests/test_v2200_mbb_command_pretest.py
+++ b/tests/test_v2200_mbb_command_pretest.py
@@ -137,11 +137,15 @@ class TestMbbGateBffOnlyCommandsHidden:
 
 
 class TestMbbGateStrictness:
-    def test_no_oplist_cached_hidden(self) -> None:
-        # MEB / not-yet-fetched → no proof → strict hide.
+    def test_no_oplist_cached_defers_not_hidden(self) -> None:
+        # v2.20.1 (#584/#866) — operationList NOT fetched (never cached or the
+        # read 401'd, an expected condition) is "no proof EITHER way", so the
+        # gate returns None and defers to the BFF gate rather than hiding a
+        # control that worked pre-v2.20.0. Proven-absent (a fetched oplist
+        # lacking the service) is still hidden — see test_disabled_service_hidden.
         stub = _coord(mbb_armed=True, oplist=None)
-        assert _cap(stub, "command_start_climate") is False
-        assert _cap(stub, "command_start_charging") is False
+        assert _cap(stub, "command_start_climate") is None
+        assert _cap(stub, "command_start_charging") is None
 
     def test_disabled_service_hidden(self) -> None:
         services = [
@@ -199,12 +203,16 @@ class TestCommandCapabilitySupportedIntegration:
             VIN, "command_start_climate") is True
         assert stub.command_capability_supported(VIN, "command_lock") is False
 
-    def test_public_gate_meb_hides_all(self) -> None:
+    def test_public_gate_no_oplist_defers(self) -> None:
+        # v2.20.1 — armed MBB but no operationList proof: the MBB gate returns
+        # None and command_capability_supported falls through to the BFF gate
+        # (permissive on an empty cap cache) instead of hiding. Phase-2 runtime
+        # failure classification still catches a genuinely unsupported command.
         stub = _coord(mbb_armed=True, oplist=None)
         assert stub.command_capability_supported(
-            VIN, "command_start_climate") is False
+            VIN, "command_start_climate") is None
         assert stub.command_capability_supported(
-            VIN, "command_start_charging") is False
+            VIN, "command_start_charging") is None
 
 
 class TestRefreshWarmVinFallback:

--- a/tests/test_v2201_584_oplist_401_retry.py
+++ b/tests/test_v2201_584_oplist_401_retry.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.20.1 (#584) — MBB operationList: refresh + retry once on a token-auth 401.
+
+Mattheisen87's Passat GTE on v2.20.0: the durable-MBB token refresh works (the
+v2.18.0 fix), reads are healthy, but the operationList GET returns
+``401 gw.error.authentication`` 26× → an empty service directory → every command
+entity stays ``unavailable``. That 401 is a TOKEN-AUTH failure (the gateway
+rejects the bearer as unauthenticated), NOT the data-plane systemId ACL
+(``mbbc.rolesandrights.unauthorized`` / ``*.security.9007``) which no refresh can
+fix. Mirroring audi_connect_ha #782, a token-auth failure is recovered by
+refreshing the bearer once and retrying — guarded to exactly one retry so the
+refresh endpoint is never stormed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+from custom_components.vag_connect.cariad.exceptions import APIError
+
+VIN = "WVWZZZ3CZ9W025570"
+
+_URL = "https://mal-1a.prd.ece.vwg-connect.com/api/rolesrights/operationlist/v3"
+_AUTH_401 = APIError(401, _URL, '{"error":{"errorCode":"gw.error.authentication","description":"Unauthorized"}}')
+_ACL_403 = APIError(403, _URL, '{"error":{"errorCode":"mbbc.rolesandrights.unauthorized","description":"Did not find permission for systemId \'XID_APP_VW\'"}}')
+_ACL_401 = APIError(401, _URL, '{"error":{"errorCode":"mbbc.rolesandrights.unauthorized"}}')
+
+_GOOD = {"operationList": {"vin": VIN, "role": "PRIMARY_USER", "status": "ENABLED",
+                           "serviceInfo": [{"serviceId": "rclima_v1",
+                                            "serviceStatus": {"status": "Enabled"}}]}}
+
+
+def _client(mbb_get_side_effect) -> VWEUClient:
+    c = VWEUClient.__new__(VWEUClient)
+    c._mbb_get = AsyncMock(side_effect=mbb_get_side_effect)
+    c._refresh_tokens = AsyncMock(return_value=None)
+    return c
+
+
+class TestOplist401Retry:
+    def test_auth_401_then_success_refreshes_and_retries(self) -> None:
+        c = _client([_AUTH_401, _GOOD])
+        oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
+        assert oplist is not None
+        assert "rclima_v1" in oplist.services
+        c._refresh_tokens.assert_awaited_once()          # refreshed exactly once
+        assert c._mbb_get.await_count == 2               # original + retry
+        # the refresh was routed to the command channel
+        assert c._refresh_tokens.await_args.kwargs.get("for_command") is True
+
+    def test_auth_401_persists_refreshes_once_then_gives_up(self) -> None:
+        # Both attempts 401 → one refresh, one retry, then None — NO storm.
+        c = _client([_AUTH_401, _AUTH_401])
+        oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
+        assert oplist is None
+        c._refresh_tokens.assert_awaited_once()
+        assert c._mbb_get.await_count == 2               # never a third attempt
+
+    def test_systemid_403_does_not_refresh(self) -> None:
+        # The data-plane ACL is unrecoverable — must NOT refresh/retry.
+        c = _client([_ACL_403])
+        oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
+        assert oplist is None
+        c._refresh_tokens.assert_not_awaited()
+        assert c._mbb_get.await_count == 1
+
+    def test_systemid_401_does_not_refresh(self) -> None:
+        # A 401 that is the systemId ACL (not gw.error.authentication) is also
+        # unrecoverable — the trigger is the error code, not the status.
+        c = _client([_ACL_401])
+        oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
+        assert oplist is None
+        c._refresh_tokens.assert_not_awaited()
+        assert c._mbb_get.await_count == 1
+
+    def test_happy_path_200_never_refreshes(self) -> None:
+        # Prash's Golf: operationList 200 on the first call — no retry logic runs.
+        c = _client([_GOOD])
+        oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
+        assert oplist is not None
+        c._refresh_tokens.assert_not_awaited()
+        assert c._mbb_get.await_count == 1

--- a/tests/test_v220_apk_audit_fixes.py
+++ b/tests/test_v220_apk_audit_fixes.py
@@ -34,9 +34,11 @@ def test_skoda_flash_is_FLASH_not_FLASH_ONLY() -> None:
 
 def test_skoda_target_soc_field() -> None:
     c = SkodaClient(MagicMock(), "u@t.de", "pw")
-    c._post = AsyncMock()  # type: ignore[method-assign]
+    c._put = AsyncMock()  # type: ignore[method-assign]
     asyncio.run(c.command_set_target_soc("VIN1", 80))
-    _, body = _url_body(c)
+    a = c._put.call_args  # v2.20.1 (#866): set-charge-limit is PUT, not POST
+    url, body = a.args[0], a.kwargs.get("json")
+    assert url.endswith("/charging/VIN1/set-charge-limit")
     assert body == {"targetSOCInPercent": 80}  # not targetStateOfChargeInPercent
 
 

--- a/tests/test_v220_skoda_new_routes.py
+++ b/tests/test_v220_skoda_new_routes.py
@@ -19,12 +19,18 @@ from custom_components.vag_connect.cariad.api.skoda import SkodaClient
 def _client() -> SkodaClient:
     client = SkodaClient(MagicMock(), "u@t.de", "pw")
     client._post = AsyncMock()  # type: ignore[method-assign]
+    client._put = AsyncMock()  # type: ignore[method-assign]
     return client
 
 
 def _call(client: SkodaClient) -> tuple[str, dict]:
-    """Return (url, json_body) of the single _post call."""
-    args = client._post.call_args
+    """Return (url, json_body) of the single command call, whichever verb it
+    used — charging-SETTINGS routes are PUT (v2.20.1 #866), actions are POST."""
+    args = (
+        client._put.call_args
+        if client._put.call_args is not None
+        else client._post.call_args
+    )
     url = args.args[0]
     body = args.kwargs.get("json")
     return url, body
@@ -35,14 +41,16 @@ def test_battery_care_mode_on() -> None:
     asyncio.run(client.command_set_battery_care("VIN1", True))
     url, body = _call(client)
     assert url.endswith("/api/v1/charging/VIN1/set-care-mode")
-    assert body == {"chargingCareMode": True}
+    # v2.20.1 (#866) — string enum, PUT (upstream myskoda), not a JSON bool.
+    assert body == {"chargingCareMode": "ACTIVATED"}
+    client._put.assert_awaited_once()
 
 
 def test_battery_care_mode_off() -> None:
     client = _client()
     asyncio.run(client.command_set_battery_care("VIN1", False))
     _, body = _call(client)
-    assert body == {"chargingCareMode": False}
+    assert body == {"chargingCareMode": "DEACTIVATED"}
 
 
 def test_auto_unlock_plug_passes_mode_through() -> None:


### PR DESCRIPTION
Patch release. Bugfixes only — no new entities/services (SemVer PATCH).

### Fixed
- **Škoda charge controls (#866).** The mysmob charging-*settings* routes are PUT, not POST — a POST 500'd server-side while the official app worked (@tader, Elroq). Fixed `set-charge-limit` and the three siblings (charging-current, battery-care, auto-unlock), with field/value shapes corrected to match the upstream myskoda library (`chargingCurrent`, `ACTIVATED`/`DEACTIVATED`, etc.).
- **MBB command entities no longer vanish on a service-directory 401 (#584).** v2.20.0's strict gate hid every lock/climate/charge control whenever the per-VIN operationList couldn't be read (which 401s on some Car-Net cars). "Could not fetch" now defers instead of hiding; "fetched and proven absent" still hides. The read is also refresh-retried once on a token-auth 401.

### Changed
- Internal: corrected stale docstrings/comments from the v2.20.0 command-routing change. No behaviour change.

Tests + Bruno fixtures updated. Full suite green (3974 passed), ruff + mypy-strict + Bruno-drift clean.