### PR TITLE
Release 2.23.2 — fix SEAT/CUPRA door inversion, complete 6-language translations, name 8 sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.23.2] - 2026-07-24
+
+### Fixed
+
+- **SEAT and CUPRA per-door sensors were showing open/closed backwards.** The individual door binary sensors on SEAT/CUPRA cars stored "closed" where the rest of the integration means "open", so a closed door read as open and vice-versa. They now match the correct convention.
+- **Eight climate/connection/power binary sensors had no name.** A handful of entities (climate zones, "Connection active", the daily-power-budget and low-battery warnings) had their name filed in the wrong place internally, so they showed up unnamed. They now have proper names in all 12 languages.
+- **French, Spanish, Dutch, Polish, Czech and Swedish are now fully translated.** Around 70 entity names were still showing in English in those six languages while the others were translated. They're now complete.
+- **The vehicle-render image entity now shows a localized name** instead of a hardcoded English "Vehicle Render".
+
 ## [2.23.1] - 2026-07-23
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -1063,19 +1063,24 @@ class SeatCupraClient(CariadBaseClient):
                 door = v(doors_obj, pos) or {}
                 if not door:
                     continue
-                # ``open`` may be bool or "open"/"closed" string — normalise
+                # ``open`` may be bool or "open"/"closed" string — normalise.
+                # v2.23.2 — store True == OPEN to match the project-wide
+                # doors_individual convention (VW EU stores `status == "open"`,
+                # and BinarySensorDeviceClass.DOOR treats True as "open"). The
+                # old code stored `is_closed` here, which inverted every SEAT /
+                # CUPRA per-door binary sensor (a closed door showed as open).
                 open_raw = door.get("open")
                 if isinstance(open_raw, bool):
-                    is_closed = not open_raw
+                    is_open = open_raw
                 elif isinstance(open_raw, str):
-                    is_closed = open_raw.lower() == "closed"
+                    is_open = open_raw.lower() == "open"
                 else:
-                    is_closed = None
-                if is_closed is not None:
-                    door_individual[pos] = is_closed
+                    is_open = None
+                if is_open is not None:
+                    door_individual[pos] = is_open
             if door_individual:
                 d.doors_individual = door_individual
-                d.doors_open = any(not closed for closed in door_individual.values())
+                d.doors_open = any(door_individual.values())
                 # ``doors_locked`` is True only when every position reports
                 # locked=True. If any position doesn't report (None),
                 # fall back to the access endpoint or stay False.

--- a/custom_components/vag_connect/image.py
+++ b/custom_components/vag_connect/image.py
@@ -448,7 +448,9 @@ class VagSkodaWidgetImageEntity(VagConnectEntity, ImageEntity):
     ) -> None:
         VagConnectEntity.__init__(self, coordinator, vin, "render_widget")
         ImageEntity.__init__(self, hass, verify_ssl=True)
