### PR TITLE
fix: stop the setup path destroying stored vehicle data (v2.24.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.24.1] - 2026-07-27
+
+### Fixed
+
+- **Your car's recorded values are no longer wiped when a restart happens during a backend outage (#702).** If the very first data fetch after starting Home Assistant came back empty, the integration wrote that emptiness over everything it had saved, and the next poll then made it permanent. So a car that the portal was quiet about lost its history on every restart, and importing an older export was pointless because the next restart deleted it again. The periodic polls have been protected against this for a while; the fetch that runs at startup was not, and now is. A brand new car still appears normally on its first setup.
+- **A parking position that is being kept during an outage now says how old it is.** Keeping the last known position when the backend answers without coordinates is deliberate, since a parked car has not moved. But it was being kept indefinitely and with nothing to indicate its age, so a position from last week looked exactly like one from a minute ago. It is now kept for at most a day, the map entry carries the time the car itself reported that position, and the address is kept and dropped together with the coordinates instead of leaving a half-filled location behind.
+- **Parking lights and parking brake no longer read as "on" when the car says they are off.** Some cars send a flag that only means "this section of the report is present" alongside the real reading. That flag was being trusted first, so a car reporting both parking lights explicitly off, or the parking brake explicitly released, was still shown as on or engaged. The real reading now wins. Cars that send nothing but the flag are unaffected.
+- **Adding the volkswagen.de channel now says why it failed.** Every failure was reported as a wrong password and nothing was written to the log, so an expired session, a redirect loop and an actual typo all looked the same and none of them could be told apart. The reason is now logged, exactly like the equivalent step during initial setup already did.
+
 ## [2.24.0] - 2026-07-26
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -4375,6 +4375,13 @@ class VWEUClient(CariadBaseClient):
             if lat is not None and lon is not None:
                 d.latitude = lat
                 d.longitude = lon
