### PR TITLE
release: 2.22.0 — evcc read-path connector + MBB command & #584 guard fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased]
+
+### Fixed
+
+- **The "please reauthenticate" prompt no longer fires on legacy Car-Net cars whose command gateway rejects them.** On some MQB / Car-Net cars the command service-directory call comes back with an authorization rejection that a fresh login can't fix — it's an enrolment / primary-user thing on that car's account, not a token problem (confirmed by re-approving a brand-new token that still gets rejected one second later). The integration used to refresh the token and retry on every poll, which slowly tripped the "token refresh storm — please reauthenticate" guard and sent you off to re-log-in for nothing. It now recognises that rejection for what it is, logs a clear one-line explanation, and stops hammering the login endpoint (#584).
+- **No more `'NoneType' object has no attribute 'get_status'` right after a Reconfigure.** Reconfiguring an entry could race a manual refresh that was already in flight, briefly leaving it without a client handle mid-fetch. Fixed (#584).
+
 ## [2.21.1] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased]
+
+### Fixed
+
+- **Two-way MBB commands (lock, climate, charging) no longer refuse themselves on cars that don't report an S-PIN attempt count.** When you send a command, the car first hands back a security challenge — and many cars report the remaining-tries count as `-1` at that stage, which just means "not tracked yet" (the real count only shows up if you actually get the PIN wrong). The command path was reading that `-1` as "you have -1 tries left" and blocking every lock/climate/charge command to dodge a lockout that couldn't happen. It now only holds back when there really are 0 or 1 attempts left.
+
 ## [2.21.1] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - **The "please reauthenticate" prompt no longer fires on legacy Car-Net cars whose command gateway rejects them (#584).** On some MQB / Car-Net cars the command service-directory call comes back with an authorization rejection that a fresh login can't fix — it's an enrolment / primary-user thing on that car's account, not a token problem (confirmed by re-approving a brand-new token that still gets rejected one second later). The integration used to refresh the token and retry on every poll, which slowly tripped the "token refresh storm — please reauthenticate" guard and sent you off to re-log-in for nothing. It now recognises that rejection for what it is, logs a clear one-line explanation, and stops hammering the login endpoint.
 - **No more `'NoneType' object has no attribute 'get_status'` right after a Reconfigure (#584).** Reconfiguring an entry could race a manual refresh that was already in flight, briefly leaving it without a client handle mid-fetch.
 
+### Thanks
+
+Thanks to **@Mattheisen87** for the meticulous #584 diagnostics that pinned down both guard fixes — the authorization-401 refresh storm and the reconfigure crash — and to **@nekas123** for raising the evcc use-case that motivated the read-path connector. Both credited in [CONTRIBUTORS.md](CONTRIBUTORS.md). 🙏
+
 ## [2.21.1] - 2026-07-21
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/_mbb.py
+++ b/custom_components/vag_connect/cariad/_mbb.py
@@ -560,6 +560,22 @@ def parse_mbb_spin_challenge(response: dict | None) -> tuple[str | None, str | N
     )
 
 
+def spin_tries_low(remaining: int | None) -> bool:
+    """True only when leg-1 reports a GENUINE low S-PIN attempt count (0 or 1),
+    so we refuse the command rather than risk a lockout.
+
+    ``remaining`` is ``parse_mbb_spin_challenge``'s third value (leg-1
+    ``securityPinTransmission.remainingTries``). The backend uses ``-1`` as a
+    "not tracked / not applicable" sentinel at the challenge stage — leg-1 does
+    NOT consume an attempt, and the real count only surfaces on a wrong-PIN
+    leg-2 403. So a NEGATIVE value is not a real countdown and must NOT block
+    the command; a bare ``remaining < 2`` guard refuses EVERY command on the
+    (common) cars that report ``-1`` here. ``None`` (unreported) never blocks.
+    Only 0 or 1 are real last-attempt warnings.
+    """
+    return remaining is not None and 0 <= remaining < 2
+
+
 def parse_mbb_completed_token(response: dict | None) -> str | None:
     """Extract the level-2 ``securityToken`` from the leg-2 response."""
     if not isinstance(response, dict):

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1788,6 +1788,7 @@ class VWEUClient(CariadBaseClient):
             parse_mbb_completed_token,
             parse_mbb_rlu_request_id,
             parse_mbb_spin_challenge,
+            spin_tries_low,
             validate_spin_format,
         )
 
@@ -1827,7 +1828,7 @@ class VWEUClient(CariadBaseClient):
         level1, challenge, remaining = parse_mbb_spin_challenge(ch_resp)
         if not level1 or not challenge:
             raise VehicleCommandError(verb, "MBB SPIN challenge missing token/challenge")
-        if remaining is not None and remaining < 2:
+        if spin_tries_low(remaining):
             raise SpinError(
                 f"S-PIN has only {remaining} attempt(s) left — refusing to "
                 "risk a lockout. Verify your S-PIN in the brand app first."
@@ -1960,6 +1961,7 @@ class VWEUClient(CariadBaseClient):
             parse_mbb_action_request_id,
             parse_mbb_completed_token,
             parse_mbb_spin_challenge,
+            spin_tries_low,
             validate_spin_format,
         )
 
@@ -1996,7 +1998,7 @@ class VWEUClient(CariadBaseClient):
         level1, challenge, remaining = parse_mbb_spin_challenge(ch)
         if not level1 or not challenge:
             raise VehicleCommandError(command_name, "SecToken challenge missing")
-        if remaining is not None and remaining < 2:
+        if spin_tries_low(remaining):
             raise SpinError(
                 f"S-PIN has only {remaining} attempt(s) left — refusing to risk "
                 "a lockout. Verify your S-PIN in the brand app first.")

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1549,7 +1549,7 @@ class VWEUClient(CariadBaseClient):
         return []
 
     async def _get_mbb_operationlist(
-        self, vin: str, *, for_command: bool = False, _refreshed: bool = False,
+        self, vin: str, *, for_command: bool = False,
     ) -> "MbbOperationList | None":
         """Fetch + cache the per-VIN MBB operationList (service directory).
 
@@ -1590,33 +1590,30 @@ class VWEUClient(CariadBaseClient):
             )
         except APIError as err:
             body = str(err.body)
-            # v2.20.1 (#584) — distinguish a TOKEN-AUTH 401 from the systemId
-            # ACL. ``gw.error.authentication`` means the gateway rejected the
-            # bearer as unauthenticated (Mattheisen87's Passat: 26× on v2.20.0 —
-            # the token exchange succeeds but the FIRST call with it 401s),
-            # unlike the data-plane ACL (``mbbc.rolesandrights.unauthorized`` /
-            # ``*.security.9007``) which no refresh can fix. A real token-auth
-            # failure IS recoverable by refreshing the bearer once — mirror
-            # audi_connect_ha #782 (keep the session token fresh on auth
-            # failure). Guarded to EXACTLY ONE retry so we never storm the
-            # refresh endpoint (the original _retry=False concern).
-            if (
-                err.status == 401
-                and "gw.error.authentication" in body
-                and not _refreshed
-            ):
-                _LOGGER.info(
-                    "MBB operationList ***%s → 401 gw.error.authentication — "
-                    "refreshing the MBB bearer and retrying once (#584).",
+            # #584 (2026-07-22, Mattheisen87) — a ``gw.error.authentication`` 401
+            # on the operationList is NOT a stale bearer, so DO NOT refresh on it.
+            # Proven twice: (1) a live Golf returns 200 on this exact call with the
+            # integration's own header set, and (2) Mattheisen re-ran the full
+            # device-code approval and a one-second-old, freshly-approved token
+            # still 401s. It is a gateway/rolesrights AUTHORIZATION rejection
+            # scoped to that vehicle↔account (Car-Net enrolment / primary-user),
+            # which no token refresh or re-auth can change. v2.20.1 refreshed-and-
+            # retried here on the (now-disproven) header-regression theory; that
+            # never helped and, once per poll, fed the command refresh budget
+            # until the storm guard raised a misleading "please reauthenticate".
+            # So: log once, spend no refresh, return None (caller treats None as
+            # "unknown" and does not block reads).
+            if err.status == 401 and "gw.error.authentication" in body:
+                _LOGGER.warning(
+                    "MBB operationList ***%s → 401 gw.error.authentication: the "
+                    "gateway rejected the bearer for this vehicle. This is an "
+                    "enrolment/authorization issue for this account and car (is "
+                    "the account the primary user in the brand app?), not an "
+                    "expired token — refreshing or re-authenticating won't "
+                    "change it.",
                     vin[-6:],
                 )
-                try:
-                    await self._refresh_tokens(for_command=for_command)
-                except Exception:  # noqa: BLE001
-                    pass
-                return await self._get_mbb_operationlist(
-                    vin, for_command=for_command, _refreshed=True,
-                )
+                return None
             _LOGGER.warning(
                 "MBB operationList ***%s → HTTP %s: %s",
                 vin[-6:], err.status, body[:160],

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -3967,6 +3967,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if not self._started or self._cariad_client is None:
             with self._vehicles_lock:
                 return dict(self.vehicles)
+        # #584 (2026-07-22, Mattheisen87) — capture the client into a local up
+        # front. A Reconfigure runs an unload that sets ``self._cariad_client =
+        # None`` mid-flight; without the local, the ``await`` below yields, the
+        # attribute is nulled, and the next ``self._cariad_client.get_status``
+        # raises ``'NoneType' object has no attribute 'get_status'`` (reported
+        # right after Reconfigure). The captured object stays valid (or fails
+        # cleanly as a closed session, handled by the except → cached data).
+        client = self._cariad_client
         try:
             # v2.20.0 — keep the durable-MBB operationList warm so the command
             # pre-test stays authoritative and a VIN whose earlier fetch failed
@@ -3975,7 +3983,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             await self._refresh_mbb_command_capabilities()
             vins = list(self.vehicles.keys())
             results = await asyncio.gather(
-                *[self._cariad_client.get_status(vin) for vin in vins],
+                *[client.get_status(vin) for vin in vins],
                 return_exceptions=True,
             )
             # v2.18.0 (A1) — same shape as the setup fetch: merge + enrich
@@ -3993,7 +4001,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 if isinstance(result, VehicleData):
                     merged = await self._merge_supplementary(vin, result)
                     data = merged.to_dict()
-                    data["_client"] = self._cariad_client
+                    data["_client"] = client
                     refreshed.append((vin, await self._enrich(data)))
 
             with self._vehicles_lock:

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -175,6 +175,30 @@ _MBB_COMMAND_SERVICE: dict[str, str | None] = {
 }
 
 
+def evcc_charge_status(data: dict[str, Any]) -> str | None:
+    """v2.22.0 — normalized IEC-61851 charge status for the evcc connector.
+
+    evcc's custom-vehicle ``status`` reads only the FIRST character and raises
+    on anything it doesn't recognise, so this returns strictly one of:
+      ``"A"`` — unplugged, ``"B"`` — plugged (idle), ``"C"`` — charging.
+
+    Returns ``None`` (field left unset → no phantom sensor) only for cars that
+    report NO charging data at all (combustion). Any car with charging data
+    always gets a valid A/B/C. See docs/EVCC.md.
+    """
+    if (
+        data.get("plug_connected") is None
+        and data.get("is_charging") is None
+        and not data.get("charging_state")
+    ):
+        return None
+    if data.get("is_charging") or data.get("charging_state") == "conservationCharging":
+        return "C"
+    if data.get("plug_connected"):
+        return "B"
+    return "A"
+
+
 def _mbb_command_channel_client(coord: Any) -> Any | None:
     """Return the client that owns the durable-MBB command path for this
     entry, or None when commands do NOT route through MBB.
@@ -3632,6 +3656,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
 
         # Always stamp when we fetched
         data["last_updated_at"] = datetime.now(tz=timezone.utc)
+
+        # v2.22.0 (evcc) — normalized IEC-61851 charge status for the evcc
+        # connector (see docs/EVCC.md). Only set for cars that report charging
+        # data (EVs); combustion cars leave it unset so no phantom sensor spawns.
+        _evcc = evcc_charge_status(data)
+        if _evcc is not None:
+            data["evcc_charge_status"] = _evcc
 
         # v1.20.0 Bundle 2 Phase A — Skoda static-info enrichment.
         # If we have a cached vehicle-information + equipment block

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.21.1"
+  "version": "2.22.0"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -148,6 +148,21 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:power-plug",
         condition="electric",
     ),
