### PR TITLE
release: 2.22.1 — Audi US/CA login fix + aux-battery alert sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [Unreleased]
+## [2.22.1] - 2026-07-22
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased]
+
+### Added
+
+- **New auxiliary-battery alert-time sensor from the EU Data Act feed.** Some VW cars report a `bem_alert_time` — the moment the 12V (auxiliary) battery's BEM level-2 pre-warning kicks in. It now shows up as a diagnostic timestamp sensor (disabled by default). Picked up from a Scout report; the tyre-pressure and charge-rate fields in the same report were already mapped in earlier versions.
+
 ## [2.22.0] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 - **Audi US / CA login now completes instead of failing with "Invalid credentials" (#13).** The North-American login itself was working — the app sign-in went through and handed back an authorization code — but the integration then tried to exchange that code at the European backend, which can't read a code the US identity server issued (it came back `invalid key id`). The exchange (and token refresh) now go to the North-American identity endpoint that issued the code, matching the QR / device-code path. Reads are unchanged (they still use the shared global backend).
 
+### Thanks
+
+Thanks to **@coreywillwhat** for loading the integration onto a real US Audi and sending the full logs that pinned down the #13 token-exchange endpoint — credited in [CONTRIBUTORS.md](CONTRIBUTORS.md). 🙏
+
 ## [2.22.0] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 - **New auxiliary-battery alert-time sensor from the EU Data Act feed.** Some VW cars report a `bem_alert_time` — the moment the 12V (auxiliary) battery's BEM level-2 pre-warning kicks in. It now shows up as a diagnostic timestamp sensor (disabled by default). Picked up from a Scout report; the tyre-pressure and charge-rate fields in the same report were already mapped in earlier versions.
 
