### PR TITLE
Release 2.23.1 — localized door/window/light names, dedup range & fuel, clearer no-vehicle message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Abhängigkeiten installieren
         run: |
           pip install \
-            ruff \
+            ruff==0.15.12 \
             mypy \
             aiohttp \
             homeassistant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [Unreleased]
+## [2.23.1] - 2026-07-23
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Door, window and light sensors now show localized names.** The per-part door / window / light binary sensors hardcoded their English names ("Door Front Left", "Trunk", "Light left"…), so they stayed English even in a German (or French, Spanish, …) Home Assistant while their neighbours were translated. They now use proper translation keys with names in all 12 languages ("Tür vorne links", "Kofferraum", "Licht links"…). Entity IDs are unchanged, only the display names.
+
 ### Changed
 
 - **Clearer message when the account has no vehicle yet.** When login works but the manufacturer lists no vehicle, the setup error used to say "No vehicles found. Check credentials and network." — which is misleading, since the credentials are fine. It now explains the real common causes: a VW data-sharing request still propagating, or a primary-user ("Hauptnutzer") re-confirmation that the brand app requires after you change your S-PIN or account settings.
+- **Fewer duplicate range and fuel sensors.** On a single-energy car (pure petrol/diesel) the total-range and combustion-range sensors just repeated the main "Range" value, so three identical range sensors showed up; the redundant two are now hidden on those cars while genuine hybrids still get the full electric / combustion / total breakdown. The second fuel-level sensor ("primary engine fuel level"), which mirrors the main tank sensor, is now a diagnostic that is disabled by default (existing setups keep it).
 
 ## [2.23.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased]
+
+### Changed
+
+- **Clearer message when the account has no vehicle yet.** When login works but the manufacturer lists no vehicle, the setup error used to say "No vehicles found. Check credentials and network." — which is misleading, since the credentials are fine. It now explains the real common causes: a VW data-sharing request still propagating, or a primary-user ("Hauptnutzer") re-confirmation that the brand app requires after you change your S-PIN or account settings.
+
 ## [2.23.0] - 2026-07-23
 
 ### Added

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -153,7 +153,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: VagConnectConfigEntry) -
         raise ConfigEntryNotReady(str(err)) from err
 
     if not ok:
-        raise ConfigEntryNotReady("No vehicles found. Check credentials and network.")
+        raise ConfigEntryNotReady(
+            "No vehicles found for this account. The login itself worked, so "
+            "this is usually not a credentials problem — check the log for the "
+            "exact reason (e.g. a VW data-sharing request still propagating, or "
+            "a primary-user / Hauptnutzer re-confirmation needed in the brand "
+            "app after a recent S-PIN or account change)."
+        )
 
     from .repairs import clear_auth_issues  # noqa: PLC0415
     clear_auth_issues(hass, entry.entry_id)

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -1107,14 +1107,17 @@ class VagAbrpDataChangedSensor(VagConnectEntity, BinarySensorEntity):
 
 
 # Per-door binary sensors.
-
-_DOOR_NAMES = {
-    "frontLeft":  "Door Front Left",
-    "frontRight": "Door Front Right",
-    "rearLeft":   "Door Rear Left",
-    "rearRight":  "Door Rear Right",
-    "trunk":      "Trunk",
-    "bonnet":     "Motorhaube",
+# v2.23.1 — map the camelCase part-id to a snake_case translation_key so the
+# friendly name is localised (all 12 locales) instead of the old hardcoded
+# English _attr_name (which leaked "Door Front Left"/"Trunk" into non-English
+# HA). Entity keys / unique_ids are unchanged (still door_<camelCaseId>).
+_DOOR_TKEYS = {
+    "frontLeft":  "door_front_left",
+    "frontRight": "door_front_right",
+    "rearLeft":   "door_rear_left",
+    "rearRight":  "door_rear_right",
+    "trunk":      "door_trunk",
+    "bonnet":     "door_bonnet",
 }
 
 
@@ -1131,7 +1134,11 @@ class VagDoorSensor(VagConnectEntity, BinarySensorEntity):
     ) -> None:
         super().__init__(coordinator, vin, f"door_{door_id}")
         self._door_id = door_id