+    # v2.22.0 (evcc) — normalized IEC-61851 charge status (A=unplugged /
+    # B=plugged-idle / C=charging) for the evcc connector's custom-vehicle
+    # `status` field (our raw charging_state strings don't map to A/B/C).
+    # Diagnostic + opt-in (enable it under the device if you use evcc);
+    # electric-only. Always A/B/C — computed in coordinator._enrich. See
+    # docs/EVCC.md.
+    VagSensorDescription(
+        key="evcc_charge_status",
+        translation_key="evcc_charge_status",
+        data_key="evcc_charge_status",
+        icon="mdi:ev-station",
+        condition="electric",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
     VagSensorDescription(
         key="target_soc",
         translation_key="target_soc",
@@ -3103,6 +3118,7 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "active_ventilation_state",
     "active_ventilation_remaining_time_min",
     "battery_support_state",  # v2.21.0 — MEB-only; no phantom on other cars
+    "evcc_charge_status",  # v2.22.0 — only set for EVs with charging data
     "connection_state_battery_power_level",
     "last_trip_total_fuel_consumption_l",
     "last_trip_total_electric_consumption_kwh",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -282,6 +282,9 @@
       "plug_state": {
         "name": "Charging Port"
       },
+      "evcc_charge_status": {
+        "name": "evcc charge status"
+      },
       "target_soc": {
         "name": "Charge Target"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "Podpora 12V baterie"
       },
+      "evcc_charge_status": {
+        "name": "evcc stav nabíjení"
+      },
       "connection_state_battery_power_level": {
         "name": "12V Battery Power Level"
       },

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "12V-batteristøtte"
       },
+      "evcc_charge_status": {
+        "name": "evcc-ladestatus"
+      },
       "connection_state_battery_power_level": {
         "name": "12V-batteri effektniveau"
       },

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "12V-Batterie-Unterstützung"
       },