+### Fixed
+
+- **Audi US / CA login now completes instead of failing with "Invalid credentials" (#13).** The North-American login itself was working — the app sign-in went through and handed back an authorization code — but the integration then tried to exchange that code at the European backend, which can't read a code the US identity server issued (it came back `invalid key id`). The exchange (and token refresh) now go to the North-American identity endpoint that issued the code, matching the QR / device-code path. Reads are unchanged (they still use the shared global backend).
+
 ## [2.22.0] - 2026-07-22
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,6 +43,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @ChristophCaina
 - @clipse2004
 - @ColinSainsbury
+- @coreywillwhat
 - @Cruiser1989
 - @crusader85
 - @CyberChris79

--- a/custom_components/vag_connect/cariad/api/audi_na.py
+++ b/custom_components/vag_connect/cariad/api/audi_na.py
@@ -54,12 +54,17 @@ from .vw_eu import VWEUClient
 # v2.20.0 (APK audit) — the current myAudi 5.6.0 app has NO ``na.bff.cariad.digital``
 # string anywhere; its ONLY data BFF is the global ``emea.bff.cariad.digital`` (same
 # host EU Audi uses). The NA split is ONLY at the IDP layer (authorize at
-# identity.na.vwgroup.io). Our old na.bff host was almost certainly NXDOMAIN,
-# breaking both token-exchange and reads — point them at emea.bff to match the app.
+# identity.na.vwgroup.io). READS go to emea.bff (global, no na.bff host exists).
+# But the TOKEN EXCHANGE must go to the IDP that ISSUED the code, not the BFF:
+# the authorization code is signed by identity.na.vwgroup.io, so exchanging it at
+# emea.bff (EU) fails with ``{"error":"invalid key id"}`` — the EU BFF has no key
+# with the NA code's kid (live-confirmed on a real US Audi, #13, coreywillwhat).
+# So token-exchange + refresh target the NA IDP's own OIDC token endpoint — the
+# same host+path the device-grant path already uses (``_NA_IDP_TOKEN_URL``).
 _NA_BFF_BASE = "https://emea.bff.cariad.digital"
 _NA_IDP_BASE = "https://identity.na.vwgroup.io"
 _NA_AUTHORIZE_URL = f"{_NA_IDP_BASE}/oidc/v1/authorize"
-_NA_TOKEN_URL = f"{_NA_BFF_BASE}/auth/v1/idk/oidc/token"
+_NA_TOKEN_URL = f"{_NA_IDP_BASE}/oidc/v1/token"
 
 
 class AudiNAClient(VWEUClient):

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -2290,6 +2290,13 @@ def map_dataset_to_vehicle_data(
     _bem = _to_int(first("bem_level"))
     if _bem is not None:
         d.aux_battery_energy_pct = _bem
+    # bem_alert_time — 12V battery BEM level-2 pre-warning alert time. Dict
+    # type=number ("delay after activation of the BEM2 pre-warning"), but the
+    # real portal payload carries an absolute ISO timestamp → _epoch_or_iso
+    # tolerates both. #897 (SparkyDan555).
+    _bem_alert = first("bem_alert_time")
+    if _bem_alert is not None and d.aux_battery_bem_alert_at is None:
+        d.aux_battery_bem_alert_at = _epoch_or_iso(str(_bem_alert))
     # active_warnings_in_instrument_cluster_feff_filtered — RAW hex/interpreted
     # bitmask only. Do NOT attempt an enum decode we can't verify; surface the
     # raw value as a disabled-by-default diagnostic.

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1606,6 +1606,12 @@ class VehicleData:
     parking_lights_state: str | None = None
     # Auxiliary/12V battery energy-management level (%). sensor, diagnostic.
     aux_battery_energy_pct: int | None = None
+    # Auxiliary/12V battery BEM level-2 pre-warning alert time (bem_alert_time).
+    # Dict type=number ("delay after activation of the BEM2 pre-warning"), but the
+    # observed portal value is an absolute ISO timestamp → passthrough via
+    # _epoch_or_iso (tolerates epoch OR ISO). sensor (TIMESTAMP), diagnostic,
+    # disabled-by-default. EU-Data-Act dialect only.
+    aux_battery_bem_alert_at: Any | None = None
     # Instrument-cluster warning bitmask — RAW hex/interpreted value only, no
     # decode. LOW — disabled-by-default. sensor, diagnostic.
     dashboard_warnings_raw: str | None = None

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.22.0"
+  "version": "2.22.1"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -2276,6 +2276,18 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:car-battery",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # 12V battery BEM level-2 pre-warning alert time (#897). EU-Data-Act dialect
+    # only; observed value is an absolute ISO timestamp. LOW value, disabled-by-
+    # default.
+    VagSensorDescription(
+        key="aux_battery_bem_alert_at",
+        translation_key="aux_battery_bem_alert_at",
+        data_key="aux_battery_bem_alert_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:car-battery",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
     # LOW — raw warning bitmask, no verified decode. Disabled-by-default.
     VagSensorDescription(
         key="dashboard_warnings_raw",
@@ -3238,6 +3250,9 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # v2.15.4 (#537) — next-charging-timer slot index. EU-Data-Act dialect only;
     # vehicles/channels without the field stay None → no phantom.
     "next_charge_timer_number",
+    # #897 — 12V battery BEM level-2 pre-warning alert time. EU-Data-Act dialect
+    # only; vehicles/channels without the field stay None → no phantom.
+    "aux_battery_bem_alert_at",
     "ascent_slope_consumption",
     "descent_slope_consumption",
     "report_type",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -897,6 +897,9 @@
       "aux_battery_energy_pct": {
         "name": "Auxiliary battery level"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Auxiliary battery alert time"
+      },
       "dashboard_warnings_raw": {
         "name": "Dashboard warnings (raw)"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Úroveň pomocné baterie"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Čas výstrahy pomocné baterie"
+      },
       "dashboard_warnings_raw": {
         "name": "Výstražné kontrolky (surová data)"
       },

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Hjælpebatteriniveau"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Alarmtidspunkt hjælpebatteri"
+      },
       "dashboard_warnings_raw": {
         "name": "Instrumentbrætadvarsler (rå)"
       },

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Zusatzbatterie-Ladestand"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Zusatzbatterie-Warnzeit"
+      },
       "dashboard_warnings_raw": {
         "name": "Warnleuchten (Rohwert)"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Auxiliary battery level"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Auxiliary battery alert time"
+      },
       "dashboard_warnings_raw": {
         "name": "Dashboard warnings (raw)"
       },

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Nivel de batería auxiliar"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Hora de alerta de batería auxiliar"
+      },
       "dashboard_warnings_raw": {
         "name": "Testigos de aviso (valor bruto)"
       },

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Lisäakun taso"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Lisäakun hälytysaika"
+      },
       "dashboard_warnings_raw": {
         "name": "Mittariston varoitukset (raakadata)"
       },

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Niveau batterie auxiliaire"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Heure d'alerte batterie auxiliaire"
+      },
       "dashboard_warnings_raw": {
         "name": "Voyants d'alerte (brut)"
       },

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Livello batteria ausiliaria"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Ora di allerta batteria ausiliaria"
+      },
       "dashboard_warnings_raw": {
         "name": "Avvisi del cruscotto (grezzi)"
       },

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Tilleggsbatterinivå"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Varseltid tilleggsbatteri"
+      },
       "dashboard_warnings_raw": {
         "name": "Dashbordvarsler (rå)"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Niveau hulpaccu"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Waarschuwingstijd hulpaccu"
+      },
       "dashboard_warnings_raw": {
         "name": "Waarschuwingslampjes (ruw)"
       },

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Poziom akumulatora pomocniczego"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Czas alarmu akumulatora pomocniczego"
+      },
       "dashboard_warnings_raw": {
         "name": "Kontrolki ostrzegawcze (surowe)"
       },

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -987,6 +987,9 @@
       "aux_battery_energy_pct": {
         "name": "Nivå hjälpbatteri"
       },