-        self._attr_name = _DOOR_NAMES.get(door_id, door_id)
+        _tkey = _DOOR_TKEYS.get(door_id)
+        if _tkey:
+            self._attr_translation_key = _tkey
+        else:
+            self._attr_name = door_id
         self._attr_icon = "mdi:car-door" if "door" in door_id.lower() or "rear" in door_id.lower() or "front" in door_id.lower() else "mdi:car-door-lock"
 
     @property
@@ -1149,11 +1156,11 @@ class VagDoorSensor(VagConnectEntity, BinarySensorEntity):
 # *closed* in ``windows_individual`` (consistent with
 # ``doors_individual``), so ``is_on`` inverts that.
 
-_WINDOW_NAMES = {
-    "frontLeft":  "Window Front Left",
-    "frontRight": "Window Front Right",
-    "rearLeft":   "Window Rear Left",
-    "rearRight":  "Window Rear Right",
+_WINDOW_TKEYS = {
+    "frontLeft":  "window_front_left",
+    "frontRight": "window_front_right",
+    "rearLeft":   "window_rear_left",
+    "rearRight":  "window_rear_right",
 }
 
 
@@ -1170,7 +1177,12 @@ class VagWindowSensor(VagConnectEntity, BinarySensorEntity):
     ) -> None:
         super().__init__(coordinator, vin, f"window_{window_id}")
         self._window_id = window_id
-        self._attr_name = _WINDOW_NAMES.get(window_id, window_id)
+        # v2.23.1 — localise via translation_key instead of hardcoded English.
+        _tkey = _WINDOW_TKEYS.get(window_id)
+        if _tkey:
+            self._attr_translation_key = _tkey
+        else:
+            self._attr_name = window_id
         self._attr_icon = "mdi:car-door"
 
     @property