+      "evcc_charge_status": {
+        "name": "evcc-Ladestatus"
+      },
       "connection_state_battery_power_level": {
         "name": "12V-Batterie Ladezustand"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "12V Battery Support"
       },
+      "evcc_charge_status": {
+        "name": "evcc charge status"
+      },
       "connection_state_battery_power_level": {
         "name": "12V Battery Power Level"
       },

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "Soporte de batería de 12 V"
       },
+      "evcc_charge_status": {
+        "name": "Estado de carga evcc"
+      },
       "connection_state_battery_power_level": {
         "name": "12V Battery Power Level"
       },

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "12V-akun tuki"
       },
+      "evcc_charge_status": {
+        "name": "evcc-lataustila"
+      },
       "connection_state_battery_power_level": {
         "name": "12 V:n akun tehotaso"
       },

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "Assistance batterie 12V"
       },
+      "evcc_charge_status": {
+        "name": "État de charge evcc"
+      },
       "connection_state_battery_power_level": {
         "name": "12V Battery Power Level"
       },

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "Supporto batteria 12V"
       },
+      "evcc_charge_status": {
+        "name": "Stato di carica evcc"
+      },
       "connection_state_battery_power_level": {
         "name": "Livello di carica batteria 12V"
       },

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "12V-batteristøtte"
       },