+      "aux_battery_bem_alert_at": {
+        "name": "Larmtid hjälpbatteri"
+      },
       "dashboard_warnings_raw": {
         "name": "Varningslampor (rådata)"
       },

--- a/tests/test_audi_na_token_endpoint.py
+++ b/tests/test_audi_na_token_endpoint.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#13 — Audi US/CA legacy token exchange must hit the NA IDP, not the EU BFF.
+
+Live report (coreywillwhat, a real US Audi): the email/password login itself
+works — the redirects complete and an authorization code comes back — but the
+token exchange then fails with ``HTTP 400 {"error":"invalid key id"}``.
+
+Root cause: the code is issued by the NA IDP (``identity.na.vwgroup.io``), but
+``_NA_TOKEN_URL`` pointed the exchange at the EU BFF
+(``emea.bff.cariad.digital/auth/v1/idk/oidc/token``). The EU BFF has no signing
+key matching the NA code's ``kid`` → "invalid key id". READS legitimately go to
+emea.bff (there is no na.bff host), but the TOKEN exchange + refresh must go to
+the IDP that issued the code — the same endpoint the device-grant path already
+uses (``_NA_IDP_TOKEN_URL``).
+"""
+
+from __future__ import annotations
+
+
+class TestAudiNaTokenEndpoint:
+    def test_na_token_url_is_the_na_idp_not_the_eu_bff(self) -> None:
+        from custom_components.vag_connect.cariad.api.audi_na import (
+            _NA_IDP_BASE,
+            _NA_TOKEN_URL,
+        )
+
+        assert _NA_TOKEN_URL == "https://identity.na.vwgroup.io/oidc/v1/token"
+        assert _NA_TOKEN_URL == f"{_NA_IDP_BASE}/oidc/v1/token"
+        # never route the NA-issued code back to the EU BFF again (#13)
+        assert "emea.bff" not in _NA_TOKEN_URL
+        assert "/auth/v1/idk/oidc/token" not in _NA_TOKEN_URL
+
+    def test_legacy_exchange_and_device_grant_share_the_na_token_endpoint(self) -> None:
+        # The authorization_code exchange (legacy login) and the device-grant
+        # refresh must agree on the endpoint — both hit the NA IDP.
+        from custom_components.vag_connect.cariad.api.audi_na import _NA_TOKEN_URL
+        from custom_components.vag_connect.cariad.auth._device_grant import (
+            _NA_IDP_TOKEN_URL,
+        )
+
+        assert _NA_TOKEN_URL == _NA_IDP_TOKEN_URL
+
+    def test_reads_still_target_emea_bff(self) -> None:
+        # The fix must NOT move reads — the NA app has no na.bff host, reads
+        # stay on the global emea.bff. Only the token endpoint moved.
+        from custom_components.vag_connect.cariad.api.audi_na import (
+            _NA_BFF_BASE,
+            BRAND_AUDI_NA,
+        )
+
+        assert _NA_BFF_BASE == "https://emea.bff.cariad.digital"
+        assert BRAND_AUDI_NA.api_base == "https://emea.bff.cariad.digital"


### PR DESCRIPTION
## 2.22.1

### Fixed
- **Audi US / CA login now completes (#13).** The NA login was working and returning a valid authorization code, but the integration exchanged that NA-issued code at the EU backend (`emea.bff`), which has no key matching the NA code's `kid` → `invalid key id` → a bogus "invalid credentials". The exchange + refresh now target the NA IDP's own token endpoint (`identity.na.vwgroup.io/oidc/v1/token`), the same one the QR/device-grant path uses. Fixes both the legacy and QR paths. Reads unchanged (global emea.bff). Live-confirmed root cause on a real US Audi by @coreywillwhat.

### Added
- **Aux-battery BEM alert-time diagnostic sensor (#897)** from the EU Data Act feed, disabled by default.

### Tests
- Full suite **4003 passed**. ruff + mypy strict clean. New: `test_audi_na_token_endpoint`.

Thanks @coreywillwhat (US Audi tester, #13) — added to CONTRIBUTORS.
