### PR TITLE
v2.21.1 — dead persisted IDK token must not kill VW EU entry (#875)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.21.1] - 2026-07-21
+
+### Fixed
+
+- **VW EU cars no longer get a false "authentication expired / check your password" (#875).** On MEB / ID. cars, the WeConnect login path is blocked by VW's device-attestation wall, so its saved token can't be refreshed. The integration was treating that dead refresh as a login failure and taking the whole entry down — even though the EU Data Act portal login (the one that actually feeds your data) was working fine. It now falls back to a fresh portal login and keeps going, instead of asking you to re-enter a password that was never wrong. A genuinely wrong password is still reported as before.
+
+### Thanks
+
+Thanks to **@bobbasli**, **@leMineGaming**, **@m3gg3** and **@shaarkys** for the reports and the debug logs that pinned this down (#875) — credited in [CONTRIBUTORS.md](CONTRIBUTORS.md). 🙏
+
 ## [2.21.0] - 2026-07-21
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @birni-debug
 - @bitte-ein-bit
 - @bmwpower530d
+- @bobbasli
 - @Brinki99
 - @brokkolo
 - @bufferoverflow1337
@@ -149,6 +150,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @Lagaff86
 - @larrybarry3003
 - @Leibinger
+- @leMineGaming
 - @liborcicvarek
 - @littlecake
 - @LouisFk

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -963,7 +963,29 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 await self.hass.async_add_executor_job(_dd._load)
             except Exception:  # noqa: BLE001
                 pass
-            vins = await self._cariad_client.get_vehicles()
+            try:
+                vins = await self._cariad_client.get_vehicles()
+            except AuthenticationError:
+                # v2.21.1 (#875) — persisted IDK/legacy tokens can no longer be
+                # refreshed (VW's device-attestation wall 403s the refresh). We
+                # skipped the fresh login above because they weren't a portal
+                # strategy, so ``_eu_portal`` was never armed and get_vehicles
+                # hit the dead BFF path. The portal login ITSELF still works, so
+                # don't kill the entry with "invalid credentials" — do the fresh
+                # login we skipped and retry once. Portal-persisted / no-persisted
+                # entries already did their fresh login above, so for them the
+                # failure is genuine → re-raise unchanged.
+                if persisted is None or persisted_is_portal:
+                    raise
+                _LOGGER.info(
+                    "VAG Connect: persisted tokens for %s no longer refresh "
+                    "(VW attestation wall) — falling back to a fresh login and "
+                    "retrying vehicle enumeration",
+                    brand,
+                )
+                await self._cariad_client.authenticate()
+                await self._arm_supplementary_channels()
+                vins = await self._cariad_client.get_vehicles()
             if not vins:
                 return False
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.21.0"
+  "version": "2.21.1"
 }

--- a/tests/test_v2211_875_portal_auth_fallback.py
+++ b/tests/test_v2211_875_portal_auth_fallback.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.21.1 (#875) — a dead persisted IDK/legacy token must not kill the entry.
+
+Repro: an entry with persisted non-portal tokens skips the fresh login, so
+``_eu_portal`` is never armed; ``get_vehicles`` then hits the dead CARIAD-BFF
+path, its token refresh 403s (VW's device-attestation wall), and the coordinator
+used to turn that into ``invalid_credentials`` — killing a config entry whose
+EU Data Act portal login actually works fine. The fix retries once with the
+fresh login that was skipped; a genuine credential failure still surfaces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _coord():
+    from custom_components.vag_connect.coordinator import VagConnectCoordinator
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    coord.hass = MagicMock()
+    coord.hass.loop = MagicMock()
+    coord.entry = MagicMock()
+    coord.entry.entry_id = "test"
+    coord.entry.data = {
+        "brand": "volkswagen", "username": "u@t.de",
+        "password": "pw", "spin": "", "scan_interval": 5,
+    }
+    coord._vehicles_lock = threading.Lock()
+    coord._cariad_client = None
+    coord._started = False
+    coord._was_available = True
+    coord.vehicles = {}
+    coord.data = None
+    coord.async_set_updated_data = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+    coord.logger = MagicMock()
+    return coord
+
+
+def _non_portal_tokens():
+    from custom_components.vag_connect.cariad.models import TokenSet
+    return TokenSet(
+        access_token="dead", refresh_token="dead", id_token="",
+        expires_at=0.0, strategy="idk",  # NON-portal → fresh login is skipped
+    )
+
+
+def _client(get_vehicles):
+    from custom_components.vag_connect.cariad.models import VehicleData
+    client = MagicMock()
+    client.authenticate = AsyncMock()
+    client.set_persisted_tokens = MagicMock()
+    client.get_vehicles = get_vehicles
+    client.get_status = AsyncMock(return_value=VehicleData(vin="VIN123", battery_soc=80))
+    return client
+
+
+def _run(coord, client):
+    from custom_components.vag_connect.cariad.api.factory import CariadClientFactory
+    with patch.object(CariadClientFactory, "create", return_value=client), \
+         patch("homeassistant.helpers.aiohttp_client.async_get_clientsession",
+               return_value=MagicMock()), \
+         patch("custom_components.vag_connect.cariad.auth._token_storage."
+               "TokenStorage.load", new=AsyncMock(return_value=_non_portal_tokens())), \
+         patch("custom_components.vag_connect.cariad.auth._token_storage."
+               "TokenStorage.save", new=AsyncMock()):
+        return asyncio.run(coord.async_setup())
+
+
+def test_dead_persisted_token_recovers_via_fresh_login():
+    from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+    # get_vehicles fails once (dead refresh) then succeeds after the fresh login.
+    gv = AsyncMock(side_effect=[AuthenticationError("Token refresh HTTP 403"),
+                                ["VIN123"]])
+    coord = _coord()
+    client = _client(gv)
+    result = _run(coord, client)
+    assert result is True                     # entry survived, not invalid_credentials
+    assert "VIN123" in coord.vehicles
+    client.authenticate.assert_awaited()      # the skipped fresh login was done
+    assert gv.await_count == 2                 # failed once, retried once
+
+
+def test_genuine_auth_failure_still_surfaces():
+    from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+    # Even after the fresh login, get_vehicles keeps failing → real bad creds.
+    gv = AsyncMock(side_effect=AuthenticationError("still dead"))
+    coord = _coord()
+    client = _client(gv)
+    with pytest.raises(ValueError, match="invalid_credentials"):
+        _run(coord, client)


### PR DESCRIPTION
Patch. Bugfix only.

### Fixed
- **VW EU MEB/ID. cars no longer get a false "authentication expired / check password" (#875).** The WeConnect/IDK login is attestation-walled so its persisted token can't refresh (403). Because those tokens aren't a portal strategy, `async_setup` skipped the fresh login, `_eu_portal` was never armed, and `get_vehicles` hit the dead BFF path — surfaced as `invalid_credentials`, killing an entry whose EU Data Act portal login works fine. Now falls back to the fresh login (arms the portal) and retries once; a genuine credential failure still surfaces.

Failure-case-only change; happy path untouched. 2 new tests (recovery survives + genuine auth failure still surfaces), full suite 3982 green, ruff + mypy-strict + Bruno clean. Credits @bobbasli/@leMineGaming/@m3gg3/@shaarkys.