+      "evcc_charge_status": {
+        "name": "evcc-ladestatus"
+      },
       "connection_state_battery_power_level": {
         "name": "12V-batteriets effektnivå"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "12V-accuondersteuning"
       },
+      "evcc_charge_status": {
+        "name": "evcc-laadstatus"
+      },
       "connection_state_battery_power_level": {
         "name": "12V Battery Power Level"
       },

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "Wsparcie akumulatora 12V"
       },
+      "evcc_charge_status": {
+        "name": "Stan ładowania evcc"
+      },
       "connection_state_battery_power_level": {
         "name": "12V Battery Power Level"
       },

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -642,6 +642,9 @@
       "battery_support_state": {
         "name": "12V-batteristöd"
       },
+      "evcc_charge_status": {
+        "name": "evcc-laddstatus"
+      },
       "connection_state_battery_power_level": {
         "name": "12V Battery Power Level"
       },

--- a/docs/EVCC.md
+++ b/docs/EVCC.md
@@ -1,0 +1,101 @@
+# Using VW Group Connect with evcc
+
+[evcc](https://evcc.io) can read your car's state of charge, range and charging status straight from Home Assistant, and — on a two-way car (Audi or Škoda via the MBB channel) — start/stop charging. This works by pointing evcc at Home Assistant's own REST API; nothing extra runs inside this integration.
+
+> **Beta.** The **read** path (SoC / range / status / charge-limit / climatisation) works on **every brand**, including read-only VW EU / portal cars. The **write** path (`chargeEnable`) only works on a **two-way** car (Audi or Škoda with a live MBB command channel) and only when evcc treats the car itself as the charger (no separate wallbox). With a real smart wallbox, evcc only needs the read path.
+
+## 1. One-time setup in Home Assistant
+
+1. **Enable the charge-status sensor.** This integration exposes a diagnostic sensor **`evcc charge status`** per EV that reports evcc's `A`/`B`/`C` status (evcc can't use our raw charging-state text). It's **disabled by default** — open your car's device page, find *evcc charge status*, and enable it.
+2. **Create a long-lived access token.** HA profile → *Security* → *Long-lived access tokens* → create one. Keep it safe — it grants API access. It will sit in `evcc.yaml` in plain text (normal for evcc); you can revoke/rotate it from the same page any time.
+3. **Find your entity IDs.** *Developer Tools → States*. The IDs below are examples — yours depend on your car's name and HA language. The typical ones:
+
+   | evcc field | Home Assistant entity | notes |
+   |---|---|---|
+   | `soc` | `sensor.<car>_battery_soc` | % |
+   | `range` | `sensor.<car>_electric_range` | km |
+   | `status` | `sensor.<car>_evcc_charge_status` | the sensor from step 1 (A/B/C) |
+   | `limitSoc` | `number.<car>_target_soc` | evcc **reads** it; set the target in HA, not evcc |
+   | `climater` | `binary_sensor.<car>_climatisation` | optional |
+   | `chargeEnable` (write) | `switch.<car>_charging` | **two-way cars only** |
+
+## 2. Recipe A — `custom` vehicle (recommended)
+
+Paste into `evcc.yaml`, replacing `<HA_URL>`, `<TOKEN>` and the entity IDs:
+
+```yaml
+vehicles:
+  - name: myvag
+    type: custom
+    title: My VW Group EV
+    capacity: 77            # usable battery kWh (static — set your car's value)
+    soc:
+      source: http
+      uri: <HA_URL>/api/states/sensor.<car>_battery_soc
+      headers: { Authorization: "Bearer <TOKEN>" }
+      jq: .state | tonumber
+    range:
+      source: http
+      uri: <HA_URL>/api/states/sensor.<car>_electric_range
+      headers: { Authorization: "Bearer <TOKEN>" }
+      jq: .state | tonumber
+    status:
+      source: http
+      uri: <HA_URL>/api/states/sensor.<car>_evcc_charge_status
+      headers: { Authorization: "Bearer <TOKEN>" }
+      jq: .state
+    limitSoc:
+      source: http
+      uri: <HA_URL>/api/states/number.<car>_target_soc
+      headers: { Authorization: "Bearer <TOKEN>" }
+      jq: .state | tonumber
+    climater:
+      source: http
+      uri: <HA_URL>/api/states/binary_sensor.<car>_climatisation
+      headers: { Authorization: "Bearer <TOKEN>" }
+      jq: .state == "on"
+    # ── two-way cars only (Audi / Škoda MBB), and only if evcc runs the car
+    #    as a vehicle-API charger. Omit this whole block otherwise. ──
+    chargeEnable:
+      source: http
+      uri: <HA_URL>/api/services/switch/turn_{{if .chargeenable}}on{{else}}off{{end}}
+      method: POST
+      headers: { Authorization: "Bearer <TOKEN>" }
+      body: '{"entity_id": "switch.<car>_charging"}'
+```
+
+`status` must be present whenever `chargeEnable` is used — evcc requires it.
+
+## 3. Recipe B — native `homeassistant` vehicle (alternative)
+
+evcc also ships a native Home Assistant template. It's cleaner but its auth has been changing across evcc versions (older `token:` is being replaced by a pairing flow), so use it only if you're on a recent evcc:
+
+```yaml
+vehicles:
+  - name: myvag
+    type: homeassistant
+    uri: <HA_URL>
+    # auth per your evcc version (token / pairing)
+    sensors:
+      soc: sensor.<car>_battery_soc
+      range: sensor.<car>_electric_range
+      status: sensor.<car>_evcc_charge_status
+      limitSoc: number.<car>_target_soc
+      climater: binary_sensor.<car>_climatisation
+    services:
+      start_charging: switch.<car>_charging   # two-way cars only; leave stop empty for a switch
+```
+
+## 4. Verify
+
+1. `curl -s -H "Authorization: Bearer <TOKEN>" <HA_URL>/api/states/sensor.<car>_battery_soc` → should return JSON with your SoC.
+2. Restart evcc, open its UI — the vehicle tile should show the same SoC, range and a plug/charging status matching the car. Check evcc's log for `[http]` parse errors.
+3. Status check: unplugged → `A`, plugged & idle → `B`, charging → `C`.
+
+## Notes & limits
+
+- **`limitSoc` is read-only in evcc** — set your charge target with the Home Assistant `number.<car>_target_soc` entity; evcc just reflects it.
+- **`maxCurrent` isn't offered** — our AC current control is a two-value (`MAXIMUM`/`REDUCED`) selector, not evcc's ampere number, so evcc current-following won't drive the car. Use a real wallbox for current control.
+- **`wakeup`** exists in HA but has a small daily budget (anti-abuse). Don't wire it into evcc's polling loop or it will be exhausted by mid-morning.
+- SoC/range go **stale** (not zero) during backend hiccups; the status sensor always keeps a valid A/B/C.
+- Read path works for **all brands**; write path is **Audi/Škoda two-way only**.

