### PR TITLE
Release 2.23.3 — VW NA garage walk (#503/#659), select read-only guard, dedup demotes, render i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.23.3] - 2026-07-24
+
+### Fixed
+
+- **VW US / CA logins that returned "no vehicles" despite a successful sign-in now find the car (#503, #659).** The North-American garage response nests the vehicle list differently for some (e.g. Canadian) accounts, and the parser was looking in one fixed spot. It now walks the whole response to find your vehicle wherever it sits. A genuinely empty account still reports empty.
+- **The charge-mode selector no longer appears in read-only mode.** It sends a command, so like the other command entities it's now hidden when the integration is running read-only.
+- **Audi/VW render images show a localized name.** The seven fixed render viewpoints (side/angle/large/small…) were showing their hardcoded German label in every language; they now use the translated name.
+
+### Changed
+
+- **Fewer duplicate diagnostic sensors.** Six sensors that mirror another sensor's value from a second source (two max-AC-current variants, the charging-block HV min/max temperature clones, and the EU-portal battery-care and energy-flow twins) are now diagnostic and disabled by default. Nothing is removed — existing setups keep them, and the primary sensor of each pair stays enabled.
+
 ## [2.23.2] - 2026-07-24
 
 ### Fixed

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -661,6 +661,7 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         device_class=BinarySensorDeviceClass.POWER,
         icon="mdi:flash",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     # ── v2.15.3 — EU Data Act portal new fields (#465/#514/#515/#516) ────────
     # Battery-care mode on/off (setting.bcam_activation). DIAGNOSTIC.
@@ -670,6 +671,7 @@ _NEW_BINARY: tuple[VagBinarySensorDescription, ...] = (
         data_key="battery_care_mode_active",
         icon="mdi:battery-heart-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     # Front bonnet lock (safe-state family, 2=locked). DIAGNOSTIC.
     VagBinarySensorDescription(

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -510,43 +510,53 @@ class VWNAClient:
         entity-naming downstream.
         """
         data = await self._get(f"{self._base}/account/v1/garage")
-        # Defensive envelope walk: prefer data.data.vehicles (matpoulin
-        # confirmed), fall back to data.vehicles (legacy / forward-
-        # compat if VW NA flattens), else empty list.
-        payload = (
-            (data.get("data") or {}).get("vehicles")
-            or data.get("vehicles")
-            or []
-        )
-        vins = []
-        for vehicle_dict in payload:
-            vin = vehicle_dict.get("vin")
-            uuid = vehicle_dict.get("uuid") or vehicle_dict.get("vehicleId")
-            if vin:
-                if uuid:
-                    self._vin_to_uuid[vin] = uuid
-                # v2.4.1 — cache the human-friendly fields per matpoulin.
-                # Surfaced as sensors in v2.4.1 audit (T1 entities).
-                nickname = vehicle_dict.get("vehicleNickName")
-                if isinstance(nickname, str) and nickname:
-                    self._vin_to_nickname[vin] = nickname
-                model = vehicle_dict.get("modelName")
-                if isinstance(model, str) and model:
-                    self._vin_to_model[vin] = model
-                vins.append(vin)
-                _LOGGER.debug(
-                    "VW NA: found VIN %s uuid=%s nickname=%s model=%s",
-                    _mask_vin(vin), uuid, nickname, model,
-                )
-        if not vins and payload == []:
-            # Empty envelope OR shape didn't match — log diagnostically
-            # so the next user-report includes the actual top-level
-            # keys for diagnosis.
+        # v2.23.3 (#503/#659, vrouleau CA) — robust recursive garage walk.
+        # The old rigid path data["data"]["vehicles"] / data["vehicles"]
+        # returned [] for accounts where VW NA nests the vehicle array deeper
+        # under the 'data' envelope (per-region Cox shape), raising a false
+        # "no vehicles" ConfigEntryNotReady even though auth + the garage call
+        # both succeeded. Mirror the EU-portal parser: walk the whole payload
+        # and treat any dict carrying a 17-char 'vin' as a vehicle, draining
+        # its uuid / nickname / model too. A genuinely empty garage still
+        # walks to zero VINs, so the empty-account behaviour is unchanged.
+        vins: list[str] = []
+
+        def _collect(node: Any) -> None:
+            if isinstance(node, dict):
+                vin = node.get("vin") or node.get("vehicleIdentificationNumber")
+                if isinstance(vin, str) and len(vin) == 17 and vin not in vins:
+                    uuid = node.get("uuid") or node.get("vehicleId")
+                    if uuid:
+                        self._vin_to_uuid[vin] = uuid
+                    nickname = node.get("vehicleNickName")
+                    if isinstance(nickname, str) and nickname:
+                        self._vin_to_nickname[vin] = nickname
+                    model = node.get("modelName")
+                    if isinstance(model, str) and model:
+                        self._vin_to_model[vin] = model
+                    vins.append(vin)
+                    _LOGGER.debug(
+                        "VW NA: found VIN %s uuid=%s nickname=%s model=%s",
+                        _mask_vin(vin), uuid, nickname, model,
+                    )
+                for value in node.values():
+                    _collect(value)
+            elif isinstance(node, list):
+                for value in node:
+                    _collect(value)
+
+        _collect(data)
+        if not vins:
+            # Genuinely empty OR a shape we still don't reach — log the nested
+            # keys (top level + one into 'data') so an unexpected empty result
+            # stays diagnosable from a single DEBUG report.
+            inner = data.get("data") if isinstance(data, dict) else None
             _LOGGER.warning(
-                "VW NA garage returned no vehicles (top-level keys=%s) — "
-                "if this is unexpected, please open an issue with the "
-                "DEBUG log so we can adjust the parser shape",
+                "VW NA garage returned no vehicles (top-level keys=%s, data "
+                "keys=%s) — if this is unexpected, please open an issue with "
+                "the DEBUG log so we can adjust the parser shape",
                 list(data.keys()) if isinstance(data, dict) else type(data).__name__,
+                list(inner.keys()) if isinstance(inner, dict) else type(inner).__name__,
             )
         return vins
 

--- a/custom_components/vag_connect/image.py
+++ b/custom_components/vag_connect/image.py
@@ -339,6 +339,18 @@ def _write_file(path: str, content: bytes) -> None:
 
 
 
+# v2.23.3 — the fixed Audi/VW GraphQL render viewpoints ship a localised name
+# under entity.image.<entity_suffix> in all 12 locales, so wire them to a
+# translation_key. Without this they used view_description, a hardcoded GERMAN
+# label ("Seitenprofil groß" …) that leaked German into every non-German HA.
+# Dynamic OLA / mysmob viewpoints (open-ended, suffix derived at runtime) keep
+# the label fallback.
+_RENDER_TKEYS = frozenset({
+    "render_side_lg", "render_angle_lg", "render_medium",
+    "render_side_sm", "render_small", "render_icon", "render_angle_hd",
+})
+
+
 class VagRenderImageEntity(VagConnectEntity, ImageEntity):
     """One render image entity for a single MediaType + vehicle combination.
 
@@ -362,7 +374,12 @@ class VagRenderImageEntity(VagConnectEntity, ImageEntity):
         VagConnectEntity.__init__(self, coordinator, vin, meta["entity_suffix"])
         ImageEntity.__init__(self, hass, verify_ssl=True)
         self._meta = meta
-        self._attr_name = self._label_for(meta)
+        _suffix = meta["entity_suffix"]
+        if _suffix in _RENDER_TKEYS:
+            self._attr_translation_key = _suffix
+        else:
+            # Open-ended OLA/mysmob viewpoint — keep the backend label.
+            self._attr_name = self._label_for(meta)
         self._attr_image_url = initial_url
         self._attr_image_last_updated = datetime.now(tz=timezone.utc)
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.23.2"
+  "version": "2.23.3"
 }

--- a/custom_components/vag_connect/select.py
+++ b/custom_components/vag_connect/select.py
@@ -136,6 +136,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up charge-mode selects. v1.25.0 PR-C: dynamic listener spawn."""
     coordinator: VagConnectCoordinator = entry.runtime_data
+    # v2.23.3 (#63) — Read-only Mode: the charge-mode select sends a command,
+    # so skip it in read-only mode, matching number/switch/button/climate/lock.
+    if coordinator.is_read_only():
+        return
 
     from .const import CONF_BRAND  # noqa: PLC0415
 

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1704,6 +1704,7 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:thermometer-low",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         suggested_display_precision=1,
     ),
     VagSensorDescription(
@@ -1715,6 +1716,7 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:thermometer-high",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         suggested_display_precision=1,
     ),
     VagSensorDescription(
@@ -1726,6 +1728,7 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:current-ac",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     VagSensorDescription(
         key="charge_max_ac_ampere",
@@ -1736,6 +1739,7 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:current-ac",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     VagSensorDescription(
         key="auto_release_ac_connector_state",

--- a/tests/test_v2233_sweep_fixes.py
+++ b/tests/test_v2233_sweep_fixes.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.23.3 — remaining sweep fixes (triaged + adversarially verified).
+
+- vw_na garage enumeration: robust recursive VIN walk (#503/#659, vrouleau CA)
+  finds a vehicle dict under any nesting, replacing the rigid data.data.vehicles
+  path that returned empty for per-region CA shapes.
+- select.py gains the read-only guard (it sends a charge-mode command).
+- Six duplicate diagnostic sensors demoted to disabled-by-default (kept, not
+  deleted): charge_max_ac_setting/ampere, hv_battery_min/max_temperature_c,
+  battery_care_mode_active, energy_flow_active.
+- Fixed Audi/VW render viewpoints wired to a translation_key (were the hardcoded
+  German "Seitenprofil groß" leaking into non-German HA).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.vag_connect.binary_sensor import BINARY_DESCRIPTIONS
+from custom_components.vag_connect.image import _RENDER_TKEYS
+from custom_components.vag_connect.sensor import SENSOR_DESCRIPTIONS
+
+
+# ── vw_na robust recursive garage walk ───────────────────────────────────────
+
+def _vwna_client():
+    from custom_components.vag_connect.cariad.api.vw_na import VWNAClient
+    c = VWNAClient.__new__(VWNAClient)
+    c._base = "https://x"
+    c._vin_to_uuid = {}
+    c._vin_to_nickname = {}
+    c._vin_to_model = {}
+    return c
+
+
+def test_vwna_finds_vin_under_deep_nesting() -> None:
+    # vrouleau's CA account: vehicles are NOT at data.data.vehicles — the old
+    # rigid path returned [] and raised "no vehicles". A vin-bearing dict nested
+    # anywhere must now be found.
+    c = _vwna_client()
+    c._get = AsyncMock(return_value={  # type: ignore[method-assign]
+        "data": {"garage": {"enrolledVehicles": [
+            {"vehicle": {"vin": "WVWZZZ7AZRE000123", "vehicleId": "uuid-1",
+                         "vehicleNickName": "Nick", "modelName": "ID.4"}},
+        ]}}
+    })
+    vins = asyncio.run(c.get_vehicles())
+    assert vins == ["WVWZZZ7AZRE000123"]
+    assert c._vin_to_uuid["WVWZZZ7AZRE000123"] == "uuid-1"
+    assert c._vin_to_nickname["WVWZZZ7AZRE000123"] == "Nick"
+    assert c._vin_to_model["WVWZZZ7AZRE000123"] == "ID.4"
+
+
+def test_vwna_still_handles_old_flat_shape() -> None:
+    c = _vwna_client()
+    c._get = AsyncMock(return_value={  # type: ignore[method-assign]
+        "data": {"vehicles": [{"vin": "WVWZZZ7AZRE000999", "uuid": "u9"}]}
+    })
+    assert asyncio.run(c.get_vehicles()) == ["WVWZZZ7AZRE000999"]
+
+
+def test_vwna_empty_garage_returns_empty() -> None:
+    c = _vwna_client()
+    c._get = AsyncMock(return_value={"data": {}})  # type: ignore[method-assign]
+    assert asyncio.run(c.get_vehicles()) == []
+
+
+def test_vwna_ignores_non_17char_vin() -> None:
+    c = _vwna_client()
+    c._get = AsyncMock(return_value={  # type: ignore[method-assign]
+        "data": {"placeholder": {"vin": "SHORT"}}
+    })
+    assert asyncio.run(c.get_vehicles()) == []
+
+
+# ── select.py read-only guard ────────────────────────────────────────────────
+
+def test_select_setup_skipped_when_read_only() -> None:
+    from custom_components.vag_connect.select import async_setup_entry
+    coord = MagicMock()
+    coord.is_read_only = MagicMock(return_value=True)
+    entry = MagicMock()
+    entry.runtime_data = coord
+    added: list = []
+    asyncio.run(async_setup_entry(MagicMock(), entry, added.extend))
+    assert added == []  # charge-mode select sends a command → skipped
+
+
+# ── dedup demotes (kept, disabled-by-default) ────────────────────────────────
+
+def test_duplicate_sensors_disabled_by_default() -> None:
+    demoted = {
+        "charge_max_ac_setting", "charge_max_ac_ampere",
+        "hv_battery_min_temperature_c", "hv_battery_max_temperature_c",
+    }
+    by_key = {d.key: d for d in SENSOR_DESCRIPTIONS}
+    for k in demoted:
+        assert k in by_key, f"{k} was deleted (should be demoted, not removed)"
+        assert by_key[k].entity_registry_enabled_default is False, k
+
+
+def test_duplicate_binary_sensors_disabled_by_default() -> None:
+    by_key = {d.key: d for d in BINARY_DESCRIPTIONS}
+    for k in ("battery_care_mode_active", "energy_flow_active"):
+        assert k in by_key, f"{k} was deleted"
+        assert by_key[k].entity_registry_enabled_default is False, k
+
+
+# ── image render viewpoints wired to translation_key ─────────────────────────
+
+def test_render_catalog_keys_have_translation_keys() -> None:
+    # the 7 fixed Audi/VW GraphQL viewpoints are the ones that leaked German.
+    assert _RENDER_TKEYS == {
+        "render_side_lg", "render_angle_lg", "render_medium",
+        "render_side_sm", "render_small", "render_icon", "render_angle_hd",
+    }

--- a/tests/test_v241_sprint_d.py
+++ b/tests/test_v241_sprint_d.py
@@ -224,9 +224,11 @@ class TestVWNAGarageEnvelope:
 
     def test_parser_walks_data_envelope(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        # Defensive walk: data.data.vehicles preferred, top-level fallback.
-        assert "(data.get(\"data\") or {}).get(\"vehicles\")" in src
-        assert 'or data.get("vehicles")' in src
+        # v2.23.3 (#503/#659) — robust recursive walk that finds a vehicle dict
+        # under any nesting, replacing the old rigid data.data.vehicles path.
+        assert "def _collect(" in src
+        assert 'node.get("vin")' in src
+        assert "len(vin) == 17" in src
 
     def test_nickname_cache_added(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")


### PR DESCRIPTION
## 2.23.3 — triaged sweep follow-ups

### Fixed
- **VW US/CA "no vehicles" despite successful login (#503, #659).** The NA garage response nests the vehicle list differently for some (CA) accounts; `get_vehicles` now walks the whole response for any 17-char VIN-bearing dict (mirrors the EU-portal parser), draining uuid/nickname/model. Strict superset of the old rigid path; a genuinely empty garage still returns []. Live-gated on vrouleau's confirmation.
- **Charge-mode selector now hidden in read-only mode** — it sends a command; it was the only command platform missing the `is_read_only()` guard.
- **Audi/VW render images localized** — the 7 fixed GraphQL viewpoints leaked a hardcoded German label; wired to their existing translation_key. Dynamic OLA/mysmob viewpoints keep the label fallback.

### Changed
- **6 duplicate diagnostic sensors demoted to disabled-by-default** (kept, not deleted): two max-AC-current variants, the charging-block HV min/max temperature clones, and the EU-portal battery-care + energy-flow twins. The 4 dedup groups already in the desired state / legit-distinct were left untouched per the triage.

All triaged + adversarially verified. tests/test_v2233_sweep_fixes.py (8 new). Full suite 4034 passed.