-        self._attr_name = "Vehicle Render"
+        # v2.23.2 — localise via translation_key instead of the hardcoded
+        # English "Vehicle Render" (which leaked into every non-English HA).
+        self._attr_translation_key = "vehicle_render"
         self._attr_image_url = initial_url
         self._attr_image_last_updated = datetime.now(tz=timezone.utc)
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.23.1"
+  "version": "2.23.2"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1378,6 +1378,30 @@
       },
       "window_rear_right": {
         "name": "Window Rear Right"
+      },
+      "climate_zone_front_left": {
+        "name": "Climate Zone Front Left"
+      },
+      "climate_zone_front_right": {
+        "name": "Climate Zone Front Right"
+      },
+      "climate_zone_rear_left": {
+        "name": "Climate Zone Rear Left"
+      },
+      "climate_zone_rear_right": {
+        "name": "Climate Zone Rear Right"
+      },
+      "climate_without_external_power": {
+        "name": "Climate Without External Power"
+      },
+      "connection_active": {
+        "name": "Connection Active"
+      },
+      "daily_power_budget_warning": {
+        "name": "Daily Power Budget Warning"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Insufficient Battery Level Warning"
       }
     },
     "switch": {
@@ -1520,6 +1544,9 @@
       },
       "render_angle_lg": {
         "name": "3/4 View Large"
+      },
+      "vehicle_render": {
+        "name": "Vehicle Render"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -376,13 +376,13 @@
         "name": "Poslední Relace — Doba"
       },
       "last_charging_session_start": {
-        "name": "Last Charging Session Start"
+        "name": "Poslední nabíjení, začátek"
       },
       "last_charging_session_current_type": {
-        "name": "Last Charging Session Current Type"
+        "name": "Poslední nabíjení, typ proudu"
       },
       "last_charging_power_curve_points": {
-        "name": "Last Charging Power Curve Points"
+        "name": "Poslední nabíjení, body křivky výkonu"
       },
       "active_charging_profile_name": {
         "name": "Aktivní Profil Nabíjení"
@@ -433,22 +433,22 @@
         "name": "Hlásič chyb"
       },
       "requests_remaining_today": {
-        "name": "API Requests Remaining"
+        "name": "Zbývající API požadavky"
       },
       "license_plate": {
-        "name": "License Plate"
+        "name": "Registrační značka"
       },
       "equipment_count": {
-        "name": "Equipment Count"
+        "name": "Počet výbavy"
       },
       "secondary_engine_range_km": {
-        "name": "Secondary Engine Range"
+        "name": "Dojezd sekundárního motoru"
       },
       "secondary_engine_type": {
-        "name": "Secondary Engine Type"
+        "name": "Typ sekundárního motoru"
       },
       "secondary_engine_fuel_level_pct": {
-        "name": "Secondary Engine Fuel Level"
+        "name": "Hladina paliva sekundárního motoru"
       },
       "subscription_expiry_at": {
         "name": "Předplatné vyprší"
@@ -505,7 +505,7 @@
         "name": "Další časovač — Cílové nabití dosažitelné"
       },
       "capabilities_count": {
-        "name": "Capabilities Count"
+        "name": "Počet funkcí"
       },
       "tire_pressure_front_left_bar": {
         "name": "Tlak Pneumatik Přední Levá"
@@ -541,103 +541,103 @@
         "name": "Varování vozidla"
       },
       "auxiliary_heating_remaining_min": {
-        "name": "Auxiliary Heating ETA"
+        "name": "Nezávislé topení, zbývající čas"
       },
       "auxiliary_heating_status": {
-        "name": "Auxiliary Heating Status"
+        "name": "Stav nezávislého topení"
       },
       "brake_fluid_change_due_at": {
-        "name": "Brake Fluid Change Due"
+        "name": "Výměna brzdové kapaliny"
       },
       "brake_pads_front_inspection_due_at": {
-        "name": "Brake Pads Front Inspection Due"
+        "name": "Kontrola předních brzdových destiček"
       },
       "brake_pads_rear_inspection_due_at": {
-        "name": "Brake Pads Rear Inspection Due"
+        "name": "Kontrola zadních brzdových destiček"
       },
       "preferred_workshop_address": {
-        "name": "Preferred Workshop Address"
+        "name": "Adresa preferovaného servisu"
       },
       "preferred_workshop_name": {
-        "name": "Preferred Workshop"
+        "name": "Preferovaný servis"
       },
       "preferred_workshop_phone": {
-        "name": "Preferred Workshop Phone"
+        "name": "Telefon preferovaného servisu"
       },
       "adblue_level_pct": {
-        "name": "AdBlue Level"
+        "name": "Hladina AdBlue"
       },
       "cng_level_pct": {
-        "name": "CNG Tank Level"
+        "name": "Hladina nádrže CNG"
       },
       "cng_range_km": {
-        "name": "CNG Range"
+        "name": "Dojezd na CNG"
       },
       "primary_engine_range_km": {
-        "name": "Primary Engine Range"
+        "name": "Dojezd hlavního motoru"
       },
       "charging_preferred_mode": {
-        "name": "Preferred Charging Mode"
+        "name": "Preferovaný režim nabíjení"
       },
       "pending_action_id": {
-        "name": "Pending action ID"
+        "name": "ID čekající akce"
       },
       "pending_action_type": {
-        "name": "Pending action type"
+        "name": "Typ čekající akce"
       },
       "pending_action_status": {
-        "name": "Pending action status"
+        "name": "Stav čekající akce"
       },
       "refuel_trip_distance_km": {
-        "name": "Distance since refuel"
+        "name": "Vzdálenost od tankování"
       },
       "refuel_trip_duration_min": {
-        "name": "Drive time since refuel"
+        "name": "Doba jízdy od tankování"
       },
       "refuel_trip_avg_speed_kmh": {
-        "name": "Avg speed since refuel"
+        "name": "Prům. rychlost od tankování"
       },
       "refuel_trip_avg_fuel_consumption_l_100km": {
-        "name": "Avg fuel since refuel"
+        "name": "Prům. spotřeba paliva od tankování"
       },
       "refuel_trip_avg_electric_consumption_kwh_100km": {
-        "name": "Avg energy since refuel"
+        "name": "Prům. spotřeba energie od tankování"
       },
       "refuel_trip_total_fuel_consumption_l": {
-        "name": "Total fuel since refuel"
+        "name": "Celkové palivo od tankování"
       },
       "refuel_trip_total_electric_consumption_kwh": {
-        "name": "Total energy since charge"
+        "name": "Celková energie od nabíjení"
       },
       "refuel_trip_recuperation_kwh": {
-        "name": "Recuperation since charge"
+        "name": "Rekuperace od nabíjení"
       },
       "refuel_trip_timestamp": {
-        "name": "Refuel cycle started"
+        "name": "Začátek cyklu tankování"
       },
       "actual_charge_rate_kw": {
-        "name": "Actual charge rate"
+        "name": "Aktuální nabíjecí výkon"
       },
       "hv_battery_min_temperature_c": {
-        "name": "HV Battery Temperature (Min)"
+        "name": "Teplota HV baterie (min.)"
       },
       "hv_battery_max_temperature_c": {
-        "name": "HV Battery Temperature (Max)"
+        "name": "Teplota HV baterie (max.)"
       },
       "charge_max_ac_setting": {
-        "name": "Max AC Current (Setting)"
+        "name": "Max. AC proud (nastavení)"
       },
       "charge_max_ac_ampere": {
-        "name": "Max AC Current (Deliverable)"
+        "name": "Max. AC proud (dodávaný)"
       },
       "auto_release_ac_connector_state": {
-        "name": "Auto Release Connector State"
+        "name": "Stav automatického uvolnění konektoru"
       },
       "active_ventilation_state": {
-        "name": "Active Ventilation"
+        "name": "Aktivní větrání"
       },
       "active_ventilation_remaining_time_min": {
-        "name": "Active Ventilation Remaining"
+        "name": "Zbývající aktivní větrání"
       },
       "battery_support_state": {
         "name": "Podpora 12V baterie"
@@ -646,31 +646,31 @@
         "name": "evcc stav nabíjení"
       },
       "connection_state_battery_power_level": {
-        "name": "12V Battery Power Level"
+        "name": "Úroveň nabití baterie 12V"
       },
       "last_trip_total_fuel_consumption_l": {
-        "name": "Last Trip Total Fuel"
+        "name": "Poslední jízda, celkové palivo"
       },
       "last_trip_total_electric_consumption_kwh": {
-        "name": "Last Trip Total Energy"
+        "name": "Poslední jízda, celková energie"
       },
       "notifications_count": {
-        "name": "Notifications count"
+        "name": "Počet oznámení"
       },
       "last_notification_subject": {
-        "name": "Last notification subject"
+        "name": "Poslední oznámení, předmět"
       },
       "last_notification_severity": {
-        "name": "Last notification severity"
+        "name": "Poslední oznámení, závažnost"
       },
       "engine_oil_temperature_c": {
-        "name": "Engine oil temperature"
+        "name": "Teplota motorového oleje"
       },
       "engine_coolant_temperature_c": {
-        "name": "Engine coolant temperature"
+        "name": "Teplota chladicí kapaliny"
       },
       "last_trip_reset_at": {
-        "name": "Last Trip Reset"
+        "name": "Poslední vynulování jízdy"
       },
       "battery_temp_c": {
         "name": "Teplota baterie"
@@ -1182,16 +1182,16 @@
         "name": "Péče o Baterii Aktivní"
       },
       "auto_unlock_when_charged": {
-        "name": "Auto Unlock When Charged"
+        "name": "Automatické odemknutí po nabití"
       },
       "climate_at_unlock": {
-        "name": "Climate at Unlock"
+        "name": "Klimatizace při odemknutí"
       },
       "window_heating_enabled": {
-        "name": "Window Heating Enabled"
+        "name": "Vyhřívání oken zapnuto"
       },
       "air_conditioning_without_external_power": {
-        "name": "AC Without External Power"
+        "name": "Klimatizace bez externího napájení"
       },
       "subscription_active": {
         "name": "Předplatné aktivní"
@@ -1233,40 +1233,40 @@
         "name": "Stav oleje"
       },
       "seat_heating": {
-        "name": "Seat Heating"
+        "name": "Vyhřívání sedadel"
       },
       "parking_light": {
-        "name": "Parking Light"
+        "name": "Parkovací světlo"
       },
       "external_power": {
-        "name": "External Power Available"
+        "name": "Externí napájení dostupné"
       },
       "battery_care": {
-        "name": "Battery Care Mode"
+        "name": "Režim šetření baterie"
       },
       "energy_flow": {
-        "name": "Energy Flow Active"
+        "name": "Tok energie aktivní"
       },
       "area_alarm": {
-        "name": "Geofence Alarm"
+        "name": "Alarm geofence"
       },
       "auto_release_ac_connector": {
-        "name": "Auto Release AC Connector"
+        "name": "Automatické uvolnění AC konektoru"
       },
       "optimised_battery_use": {
-        "name": "Optimised Battery Use"
+        "name": "Optimalizované využití baterie"
       },
       "sunroof_rear_closed": {
-        "name": "Rear Sunroof"
+        "name": "Zadní střešní okno"
       },
       "roof_cover_closed": {
-        "name": "Roof Cover"
+        "name": "Střecha kabrioletu"
       },
       "permission_is_owner": {
-        "name": "Account is primary owner"
+        "name": "Účet je hlavní vlastník"
       },
       "permission_can_command": {
-        "name": "Account can send commands"
+        "name": "Účet může odesílat příkazy"
       },
       "external_power_available": {
         "name": "Externí napájení k dispozici"
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Okno zadní pravé"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimatická zóna vpředu vlevo"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimatická zóna vpředu vpravo"
+      },
+      "climate_zone_rear_left": {
+        "name": "Klimatická zóna vzadu vlevo"
+      },
+      "climate_zone_rear_right": {
+        "name": "Klimatická zóna vzadu vpravo"
+      },
+      "climate_without_external_power": {
+        "name": "Klimatizace bez externího napájení"
+      },
+      "connection_active": {
+        "name": "Připojení aktivní"
+      },
+      "daily_power_budget_warning": {
+        "name": "Varování denního energetického limitu"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Varování nedostatečné úrovně baterie"
       }
     },
     "switch": {
@@ -1435,10 +1459,10 @@
         "name": "Max. nabíjecí proud"
       },
       "auxheat_duration": {
-        "name": "Auxiliary Heating Duration"
+        "name": "Doba nezávislého topení"
       },
       "auxheat_target_temp": {
-        "name": "Auxiliary Heating Target Temperature"
+        "name": "Cílová teplota nezávislého topení"
       },
       "battery_care_target": {
         "name": "Cíl ochrany baterie"
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "Pohled 3/4 velký"
+      },
+      "vehicle_render": {
+        "name": "Vykreslení vozidla"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Rude bag højre"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimazone for venstre"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimazone for højre"
+      },
+      "climate_zone_rear_left": {
+        "name": "Klimazone bag venstre"
+      },
+      "climate_zone_rear_right": {
+        "name": "Klimazone bag højre"
+      },
+      "climate_without_external_power": {
+        "name": "Klima uden ekstern strøm"
+      },
+      "connection_active": {
+        "name": "Forbindelse aktiv"
+      },
+      "daily_power_budget_warning": {
+        "name": "Advarsel: dagligt strømbudget"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Advarsel: for lavt batteriniveau"
       }
     },
     "switch": {
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "3/4-visning stor"
+      },
+      "vehicle_render": {
+        "name": "Køretøjsgengivelse"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Fenster hinten rechts"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimazone vorne links"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimazone vorne rechts"
+      },
+      "climate_zone_rear_left": {
+        "name": "Klimazone hinten links"
+      },
+      "climate_zone_rear_right": {
+        "name": "Klimazone hinten rechts"
+      },
+      "climate_without_external_power": {
+        "name": "Klima ohne externe Stromversorgung"
+      },
+      "connection_active": {
+        "name": "Verbindung aktiv"
+      },
+      "daily_power_budget_warning": {
+        "name": "Warnung: tägliches Strombudget"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Warnung: Batteriestand zu niedrig"
       }
     },
     "switch": {
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "3/4-Ansicht Groß"
+      },
+      "vehicle_render": {
+        "name": "Fahrzeug-Rendering"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Window Rear Right"
+      },
+      "climate_zone_front_left": {
+        "name": "Climate Zone Front Left"
+      },
+      "climate_zone_front_right": {
+        "name": "Climate Zone Front Right"
+      },
+      "climate_zone_rear_left": {
+        "name": "Climate Zone Rear Left"
+      },
+      "climate_zone_rear_right": {
+        "name": "Climate Zone Rear Right"
+      },
+      "climate_without_external_power": {
+        "name": "Climate Without External Power"
+      },
+      "connection_active": {
+        "name": "Connection Active"
+      },
+      "daily_power_budget_warning": {
+        "name": "Daily Power Budget Warning"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Insufficient Battery Level Warning"
       }
     },
     "switch": {
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "3/4 View Large"
+      },
+      "vehicle_render": {
+        "name": "Vehicle Render"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -376,13 +376,13 @@
         "name": "Última Sesión — Duración"
       },
       "last_charging_session_start": {
-        "name": "Last Charging Session Start"
+        "name": "Última carga, inicio"
       },
       "last_charging_session_current_type": {
-        "name": "Last Charging Session Current Type"
+        "name": "Última carga, tipo de corriente"
       },
       "last_charging_power_curve_points": {
-        "name": "Last Charging Power Curve Points"
+        "name": "Última carga, puntos de la curva de potencia"
       },
       "active_charging_profile_name": {
         "name": "Perfil de Carga Activo"
@@ -433,22 +433,22 @@
         "name": "Reportador de errores"
       },
       "requests_remaining_today": {
-        "name": "API Requests Remaining"
+        "name": "Solicitudes API restantes"
       },
       "license_plate": {
-        "name": "License Plate"
+        "name": "Matrícula"
       },
       "equipment_count": {
-        "name": "Equipment Count"
+        "name": "Número de equipamientos"
       },
       "secondary_engine_range_km": {
-        "name": "Secondary Engine Range"
+        "name": "Autonomía del motor secundario"
       },
       "secondary_engine_type": {
-        "name": "Secondary Engine Type"
+        "name": "Tipo de motor secundario"
       },
       "secondary_engine_fuel_level_pct": {
-        "name": "Secondary Engine Fuel Level"
+        "name": "Nivel de combustible del motor secundario"
       },
       "subscription_expiry_at": {
         "name": "Suscripción expira"
@@ -505,7 +505,7 @@
         "name": "Próximo temporizador — Carga objetivo alcanzable"
       },
       "capabilities_count": {
-        "name": "Capabilities Count"
+        "name": "Número de funciones"
       },
       "tire_pressure_front_left_bar": {
         "name": "Presión Neumático Delantero Izquierdo"
@@ -541,103 +541,103 @@
         "name": "Avisos del vehículo"
       },
       "auxiliary_heating_remaining_min": {
-        "name": "Auxiliary Heating ETA"
+        "name": "Calefacción auxiliar, tiempo restante"
       },
       "auxiliary_heating_status": {
-        "name": "Auxiliary Heating Status"
+        "name": "Estado de la calefacción auxiliar"
       },
       "brake_fluid_change_due_at": {
-        "name": "Brake Fluid Change Due"
+        "name": "Cambio de líquido de frenos previsto"
       },
       "brake_pads_front_inspection_due_at": {
-        "name": "Brake Pads Front Inspection Due"
+        "name": "Revisión de pastillas delanteras prevista"
       },
       "brake_pads_rear_inspection_due_at": {
-        "name": "Brake Pads Rear Inspection Due"
+        "name": "Revisión de pastillas traseras prevista"
       },
       "preferred_workshop_address": {
-        "name": "Preferred Workshop Address"
+        "name": "Dirección del taller preferido"
       },
       "preferred_workshop_name": {
-        "name": "Preferred Workshop"
+        "name": "Taller preferido"
       },
       "preferred_workshop_phone": {
-        "name": "Preferred Workshop Phone"
+        "name": "Teléfono del taller preferido"
       },
       "adblue_level_pct": {
-        "name": "AdBlue Level"
+        "name": "Nivel de AdBlue"
       },
       "cng_level_pct": {
-        "name": "CNG Tank Level"
+        "name": "Nivel del depósito de GNC"
       },
       "cng_range_km": {
-        "name": "CNG Range"
+        "name": "Autonomía de GNC"
       },
       "primary_engine_range_km": {
-        "name": "Primary Engine Range"
+        "name": "Autonomía del motor principal"
       },
       "charging_preferred_mode": {
-        "name": "Preferred Charging Mode"
+        "name": "Modo de carga preferido"
       },
       "pending_action_id": {
-        "name": "Pending action ID"
+        "name": "ID de acción pendiente"
       },
       "pending_action_type": {
-        "name": "Pending action type"
+        "name": "Tipo de acción pendiente"
       },
       "pending_action_status": {
-        "name": "Pending action status"
+        "name": "Estado de acción pendiente"
       },
       "refuel_trip_distance_km": {
-        "name": "Distance since refuel"
+        "name": "Distancia desde el repostaje"
       },
       "refuel_trip_duration_min": {
-        "name": "Drive time since refuel"
+        "name": "Tiempo de conducción desde el repostaje"
       },
       "refuel_trip_avg_speed_kmh": {
-        "name": "Avg speed since refuel"
+        "name": "Velocidad media desde el repostaje"
       },
       "refuel_trip_avg_fuel_consumption_l_100km": {
-        "name": "Avg fuel since refuel"
+        "name": "Consumo medio de combustible desde el repostaje"
       },
       "refuel_trip_avg_electric_consumption_kwh_100km": {
-        "name": "Avg energy since refuel"
+        "name": "Consumo medio de energía desde el repostaje"
       },
       "refuel_trip_total_fuel_consumption_l": {
-        "name": "Total fuel since refuel"
+        "name": "Combustible total desde el repostaje"
       },
       "refuel_trip_total_electric_consumption_kwh": {
-        "name": "Total energy since charge"
+        "name": "Energía total desde la carga"
       },
       "refuel_trip_recuperation_kwh": {
-        "name": "Recuperation since charge"
+        "name": "Recuperación desde la carga"
       },
       "refuel_trip_timestamp": {
-        "name": "Refuel cycle started"
+        "name": "Inicio del ciclo de repostaje"
       },
       "actual_charge_rate_kw": {
-        "name": "Actual charge rate"
+        "name": "Potencia de carga actual"
       },
       "hv_battery_min_temperature_c": {
-        "name": "HV Battery Temperature (Min)"
+        "name": "Temperatura de la batería HV (mín.)"
       },
       "hv_battery_max_temperature_c": {
-        "name": "HV Battery Temperature (Max)"
+        "name": "Temperatura de la batería HV (máx.)"
       },
       "charge_max_ac_setting": {
-        "name": "Max AC Current (Setting)"
+        "name": "Corriente AC máx. (ajuste)"
       },
       "charge_max_ac_ampere": {
-        "name": "Max AC Current (Deliverable)"
+        "name": "Corriente AC máx. (disponible)"
       },
       "auto_release_ac_connector_state": {
-        "name": "Auto Release Connector State"
+        "name": "Estado de liberación automática del conector"
       },
       "active_ventilation_state": {
-        "name": "Active Ventilation"
+        "name": "Ventilación activa"
       },
       "active_ventilation_remaining_time_min": {
-        "name": "Active Ventilation Remaining"
+        "name": "Ventilación activa restante"
       },
       "battery_support_state": {
         "name": "Soporte de batería de 12 V"
@@ -646,31 +646,31 @@
         "name": "Estado de carga evcc"
       },
       "connection_state_battery_power_level": {
-        "name": "12V Battery Power Level"
+        "name": "Nivel de carga de la batería de 12V"
       },
       "last_trip_total_fuel_consumption_l": {
-        "name": "Last Trip Total Fuel"
+        "name": "Último viaje, combustible total"
       },
       "last_trip_total_electric_consumption_kwh": {
-        "name": "Last Trip Total Energy"
+        "name": "Último viaje, energía total"
       },
       "notifications_count": {
-        "name": "Notifications count"
+        "name": "Número de notificaciones"
       },
       "last_notification_subject": {
-        "name": "Last notification subject"
+        "name": "Última notificación, asunto"
       },
       "last_notification_severity": {
-        "name": "Last notification severity"
+        "name": "Última notificación, gravedad"
       },
       "engine_oil_temperature_c": {
-        "name": "Engine oil temperature"
+        "name": "Temperatura del aceite del motor"
       },
       "engine_coolant_temperature_c": {
-        "name": "Engine coolant temperature"
+        "name": "Temperatura del refrigerante"
       },
       "last_trip_reset_at": {
-        "name": "Last Trip Reset"
+        "name": "Último reinicio de viaje"
       },
       "battery_temp_c": {
         "name": "Temperatura de la batería"
@@ -1182,16 +1182,16 @@
         "name": "Cuidado de Batería Activo"
       },
       "auto_unlock_when_charged": {
-        "name": "Auto Unlock When Charged"
+        "name": "Desbloqueo automático al cargar"
       },
       "climate_at_unlock": {
-        "name": "Climate at Unlock"
+        "name": "Climatización al desbloquear"
       },
       "window_heating_enabled": {
-        "name": "Window Heating Enabled"
+        "name": "Calefacción de ventanas activada"
       },
       "air_conditioning_without_external_power": {
-        "name": "AC Without External Power"
+        "name": "Climatización sin alimentación externa"
       },
       "subscription_active": {
         "name": "Suscripción activa"
@@ -1233,40 +1233,40 @@
         "name": "Nivel de aceite"
       },
       "seat_heating": {
-        "name": "Seat Heating"
+        "name": "Calefacción de asientos"
       },
       "parking_light": {
-        "name": "Parking Light"
+        "name": "Luz de estacionamiento"
       },
       "external_power": {
-        "name": "External Power Available"
+        "name": "Alimentación externa disponible"
       },
       "battery_care": {
-        "name": "Battery Care Mode"
+        "name": "Modo cuidado de la batería"
       },
       "energy_flow": {
-        "name": "Energy Flow Active"
+        "name": "Flujo de energía activo"
       },
       "area_alarm": {
-        "name": "Geofence Alarm"
+        "name": "Alarma de geovalla"
       },
       "auto_release_ac_connector": {
-        "name": "Auto Release AC Connector"
+        "name": "Liberación automática del conector AC"
       },
       "optimised_battery_use": {
-        "name": "Optimised Battery Use"
+        "name": "Uso optimizado de la batería"
       },
       "sunroof_rear_closed": {
-        "name": "Rear Sunroof"
+        "name": "Techo solar trasero"
       },
       "roof_cover_closed": {
-        "name": "Roof Cover"
+        "name": "Capota"
       },
       "permission_is_owner": {
-        "name": "Account is primary owner"
+        "name": "La cuenta es la propietaria principal"
       },
       "permission_can_command": {
-        "name": "Account can send commands"
+        "name": "La cuenta puede enviar comandos"
       },
       "external_power_available": {
         "name": "Alimentación externa disponible"
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Ventanilla trasera derecha"
+      },
+      "climate_zone_front_left": {
+        "name": "Zona de climatización delantera izquierda"
+      },
+      "climate_zone_front_right": {
+        "name": "Zona de climatización delantera derecha"
+      },
+      "climate_zone_rear_left": {
+        "name": "Zona de climatización trasera izquierda"
+      },
+      "climate_zone_rear_right": {
+        "name": "Zona de climatización trasera derecha"
+      },
+      "climate_without_external_power": {
+        "name": "Climatización sin alimentación externa"
+      },
+      "connection_active": {
+        "name": "Conexión activa"
+      },
+      "daily_power_budget_warning": {
+        "name": "Aviso de presupuesto de energía diario"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Aviso de nivel de batería insuficiente"
       }
     },
     "switch": {
@@ -1435,10 +1459,10 @@
         "name": "Corriente de carga máx."
       },
       "auxheat_duration": {
-        "name": "Auxiliary Heating Duration"
+        "name": "Duración de la calefacción auxiliar"
       },
       "auxheat_target_temp": {
-        "name": "Auxiliary Heating Target Temperature"
+        "name": "Temperatura objetivo de la calefacción auxiliar"
       },
       "battery_care_target": {
         "name": "Objetivo de cuidado"
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "Vista 3/4 grande"
+      },
+      "vehicle_render": {
+        "name": "Renderizado del vehículo"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Ikkuna takana oikealla"
+      },
+      "climate_zone_front_left": {
+        "name": "Ilmastointivyöhyke vasen etu"
+      },
+      "climate_zone_front_right": {
+        "name": "Ilmastointivyöhyke oikea etu"
+      },
+      "climate_zone_rear_left": {
+        "name": "Ilmastointivyöhyke vasen taka"
+      },
+      "climate_zone_rear_right": {
+        "name": "Ilmastointivyöhyke oikea taka"
+      },
+      "climate_without_external_power": {
+        "name": "Ilmastointi ilman ulkoista virtaa"
+      },
+      "connection_active": {
+        "name": "Yhteys aktiivinen"
+      },
+      "daily_power_budget_warning": {
+        "name": "Päivittäisen tehobudjetin varoitus"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Riittämättömän akkutason varoitus"
       }
     },
     "switch": {
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "3/4-näkymä suuri"
+      },
+      "vehicle_render": {
+        "name": "Ajoneuvon renderöinti"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -376,13 +376,13 @@
         "name": "Dernière Session — Durée"
       },
       "last_charging_session_start": {
-        "name": "Last Charging Session Start"
+        "name": "Dernière charge, début"
       },
       "last_charging_session_current_type": {
-        "name": "Last Charging Session Current Type"
+        "name": "Dernière charge, type de courant"
       },
       "last_charging_power_curve_points": {
-        "name": "Last Charging Power Curve Points"
+        "name": "Dernière charge, points de courbe de puissance"
       },
       "active_charging_profile_name": {
         "name": "Profil de Charge Actif"
@@ -433,22 +433,22 @@
         "name": "Rapporteur d'erreurs"
       },
       "requests_remaining_today": {
-        "name": "API Requests Remaining"
+        "name": "Requêtes API restantes"
       },
       "license_plate": {
-        "name": "License Plate"
+        "name": "Plaque d'immatriculation"
       },
       "equipment_count": {
-        "name": "Equipment Count"
+        "name": "Nombre d'équipements"
       },
       "secondary_engine_range_km": {
-        "name": "Secondary Engine Range"
+        "name": "Autonomie moteur secondaire"
       },
       "secondary_engine_type": {
-        "name": "Secondary Engine Type"
+        "name": "Type moteur secondaire"
       },
       "secondary_engine_fuel_level_pct": {
-        "name": "Secondary Engine Fuel Level"
+        "name": "Niveau de carburant moteur secondaire"
       },
       "subscription_expiry_at": {
         "name": "Abonnement expire"
@@ -505,7 +505,7 @@
         "name": "Prochain timer — Charge cible atteignable"
       },
       "capabilities_count": {
-        "name": "Capabilities Count"
+        "name": "Nombre de fonctionnalités"
       },
       "tire_pressure_front_left_bar": {
         "name": "Pression Pneu Avant Gauche"
@@ -541,103 +541,103 @@
         "name": "Avertissements véhicule"
       },
       "auxiliary_heating_remaining_min": {
-        "name": "Auxiliary Heating ETA"
+        "name": "Chauffage d'appoint, temps restant"
       },
       "auxiliary_heating_status": {
-        "name": "Auxiliary Heating Status"
+        "name": "État du chauffage d'appoint"
       },
       "brake_fluid_change_due_at": {
-        "name": "Brake Fluid Change Due"
+        "name": "Vidange du liquide de frein prévue"
       },
       "brake_pads_front_inspection_due_at": {
-        "name": "Brake Pads Front Inspection Due"
+        "name": "Contrôle plaquettes avant prévu"
       },
       "brake_pads_rear_inspection_due_at": {
-        "name": "Brake Pads Rear Inspection Due"
+        "name": "Contrôle plaquettes arrière prévu"
       },
       "preferred_workshop_address": {
-        "name": "Preferred Workshop Address"
+        "name": "Adresse du garage préféré"
       },
       "preferred_workshop_name": {
-        "name": "Preferred Workshop"
+        "name": "Garage préféré"
       },
       "preferred_workshop_phone": {
-        "name": "Preferred Workshop Phone"
+        "name": "Téléphone du garage préféré"
       },
       "adblue_level_pct": {
-        "name": "AdBlue Level"
+        "name": "Niveau d'AdBlue"
       },
       "cng_level_pct": {
-        "name": "CNG Tank Level"
+        "name": "Niveau du réservoir GNC"
       },
       "cng_range_km": {
-        "name": "CNG Range"
+        "name": "Autonomie GNC"
       },
       "primary_engine_range_km": {
-        "name": "Primary Engine Range"
+        "name": "Autonomie moteur principal"
       },
       "charging_preferred_mode": {
-        "name": "Preferred Charging Mode"
+        "name": "Mode de charge préféré"
       },
       "pending_action_id": {
-        "name": "Pending action ID"
+        "name": "ID de l'action en attente"
       },
       "pending_action_type": {
-        "name": "Pending action type"
+        "name": "Type de l'action en attente"
       },
       "pending_action_status": {
-        "name": "Pending action status"
+        "name": "État de l'action en attente"
       },
       "refuel_trip_distance_km": {
-        "name": "Distance since refuel"
+        "name": "Distance depuis le plein"
       },
       "refuel_trip_duration_min": {
-        "name": "Drive time since refuel"
+        "name": "Temps de conduite depuis le plein"
       },
       "refuel_trip_avg_speed_kmh": {
-        "name": "Avg speed since refuel"
+        "name": "Vitesse moy. depuis le plein"
       },
       "refuel_trip_avg_fuel_consumption_l_100km": {
-        "name": "Avg fuel since refuel"
+        "name": "Conso carburant moy. depuis le plein"
       },
       "refuel_trip_avg_electric_consumption_kwh_100km": {
-        "name": "Avg energy since refuel"
+        "name": "Conso énergie moy. depuis le plein"
       },
       "refuel_trip_total_fuel_consumption_l": {
-        "name": "Total fuel since refuel"
+        "name": "Carburant total depuis le plein"
       },
       "refuel_trip_total_electric_consumption_kwh": {
-        "name": "Total energy since charge"
+        "name": "Énergie totale depuis la charge"
       },
       "refuel_trip_recuperation_kwh": {
-        "name": "Recuperation since charge"
+        "name": "Récupération depuis la charge"
       },
       "refuel_trip_timestamp": {
-        "name": "Refuel cycle started"
+        "name": "Début du cycle de plein"
       },
       "actual_charge_rate_kw": {
-        "name": "Actual charge rate"
+        "name": "Puissance de charge actuelle"
       },
       "hv_battery_min_temperature_c": {
-        "name": "HV Battery Temperature (Min)"
+        "name": "Température batterie HV (min)"
       },
       "hv_battery_max_temperature_c": {
-        "name": "HV Battery Temperature (Max)"
+        "name": "Température batterie HV (max)"
       },
       "charge_max_ac_setting": {
-        "name": "Max AC Current (Setting)"
+        "name": "Courant AC max (réglage)"
       },
       "charge_max_ac_ampere": {
-        "name": "Max AC Current (Deliverable)"
+        "name": "Courant AC max (disponible)"
       },
       "auto_release_ac_connector_state": {
-        "name": "Auto Release Connector State"
+        "name": "État du déverrouillage auto du connecteur"
       },
       "active_ventilation_state": {
-        "name": "Active Ventilation"
+        "name": "Ventilation active"
       },
       "active_ventilation_remaining_time_min": {
-        "name": "Active Ventilation Remaining"
+        "name": "Ventilation active restante"
       },
       "battery_support_state": {
         "name": "Assistance batterie 12V"
@@ -646,31 +646,31 @@
         "name": "État de charge evcc"
       },
       "connection_state_battery_power_level": {
-        "name": "12V Battery Power Level"
+        "name": "Niveau de charge batterie 12V"
       },
       "last_trip_total_fuel_consumption_l": {
-        "name": "Last Trip Total Fuel"
+        "name": "Dernier trajet, carburant total"
       },
       "last_trip_total_electric_consumption_kwh": {
-        "name": "Last Trip Total Energy"
+        "name": "Dernier trajet, énergie totale"
       },
       "notifications_count": {
-        "name": "Notifications count"
+        "name": "Nombre de notifications"
       },
       "last_notification_subject": {
-        "name": "Last notification subject"
+        "name": "Dernière notification, objet"
       },
       "last_notification_severity": {
-        "name": "Last notification severity"
+        "name": "Dernière notification, gravité"
       },
       "engine_oil_temperature_c": {
-        "name": "Engine oil temperature"
+        "name": "Température de l'huile moteur"
       },
       "engine_coolant_temperature_c": {
-        "name": "Engine coolant temperature"
+        "name": "Température du liquide de refroidissement"
       },
       "last_trip_reset_at": {
-        "name": "Last Trip Reset"
+        "name": "Dernière réinitialisation du trajet"
       },
       "battery_temp_c": {
         "name": "Température de la batterie"
@@ -1182,16 +1182,16 @@
         "name": "Soin Batterie Actif"
       },
       "auto_unlock_when_charged": {
-        "name": "Auto Unlock When Charged"
+        "name": "Déverrouillage auto à pleine charge"
       },
       "climate_at_unlock": {
-        "name": "Climate at Unlock"
+        "name": "Climatisation au déverrouillage"
       },
       "window_heating_enabled": {
-        "name": "Window Heating Enabled"
+        "name": "Dégivrage des vitres activé"
       },
       "air_conditioning_without_external_power": {
-        "name": "AC Without External Power"
+        "name": "Climatisation sans alimentation externe"
       },
       "subscription_active": {
         "name": "Abonnement actif"
@@ -1233,40 +1233,40 @@
         "name": "Niveau d huile"
       },
       "seat_heating": {
-        "name": "Seat Heating"
+        "name": "Chauffage des sièges"
       },
       "parking_light": {
-        "name": "Parking Light"
+        "name": "Feu de stationnement"
       },
       "external_power": {
-        "name": "External Power Available"
+        "name": "Alimentation externe disponible"
       },
       "battery_care": {
-        "name": "Battery Care Mode"
+        "name": "Mode préservation de la batterie"
       },
       "energy_flow": {
-        "name": "Energy Flow Active"
+        "name": "Flux d'énergie actif"
       },
       "area_alarm": {
-        "name": "Geofence Alarm"
+        "name": "Alarme de géorepérage"
       },
       "auto_release_ac_connector": {
-        "name": "Auto Release AC Connector"
+        "name": "Déverrouillage auto du connecteur AC"
       },
       "optimised_battery_use": {
-        "name": "Optimised Battery Use"
+        "name": "Utilisation optimisée de la batterie"
       },
       "sunroof_rear_closed": {
-        "name": "Rear Sunroof"
+        "name": "Toit ouvrant arrière"
       },
       "roof_cover_closed": {
-        "name": "Roof Cover"
+        "name": "Capote"
       },
       "permission_is_owner": {
-        "name": "Account is primary owner"
+        "name": "Le compte est le propriétaire principal"
       },
       "permission_can_command": {
-        "name": "Account can send commands"
+        "name": "Le compte peut envoyer des commandes"
       },
       "external_power_available": {
         "name": "Alimentation externe disponible"
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Vitre arrière droite"
+      },
+      "climate_zone_front_left": {
+        "name": "Zone climatique avant gauche"
+      },
+      "climate_zone_front_right": {
+        "name": "Zone climatique avant droite"
+      },
+      "climate_zone_rear_left": {
+        "name": "Zone climatique arrière gauche"
+      },
+      "climate_zone_rear_right": {
+        "name": "Zone climatique arrière droite"
+      },
+      "climate_without_external_power": {
+        "name": "Climatisation sans alimentation externe"
+      },
+      "connection_active": {
+        "name": "Connexion active"
+      },
+      "daily_power_budget_warning": {
+        "name": "Alerte budget d'énergie quotidien"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Alerte niveau de batterie insuffisant"
       }
     },
     "switch": {
@@ -1435,10 +1459,10 @@
         "name": "Courant de charge max."
       },
       "auxheat_duration": {
-        "name": "Auxiliary Heating Duration"
+        "name": "Durée du chauffage d'appoint"
       },
       "auxheat_target_temp": {
-        "name": "Auxiliary Heating Target Temperature"
+        "name": "Température cible du chauffage d'appoint"
       },
       "battery_care_target": {
         "name": "Cible de préservation"
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "Vue 3/4 grande"
+      },
+      "vehicle_render": {
+        "name": "Rendu du véhicule"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -427,7 +427,7 @@
         "name": "Autonomia AdBlue"
       },
       "api_observer_findings": {
-        "name": "Vehicle Data Scout"
+        "name": "Osservatore API"
       },
       "raw_api_fields": {
         "name": "Campi API grezzi"
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Finestrino posteriore destro"
+      },
+      "climate_zone_front_left": {
+        "name": "Zona clima anteriore sinistra"
+      },
+      "climate_zone_front_right": {
+        "name": "Zona clima anteriore destra"
+      },
+      "climate_zone_rear_left": {
+        "name": "Zona clima posteriore sinistra"
+      },
+      "climate_zone_rear_right": {
+        "name": "Zona clima posteriore destra"
+      },
+      "climate_without_external_power": {
+        "name": "Clima senza alimentazione esterna"
+      },
+      "connection_active": {
+        "name": "Connessione attiva"
+      },
+      "daily_power_budget_warning": {
+        "name": "Avviso budget energetico giornaliero"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Avviso livello batteria insufficiente"
       }
     },
     "switch": {
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "Vista 3/4 grande"
+      },
+      "vehicle_render": {
+        "name": "Rendering del veicolo"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Vindu bak høyre"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimasone foran venstre"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimasone foran høyre"
+      },
+      "climate_zone_rear_left": {
+        "name": "Klimasone bak venstre"
+      },
+      "climate_zone_rear_right": {
+        "name": "Klimasone bak høyre"
+      },
+      "climate_without_external_power": {
+        "name": "Klima uten ekstern strøm"
+      },
+      "connection_active": {
+        "name": "Tilkobling aktiv"
+      },
+      "daily_power_budget_warning": {
+        "name": "Advarsel om daglig strømbudsjett"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Advarsel om for lavt batterinivå"
       }
     },
     "switch": {
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "3/4-visning, stor"
+      },
+      "vehicle_render": {
+        "name": "Kjøretøysgjengivelse"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -376,13 +376,13 @@
         "name": "Laatste Sessie — Duur"
       },
       "last_charging_session_start": {
-        "name": "Last Charging Session Start"
+        "name": "Laatste laadsessie, start"
       },
       "last_charging_session_current_type": {
-        "name": "Last Charging Session Current Type"
+        "name": "Laatste laadsessie, stroomtype"
       },
       "last_charging_power_curve_points": {
-        "name": "Last Charging Power Curve Points"
+        "name": "Laatste laadsessie, vermogenscurvepunten"
       },
       "active_charging_profile_name": {
         "name": "Actief Laadprofiel"
@@ -433,22 +433,22 @@
         "name": "Foutmelder"
       },
       "requests_remaining_today": {
-        "name": "API Requests Remaining"
+        "name": "Resterende API-verzoeken"
       },
       "license_plate": {
-        "name": "License Plate"
+        "name": "Kenteken"
       },
       "equipment_count": {
-        "name": "Equipment Count"
+        "name": "Aantal uitrustingen"
       },
       "secondary_engine_range_km": {
-        "name": "Secondary Engine Range"
+        "name": "Actieradius secundaire motor"
       },
       "secondary_engine_type": {
-        "name": "Secondary Engine Type"
+        "name": "Type secundaire motor"
       },
       "secondary_engine_fuel_level_pct": {
-        "name": "Secondary Engine Fuel Level"
+        "name": "Brandstofniveau secundaire motor"
       },
       "subscription_expiry_at": {
         "name": "Abonnement verloopt"
@@ -490,7 +490,7 @@
         "name": "Klimaattimers ingeschakeld"
       },
       "primary_engine_type": {
-        "name": "Primary Engine Type"
+        "name": "Type primaire motor"
       },
       "steering_wheel_position": {
         "name": "Stuurpositie"
@@ -505,7 +505,7 @@
         "name": "Volgende timer — Doel-lading haalbaar"
       },
       "capabilities_count": {
-        "name": "Capabilities Count"
+        "name": "Aantal functies"
       },
       "tire_pressure_front_left_bar": {
         "name": "Bandenspanning Voor Links"
@@ -541,103 +541,103 @@
         "name": "Voertuig waarschuwingen"
       },
       "auxiliary_heating_remaining_min": {
-        "name": "Auxiliary Heating ETA"
+        "name": "Standkachel resterende tijd"
       },
       "auxiliary_heating_status": {
-        "name": "Auxiliary Heating Status"
+        "name": "Status standkachel"
       },
       "brake_fluid_change_due_at": {
-        "name": "Brake Fluid Change Due"
+        "name": "Vervanging remvloeistof vereist"
       },
       "brake_pads_front_inspection_due_at": {
-        "name": "Brake Pads Front Inspection Due"
+        "name": "Inspectie remblokken voor vereist"
       },
       "brake_pads_rear_inspection_due_at": {
-        "name": "Brake Pads Rear Inspection Due"
+        "name": "Inspectie remblokken achter vereist"
       },
       "preferred_workshop_address": {
-        "name": "Preferred Workshop Address"
+        "name": "Adres voorkeursgarage"
       },
       "preferred_workshop_name": {
-        "name": "Preferred Workshop"
+        "name": "Voorkeursgarage"
       },
       "preferred_workshop_phone": {
-        "name": "Preferred Workshop Phone"
+        "name": "Telefoon voorkeursgarage"
       },
       "adblue_level_pct": {
-        "name": "AdBlue Level"
+        "name": "AdBlue-niveau"
       },
       "cng_level_pct": {
-        "name": "CNG Tank Level"
+        "name": "CNG-tankniveau"
       },
       "cng_range_km": {
-        "name": "CNG Range"
+        "name": "CNG-actieradius"
       },
       "primary_engine_range_km": {
-        "name": "Primary Engine Range"
+        "name": "Actieradius primaire motor"
       },
       "charging_preferred_mode": {
-        "name": "Preferred Charging Mode"
+        "name": "Voorkeurslaadmodus"
       },
       "pending_action_id": {
-        "name": "Pending action ID"
+        "name": "ID openstaande actie"
       },
       "pending_action_type": {
-        "name": "Pending action type"
+        "name": "Type openstaande actie"
       },
       "pending_action_status": {
-        "name": "Pending action status"
+        "name": "Status openstaande actie"
       },
       "refuel_trip_distance_km": {
-        "name": "Distance since refuel"
+        "name": "Afstand sinds tanken"
       },
       "refuel_trip_duration_min": {
-        "name": "Drive time since refuel"
+        "name": "Rijtijd sinds tanken"
       },
       "refuel_trip_avg_speed_kmh": {
-        "name": "Avg speed since refuel"
+        "name": "Gem. snelheid sinds tanken"
       },
       "refuel_trip_avg_fuel_consumption_l_100km": {
-        "name": "Avg fuel since refuel"
+        "name": "Gem. brandstofverbruik sinds tanken"
       },
       "refuel_trip_avg_electric_consumption_kwh_100km": {
-        "name": "Avg energy since refuel"
+        "name": "Gem. energieverbruik sinds tanken"
       },
       "refuel_trip_total_fuel_consumption_l": {
-        "name": "Total fuel since refuel"
+        "name": "Totale brandstof sinds tanken"
       },
       "refuel_trip_total_electric_consumption_kwh": {
-        "name": "Total energy since charge"
+        "name": "Totale energie sinds laden"
       },
       "refuel_trip_recuperation_kwh": {
-        "name": "Recuperation since charge"
+        "name": "Recuperatie sinds laden"
       },
       "refuel_trip_timestamp": {
-        "name": "Refuel cycle started"
+        "name": "Tankcyclus gestart"
       },
       "actual_charge_rate_kw": {
-        "name": "Actual charge rate"
+        "name": "Actueel laadvermogen"
       },
       "hv_battery_min_temperature_c": {
-        "name": "HV Battery Temperature (Min)"
+        "name": "HV-accutemperatuur (min)"
       },
       "hv_battery_max_temperature_c": {
-        "name": "HV Battery Temperature (Max)"
+        "name": "HV-accutemperatuur (max)"
       },
       "charge_max_ac_setting": {
-        "name": "Max AC Current (Setting)"
+        "name": "Max AC-stroom (instelling)"
       },
       "charge_max_ac_ampere": {
-        "name": "Max AC Current (Deliverable)"
+        "name": "Max AC-stroom (leverbaar)"
       },
       "auto_release_ac_connector_state": {
-        "name": "Auto Release Connector State"
+        "name": "Status automatische ontgrendeling connector"
       },
       "active_ventilation_state": {
-        "name": "Active Ventilation"
+        "name": "Actieve ventilatie"
       },
       "active_ventilation_remaining_time_min": {
-        "name": "Active Ventilation Remaining"
+        "name": "Actieve ventilatie resterend"
       },
       "battery_support_state": {
         "name": "12V-accuondersteuning"
@@ -646,31 +646,31 @@
         "name": "evcc-laadstatus"
       },
       "connection_state_battery_power_level": {
-        "name": "12V Battery Power Level"
+        "name": "12V-accu laadniveau"
       },
       "last_trip_total_fuel_consumption_l": {
-        "name": "Last Trip Total Fuel"
+        "name": "Laatste rit, totale brandstof"
       },
       "last_trip_total_electric_consumption_kwh": {
-        "name": "Last Trip Total Energy"
+        "name": "Laatste rit, totale energie"
       },
       "notifications_count": {
-        "name": "Notifications count"
+        "name": "Aantal meldingen"
       },
       "last_notification_subject": {
-        "name": "Last notification subject"
+        "name": "Laatste melding, onderwerp"
       },
       "last_notification_severity": {
-        "name": "Last notification severity"
+        "name": "Laatste melding, ernst"
       },
       "engine_oil_temperature_c": {
-        "name": "Engine oil temperature"
+        "name": "Motorolietemperatuur"
       },
       "engine_coolant_temperature_c": {
-        "name": "Engine coolant temperature"
+        "name": "Koelvloeistoftemperatuur"
       },
       "last_trip_reset_at": {
-        "name": "Last Trip Reset"
+        "name": "Laatste ritreset"
       },
       "battery_temp_c": {
         "name": "Batterijtemperatuur"
@@ -1182,16 +1182,16 @@
         "name": "Batterij-Zorg Actief"
       },
       "auto_unlock_when_charged": {
-        "name": "Auto Unlock When Charged"
+        "name": "Automatisch ontgrendelen bij volle lading"
       },
       "climate_at_unlock": {
-        "name": "Climate at Unlock"
+        "name": "Klimaat bij ontgrendelen"
       },
       "window_heating_enabled": {
-        "name": "Window Heating Enabled"
+        "name": "Ruitverwarming ingeschakeld"
       },
       "air_conditioning_without_external_power": {
-        "name": "AC Without External Power"
+        "name": "Airco zonder externe voeding"
       },
       "subscription_active": {
         "name": "Abonnement actief"
@@ -1233,40 +1233,40 @@
         "name": "Oliepeil"
       },
       "seat_heating": {
-        "name": "Seat Heating"
+        "name": "Stoelverwarming"
       },
       "parking_light": {
-        "name": "Parking Light"
+        "name": "Parkeerlicht"
       },
       "external_power": {
-        "name": "External Power Available"
+        "name": "Externe voeding beschikbaar"
       },
       "battery_care": {
-        "name": "Battery Care Mode"
+        "name": "Batterijbeschermingsmodus"
       },
       "energy_flow": {
-        "name": "Energy Flow Active"
+        "name": "Energiestroom actief"
       },
       "area_alarm": {
-        "name": "Geofence Alarm"
+        "name": "Geofence-alarm"
       },
       "auto_release_ac_connector": {
-        "name": "Auto Release AC Connector"
+        "name": "Automatische ontgrendeling AC-connector"
       },
       "optimised_battery_use": {
-        "name": "Optimised Battery Use"
+        "name": "Geoptimaliseerd batterijgebruik"
       },
       "sunroof_rear_closed": {
-        "name": "Rear Sunroof"
+        "name": "Schuifdak achter"
       },
       "roof_cover_closed": {
-        "name": "Roof Cover"
+        "name": "Cabriokap"
       },
       "permission_is_owner": {
-        "name": "Account is primary owner"
+        "name": "Account is hoofdeigenaar"
       },
       "permission_can_command": {
-        "name": "Account can send commands"
+        "name": "Account kan opdrachten verzenden"
       },
       "external_power_available": {
         "name": "Externe voeding beschikbaar"
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Raam rechtsachter"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimaatzone linksvoor"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimaatzone rechtsvoor"
+      },
+      "climate_zone_rear_left": {
+        "name": "Klimaatzone linksachter"
+      },
+      "climate_zone_rear_right": {
+        "name": "Klimaatzone rechtsachter"
+      },
+      "climate_without_external_power": {
+        "name": "Klimaat zonder externe voeding"
+      },
+      "connection_active": {
+        "name": "Verbinding actief"
+      },
+      "daily_power_budget_warning": {
+        "name": "Waarschuwing dagelijks energiebudget"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Waarschuwing batterijniveau te laag"
       }
     },
     "switch": {
@@ -1435,10 +1459,10 @@
         "name": "Max. laadstroom"
       },
       "auxheat_duration": {
-        "name": "Auxiliary Heating Duration"
+        "name": "Duur standkachel"
       },
       "auxheat_target_temp": {
-        "name": "Auxiliary Heating Target Temperature"
+        "name": "Doeltemperatuur standkachel"
       },
       "battery_care_target": {
         "name": "Doel batterijbehoud"
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "3/4 weergave groot"
+      },
+      "vehicle_render": {
+        "name": "Voertuigweergave"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -376,13 +376,13 @@
         "name": "Ostatnia Sesja — Czas Trwania"
       },
       "last_charging_session_start": {
-        "name": "Last Charging Session Start"
+        "name": "Ostatnia sesja ładowania, początek"
       },
       "last_charging_session_current_type": {
-        "name": "Last Charging Session Current Type"
+        "name": "Ostatnia sesja ładowania, typ prądu"
       },
       "last_charging_power_curve_points": {
-        "name": "Last Charging Power Curve Points"
+        "name": "Ostatnia sesja ładowania, punkty krzywej mocy"
       },
       "active_charging_profile_name": {
         "name": "Aktywny Profil Ładowania"
@@ -433,22 +433,22 @@
         "name": "Raporter błędów"
       },
       "requests_remaining_today": {
-        "name": "API Requests Remaining"
+        "name": "Pozostałe żądania API"
       },
       "license_plate": {
-        "name": "License Plate"
+        "name": "Tablica rejestracyjna"
       },
       "equipment_count": {
-        "name": "Equipment Count"
+        "name": "Liczba wyposażenia"
       },
       "secondary_engine_range_km": {
-        "name": "Secondary Engine Range"
+        "name": "Zasięg silnika dodatkowego"
       },
       "secondary_engine_type": {
-        "name": "Secondary Engine Type"
+        "name": "Typ silnika dodatkowego"
       },
       "secondary_engine_fuel_level_pct": {
-        "name": "Secondary Engine Fuel Level"
+        "name": "Poziom paliwa silnika dodatkowego"
       },
       "subscription_expiry_at": {
         "name": "Subskrypcja wygasa"
@@ -505,7 +505,7 @@
         "name": "Następny timer — Docelowe naładowanie osiągalne"
       },
       "capabilities_count": {
-        "name": "Capabilities Count"
+        "name": "Liczba funkcji"
       },
       "tire_pressure_front_left_bar": {
         "name": "Ciśnienie Opony Przód Lewy"
@@ -541,103 +541,103 @@
         "name": "Ostrzeżenia pojazdu"
       },
       "auxiliary_heating_remaining_min": {
-        "name": "Auxiliary Heating ETA"
+        "name": "Ogrzewanie postojowe, pozostały czas"
       },
       "auxiliary_heating_status": {
-        "name": "Auxiliary Heating Status"
+        "name": "Stan ogrzewania postojowego"
       },
       "brake_fluid_change_due_at": {
-        "name": "Brake Fluid Change Due"
+        "name": "Wymiana płynu hamulcowego wymagana"
       },
       "brake_pads_front_inspection_due_at": {
-        "name": "Brake Pads Front Inspection Due"
+        "name": "Przegląd przednich klocków hamulcowych"
       },
       "brake_pads_rear_inspection_due_at": {
-        "name": "Brake Pads Rear Inspection Due"
+        "name": "Przegląd tylnych klocków hamulcowych"
       },
       "preferred_workshop_address": {
-        "name": "Preferred Workshop Address"
+        "name": "Adres preferowanego warsztatu"
       },
       "preferred_workshop_name": {
-        "name": "Preferred Workshop"
+        "name": "Preferowany warsztat"
       },
       "preferred_workshop_phone": {
-        "name": "Preferred Workshop Phone"
+        "name": "Telefon preferowanego warsztatu"
       },
       "adblue_level_pct": {
-        "name": "AdBlue Level"
+        "name": "Poziom AdBlue"
       },
       "cng_level_pct": {
-        "name": "CNG Tank Level"
+        "name": "Poziom zbiornika CNG"
       },
       "cng_range_km": {
-        "name": "CNG Range"
+        "name": "Zasięg na CNG"
       },
       "primary_engine_range_km": {
-        "name": "Primary Engine Range"
+        "name": "Zasięg silnika głównego"
       },
       "charging_preferred_mode": {
-        "name": "Preferred Charging Mode"
+        "name": "Preferowany tryb ładowania"
       },
       "pending_action_id": {
-        "name": "Pending action ID"
+        "name": "ID oczekującej akcji"
       },
       "pending_action_type": {
-        "name": "Pending action type"
+        "name": "Typ oczekującej akcji"
       },
       "pending_action_status": {
-        "name": "Pending action status"
+        "name": "Stan oczekującej akcji"
       },
       "refuel_trip_distance_km": {
-        "name": "Distance since refuel"
+        "name": "Dystans od tankowania"
       },
       "refuel_trip_duration_min": {
-        "name": "Drive time since refuel"
+        "name": "Czas jazdy od tankowania"
       },
       "refuel_trip_avg_speed_kmh": {
-        "name": "Avg speed since refuel"
+        "name": "Śr. prędkość od tankowania"
       },
       "refuel_trip_avg_fuel_consumption_l_100km": {
-        "name": "Avg fuel since refuel"
+        "name": "Śr. zużycie paliwa od tankowania"
       },
       "refuel_trip_avg_electric_consumption_kwh_100km": {
-        "name": "Avg energy since refuel"
+        "name": "Śr. zużycie energii od tankowania"
       },
       "refuel_trip_total_fuel_consumption_l": {
-        "name": "Total fuel since refuel"
+        "name": "Całkowite paliwo od tankowania"
       },
       "refuel_trip_total_electric_consumption_kwh": {
-        "name": "Total energy since charge"
+        "name": "Całkowita energia od ładowania"
       },
       "refuel_trip_recuperation_kwh": {
-        "name": "Recuperation since charge"
+        "name": "Rekuperacja od ładowania"
       },
       "refuel_trip_timestamp": {
-        "name": "Refuel cycle started"
+        "name": "Początek cyklu tankowania"
       },
       "actual_charge_rate_kw": {
-        "name": "Actual charge rate"
+        "name": "Aktualna moc ładowania"
       },
       "hv_battery_min_temperature_c": {
-        "name": "HV Battery Temperature (Min)"
+        "name": "Temperatura akumulatora HV (min.)"
       },
       "hv_battery_max_temperature_c": {
-        "name": "HV Battery Temperature (Max)"
+        "name": "Temperatura akumulatora HV (maks.)"
       },
       "charge_max_ac_setting": {
-        "name": "Max AC Current (Setting)"
+        "name": "Maks. prąd AC (ustawienie)"
       },
       "charge_max_ac_ampere": {
-        "name": "Max AC Current (Deliverable)"
+        "name": "Maks. prąd AC (dostępny)"
       },
       "auto_release_ac_connector_state": {
-        "name": "Auto Release Connector State"
+        "name": "Stan automatycznego zwolnienia złącza"
       },
       "active_ventilation_state": {
-        "name": "Active Ventilation"
+        "name": "Aktywna wentylacja"
       },
       "active_ventilation_remaining_time_min": {
-        "name": "Active Ventilation Remaining"
+        "name": "Pozostała aktywna wentylacja"
       },
       "battery_support_state": {
         "name": "Wsparcie akumulatora 12V"
@@ -646,31 +646,31 @@
         "name": "Stan ładowania evcc"
       },
       "connection_state_battery_power_level": {
-        "name": "12V Battery Power Level"
+        "name": "Poziom naładowania akumulatora 12V"
       },
       "last_trip_total_fuel_consumption_l": {
-        "name": "Last Trip Total Fuel"
+        "name": "Ostatnia podróż, paliwo całkowite"
       },
       "last_trip_total_electric_consumption_kwh": {
-        "name": "Last Trip Total Energy"
+        "name": "Ostatnia podróż, energia całkowita"
       },
       "notifications_count": {
-        "name": "Notifications count"
+        "name": "Liczba powiadomień"
       },
       "last_notification_subject": {
-        "name": "Last notification subject"
+        "name": "Ostatnie powiadomienie, temat"
       },
       "last_notification_severity": {
-        "name": "Last notification severity"
+        "name": "Ostatnie powiadomienie, ważność"
       },
       "engine_oil_temperature_c": {
-        "name": "Engine oil temperature"
+        "name": "Temperatura oleju silnikowego"
       },
       "engine_coolant_temperature_c": {
-        "name": "Engine coolant temperature"
+        "name": "Temperatura płynu chłodzącego"
       },
       "last_trip_reset_at": {
-        "name": "Last Trip Reset"
+        "name": "Ostatnie zerowanie podróży"
       },
       "battery_temp_c": {
         "name": "Temperatura akumulatora"
@@ -1182,16 +1182,16 @@
         "name": "Ochrona Baterii Aktywna"
       },
       "auto_unlock_when_charged": {
-        "name": "Auto Unlock When Charged"
+        "name": "Automatyczne odblokowanie po naładowaniu"
       },
       "climate_at_unlock": {
-        "name": "Climate at Unlock"
+        "name": "Klimatyzacja przy odblokowaniu"
       },
       "window_heating_enabled": {
-        "name": "Window Heating Enabled"
+        "name": "Ogrzewanie szyb włączone"
       },
       "air_conditioning_without_external_power": {
-        "name": "AC Without External Power"
+        "name": "Klimatyzacja bez zasilania zewnętrznego"
       },
       "subscription_active": {
         "name": "Subskrypcja aktywna"
@@ -1233,40 +1233,40 @@
         "name": "Poziom oleju"
       },
       "seat_heating": {
-        "name": "Seat Heating"
+        "name": "Podgrzewanie foteli"
       },
       "parking_light": {
-        "name": "Parking Light"
+        "name": "Światło postojowe"
       },
       "external_power": {
-        "name": "External Power Available"
+        "name": "Zasilanie zewnętrzne dostępne"
       },
       "battery_care": {
-        "name": "Battery Care Mode"
+        "name": "Tryb ochrony akumulatora"
       },
       "energy_flow": {
-        "name": "Energy Flow Active"
+        "name": "Przepływ energii aktywny"
       },
       "area_alarm": {
-        "name": "Geofence Alarm"
+        "name": "Alarm geofence"
       },
       "auto_release_ac_connector": {
-        "name": "Auto Release AC Connector"
+        "name": "Automatyczne zwolnienie złącza AC"
       },
       "optimised_battery_use": {
-        "name": "Optimised Battery Use"
+        "name": "Zoptymalizowane użycie akumulatora"
       },
       "sunroof_rear_closed": {
-        "name": "Rear Sunroof"
+        "name": "Tylny szyberdach"
       },
       "roof_cover_closed": {
-        "name": "Roof Cover"
+        "name": "Dach składany"
       },
       "permission_is_owner": {
-        "name": "Account is primary owner"
+        "name": "Konto jest głównym właścicielem"
       },
       "permission_can_command": {
-        "name": "Account can send commands"
+        "name": "Konto może wysyłać polecenia"
       },
       "external_power_available": {
         "name": "Zasilanie zewnętrzne dostępne"
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Szyba tylna prawa"
+      },
+      "climate_zone_front_left": {
+        "name": "Strefa klimatyzacji przód lewa"
+      },
+      "climate_zone_front_right": {
+        "name": "Strefa klimatyzacji przód prawa"
+      },
+      "climate_zone_rear_left": {
+        "name": "Strefa klimatyzacji tył lewa"
+      },
+      "climate_zone_rear_right": {
+        "name": "Strefa klimatyzacji tył prawa"
+      },
+      "climate_without_external_power": {
+        "name": "Klimatyzacja bez zasilania zewnętrznego"
+      },
+      "connection_active": {
+        "name": "Połączenie aktywne"
+      },
+      "daily_power_budget_warning": {
+        "name": "Ostrzeżenie o dziennym limicie energii"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Ostrzeżenie o zbyt niskim poziomie baterii"
       }
     },
     "switch": {
@@ -1435,10 +1459,10 @@
         "name": "Maks. prąd ładowania"
       },
       "auxheat_duration": {
-        "name": "Auxiliary Heating Duration"
+        "name": "Czas ogrzewania postojowego"
       },
       "auxheat_target_temp": {
-        "name": "Auxiliary Heating Target Temperature"
+        "name": "Docelowa temperatura ogrzewania postojowego"
       },
       "battery_care_target": {
         "name": "Cel ochrony baterii"
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "Widok 3/4 duży"
+      },
+      "vehicle_render": {
+        "name": "Render pojazdu"
       }
     },
     "lock": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -376,13 +376,13 @@
         "name": "Senaste Sessionen — Längd"
       },
       "last_charging_session_start": {
-        "name": "Last Charging Session Start"
+        "name": "Senaste laddning, start"
       },
       "last_charging_session_current_type": {
-        "name": "Last Charging Session Current Type"
+        "name": "Senaste laddning, strömtyp"
       },
       "last_charging_power_curve_points": {
-        "name": "Last Charging Power Curve Points"
+        "name": "Senaste laddning, effektkurvpunkter"
       },
       "active_charging_profile_name": {
         "name": "Aktiv Laddningsprofil"
@@ -433,22 +433,22 @@
         "name": "Felrapportör"
       },
       "requests_remaining_today": {
-        "name": "API Requests Remaining"
+        "name": "Återstående API-förfrågningar"
       },
       "license_plate": {
-        "name": "License Plate"
+        "name": "Registreringsskylt"
       },
       "equipment_count": {
-        "name": "Equipment Count"
+        "name": "Antal utrustning"
       },
       "secondary_engine_range_km": {
-        "name": "Secondary Engine Range"
+        "name": "Räckvidd sekundärmotor"
       },
       "secondary_engine_type": {
-        "name": "Secondary Engine Type"
+        "name": "Sekundär motortyp"
       },
       "secondary_engine_fuel_level_pct": {
-        "name": "Secondary Engine Fuel Level"
+        "name": "Bränslenivå sekundärmotor"
       },
       "subscription_expiry_at": {
         "name": "Prenumeration löper ut"
@@ -490,7 +490,7 @@
         "name": "Aktiva klimattimer"
       },
       "primary_engine_type": {
-        "name": "Primary Engine Type"
+        "name": "Primär motortyp"
       },
       "steering_wheel_position": {
         "name": "Ratt-position"
@@ -505,7 +505,7 @@
         "name": "Nästa timer — Mål-laddning nåbar"
       },
       "capabilities_count": {
-        "name": "Capabilities Count"
+        "name": "Antal funktioner"
       },
       "tire_pressure_front_left_bar": {
         "name": "Däcktryck Fram Vänster"
@@ -541,103 +541,103 @@
         "name": "Fordonsvarningar"
       },
       "auxiliary_heating_remaining_min": {
-        "name": "Auxiliary Heating ETA"
+        "name": "Parkeringsvärmare, återstående tid"
       },
       "auxiliary_heating_status": {
-        "name": "Auxiliary Heating Status"
+        "name": "Status för parkeringsvärmare"
       },
       "brake_fluid_change_due_at": {
-        "name": "Brake Fluid Change Due"
+        "name": "Bromsvätskebyte förfaller"
       },
       "brake_pads_front_inspection_due_at": {
-        "name": "Brake Pads Front Inspection Due"
+        "name": "Kontroll av bromsbelägg fram"
       },
       "brake_pads_rear_inspection_due_at": {
-        "name": "Brake Pads Rear Inspection Due"
+        "name": "Kontroll av bromsbelägg bak"
       },
       "preferred_workshop_address": {
-        "name": "Preferred Workshop Address"
+        "name": "Adress till föredragen verkstad"
       },
       "preferred_workshop_name": {
-        "name": "Preferred Workshop"
+        "name": "Föredragen verkstad"
       },
       "preferred_workshop_phone": {
-        "name": "Preferred Workshop Phone"
+        "name": "Telefon till föredragen verkstad"
       },
       "adblue_level_pct": {
-        "name": "AdBlue Level"
+        "name": "AdBlue-nivå"
       },
       "cng_level_pct": {
-        "name": "CNG Tank Level"
+        "name": "CNG-tanknivå"
       },
       "cng_range_km": {
-        "name": "CNG Range"
+        "name": "CNG-räckvidd"
       },
       "primary_engine_range_km": {
-        "name": "Primary Engine Range"
+        "name": "Räckvidd primärmotor"
       },
       "charging_preferred_mode": {
-        "name": "Preferred Charging Mode"
+        "name": "Föredraget laddläge"
       },
       "pending_action_id": {
-        "name": "Pending action ID"
+        "name": "ID för väntande åtgärd"
       },
       "pending_action_type": {
-        "name": "Pending action type"
+        "name": "Typ av väntande åtgärd"
       },
       "pending_action_status": {
-        "name": "Pending action status"
+        "name": "Status för väntande åtgärd"
       },
       "refuel_trip_distance_km": {
-        "name": "Distance since refuel"
+        "name": "Sträcka sedan tankning"
       },
       "refuel_trip_duration_min": {
-        "name": "Drive time since refuel"
+        "name": "Körtid sedan tankning"
       },
       "refuel_trip_avg_speed_kmh": {
-        "name": "Avg speed since refuel"
+        "name": "Snitthastighet sedan tankning"
       },
       "refuel_trip_avg_fuel_consumption_l_100km": {
-        "name": "Avg fuel since refuel"
+        "name": "Snittbränsle sedan tankning"
       },
       "refuel_trip_avg_electric_consumption_kwh_100km": {
-        "name": "Avg energy since refuel"
+        "name": "Snittenergi sedan tankning"
       },
       "refuel_trip_total_fuel_consumption_l": {
-        "name": "Total fuel since refuel"
+        "name": "Totalt bränsle sedan tankning"
       },
       "refuel_trip_total_electric_consumption_kwh": {
-        "name": "Total energy since charge"
+        "name": "Total energi sedan laddning"
       },
       "refuel_trip_recuperation_kwh": {
-        "name": "Recuperation since charge"
+        "name": "Återvinning sedan laddning"
       },
       "refuel_trip_timestamp": {
-        "name": "Refuel cycle started"
+        "name": "Tankningscykel startad"
       },
       "actual_charge_rate_kw": {
-        "name": "Actual charge rate"
+        "name": "Aktuell laddeffekt"
       },
       "hv_battery_min_temperature_c": {
-        "name": "HV Battery Temperature (Min)"
+        "name": "HV-batteritemperatur (min)"
       },
       "hv_battery_max_temperature_c": {
-        "name": "HV Battery Temperature (Max)"
+        "name": "HV-batteritemperatur (max)"
       },
       "charge_max_ac_setting": {
-        "name": "Max AC Current (Setting)"
+        "name": "Max AC-ström (inställning)"
       },
       "charge_max_ac_ampere": {
-        "name": "Max AC Current (Deliverable)"
+        "name": "Max AC-ström (levererbar)"
       },
       "auto_release_ac_connector_state": {
-        "name": "Auto Release Connector State"
+        "name": "Status för automatisk frigöring av kontakt"
       },
       "active_ventilation_state": {
-        "name": "Active Ventilation"
+        "name": "Aktiv ventilation"
       },
       "active_ventilation_remaining_time_min": {
-        "name": "Active Ventilation Remaining"
+        "name": "Aktiv ventilation återstår"
       },
       "battery_support_state": {
         "name": "12V-batteristöd"
@@ -646,31 +646,31 @@
         "name": "evcc-laddstatus"
       },
       "connection_state_battery_power_level": {
-        "name": "12V Battery Power Level"
+        "name": "12V-batteriets laddnivå"
       },
       "last_trip_total_fuel_consumption_l": {
-        "name": "Last Trip Total Fuel"
+        "name": "Senaste tur, totalt bränsle"
       },
       "last_trip_total_electric_consumption_kwh": {
-        "name": "Last Trip Total Energy"
+        "name": "Senaste tur, total energi"
       },
       "notifications_count": {
-        "name": "Notifications count"
+        "name": "Antal aviseringar"
       },
       "last_notification_subject": {
-        "name": "Last notification subject"
+        "name": "Senaste avisering, ämne"
       },
       "last_notification_severity": {
-        "name": "Last notification severity"
+        "name": "Senaste avisering, allvarsgrad"
       },
       "engine_oil_temperature_c": {
-        "name": "Engine oil temperature"
+        "name": "Motoroljetemperatur"
       },
       "engine_coolant_temperature_c": {
-        "name": "Engine coolant temperature"
+        "name": "Kylvätsketemperatur"
       },
       "last_trip_reset_at": {
-        "name": "Last Trip Reset"
+        "name": "Senaste turnollställning"
       },
       "battery_temp_c": {
         "name": "Batteritemperatur"
@@ -1182,16 +1182,16 @@
         "name": "Batteri-Vård Aktiv"
       },
       "auto_unlock_when_charged": {
-        "name": "Auto Unlock When Charged"
+        "name": "Lås upp automatiskt vid fulladdning"
       },
       "climate_at_unlock": {
-        "name": "Climate at Unlock"
+        "name": "Klimat vid upplåsning"
       },
       "window_heating_enabled": {
-        "name": "Window Heating Enabled"
+        "name": "Rutvärme aktiverad"
       },
       "air_conditioning_without_external_power": {
-        "name": "AC Without External Power"
+        "name": "AC utan extern ström"
       },
       "subscription_active": {
         "name": "Prenumeration aktiv"
@@ -1233,40 +1233,40 @@
         "name": "Oljenivå"
       },
       "seat_heating": {
-        "name": "Seat Heating"
+        "name": "Sätesvärme"
       },
       "parking_light": {
-        "name": "Parking Light"
+        "name": "Parkeringsljus"
       },
       "external_power": {
-        "name": "External Power Available"
+        "name": "Extern ström tillgänglig"
       },
       "battery_care": {
-        "name": "Battery Care Mode"
+        "name": "Batteriskyddsläge"
       },
       "energy_flow": {
-        "name": "Energy Flow Active"
+        "name": "Energiflöde aktivt"
       },
       "area_alarm": {
-        "name": "Geofence Alarm"
+        "name": "Geofence-larm"
       },
       "auto_release_ac_connector": {
-        "name": "Auto Release AC Connector"
+        "name": "Automatisk frigöring av AC-kontakt"
       },
       "optimised_battery_use": {
-        "name": "Optimised Battery Use"
+        "name": "Optimerad batterianvändning"
       },
       "sunroof_rear_closed": {
-        "name": "Rear Sunroof"
+        "name": "Bakre soltak"
       },
       "roof_cover_closed": {
-        "name": "Roof Cover"
+        "name": "Sufflett"
       },
       "permission_is_owner": {
-        "name": "Account is primary owner"
+        "name": "Kontot är primär ägare"
       },
       "permission_can_command": {
-        "name": "Account can send commands"
+        "name": "Kontot kan skicka kommandon"
       },
       "external_power_available": {
         "name": "Extern strömförsörjning tillgänglig"
@@ -1381,6 +1381,30 @@
       },
       "window_rear_right": {
         "name": "Fönster bak höger"
+      },
+      "climate_zone_front_left": {
+        "name": "Klimatzon fram vänster"
+      },
+      "climate_zone_front_right": {
+        "name": "Klimatzon fram höger"
+      },
+      "climate_zone_rear_left": {
+        "name": "Klimatzon bak vänster"
+      },
+      "climate_zone_rear_right": {
+        "name": "Klimatzon bak höger"
+      },
+      "climate_without_external_power": {
+        "name": "Klimat utan extern ström"
+      },
+      "connection_active": {
+        "name": "Anslutning aktiv"
+      },
+      "daily_power_budget_warning": {
+        "name": "Varning för daglig energibudget"
+      },
+      "insufficient_battery_level_warning": {
+        "name": "Varning för låg batterinivå"
       }
     },
     "switch": {
@@ -1435,10 +1459,10 @@
         "name": "Max laddström"
       },
       "auxheat_duration": {
-        "name": "Auxiliary Heating Duration"
+        "name": "Parkeringsvärmare varaktighet"
       },
       "auxheat_target_temp": {
-        "name": "Auxiliary Heating Target Temperature"
+        "name": "Parkeringsvärmare måltemperatur"
       },
       "battery_care_target": {
         "name": "Mål för batterivård"
@@ -1523,6 +1547,9 @@
       },
       "render_angle_lg": {
         "name": "3/4 vy stor"
+      },
+      "vehicle_render": {
+        "name": "Fordonsrendering"
       }
     },
     "lock": {

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -1964,11 +1964,13 @@ class TestSeatCupraGetStatus:
         result = asyncio.run(
             client.get_status("VSSZZE1KZLR000001"))
 
+        # v2.23.2 — doors_individual stores True == OPEN (matches VW EU + the
+        # BinarySensorDeviceClass.DOOR convention). Only frontRight is open.
         assert result.doors_individual == {
-            "frontLeft":  True,
-            "frontRight": False,  # open
-            "rearLeft":   True,
-            "rearRight":  True,
+            "frontLeft":  False,
+            "frontRight": True,   # open
+            "rearLeft":   False,
+            "rearRight":  False,
         }
         assert result.doors_open is True       # frontRight open → at least one
         assert result.doors_locked is False    # rearRight not locked → not all


### PR DESCRIPTION
## 2.23.2 — quality sweep

### Fixed
- **SEAT/CUPRA per-door binary sensors were inverted** — stored "closed" where the rest of the integration (and `BinarySensorDeviceClass.DOOR`) means "open", so a closed door read as open. Now stores `is_open`, matching VW EU + the project convention. (HIGH — a closed door showing open.)
- **8 nameless binary sensors** (climate zones, connection-active, daily-power-budget / low-battery warnings) had their `.name` filed under `entity.sensor` instead of `entity.binary_sensor`, so they rendered without a name. Added under `entity.binary_sensor` in all 12 locales + strings.json.
- **fr / es / nl / pl / cs / sv fully translated** — ~70 entity names were still English in those six languages (de/da/fi/it/nb already done). Filled 422 names, cross-checked against the translated locales; recomputed English-leak count = 0.
- **Vehicle-render image entity localized** — wired to `translation_key="vehicle_render"` instead of a hardcoded English name.

Found by an adversarial-verified integration sweep. Full suite: 4034 passed.