--- a/tests/test_584_oplist_401_no_refresh.py
+++ b/tests/test_584_oplist_401_no_refresh.py
@@ -1,16 +1,22 @@
 # Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""v2.20.1 (#584) — MBB operationList: refresh + retry once on a token-auth 401.
+"""#584 — MBB operationList: a gw.error.authentication 401 must NOT refresh.
 
-Mattheisen87's Passat GTE on v2.20.0: the durable-MBB token refresh works (the
-v2.18.0 fix), reads are healthy, but the operationList GET returns
-``401 gw.error.authentication`` 26× → an empty service directory → every command
-entity stays ``unavailable``. That 401 is a TOKEN-AUTH failure (the gateway
-rejects the bearer as unauthenticated), NOT the data-plane systemId ACL
-(``mbbc.rolesandrights.unauthorized`` / ``*.security.9007``) which no refresh can
-fix. Mirroring audi_connect_ha #782, a token-auth failure is recovered by
-refreshing the bearer once and retrying — guarded to exactly one retry so the
-refresh endpoint is never stormed.
+History: v2.20.1 refreshed-and-retried once on a ``gw.error.authentication`` 401,
+on the theory that the gateway had rejected a stale bearer (mirroring
+audi_connect_ha #782). That premise was disproven 2026-07-22:
+
+- a live Golf 7 GTE returns 200 on this exact operationList call with the
+  integration's own header set (the header-provenance A/B test), and
+- Mattheisen87 re-ran the full device-code approval and a one-second-old,
+  freshly-approved token STILL 401s on the first call.
+
+So the 401 is a gateway/rolesrights AUTHORIZATION rejection scoped to the
+vehicle↔account (Car-Net enrolment / primary-user), which no token refresh can
+fix. Worse, refreshing once per poll fed the command refresh budget until the
+storm guard raised a misleading "please reauthenticate". The operationList now
+treats every 401 (gw.error.authentication OR the systemId ACL) the same: log
+once, spend no refresh, return None.
 """
 
 from __future__ import annotations