+                # v2.24.1 — record the BACKEND's capture time alongside the
+                # coordinates. #923 made the position carry forward through an
+                # outage, which is correct, but without this the carried value
+                # had no age and read as current no matter how old it was.
+                _pos_ts = parking_data.get("carCapturedTimestamp")
+                if isinstance(_pos_ts, str) and _pos_ts:
+                    d.position_captured_at = _pos_ts
             # v1.25.0 PR-A — Cross-brand parity: parking_address from
             # Cariad-BFF if present (Skoda mysmob ships
             # ``formattedAddress`` since v1.20.0). Cariad-BFF

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1961,12 +1961,20 @@ def map_dataset_to_vehicle_data(
         d.parking_light_right = _plr_b
     # v2.17.5 — parkinglightstate.is_set: some dialects send only this flag and
     # not the per-side lights above (mirrors the parking_brake.is_set precedent).
-    # "true"/"set" = a parking light is on.
+    #
+    # v2.24.1 — ORDER FIX. ``is_set`` says "this container was populated", not
+    # "the light is on", so it must never outrank a real reading. It used to be
+    # evaluated FIRST, so a car sending is_set=true together with both per-side
+    # lights explicitly off came out as "parking light on", and the per-side
+    # branch below could no longer correct it because parking_light was no
+    # longer None. Real per-side values now win; the flag survives only as the
+    # fallback for dialects that send nothing else.
     _pls = first("parkinglightstate.is_set", "parkinglightstate_is_set")
-    if _pls is not None and d.parking_light is None:
-        d.parking_light = str(_pls).strip().lower() in ("true", "1", "set")
-    if (_pll_b is not None or _plr_b is not None) and d.parking_light is None:
-        d.parking_light = bool(_pll_b) or bool(_plr_b)
+    if d.parking_light is None:
+        if _pll_b is not None or _plr_b is not None:
+            d.parking_light = bool(_pll_b) or bool(_plr_b)
+        elif _pls is not None:
+            d.parking_light = str(_pls).strip().lower() in ("true", "1", "set")
 
     # Capture timestamp → last_seen_at. epoch-seconds→ISO-8601 UTC; ISO
     # passthrough. (_dataset_captured_ts already reads these for freshness —
@@ -2007,13 +2015,20 @@ def map_dataset_to_vehicle_data(
         d.last_seen_at = cap_iso
 
     # parking_brake.is_set → parking_brake_engaged (shared field).
-    # Unreleased (Scout #947) — `parking_brake.parking_brake` is the same datum
-    # SELF-QUALIFIED (leaf nested under its own container). Added LAST so the
-    # is_set spellings still win; without it the dotted key re-surfaced in the
-    # Scout every poll because the synonym-collapse only reclaims the spelling
-    # that was actually matched. No new entity.
-    _pb = first("parking_brake.is_set", "parking_brake_is_set", "parking_brake",
-                "parking_brake.parking_brake")
+    # Scout #947 — `parking_brake.parking_brake` is the same datum SELF-QUALIFIED
+    # (leaf nested under its own container).
+    #
+    # v2.24.1 — PRECEDENCE FIX, same defect as the parking light above. These
+    # used to share one ``first()`` with the is_set spellings listed first, and
+    # the comment even said the is_set spellings were meant to win. They must
+    # not: a payload carrying is_set=true alongside parking_brake=false made us
+    # report the brake ENGAGED on a car that had said it was released. Read the
+    # two groups separately so the real value wins and the flag is only a
+    # fallback — and so BOTH spellings still get reclaimed by the synonym
+    # collapse, which is what kept the dotted key out of the Scout.
+    _pb_real = first("parking_brake.parking_brake", "parking_brake")
+    _pb_flag = first("parking_brake.is_set", "parking_brake_is_set")
+    _pb = _pb_real if _pb_real is not None else _pb_flag
     if _pb is not None:
         d.parking_brake_engaged = str(_pb).lower() in ("true", "1", "set")
 

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -697,6 +697,13 @@ class VehicleData:
     parking_address: str | None = None
     parking_city: str | None = None
     heading: int | None = None
+    # v2.24.1 — when the BACKEND says the position was captured, as opposed to
+    # when we polled. Carrying a parked position forward through an outage is
+    # right (the car has not moved), but doing it with no age attached made a
+    # week-old position indistinguishable from a current one. This is what the
+    # carry-forward TTL in ``vehicle_cache.reconcile`` measures against, and what
+    # the device_tracker exposes so the age is visible rather than implied.
+    position_captured_at: str | None = None
 
     # Status
     vehicle_state: str | None = None

--- a/custom_components/vag_connect/cariad/vehicle_cache.py
+++ b/custom_components/vag_connect/cariad/vehicle_cache.py
@@ -12,6 +12,7 @@ This module is the pure reconcile/serialise logic; the coordinator owns the
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 VEHICLE_CACHE_VERSION = 1
@@ -38,13 +39,56 @@ CARRY_FORWARD_FIELDS: frozenset[str] = frozenset({
     "fuel_tank_capacity_liters",
     "service_km", "oil_service_km", "service_due_in_days", "oil_service_due_in_days",
     "last_seen_at",
-    # #923 — the parked position belongs in the "old but visible" class too: a
-    # degraded parkingposition response that omits the coordinates does NOT mean
-    # the car moved, and blanking them sent the device_tracker to "unknown"
-    # mid-outage. A parked car is still where it last was, and the poll that
-    # brings real coordinates back overwrites these immediately.
-    "latitude", "longitude",
 })
+
+# #923 — the parked position belongs in the "old but visible" class too: a
+# degraded parkingposition response that omits the coordinates does NOT mean the
+# car moved, and blanking them sent the device_tracker to "unknown" mid-outage.
+# A parked car is still where it last was, and the poll that brings real
+# coordinates back overwrites these immediately.
+#
+# v2.24.1 — but NOT forever, and not as a bare pair. Held in CARRY_FORWARD_FIELDS
+# these were carried with no age attached and across restarts, so a position from
+# last week presented exactly like one from a minute ago, and the backend's own
+# ``parkingPositionNotAvailable`` was masked rather than surfaced. They are now
+# reconciled as one group under a TTL, address and city included: carrying
+# coordinates while dropping the address left a half-position that read as a
+# parser fault, and the address is the only staleness hint a user actually sees.
+POSITION_FIELDS: tuple[str, ...] = (
+    "latitude", "longitude", "parking_address", "parking_city",
+)
+
+# How long a recorded position may still be shown when the backend stops serving
+# one. A parked car really does stay put, so this is generous; it exists to stop
+# an indefinitely stale position, not to expire a legitimately parked one.
+POSITION_MAX_AGE_S: int = 24 * 3600
+
+
+def _parse_iso(raw: Any) -> datetime | None:
+    """Best-effort ISO-8601 → aware datetime. ``None`` when unparseable."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def position_age_seconds(previous: dict[str, Any]) -> float | None:
+    """Age of a recorded position, or ``None`` when it cannot be established.
+
+    Prefers the backend's own capture time and falls back to ``last_seen_at``.
+    An unknown age is deliberately NOT treated as expired: brands that never
+    supply a timestamp would otherwise lose a working position entirely.
+    """
+    for key in ("position_captured_at", "last_seen_at"):
+        stamp = _parse_iso(previous.get(key))
+        if stamp is not None:
+            return (datetime.now(tz=timezone.utc) - stamp).total_seconds()
+    return None
 
 # Fields that physically only ever increase. A fresh value below the recorded
 # one is a bad reading (the portal occasionally serves a stale / zero odometer)
@@ -77,6 +121,21 @@ def reconcile(
     for field in CARRY_FORWARD_FIELDS:
         if merged.get(field) is None and previous.get(field) is not None:
             merged[field] = previous[field]
+    # Position — carried as ONE group and only when the fresh poll has no
+    # coordinates at all. Topping a fresh position up with the previous
+    # address would pin last week's street name onto this minute's
+    # coordinates, which is worse than showing no address.
+    if merged.get("latitude") is None and merged.get("longitude") is None:
+        age = position_age_seconds(previous)
+        if age is not None and age > POSITION_MAX_AGE_S:
+            notes.append(
+                f"recorded position is {age / 3600:.0f}h old "
+                f"(limit {POSITION_MAX_AGE_S // 3600}h); dropped, not carried"
+            )
+        else:
+            for field in (*POSITION_FIELDS, "position_captured_at"):
+                if merged.get(field) is None and previous.get(field) is not None:
+                    merged[field] = previous[field]
     for field in MONOTONIC_INCREASING_FIELDS:
         new = merged.get(field)
         old = previous.get(field)

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -2337,9 +2337,19 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
             return True
         except AuthenticationError as err:
             await self._ovw_close_session()
+            # v2.24.1 (#957) — this is the options-flow twin of the setup-time
+            # login at line ~637, and it was the only one of the two that stayed
+            # silent. Every one of the upstream raise sites landed here as a bare
+            # "invalid_credentials", so a redirect loop, an expired SSO session or
+            # a portal outage all told the user their password was wrong and left
+            # nothing in the log to tell them apart.
+            _LOGGER.warning("Website authproxy login failed: %s", err)
             raise ValueError("invalid_credentials") from err
         except Exception as err:  # noqa: BLE001
             await self._ovw_close_session()
+            _LOGGER.error(
+                "Website authproxy unexpected error: %s", type(err).__name__,
+            )
             raise ValueError("cannot_connect") from err
         if result == "otp_required":
             return True

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1035,24 +1035,63 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # threading.Lock, and awaiting while holding one parks the whole
             # event loop for any other task that tries to acquire it — the
             # merge does network I/O, so it must not run inside.
-            prepared: list[tuple[str, dict[str, Any] | None, bool]] = []
+            prepared: list[tuple[str, dict[str, Any] | None, bool, bool]] = []
             for vin, result in zip(vins, results):
                 if isinstance(result, Exception):
                     _LOGGER.warning("Could not fetch status for %s: %s", mask_vin(vin), result)
-                    prepared.append((vin, None, True))
+                    prepared.append((vin, None, True, False))
                     continue
                 if isinstance(result, VehicleData):
                     merged = await self._merge_supplementary(vin, result)
                     data = merged.to_dict()
                     data["_client"] = self._cariad_client
-                    prepared.append((vin, await self._enrich(data), False))
+                    prepared.append((
+                        vin,
+                        await self._enrich(data),
+                        False,
+                        bool(getattr(merged, "no_data", False)),
+                    ))
+
+            # v2.24.1 (#702) — the poll loop has guarded this since v2.15.0a10
+            # (line ~1994) and this path never did, which made the fix only half
+            # landed. A no-data portal response is NOT an exception: it returns a
+            # bare VehicleData, so it arrived here with failed=False and wrote
+            # blanks straight over the snapshot restored at line ~874. The first
+            # poll afterwards then reconciled against those blanks (nothing left
+            # to carry forward) and persisted them, so every restart of a car
+            # whose setup poll came back empty destroyed its stored values for
+            # good — and made ``import_historical_export`` a no-op for exactly
+            # the users it exists for. Same two-stage treatment as the poll loop:
+            # keep last-known-good VISIBLE on no-data, and reconcile a partial
+            # payload instead of letting it blank recorded fields.
+            from .cariad.vehicle_cache import reconcile  # noqa: PLC0415
 
             with self._vehicles_lock:
-                for vin, prepared_data, failed in prepared:
+                for vin, prepared_data, failed, no_data in prepared:
                     if failed or prepared_data is None:
                         if hasattr(self, "vehicle_success"):
                             self.vehicle_success[vin] = False
                         continue
+                    # "Old but visible": a VIN we have never seen still falls
+                    # through, so a brand-new car appears on first setup.
+                    if no_data and self.vehicles.get(vin):
+                        self.vehicles[vin]["_poll_failed"] = True
+                        if hasattr(self, "vehicle_success"):
+                            self.vehicle_success[vin] = False
+                        _LOGGER.debug(
+                            "VAG Connect portal-safety %s: setup poll returned "
+                            "no data; keeping the restored snapshot",
+                            mask_vin(vin),
+                        )
+                        continue
+                    prepared_data, _setup_disc = reconcile(
+                        self.vehicles.get(vin), prepared_data
+                    )
+                    if _setup_disc:
+                        _LOGGER.debug(
+                            "VAG Connect portal-safety %s (setup): %s",
+                            mask_vin(vin), "; ".join(_setup_disc),
+                        )
                     self.vehicles[vin] = self._apply_optimistic_hold(vin, prepared_data)
                     if hasattr(self, "vehicle_success"):
                         self.vehicle_success[vin] = True

--- a/custom_components/vag_connect/device_tracker.py
+++ b/custom_components/vag_connect/device_tracker.py
@@ -122,6 +122,12 @@ class VagConnectTracker(VagConnectEntity, TrackerEntity):
             "parking_address",
             "parking_city",
             "last_seen_at",
+            # v2.24.1 — when the BACKEND captured this position, which is not
+            # the same as when we last polled. A parked position is carried
+            # through a backend outage on purpose (#923); this is what lets a
+            # user tell a position from a minute ago from one from yesterday
+            # instead of having to trust that the marker is current.
+            "position_captured_at",
             "vehicle_state",
             "model",
             "model_year",

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -18,5 +18,5 @@
     "firebase-messaging>=0.4.0",
     "aiomqtt>=2.0.0"
   ],
-  "version": "2.24.0"
+  "version": "2.24.1"
 }

--- a/tests/test_v2241_setup_data_loss_and_position_ttl.py
+++ b/tests/test_v2241_setup_data_loss_and_position_ttl.py
@@ -1,0 +1,313 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.24.1 — the setup path stops destroying stored data, and a carried
+position stops pretending to be current.
+
+The headline bug (#702, Bugi66's Touareg): he reported that values used to
+appear and then stopped, and we were one reply away from telling him he was
+misremembering. He was not. ``async_setup`` restored the last-known-good
+snapshot and then overwrote it twelve lines later, because the only guard was
+``isinstance(result, Exception)`` and a no-data portal response is not an
+exception — it is a bare ``VehicleData``. It therefore arrived with
+``failed=False`` and blanked the restore. The first poll afterwards reconciled
+against those blanks, found nothing left to carry, and persisted them.
+
+The poll loop has guarded exactly this since v2.15.0a10. This path never did,
+which is what made the fix only half landed and turned
+``import_historical_export`` into a no-op for the users it exists for: import,
+see data, restart, gone.
+
+Second theme, from the same sweep: v2.24.0 fixed #923 by carrying the parked
+position forward, which is right — a parked car has not moved — but it carried
+it with no age attached and across restarts, so a week-old position was
+indistinguishable from a current one, and the backend's own
+``parkingPositionNotAvailable`` was masked rather than surfaced.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.vag_connect.cariad.models import VehicleData
+from custom_components.vag_connect.cariad.vehicle_cache import (
+    CARRY_FORWARD_FIELDS,
+    POSITION_FIELDS,
+    POSITION_MAX_AGE_S,
+    position_age_seconds,
+    reconcile,
+)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _ago(**kw) -> str:
+    return _iso(datetime.now(tz=timezone.utc) - timedelta(**kw))
+
+
+# ── 1. the setup path must not destroy the restored snapshot ────────────────
+
+
+class TestSetupPathDataLoss:
+    """#702 — a no-data setup poll must keep last-known-good visible."""
+
+    def _coord(self, restored: dict | None = None):
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        coord.hass = MagicMock()
+        coord.hass.loop = MagicMock()
+        coord.hass.loop.call_soon_threadsafe = MagicMock()
+        coord.entry = MagicMock()
+        coord.entry.entry_id = "test"
+        coord.entry.data = {
+            "brand": "volkswagen", "username": "u@t.de",
+            "password": "pw", "spin": "", "scan_interval": 5,
+        }
+        coord._vehicles_lock = threading.Lock()
+        coord._cariad_client = None
+        coord._started = False
+        coord._was_available = True
+        coord.vehicles = {"VIN123": dict(restored)} if restored else {}
+        coord.data = None
+        coord.async_set_updated_data = MagicMock()
+        coord.async_request_refresh = AsyncMock()
+        coord.logger = MagicMock()
+        return coord
+
+    def _client(self, status):
+        client = MagicMock()
+        client.authenticate = AsyncMock()
+        client.get_vehicles = AsyncMock(return_value=["VIN123"])
+        client.get_status = AsyncMock(return_value=status)
+        return client
+
+    def _run(self, coord, client):
+        from custom_components.vag_connect.cariad.api.factory import CariadClientFactory
+        with patch.object(CariadClientFactory, "create", return_value=client), \
+             patch(
+                 "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+                 return_value=MagicMock(),
+             ):
+            return asyncio.run(coord.async_setup())
+
+    def test_no_data_poll_does_not_blank_the_restored_snapshot(self) -> None:
+        """THE regression. Before the fix this asserted-away his data."""
+        restored = {
+            "vin": "VIN123", "battery_soc": 64, "odometer_km": 81234,
+            "fuel_level": 30, "_restored": True, "_poll_failed": False,
+        }
+        coord = self._coord(restored=restored)
+        empty = VehicleData(vin="VIN123")
+        empty.no_data = True
+
+        self._run(coord, self._client(empty))
+
+        kept = coord.vehicles["VIN123"]
+        assert kept["battery_soc"] == 64, "a no-data setup poll wiped stored data"
+        assert kept["odometer_km"] == 81234
+        assert kept["fuel_level"] == 30
+        # ...and it is marked as a failed poll so the stale-cache watchdog engages
+        assert kept["_poll_failed"] is True
+
+    def test_a_brand_new_vin_still_appears_on_no_data(self) -> None:
+        """The guard must not stop a first-ever car from being created."""
+        coord = self._coord(restored=None)
+        empty = VehicleData(vin="VIN123")
+        empty.no_data = True
+
+        self._run(coord, self._client(empty))
+
+        assert "VIN123" in coord.vehicles
+
+    def test_real_data_still_overwrites_normally(self) -> None:
+        coord = self._coord(restored={"vin": "VIN123", "battery_soc": 10})
+        fresh = VehicleData(vin="VIN123", battery_soc=88)
+
+        self._run(coord, self._client(fresh))
+
+        assert coord.vehicles["VIN123"]["battery_soc"] == 88
+
+    def test_partial_setup_payload_carries_recorded_values_forward(self) -> None:
+        """The setup path now reconciles, exactly like the poll loop."""
+        coord = self._coord(restored={
+            "vin": "VIN123", "battery_soc": 64, "odometer_km": 81234,
+        })
+        # fresh poll knows the SoC but omits the odometer entirely
+        partial = VehicleData(vin="VIN123", battery_soc=70)
+
+        self._run(coord, self._client(partial))
+
+        kept = coord.vehicles["VIN123"]
+        assert kept["battery_soc"] == 70, "fresh value must win"
+        assert kept["odometer_km"] == 81234, "omitted value must carry forward"
+
+
+# ── 2. position carry-forward is bounded and dated ──────────────────────────
+
+
+class TestPositionTTL:
+    """#923 follow-up — carrying a position is right, hiding its age is not."""
+
+    def test_a_recent_position_is_still_carried(self) -> None:
+        previous = {
+            "latitude": 47.39, "longitude": 8.05,
+            "parking_address": "Bünzweg 16", "parking_city": "Othmarsingen",
+            "position_captured_at": _ago(hours=2),
+        }
+        merged, notes = reconcile(previous, {"vin": "X"})
+        assert merged["latitude"] == 47.39
+        assert merged["parking_address"] == "Bünzweg 16"
+        assert not notes
+
+    def test_a_stale_position_is_dropped_not_carried(self) -> None:
+        previous = {
+            "latitude": 47.39, "longitude": 8.05,
+            "parking_address": "Bünzweg 16",
+            "position_captured_at": _ago(days=9),
+        }
+        merged, notes = reconcile(previous, {"vin": "X"})
+        assert merged.get("latitude") is None, "a 9-day-old position read as current"
+        assert merged.get("parking_address") is None
+        assert any("dropped" in n for n in notes)
+
+    def test_unknown_age_is_not_treated_as_expired(self) -> None:
+        """Brands that never send a timestamp must not lose their position."""
+        previous = {"latitude": 47.39, "longitude": 8.05}
+        merged, _ = reconcile(previous, {"vin": "X"})
+        assert merged["latitude"] == 47.39
+
+    def test_last_seen_at_is_the_fallback_clock(self) -> None:
+        old = {"latitude": 1.0, "longitude": 2.0, "last_seen_at": _ago(days=5)}
+        merged, notes = reconcile(old, {"vin": "X"})
+        assert merged.get("latitude") is None
+        assert any("dropped" in n for n in notes)
+
+        recent = {"latitude": 1.0, "longitude": 2.0, "last_seen_at": _ago(hours=1)}
+        merged2, _ = reconcile(recent, {"vin": "X"})
+        assert merged2["latitude"] == 1.0
+
+    def test_a_fresh_position_never_inherits_the_old_address(self) -> None:
+        """The subtle one: topping fresh coordinates up with a previous address
+        would pin last week's street name onto this minute's position."""
+        previous = {
+            "latitude": 47.39, "longitude": 8.05,
+            "parking_address": "Bünzweg 16", "parking_city": "Othmarsingen",
+            "position_captured_at": _ago(minutes=5),
+        }
+        fresh = {"vin": "X", "latitude": 46.20, "longitude": 6.14}
+        merged, _ = reconcile(previous, fresh)
+        assert merged["latitude"] == 46.20
+        assert merged.get("parking_address") is None, "stale address pinned to a new position"
+        assert merged.get("parking_city") is None
+
+    def test_the_capture_timestamp_travels_with_a_carried_position(self) -> None:
+        """Otherwise the carried position loses its age and is carried forever."""
+        stamp = _ago(hours=3)
+        previous = {"latitude": 1.0, "longitude": 2.0, "position_captured_at": stamp}
+        merged, _ = reconcile(previous, {"vin": "X"})
+        assert merged["position_captured_at"] == stamp
+
+    def test_position_fields_left_the_blanket_carry_forward_set(self) -> None:
+        # they are reconciled as a TTL'd group now, not unconditionally
+        for field in POSITION_FIELDS:
+            assert field not in CARRY_FORWARD_FIELDS, field
+
+    def test_position_age_helper(self) -> None:
+        assert position_age_seconds({}) is None
+        assert position_age_seconds({"position_captured_at": "not-a-date"}) is None
+        age = position_age_seconds({"position_captured_at": _ago(hours=1)})
+        assert age is not None and 3000 < age < 4200
+        # a Z-suffixed stamp is the shape the backend actually sends
+        assert position_age_seconds(
+            {"position_captured_at": datetime.now(tz=timezone.utc)
+             .replace(microsecond=0).isoformat().replace("+00:00", "Z")}
+        ) is not None
+
+    def test_ttl_is_a_day(self) -> None:
+        assert POSITION_MAX_AGE_S == 24 * 3600
+
+
+# ── 3. is_set is a presence flag, never a state ─────────────────────────────
+
+
+class TestIsSetPrecedence:
+    """A container being populated does not mean the thing is switched on."""
+
+    def _map(self, payload: dict) -> VehicleData:
+        from custom_components.vag_connect.cariad.auth._eu_data_act import (
+            map_dataset_to_vehicle_data,
+        )
+        return map_dataset_to_vehicle_data(payload, VehicleData(vin="X"))
+
+    def test_both_lights_off_beats_is_set_true(self) -> None:
+        """The reported symptom: parking lights permanently "on"."""
+        d = self._map({
+            "parkinglightstate.is_set": "true",
+            "parking_light_left": "false",
+            "parking_light_right": "false",
+        })
+        assert d.parking_light is False, "is_set outranked two explicit 'off' readings"
+
+    def test_one_light_on_still_reads_on(self) -> None:
+        d = self._map({
+            "parkinglightstate.is_set": "true",
+            "parking_light_left": "true",
+            "parking_light_right": "false",
+        })
+        assert d.parking_light is True
+
+    def test_is_set_alone_is_still_honoured(self) -> None:
+        """v2.17.5 behaviour for dialects that send nothing else — kept."""
+        assert self._map({"parkinglightstate.is_set": "true"}).parking_light is True
+        assert self._map({"parkinglightstate.is_set": "false"}).parking_light is False
+
+    def test_released_parking_brake_beats_is_set_true(self) -> None:
+        d = self._map({
+            "parking_brake.is_set": "true",
+            "parking_brake.parking_brake": "false",
+        })
+        assert d.parking_brake_engaged is False, "reported a released brake as engaged"
+
+    def test_engaged_parking_brake_still_reads_engaged(self) -> None:
+        d = self._map({
+            "parking_brake.is_set": "true",
+            "parking_brake.parking_brake": "true",
+        })
+        assert d.parking_brake_engaged is True
+
+    def test_parking_brake_is_set_alone_is_still_honoured(self) -> None:
+        assert self._map({"parking_brake.is_set": "true"}).parking_brake_engaged is True
+
+
+# ── 4. the position timestamp is parsed and exposed ────────────────────────
+
+
+def test_vw_eu_records_the_backend_capture_time() -> None:
+    from custom_components.vag_connect.cariad.models import VehicleData as VD
+    d = VD(vin="X")
+    parking = {"data": {
+        "lat": 47.39, "lon": 8.05,
+        "carCapturedTimestamp": "2026-07-26T17:51:13Z",
+    }}
+    # mirror the assignment block in vw_eu.get_status
+    pd = parking["data"]
+    if pd.get("lat") is not None and pd.get("lon") is not None:
+        d.latitude, d.longitude = pd["lat"], pd["lon"]
+        ts = pd.get("carCapturedTimestamp")
+        if isinstance(ts, str) and ts:
+            d.position_captured_at = ts
+    assert d.position_captured_at == "2026-07-26T17:51:13Z"
+    assert "position_captured_at" in d.to_dict()
+
+
+def test_device_tracker_exposes_the_capture_time() -> None:
+    import inspect
+    from custom_components.vag_connect import device_tracker
+    src = inspect.getsource(device_tracker)
+    assert '"position_captured_at",' in src, (
+        "the carried position must expose its age, otherwise a user cannot "
+        "tell yesterday's marker from this minute's"
+    )


### PR DESCRIPTION
## The bug

`async_setup` restored the last-known-good snapshot from `.storage` and then overwrote it twelve lines later. The only guard was `isinstance(result, Exception)`, and a no-data portal response is not an exception: it is a bare `VehicleData`, so it arrived with `failed=False` and blanked the restore. The first poll afterwards reconciled against those blanks, found nothing left to carry forward, and persisted them.

Net effect: every restart of a car whose setup poll came back empty destroyed its stored values permanently, and `import_historical_export` was a no-op for exactly the users it exists for. Import, see data, restart, gone.

The poll loop has guarded this since v2.15.0a10. This path never did, which made that fix only half landed. `reconcile()` had exactly one call site in the whole codebase, in the poll loop.

Found while re-triaging #702, where the reporter said values used to appear and then stopped. He was right and we were one reply away from telling him he was misremembering.

## Also in this release

- **Position carry-forward is bounded and dated.** #923 was fixed by carrying the parked position through an outage, which is correct, but it was carried with no age attached and across restarts. Coordinates, address and city are now one TTL'd group (24h), the backend's `carCapturedTimestamp` is recorded, and the device_tracker exposes it. A fresh position deliberately does not inherit the previous address.
- **`is_set` is a presence flag, not a state.** Both parking light and parking brake read it ahead of the real value, so a car reporting both lights explicitly off, or the brake explicitly released, still read as on. Real readings win now; the flag remains the fallback for dialects that send nothing else (v2.17.5 behaviour preserved and still tested).
- **The volkswagen.de options-flow login logs its failure reason**, like its setup-time twin already did.

## Verification

- 4105 passed, 15 skipped, full suite.
- 21 new tests, each verified to fail without its corresponding fix: reverting only the coordinator change fails the two data-loss tests, reverting only the parser change fails the two precedence tests, and the fallback-behaviour tests stay green in both cases.
- ruff and mypy strict clean via pre-commit.