@@ -1199,6 +1211,17 @@ class VagLightSensor(VagConnectEntity, BinarySensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:lightbulb-on-outline"
 
+    # v2.23.1 — localise the common light positions instead of the old
+    # hardcoded English "Light <id>". CARIAD light names are open-ended, so
+    # unknown ids keep the English fallback.
+    # Only the positions we ship verified 12-locale names for. Any other
+    # CARIAD light name keeps the English fallback rather than pointing at a
+    # missing translation_key (which would render an empty friendly name).
+    _LIGHT_TKEYS = {
+        "left":  "light_left",
+        "right": "light_right",
+    }
+
     def __init__(
         self,
         coordinator: VagConnectCoordinator,
@@ -1207,8 +1230,12 @@ class VagLightSensor(VagConnectEntity, BinarySensorEntity):
     ) -> None:
         super().__init__(coordinator, vin, f"light_{light_id}")
         self._light_id = light_id
-        # Friendly fallback name; HA will use translation_key if available.
-        self._attr_name = f"Light {light_id}"
+        _tkey = self._LIGHT_TKEYS.get(light_id)
+        if _tkey:
+            self._attr_translation_key = _tkey
+        else:
+            # Unknown light name — keep a readable fallback.
+            self._attr_name = f"Light {light_id}"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -243,9 +243,14 @@ class VWEUClient(CariadBaseClient):
             if not vins:
                 _LOGGER.warning(
                     "EU Data Act portal: login OK but the portal returned "
-                    "no vehicle. Enable the data-sharing / continuous data "
-                    "request for this car on the VW data portal — it can "
-                    "take a while to propagate before the car appears."
+                    "no vehicle. Two common causes: (1) if you recently "
+                    "changed your S-PIN or account settings, the brand may "
+                    "require you to re-confirm as the primary user (Hauptnutzer) "
+                    "in the brand app before it lists the car again; (2) the "
+                    "data-sharing / continuous data request for this car is not "
+                    "enabled yet on the VW data portal. Either way it can take a "
+                    "while to propagate before the car reappears — your login is "
+                    "fine, so this is not a credentials problem."
                 )
             return vins
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.23.0"
+  "version": "2.23.1"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1336,6 +1336,12 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:car-info",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # v2.23.1 — this is the same combustion-tank percentage as the primary
+    # "fuel_level" sensor (fuel_level even falls back to this very field), so
+    # showing both was a duplicate ("Tankstand" + "Tankfüllstand (primär)").
+    # Demote it to a diagnostic, disabled-by-default comparison value instead of
+    # deleting it (entity_id + registry entry preserved); fuel_level stays the
+    # primary user-facing tank sensor.
     VagSensorDescription(
         key="primary_engine_fuel_level_pct",
         translation_key="primary_engine_fuel_level_pct",
@@ -1345,6 +1351,8 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:fuel",
         condition="combustion",
         suggested_display_precision=0,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     VagSensorDescription(
         key="maintenance_report_captured_at",
@@ -3381,6 +3389,22 @@ async def async_setup_entry(
             if desc.condition == "electric" and not has_battery:
                 continue
             if desc.condition == "combustion" and not has_combustion:
+                continue
+            # v2.23.1 — de-duplicate the range family on single-energy cars. The
+            # parser collapses range_km to the total on any non-hybrid, so on a
+            # pure-combustion car range_km == combustion_range_km == total_range_km
+            # (three identical "Reichweite" sensors). Keep the single range_km
+            # headline and hide the redundant two. A real hybrid (battery AND
+            # combustion) keeps all three because they genuinely differ, and
+            # combustion_range_km is hidden ONLY when it actually equals range_km,
+            # so a bi-fuel car reporting a distinct combustion range still keeps it.
+            if desc.key == "total_range_km" and not (has_battery and has_combustion):
+                continue
+            if (
+                desc.key == "combustion_range_km"
+                and not has_battery
+                and vehicle.get("combustion_range_km") == vehicle.get("range_km")
+            ):
                 continue
             if desc.key in _DATA_PRESENT_REQUIRED:
                 _present = vehicle.get(desc.data_key)

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1342,6 +1342,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Climate without external power"
+      },
+      "door_front_left": {
+        "name": "Door Front Left"
+      },
+      "door_front_right": {
+        "name": "Door Front Right"
+      },
+      "door_rear_left": {
+        "name": "Door Rear Left"
+      },
+      "door_rear_right": {
+        "name": "Door Rear Right"
+      },
+      "door_trunk": {
+        "name": "Trunk"
+      },
+      "door_bonnet": {
+        "name": "Bonnet"
+      },
+      "light_left": {
+        "name": "Light Left"
+      },
+      "light_right": {
+        "name": "Light Right"
+      },
+      "window_front_left": {
+        "name": "Window Front Left"
+      },
+      "window_front_right": {
+        "name": "Window Front Right"
+      },
+      "window_rear_left": {
+        "name": "Window Rear Left"
+      },
+      "window_rear_right": {
+        "name": "Window Rear Right"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Klimatizace bez externího napájení"
+      },
+      "door_front_left": {
+        "name": "Dveře přední levé"
+      },
+      "door_front_right": {
+        "name": "Dveře přední pravé"
+      },
+      "door_rear_left": {
+        "name": "Dveře zadní levé"
+      },
+      "door_rear_right": {
+        "name": "Dveře zadní pravé"
+      },
+      "door_trunk": {
+        "name": "Kufr"
+      },
+      "door_bonnet": {
+        "name": "Kapota"
+      },
+      "light_left": {
+        "name": "Světlo vlevo"
+      },
+      "light_right": {
+        "name": "Světlo vpravo"
+      },
+      "window_front_left": {
+        "name": "Okno přední levé"
+      },
+      "window_front_right": {
+        "name": "Okno přední pravé"
+      },
+      "window_rear_left": {
+        "name": "Okno zadní levé"
+      },
+      "window_rear_right": {
+        "name": "Okno zadní pravé"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Klimaanlæg uden ekstern strøm"
+      },
+      "door_front_left": {
+        "name": "Dør foran venstre"
+      },
+      "door_front_right": {
+        "name": "Dør foran højre"
+      },
+      "door_rear_left": {
+        "name": "Dør bag venstre"
+      },
+      "door_rear_right": {
+        "name": "Dør bag højre"
+      },
+      "door_trunk": {
+        "name": "Bagagerum"
+      },
+      "door_bonnet": {
+        "name": "Motorhjelm"
+      },
+      "light_left": {
+        "name": "Lys venstre"
+      },
+      "light_right": {
+        "name": "Lys højre"
+      },
+      "window_front_left": {
+        "name": "Rude foran venstre"
+      },
+      "window_front_right": {
+        "name": "Rude foran højre"
+      },
+      "window_rear_left": {
+        "name": "Rude bag venstre"
+      },
+      "window_rear_right": {
+        "name": "Rude bag højre"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Klimatisierung ohne Netzstrom"
+      },
+      "door_front_left": {
+        "name": "Tür vorne links"
+      },
+      "door_front_right": {
+        "name": "Tür vorne rechts"
+      },
+      "door_rear_left": {
+        "name": "Tür hinten links"
+      },
+      "door_rear_right": {
+        "name": "Tür hinten rechts"
+      },
+      "door_trunk": {
+        "name": "Kofferraum"
+      },
+      "door_bonnet": {
+        "name": "Motorhaube"
+      },
+      "light_left": {
+        "name": "Licht links"
+      },
+      "light_right": {
+        "name": "Licht rechts"
+      },
+      "window_front_left": {
+        "name": "Fenster vorne links"
+      },
+      "window_front_right": {
+        "name": "Fenster vorne rechts"
+      },
+      "window_rear_left": {
+        "name": "Fenster hinten links"
+      },
+      "window_rear_right": {
+        "name": "Fenster hinten rechts"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Climate without external power"
+      },
+      "door_front_left": {
+        "name": "Door Front Left"
+      },
+      "door_front_right": {
+        "name": "Door Front Right"
+      },
+      "door_rear_left": {
+        "name": "Door Rear Left"
+      },
+      "door_rear_right": {
+        "name": "Door Rear Right"
+      },
+      "door_trunk": {
+        "name": "Trunk"
+      },
+      "door_bonnet": {
+        "name": "Bonnet"
+      },
+      "light_left": {
+        "name": "Light Left"
+      },
+      "light_right": {
+        "name": "Light Right"
+      },
+      "window_front_left": {
+        "name": "Window Front Left"
+      },
+      "window_front_right": {
+        "name": "Window Front Right"
+      },
+      "window_rear_left": {
+        "name": "Window Rear Left"
+      },
+      "window_rear_right": {
+        "name": "Window Rear Right"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Climatización sin corriente externa"
+      },
+      "door_front_left": {
+        "name": "Puerta delantera izquierda"
+      },
+      "door_front_right": {
+        "name": "Puerta delantera derecha"
+      },
+      "door_rear_left": {
+        "name": "Puerta trasera izquierda"
+      },
+      "door_rear_right": {
+        "name": "Puerta trasera derecha"
+      },
+      "door_trunk": {
+        "name": "Maletero"
+      },
+      "door_bonnet": {
+        "name": "Capó"
+      },
+      "light_left": {
+        "name": "Luz izquierda"
+      },
+      "light_right": {
+        "name": "Luz derecha"
+      },
+      "window_front_left": {
+        "name": "Ventanilla delantera izquierda"
+      },
+      "window_front_right": {
+        "name": "Ventanilla delantera derecha"
+      },
+      "window_rear_left": {
+        "name": "Ventanilla trasera izquierda"
+      },
+      "window_rear_right": {
+        "name": "Ventanilla trasera derecha"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Ilmastointi ilman ulkoista virtaa"
+      },
+      "door_front_left": {
+        "name": "Ovi edessä vasemmalla"
+      },
+      "door_front_right": {
+        "name": "Ovi edessä oikealla"
+      },
+      "door_rear_left": {
+        "name": "Ovi takana vasemmalla"
+      },
+      "door_rear_right": {
+        "name": "Ovi takana oikealla"
+      },
+      "door_trunk": {
+        "name": "Tavaratila"
+      },
+      "door_bonnet": {
+        "name": "Konepelti"
+      },
+      "light_left": {
+        "name": "Valo vasen"
+      },
+      "light_right": {
+        "name": "Valo oikea"
+      },
+      "window_front_left": {
+        "name": "Ikkuna edessä vasemmalla"
+      },
+      "window_front_right": {
+        "name": "Ikkuna edessä oikealla"
+      },
+      "window_rear_left": {
+        "name": "Ikkuna takana vasemmalla"
+      },
+      "window_rear_right": {
+        "name": "Ikkuna takana oikealla"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Climatisation sans alimentation externe"
+      },
+      "door_front_left": {
+        "name": "Porte avant gauche"
+      },
+      "door_front_right": {
+        "name": "Porte avant droite"
+      },
+      "door_rear_left": {
+        "name": "Porte arrière gauche"
+      },
+      "door_rear_right": {
+        "name": "Porte arrière droite"
+      },
+      "door_trunk": {
+        "name": "Coffre"
+      },
+      "door_bonnet": {
+        "name": "Capot"
+      },
+      "light_left": {
+        "name": "Feu gauche"
+      },
+      "light_right": {
+        "name": "Feu droit"
+      },
+      "window_front_left": {
+        "name": "Vitre avant gauche"
+      },
+      "window_front_right": {
+        "name": "Vitre avant droite"
+      },
+      "window_rear_left": {
+        "name": "Vitre arrière gauche"
+      },
+      "window_rear_right": {
+        "name": "Vitre arrière droite"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Climatizzazione senza alimentazione esterna"
+      },
+      "door_front_left": {
+        "name": "Porta anteriore sinistra"
+      },
+      "door_front_right": {
+        "name": "Porta anteriore destra"
+      },
+      "door_rear_left": {
+        "name": "Porta posteriore sinistra"
+      },
+      "door_rear_right": {
+        "name": "Porta posteriore destra"
+      },
+      "door_trunk": {
+        "name": "Bagagliaio"
+      },
+      "door_bonnet": {
+        "name": "Cofano"
+      },
+      "light_left": {
+        "name": "Luce sinistra"
+      },
+      "light_right": {
+        "name": "Luce destra"
+      },
+      "window_front_left": {
+        "name": "Finestrino anteriore sinistro"
+      },
+      "window_front_right": {
+        "name": "Finestrino anteriore destro"
+      },
+      "window_rear_left": {
+        "name": "Finestrino posteriore sinistro"
+      },
+      "window_rear_right": {
+        "name": "Finestrino posteriore destro"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Klimaanlegg uten ekstern strøm"
+      },
+      "door_front_left": {
+        "name": "Dør foran venstre"
+      },
+      "door_front_right": {
+        "name": "Dør foran høyre"
+      },
+      "door_rear_left": {
+        "name": "Dør bak venstre"
+      },
+      "door_rear_right": {
+        "name": "Dør bak høyre"
+      },
+      "door_trunk": {
+        "name": "Bagasjerom"
+      },
+      "door_bonnet": {
+        "name": "Panser"
+      },
+      "light_left": {
+        "name": "Lys venstre"
+      },
+      "light_right": {
+        "name": "Lys høyre"
+      },
+      "window_front_left": {
+        "name": "Vindu foran venstre"
+      },
+      "window_front_right": {
+        "name": "Vindu foran høyre"
+      },
+      "window_rear_left": {
+        "name": "Vindu bak venstre"
+      },
+      "window_rear_right": {
+        "name": "Vindu bak høyre"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Klimaatregeling zonder externe stroom"
+      },
+      "door_front_left": {
+        "name": "Portier linksvoor"
+      },
+      "door_front_right": {
+        "name": "Portier rechtsvoor"
+      },
+      "door_rear_left": {
+        "name": "Portier linksachter"
+      },
+      "door_rear_right": {
+        "name": "Portier rechtsachter"
+      },
+      "door_trunk": {
+        "name": "Kofferbak"
+      },
+      "door_bonnet": {
+        "name": "Motorkap"
+      },
+      "light_left": {
+        "name": "Licht links"
+      },
+      "light_right": {
+        "name": "Licht rechts"
+      },
+      "window_front_left": {
+        "name": "Raam linksvoor"
+      },
+      "window_front_right": {
+        "name": "Raam rechtsvoor"
+      },
+      "window_rear_left": {
+        "name": "Raam linksachter"
+      },
+      "window_rear_right": {
+        "name": "Raam rechtsachter"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Klimatyzacja bez zasilania zewnętrznego"
+      },
+      "door_front_left": {
+        "name": "Drzwi przednie lewe"
+      },
+      "door_front_right": {
+        "name": "Drzwi przednie prawe"
+      },
+      "door_rear_left": {
+        "name": "Drzwi tylne lewe"
+      },
+      "door_rear_right": {
+        "name": "Drzwi tylne prawe"
+      },
+      "door_trunk": {
+        "name": "Bagażnik"
+      },
+      "door_bonnet": {
+        "name": "Maska"
+      },
+      "light_left": {
+        "name": "Światło lewe"
+      },
+      "light_right": {
+        "name": "Światło prawe"
+      },
+      "window_front_left": {
+        "name": "Szyba przednia lewa"
+      },
+      "window_front_right": {
+        "name": "Szyba przednia prawa"
+      },
+      "window_rear_left": {
+        "name": "Szyba tylna lewa"
+      },
+      "window_rear_right": {
+        "name": "Szyba tylna prawa"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1345,6 +1345,42 @@
       },
       "climatisation_without_hv_power": {
         "name": "Klimatanläggning utan extern ström"
+      },
+      "door_front_left": {
+        "name": "Dörr fram vänster"
+      },
+      "door_front_right": {
+        "name": "Dörr fram höger"
+      },
+      "door_rear_left": {
+        "name": "Dörr bak vänster"
+      },
+      "door_rear_right": {
+        "name": "Dörr bak höger"
+      },
+      "door_trunk": {
+        "name": "Baklucka"
+      },
+      "door_bonnet": {
+        "name": "Motorhuv"
+      },
+      "light_left": {
+        "name": "Ljus vänster"
+      },
+      "light_right": {
+        "name": "Ljus höger"
+      },
+      "window_front_left": {
+        "name": "Fönster fram vänster"
+      },
+      "window_front_right": {
+        "name": "Fönster fram höger"
+      },
+      "window_rear_left": {
+        "name": "Fönster bak vänster"
+      },
+      "window_rear_right": {
+        "name": "Fönster bak höger"
       }
     },
     "switch": {

--- a/tests/test_v2231_entity_cleanup.py
+++ b/tests/test_v2231_entity_cleanup.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.23.1 — Audi S6 device-page cleanup: localise dynamic names + de-dup.
+
+Three fixes, verified live on a real diesel Audi S6 (German HA):
+1. The per-part door / window / light binary sensors hardcoded English into
+   ``_attr_name`` — they now use a ``translation_key`` so the name localises.
+2. The range family collapses to one value on a single-energy car, so the
+   redundant total_range_km / combustion_range_km are gated off there (hybrids
+   keep all three).
+3. ``primary_engine_fuel_level_pct`` duplicates ``fuel_level`` — demoted to a
+   disabled-by-default diagnostic (not deleted).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from homeassistant.const import EntityCategory
+
+from custom_components.vag_connect.binary_sensor import (
+    VagDoorSensor,
+    VagLightSensor,
+    VagWindowSensor,
+)
+from custom_components.vag_connect.sensor import SENSOR_DESCRIPTIONS
+
+
+def _coord():
+    c = MagicMock()
+    c.data = {}
+    return c
+
+
+# ── Fix 1: dynamic sensors use translation_key, not hardcoded English ────────
+
+def test_door_sensor_uses_translation_key() -> None:
+    d = VagDoorSensor(_coord(), "VIN", "frontLeft")
+    assert d._attr_translation_key == "door_front_left"
+    assert getattr(d, "_attr_name", None) is None
+    assert d.unique_id == "VIN_door_frontLeft"  # entity id unchanged (camelCase)
+
+
+def test_door_trunk_and_bonnet_translation_keys() -> None:
+    assert VagDoorSensor(_coord(), "V", "trunk")._attr_translation_key == "door_trunk"
+    assert VagDoorSensor(_coord(), "V", "bonnet")._attr_translation_key == "door_bonnet"
+
+
+def test_window_sensor_uses_translation_key() -> None:
+    w = VagWindowSensor(_coord(), "V", "rearRight")
+    assert w._attr_translation_key == "window_rear_right"
+    assert getattr(w, "_attr_name", None) is None
+
+
+def test_light_left_right_use_translation_key() -> None:
+    assert VagLightSensor(_coord(), "V", "left")._attr_translation_key == "light_left"
+    assert VagLightSensor(_coord(), "V", "right")._attr_translation_key == "light_right"
+
+
+def test_unknown_light_keeps_readable_fallback() -> None:
+    # an open-ended CARIAD light name we ship no translation for must not point
+    # at a missing translation_key (empty name) — keep the plain fallback.
+    lg = VagLightSensor(_coord(), "V", "dippedBeam")
+    assert getattr(lg, "_attr_translation_key", None) is None
+    assert lg._attr_name == "Light dippedBeam"
+
+
+# ── Fix 3: primary_engine_fuel_level_pct demoted (not deleted) ───────────────
+
+def test_primary_fuel_level_is_disabled_diagnostic() -> None:
+    desc = next(
+        d for d in SENSOR_DESCRIPTIONS if d.key == "primary_engine_fuel_level_pct"
+    )
+    assert desc.entity_category == EntityCategory.DIAGNOSTIC
+    assert desc.entity_registry_enabled_default is False
+    # still present (not deleted) so existing entity_ids survive
+    assert desc.data_key == "primary_engine_fuel_level_pct"
+
+
+# ── Fix 2: range de-dup on single-energy cars ────────────────────────────────
+
+def _built_keys(vehicle: dict) -> set[str]:
+    """Run sensor.async_setup_entry for one vehicle and return the sensor keys.
+
+    Mirrors the pattern in tests/test_entities.py — a mock coordinator + a
+    capturing async_add_entities.
+    """
+    from custom_components.vag_connect import sensor as sensor_mod
+
+    coord = MagicMock()
+    coord.is_read_only = MagicMock(return_value=False)
+    coord.data = {"VINX": vehicle}
+    coord.vehicles = coord.data
+    coord.entry = MagicMock()
+    coord.entry.data = {"brand": "audi"}
+    coord.command_capability_supported = MagicMock(return_value=True)
+    entry = MagicMock()
+    entry.runtime_data = coord
+    added: list = []
+
+    def _collect(entities, **kw):
+        added.extend(entities)
+
+    asyncio.run(sensor_mod.async_setup_entry(MagicMock(), entry, _collect))
+    return {
+        e.entity_description.key
+        for e in added
+        if hasattr(e, "entity_description")
+    }
+
+
+_COMBUSTION = {
+    "vin": "VINX", "has_battery": False, "has_combustion": True,
+    "range_km": 890, "combustion_range_km": 890, "total_range_km": 890,
+}
+_HYBRID = {
+    "vin": "VINX", "has_battery": True, "has_combustion": True,
+    "range_km": 60, "combustion_range_km": 500, "total_range_km": 560,
+    "electric_range_km": 60,
+}
+
+
+def test_single_energy_car_hides_redundant_range_sensors() -> None:
+    keys = _built_keys(_COMBUSTION)
+    assert "range_km" in keys  # the single headline stays
+    assert "total_range_km" not in keys  # redundant, hidden
+    assert "combustion_range_km" not in keys  # equals range_km → hidden
+
+
+def test_hybrid_keeps_all_three_ranges() -> None:
+    keys = _built_keys(_HYBRID)
+    assert "range_km" in keys
+    assert "total_range_km" in keys  # genuinely distinct on a hybrid
+    assert "combustion_range_km" in keys


### PR DESCRIPTION
## 2.23.1

### Fixed
- **Door / window / light sensors now show localized names.** The per-part binary sensors hardcoded English into `_attr_name` ("Door Front Left", "Trunk", "Light left"), so they stayed English in a non-English Home Assistant. They now use translation keys with names in all 12 languages. Entity IDs unchanged.

### Changed
- **Clearer "no vehicle" setup message.** Instead of the misleading "No vehicles found. Check credentials and network.", it now names the real causes (a VW data-sharing request still propagating, or a primary-user / "Hauptnutzer" re-confirmation the brand app requires after an S-PIN / account change).
- **Fewer duplicate range & fuel sensors.** On a single-energy car the total-range and combustion-range sensors just repeated the main range value (three identical sensors); the redundant two are hidden there, hybrids keep the full breakdown. The duplicate "primary engine fuel level" sensor is now a disabled-by-default diagnostic (existing setups keep it).

Full suite: 4034 passed. Manifest 2.23.1.