@@ -40,24 +46,25 @@ def _client(mbb_get_side_effect) -> VWEUClient:
     return c
 
 
-class TestOplist401Retry:
-    def test_auth_401_then_success_refreshes_and_retries(self) -> None:
-        c = _client([_AUTH_401, _GOOD])
-        oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
-        assert oplist is not None
-        assert "rclima_v1" in oplist.services
-        c._refresh_tokens.assert_awaited_once()          # refreshed exactly once
-        assert c._mbb_get.await_count == 2               # original + retry
-        # the refresh was routed to the command channel
-        assert c._refresh_tokens.await_args.kwargs.get("for_command") is True
-
-    def test_auth_401_persists_refreshes_once_then_gives_up(self) -> None:
-        # Both attempts 401 → one refresh, one retry, then None — NO storm.
-        c = _client([_AUTH_401, _AUTH_401])
+class TestOplist401NoRefresh:
+    def test_gw_error_authentication_returns_none_without_refresh(self) -> None:
+        # The core reversal: the gw.error.authentication 401 is a vehicle/account
+        # authz rejection, NOT a stale bearer → no refresh, no retry, None.
+        c = _client([_AUTH_401])
         oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
         assert oplist is None
-        c._refresh_tokens.assert_awaited_once()
-        assert c._mbb_get.await_count == 2               # never a third attempt
+        c._refresh_tokens.assert_not_awaited()           # never spends the budget
+        assert c._mbb_get.await_count == 1               # single call, no retry
+
+    def test_gw_error_authentication_never_storms(self) -> None:
+        # Even called repeatedly (e.g. once per poll), it must never refresh —
+        # that is exactly what used to trip the storm guard into a false
+        # "please reauthenticate".
+        c = _client([_AUTH_401, _AUTH_401, _AUTH_401, _AUTH_401])
+        for _ in range(4):
+            assert asyncio.run(c._get_mbb_operationlist(VIN, for_command=True)) is None
+        c._refresh_tokens.assert_not_awaited()
+        assert c._mbb_get.await_count == 4               # 1 per call, never a retry
 
     def test_systemid_403_does_not_refresh(self) -> None:
         # The data-plane ACL is unrecoverable — must NOT refresh/retry.
@@ -68,8 +75,6 @@ class TestOplist401Retry:
         assert c._mbb_get.await_count == 1
 
     def test_systemid_401_does_not_refresh(self) -> None:
-        # A 401 that is the systemId ACL (not gw.error.authentication) is also
-        # unrecoverable — the trigger is the error code, not the status.
         c = _client([_ACL_401])
         oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
         assert oplist is None
@@ -81,5 +86,6 @@ class TestOplist401Retry:
         c = _client([_GOOD])
         oplist = asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
         assert oplist is not None
+        assert "rclima_v1" in oplist.services
         c._refresh_tokens.assert_not_awaited()
         assert c._mbb_get.await_count == 1

--- a/tests/test_584_reconfigure_client_race.py
+++ b/tests/test_584_reconfigure_client_race.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#584 — manual refresh must not crash when Reconfigure nulls the client.
+
+Mattheisen87 saw ``'NoneType' object has no attribute 'get_status'`` right after
+a Reconfigure. A Reconfigure runs an unload that sets ``self._cariad_client =
+None``; ``_async_update_data`` had checked the client for None at the top, then
+``await``-ed ``_refresh_mbb_command_capabilities()`` — and the unload landed in
+that window, so the following ``self._cariad_client.get_status`` dereferenced
+None. The fix captures the client into a local right after the guard and uses
+that local, so a mid-flight null can't turn the read into a NoneType crash.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock
+
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+VIN = "WVWZZZ3CZ9W025570"
+
+
+def _coord(client) -> VagConnectCoordinator:
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c._started = True
+    c._cariad_client = client
+    c._vehicles_lock = threading.Lock()
+    c.vehicles = {VIN: {"cached": True}}
+    return c
+
+
+class TestReconfigureClientRace:
+    def test_client_nulled_mid_flight_does_not_crash_and_uses_captured(self) -> None:
+        client = AsyncMock()
+        client.get_status = AsyncMock(return_value=object())  # non-VehicleData → skipped
+        coord = _coord(client)
+
+        # Simulate the Reconfigure unload landing during the pre-fetch await:
+        # _refresh_mbb_command_capabilities() nulls self._cariad_client.
+        async def _null_the_client() -> None:
+            coord._cariad_client = None
+
+        coord._refresh_mbb_command_capabilities = AsyncMock(side_effect=_null_the_client)
+        coord._persist_website_cookies = lambda: None
+
+        # Must NOT raise 'NoneType' object has no attribute 'get_status'.
+        result = asyncio.run(coord._async_update_data())
+
+        # The captured client's get_status was still used (proof of the fix:
+        # self._cariad_client is None by now, so without the local capture the
+        # list comprehension would AttributeError before any await).
+        client.get_status.assert_awaited_once_with(VIN)
+        assert coord._cariad_client is None          # the unload did happen
+        assert result == {VIN: {"cached": True}}     # cached data returned
+
+    def test_client_none_at_entry_returns_cached(self) -> None:
+        coord = _coord(None)
+        result = asyncio.run(coord._async_update_data())
+        assert result == {VIN: {"cached": True}}

--- a/tests/test_mbb_spin_remaining_sentinel.py
+++ b/tests/test_mbb_spin_remaining_sentinel.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Regression: the leg-1 ``remainingTries: -1`` sentinel must NOT block MBB commands.
+
+Live evidence (Golf 7 GTE, 2026-07-22): the MBB S-PIN leg-1
+(``security-pin-auth-requested`` / ``op-auth``) returns
+``securityPinTransmission.remainingTries = -1`` for lock, unlock, climate-start
+and charge-start. Leg-1 does NOT consume an attempt — ``-1`` is a
+"not tracked / not applicable" sentinel, not a real countdown.
+
+The old guard ``if remaining is not None and remaining < 2`` treated ``-1`` as
+"only -1 attempts left" and raised ``SpinError`` at BOTH command sites
+(vw_eu.py lock/unlock and the generic climate/charge/timer op), refusing EVERY
+two-way MBB command on exactly the account state the evidence documents — the
+write path was dead-on-arrival. ``spin_tries_low`` fixes it: only a GENUINE
+0 or 1 blocks; a negative sentinel (and ``None``) proceeds.
+"""
+
+from __future__ import annotations
+
+
+class TestSpinTriesLow:
+    def test_minus_one_sentinel_does_not_block(self):
+        """The core regression: leg-1's -1 sentinel must proceed, not block."""
+        from custom_components.vag_connect.cariad._mbb import spin_tries_low
+
+        assert spin_tries_low(-1) is False
+
+    def test_any_negative_is_sentinel_not_countdown(self):
+        from custom_components.vag_connect.cariad._mbb import spin_tries_low
+
+        assert spin_tries_low(-2) is False
+        assert spin_tries_low(-99) is False
+
+    def test_none_unreported_does_not_block(self):
+        from custom_components.vag_connect.cariad._mbb import spin_tries_low
+
+        assert spin_tries_low(None) is False
+
+    def test_genuine_last_attempts_still_block(self):
+        """0 and 1 are real last-attempt warnings — keep refusing to avoid lockout."""
+        from custom_components.vag_connect.cariad._mbb import spin_tries_low
+
+        assert spin_tries_low(0) is True
+        assert spin_tries_low(1) is True
+
+    def test_two_or_more_proceeds(self):
+        from custom_components.vag_connect.cariad._mbb import spin_tries_low
+
+        assert spin_tries_low(2) is False
+        assert spin_tries_low(3) is False
+        assert spin_tries_low(255) is False
+
+
+class TestParsePreservesMinusOne:
+    def test_parser_keeps_minus_one_feeding_the_guard(self):
+        """parse_mbb_spin_challenge preserves -1 (regression cause) — the guard,
+        not the parser, is where the sentinel must be tolerated."""
+        from custom_components.vag_connect.cariad._mbb import (
+            parse_mbb_spin_challenge,
+            spin_tries_low,
+        )
+
+        leg1 = {
+            "securityPinAuthInfo": {
+                "securityToken": "tok",
+                "securityPinTransmission": {
+                    "hashProcedureVersion": 2,
+                    "challenge": "ABCD1234",
+                    "remainingTries": -1,
+                },
+            }
+        }
+        token, challenge, remaining = parse_mbb_spin_challenge(leg1)
+        assert token == "tok"
+        assert challenge == "ABCD1234"
+        assert remaining == -1
+        # end to end: a -1 leg-1 must NOT trip the low-tries guard
+        assert spin_tries_low(remaining) is False
+
+    def test_genuine_one_try_left_trips_guard(self):
+        from custom_components.vag_connect.cariad._mbb import (
+            parse_mbb_spin_challenge,
+            spin_tries_low,
+        )
+
+        leg1 = {
+            "securityPinAuthInfo": {
+                "securityToken": "tok",
+                "securityPinTransmission": {
+                    "challenge": "DEAD",
+                    "remainingTries": 1,
+                },
+            }
+        }
+        _, _, remaining = parse_mbb_spin_challenge(leg1)
+        assert remaining == 1
+        assert spin_tries_low(remaining) is True

--- a/tests/test_v2220_evcc_connector.py
+++ b/tests/test_v2220_evcc_connector.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.22.0 — evcc connector: the normalized IEC-61851 charge-status helper.
+
+evcc's custom-vehicle ``status`` parses the first char and throws on anything
+unrecognised, so the helper must return strictly A/B/C for any car with
+charging data, and None (no phantom sensor) for combustion cars. See docs/EVCC.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from custom_components.vag_connect.coordinator import evcc_charge_status
+
+
+def test_charging_is_C() -> None:
+    assert evcc_charge_status({"is_charging": True, "plug_connected": True}) == "C"
+
+
+def test_conservation_charging_is_C() -> None:
+    assert evcc_charge_status(
+        {"charging_state": "conservationCharging", "plug_connected": True}
+    ) == "C"
+
+
+def test_plugged_idle_is_B() -> None:
+    assert evcc_charge_status({"is_charging": False, "plug_connected": True}) == "B"
+
+
+def test_unplugged_is_A() -> None:
+    assert evcc_charge_status({"is_charging": False, "plug_connected": False}) == "A"
+
+
+def test_ev_with_only_state_defaults_to_A_not_none() -> None:
+    # readyForCharging etc. → not charging, unknown plug → A (never None/unknown).
+    assert evcc_charge_status({"charging_state": "readyForCharging"}) == "A"
+
+
+def test_combustion_no_charging_data_is_none() -> None:
+    # No charging fields at all → None → the sensor never spawns (no phantom).
+    assert evcc_charge_status({"fuel_level": 55, "odometer_km": 1000}) is None
+
+
+def test_never_returns_unknown_for_any_charging_car() -> None:
+    for d in (
+        {"plug_connected": True},
+        {"plug_connected": False},
+        {"is_charging": True},
+        {"is_charging": False},
+        {"charging_state": "off"},
+        {"charging_state": "charging"},
+    ):
+        assert evcc_charge_status(d) in {"A", "B", "C"}, d
+
+
+def test_sensor_registered_electric_diagnostic_disabled_and_phantom_gated() -> None:
+    from custom_components.vag_connect.sensor import (
+        _DATA_PRESENT_REQUIRED,
+        SENSOR_DESCRIPTIONS,
+    )
+    desc = next((d for d in SENSOR_DESCRIPTIONS if d.key == "evcc_charge_status"), None)
+    assert desc is not None
+    assert desc.condition == "electric"
+    assert desc.entity_registry_enabled_default is False
+    assert "evcc_charge_status" in _DATA_PRESENT_REQUIRED
+
+
+def test_translation_in_all_locales() -> None:
+    trans = Path("custom_components/vag_connect/translations")
+    for f in trans.glob("*.json"):
+        assert '"evcc_charge_status"' in f.read_text(encoding="utf-8"), f.name


### PR DESCRIPTION
## 2.22.0

### Added
- **evcc read-path connector.** A new `evcc charge status` (IEC-61851 A/B/C) diagnostic sensor + `docs/EVCC.md`. evcc reads SoC / range / status / charge-limit / climate straight from Home Assistant's REST API — nothing extra runs in the integration. Read path works on every brand (incl. read-only VW EU); write path is two-way cars only (Audi / Škoda via MBB). Sensor is disabled by default.

### Fixed
- **MBB two-way commands no longer refuse themselves** on cars whose S-PIN leg-1 reports `remainingTries=-1` (a "not tracked" sentinel, not a real countdown). The old `remaining < 2` guard blocked every lock/climate/charge command on those cars.
- **#584 (A):** the operationList `gw.error.authentication` 401 no longer triggers a token refresh. It's a per-vehicle/account authorization rejection that no refresh can fix (proven: a fresh 1-second-old re-approved token still 401s), and refreshing per poll tripped the false "token refresh storm — please reauthenticate".
- **#584 (B):** the post-Reconfigure `'NoneType' object has no attribute 'get_status'` race is fixed by capturing the client into a local after the None-guard.

### Tests
- Full suite **4000 passed**, 15 skipped. ruff + mypy strict clean.
- Replaced `test_v2201_584_oplist_401_retry` (asserted the removed retry) with `test_584_oplist_401_no_refresh`; added `test_584_reconfigure_client_race`, `test_mbb_spin_remaining_sentinel`, `test_v2220_evcc_connector`.

Thanks to @Mattheisen87 (#584 guards) and @nekas123 (evcc use-case).
