### PR TITLE
feat: companion (ADB) channel — v3.0.0-alpha (experimental, opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [3.0.0a1] - 2026-07-27
+
+> **Pre-release, experimental.** This alpha adds one new opt-in source and changes nothing for existing setups. It only appears in HACS if you have beta versions enabled. If you do not set up the companion channel, the integration behaves exactly like 2.24.2.
+
+### Added
+
+- **Companion phone (ADB) channel — experimental, opt-in.** A fourth source in the hub menu at the start of setup, next to the QR login, the portal login, and MBB. It drives the official manufacturer app on a spare Android phone over ADB and reads the values off the screen, so it works as a last-resort two-way path on cars where the network side is read-only. There is no separate login and no credentials are stored: the phone is already signed in, nothing is rooted, and no app tokens are read. The integration only reads the screen and taps buttons.
+  - **Volkswagen is verified** (built and tested against the We Connect app 4.2.1): it reads state of charge, range and charging state, and can start/stop climate and charging.
+  - **Audi, Škoda, SEAT and CUPRA ship read-only for now.** The structure is there, but their on-screen maps are not yet confirmed against a real device, so they read what they can and refuse to tap a button rather than risk hitting the wrong control. They switch to two-way once a tester with that car confirms the screen map.
+  - Safety built in: a conservative read budget so it never looks like abuse to the backend, and a write quarantine that disables taps whenever the app version on the phone differs from the one a preset was verified against (reads keep working).
+  - Needs a spare Android phone signed into the brand app with ADB over Wi-Fi, and the app language set to German or English. See the tracking issue for setup and to volunteer as a tester for the non-VW brands.
+
 ## [2.24.2] - 2026-07-27
 
 ### Fixed

--- a/custom_components/vag_connect/button.py
+++ b/custom_components/vag_connect/button.py
@@ -47,9 +47,17 @@ async def async_setup_entry(
             # inside Home Assistant instead of the portal UI.
             entities.append(VagDataActRequestButton(coordinator, vin))
             return entities
-        if coordinator.command_capability_supported(vin, "command_flash") is not False:
+        # v3.0.0a1 — also require the client to implement the command, else the
+        # button raises AttributeError on press (companion/ADB has neither).
+        if (
+            coordinator.command_capability_supported(vin, "command_flash") is not False
+            and coordinator.command_method_available("command_flash")
+        ):
             entities.append(VagFlashButton(coordinator, vin))
-        if coordinator.command_capability_supported(vin, "command_wake") is not False:
+        if (
+            coordinator.command_capability_supported(vin, "command_wake") is not False
+            and coordinator.command_method_available("command_wake")
+        ):
             entities.append(VagWakeButton(coordinator, vin))
         return entities
 

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1461,6 +1461,11 @@ class VehicleData:
     # (e.g. "eu_data_act+mbb"); None for a single-channel poll. Surfaced as a
     # diagnostic attribute so users/maintainers can see where data came from.
     source_channel: str | None = None
+    # v3.0.0-alpha — companion (ADB) channel only. True when this snapshot came
+    # from a phone whose app version matched a verified preset, so writes (tap
+    # actions) are currently allowed. None for every network channel. Lets the
+    # entity layer show whether the experimental two-way path is live.
+    companion_writes_enabled: bool | None = None
     # v2.18.0 (A2) — per-FIELD provenance: {field_name: channel} for every
     # field that actually carries a value, recorded by the channel-merge layer.
     # ``source_channel`` answers "which channels fed this car"; this answers

--- a/custom_components/vag_connect/climate.py
+++ b/custom_components/vag_connect/climate.py
@@ -63,6 +63,14 @@ class VagClimate(VagConnectEntity, ClimateEntity):
 
     def __init__(self, coordinator: VagConnectCoordinator, vin: str) -> None:
         super().__init__(coordinator, vin, "climate")
+        # v3.0.0a1 — only advertise settable target temperature when the client
+        # can actually set it. The companion (ADB) client does climate on/off
+        # (command_start/stop_climate) but has no command_set_climate_temperature,
+        # so offering the slider there would AttributeError on use. A full
+        # network client keeps the feature (it has the method), so existing
+        # setups are unchanged.
+        if not coordinator.command_method_available("command_set_climate_temperature"):
+            self._attr_supported_features = ClimateEntityFeature(0)
 
     @property
     def hvac_mode(self) -> HVACMode:

--- a/custom_components/vag_connect/companion/__init__.py
+++ b/custom_components/vag_connect/companion/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Companion-phone (ADB) channel — v3.0.0-alpha, EXPERIMENTAL.
+
+An optional fourth source, picked in the hub menu at the start of setup. It
+drives the official manufacturer Android app on a spare, signed-in phone over
+ADB and reads the displayed values off the screen. Because it is the real app
+on a real device, it needs no separate login, stores no credentials, and is a
+last-resort two-way path on cars where every network channel is read-only.
+
+Design notes and honesty markers live in the individual modules. The short
+version:
+
+- We do NOT root the phone, read its stored tokens, or intercept traffic. The
+  whole contract is: screen in (uiautomator dump), taps out (input tap).
+- Values are matched from the accessibility tree by resource-id and
+  content-description where the app exposes them, falling back to localized
+  visible labels. That label fallback is why the app language has to be German
+  or English for now, exactly like the prior-art projects in this space.
+- Volkswagen is the only brand we can test in-house (a Golf GTE). Audi, Škoda,
+  SEAT and CUPRA ship as ``verified=False`` presets: the structure is there,
+  but the field selectors are best-effort until a real uiautomator dump from
+  that brand's app confirms them. An unverified preset reads what it can and
+  refuses writes, rather than guessing a tap onto the wrong button.
+"""
+from __future__ import annotations
+
+from .channel import CompanionChannel
+from .client import CompanionClient
+from .presets import PRESETS, BrandPreset, FieldSelector
+
+__all__ = [
+    "CompanionChannel",
+    "CompanionClient",
+    "PRESETS",
+    "BrandPreset",
+    "FieldSelector",
+]

--- a/custom_components/vag_connect/companion/channel.py
+++ b/custom_components/vag_connect/companion/channel.py
@@ -1,0 +1,190 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Companion channel orchestration — v3.0.0-alpha.
+
+Ties the transport and the screen parser to a brand preset, and adds the two
+safety layers that keep this from misbehaving against the car:
+
+- **Failure cooldown.** After a transport failure the channel backs off for a
+  fixed window instead of retrying every poll, so a phone that is asleep or off
+  the network does not turn into a per-poll error storm. Read cadence in the
+  healthy case is simply the coordinator's ``scan_interval`` — a uiautomator
+  dump reads the LOCAL screen and generates no manufacturer-backend traffic of
+  its own, so there is no abuse argument for a second, private read budget on
+  top of the interval the user already controls.
+- **Write quarantine.** Writes require a verified preset AND a live app version
+  that matches the one the preset was built against. A version drift disables
+  writes but leaves reads running, because a stale tap map is how you tap the
+  wrong control on a real car.
+
+The cooldown clock is injected (``time_fn``) so the whole thing is testable
+without sleeping or touching a device.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from .presets import ACTION_TO_COMMAND, BrandPreset
+from .screen import find_action_node, parse_ui_dump, read_fields
+from .transport import CompanionTransportError, NetworkAdbTransport
+
+_LOGGER = logging.getLogger(__name__)
+
+_FAILURE_COOLDOWN_S = 1800.0        # 30 min after any transport failure
+
+
+class CompanionWriteBlocked(RuntimeError):
+    """A write was refused by the quarantine, with a human-readable reason."""
+
+
+class CompanionChannel:
+    """One brand's read/write flow over one phone."""
+
+    def __init__(
+        self,
+        transport: NetworkAdbTransport,
+        preset: BrandPreset,
+        *,
+        time_fn: Callable[[], float],
+    ) -> None:
+        self._t = transport
+        self._preset = preset
+        self._now = time_fn
+        self._cooldown_until: float = 0.0
+        self._live_app_version: str | None = None
+        self._writes_ok: bool | None = None  # decided on first read
+
+    @property
+    def preset(self) -> BrandPreset:
+        return self._preset
+
+    @property
+    def writes_enabled(self) -> bool:
+        """Whether writes are currently allowed, with all gates applied."""
+        return bool(self._writes_ok) and self._preset.writable
+
+    # -- read -----------------------------------------------------------------
+
+    def _in_cooldown(self) -> bool:
+        return self._now() < self._cooldown_until
+
+    async def read(self) -> dict[str, object] | None:
+        """Bring the app forward, dump the screen, resolve the preset fields.
+
+        Returns:
+          - ``None`` when the channel is in its post-failure cooldown: nothing
+            was done, and the caller must NOT treat this as a failed or empty
+            poll (otherwise a single failure would self-reinforce into a
+            permanent "failed" state). The cooldown is short and clears on an
+            HA restart, so it self-heals without user action.
+          - ``{}`` when a read ran but matched no fields (a genuine empty
+            screen).
+          - a dict of matched fields otherwise.
+
+        Read cadence in the healthy case is just the coordinator's poll
+        interval; there is no separate per-read throttle. A transport failure
+        trips the cooldown and re-raises, so the coordinator counts a real
+        failure as a failed poll rather than a blank overwrite.
+        """
+        if self._in_cooldown():
+            return None
+        try:
+            if not self._t.connected:
+                await self._t.connect()
+            await self._t.foreground_app(self._preset.package)
+            # Decide the write quarantine on every read: the app can be updated
+            # under us at any time.
+            await self._refresh_write_gate()
+            xml = await self._t.dump_ui()
+        except CompanionTransportError:
+            self._cooldown_until = self._now() + _FAILURE_COOLDOWN_S
+            raise
+        nodes = parse_ui_dump(xml)
+        return read_fields(nodes, self._preset)
+
+    async def _refresh_write_gate(self) -> None:
+        """Read the live app version and (re)decide whether writes are allowed.
+
+        Called on every read, and lazily by ``do_action`` when a command is
+        issued before the first scheduled poll — otherwise ``_writes_ok`` would
+        still be ``None`` and a perfectly valid command on the verified VW at the
+        right version would be rejected as a version mismatch until the first
+        poll (up to a full scan interval, and again after every restart).
+        """
+        self._live_app_version = await self._t.current_app_version(self._preset.package)
+        self._writes_ok = self._decide_writes(self._live_app_version)
+
+    def _decide_writes(self, live_version: str | None) -> bool:
+        if not self._preset.writable:
+            return False
+        want = self._preset.verified_app_version
+        if want is None:
+            return False
+        if live_version is None:
+            # Could not read the version → do not risk a tap.
+            _LOGGER.debug(
+                "companion %s: could not read the app version; writes disabled "
+                "until it is confirmed", self._preset.brand,
+            )
+            return False
+        if live_version != want:
+            _LOGGER.warning(
+                "companion %s: app is %s but this preset was built for %s; "
+                "writes are disabled until the preset is confirmed against the "
+                "new version. Reads keep working.",
+                self._preset.brand, live_version, want,
+            )
+            return False
+        return True
+
+    # -- write ----------------------------------------------------------------
+
+    async def do_action(self, action: str) -> None:
+        """Tap the control for a logical action, subject to the quarantine.
+
+        Raises ``CompanionWriteBlocked`` with a clear reason rather than tapping
+        into the dark. That reason is what the coordinator surfaces to the user.
+        """
+        if action not in ACTION_TO_COMMAND:
+            raise CompanionWriteBlocked(f"unknown companion action: {action}")
+        if not self._preset.writable:
+            raise CompanionWriteBlocked(
+                f"the {self._preset.brand} companion preset is experimental and "
+                "read-only; writing would risk tapping the wrong control. It "
+                "needs a confirmed screen map from a real device first."
+            )
+        # v3.0.0a1 — if no poll has decided the write gate yet (e.g. a command
+        # issued right after startup, before the first scheduled read), decide
+        # it now from the live app version rather than rejecting on the initial
+        # ``None``. Needs the connection up first.
+        if self._writes_ok is None:
+            try:
+                if not self._t.connected:
+                    await self._t.connect()
+                await self._t.foreground_app(self._preset.package)
+                await self._refresh_write_gate()
+            except CompanionTransportError as err:
+                raise CompanionWriteBlocked(str(err)) from err
+        if not self._writes_ok:
+            raise CompanionWriteBlocked(
+                f"writes are disabled for {self._preset.brand}: the app version "
+                f"on the phone ({self._live_app_version or 'unknown'}) does not "
+                f"match the one this preset was verified against "
+                f"({self._preset.verified_app_version}). Reads still work."
+            )
+        try:
+            if not self._t.connected:
+                await self._t.connect()
+            await self._t.foreground_app(self._preset.package)
+            xml = await self._t.dump_ui()
+        except CompanionTransportError as err:
+            raise CompanionWriteBlocked(str(err)) from err
+        node = find_action_node(parse_ui_dump(xml), self._preset, action)
+        if node is None or node.tap_point is None:
+            raise CompanionWriteBlocked(
+                f"could not find the '{action}' control on the current screen; "
+                "the app may be on a different view than expected"
+            )
+        x, y = node.tap_point
+        await self._t.tap(x, y)

--- a/custom_components/vag_connect/companion/client.py
+++ b/custom_components/vag_connect/companion/client.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Companion (ADB) client adapter — v3.0.0-alpha.
+
+Presents the same duck-typed surface the coordinator already expects from a
+CARIAD client (``authenticate`` / ``get_vehicles`` / ``get_status`` /
+``command_*``), so the companion channel slots in as just another source with
+no special-casing in the poll loop. The token/portal/MBB attributes the
+coordinator touches via ``getattr(..., default)`` simply are not here, so those
+paths fall through cleanly.
+
+There is no network login: the "auth" is the phone already being signed into the
+app. ``get_vehicles`` returns the single VIN the user entered at setup, because
+this channel reads one phone showing one account's car.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from ..cariad.models import VehicleData
+from .channel import CompanionChannel, CompanionWriteBlocked
+from .presets import ACTION_TO_COMMAND, PRESETS
+from .transport import NetworkAdbTransport
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CompanionClient:
+    """Coordinator-compatible client backed by a companion phone."""
+
+    def __init__(
+        self,
+        *,
+        brand: str,
+        vin: str,
+        host: str,
+        port: int,
+        adbkey_path: str,
+        time_fn: Callable[[], float],
+    ) -> None:
+        self._brand = brand.lower()
+        self._vin = vin.upper()
+        preset = PRESETS.get(self._brand)
+        if preset is None:
+            raise ValueError(f"no companion preset for brand {brand!r}")
+        self._transport = NetworkAdbTransport(host, port, adbkey_path)
+        self._channel = CompanionChannel(self._transport, preset, time_fn=time_fn)
+        # Last snapshot we actually read, so a throttled poll can return the
+        # known values instead of a spurious no_data that the coordinator would
+        # count as a failed poll (the channel reads far less often than the poll
+        # interval on purpose).
+        self._last_data: VehicleData | None = None
+        # Attributes the coordinator reads via getattr with a default; declared
+        # here so a plain attribute access also works.
+        self.on_tokens_changed: Callable[[Any], None] | None = None
+        self._eu_portal = None
+        self._tokens = None
+
+    # -- token/portal no-ops the coordinator may call directly ----------------
+
+    def set_persisted_tokens(self, _tokens: Any) -> None:
+        """No stored tokens on this channel; nothing to restore."""
+
+    def set_website_authproxy_mode(self, *_args: Any, **_kwargs: Any) -> None:
+        """No supplementary web channel on this channel."""
+
+    # -- the read surface -----------------------------------------------------
+
+    async def authenticate(self) -> None:
+        """'Auth' is the phone being signed in; just open the ADB connection."""
+        await self._transport.connect()
+
+    async def get_vehicles(self) -> list[str]:
+        return [self._vin]
+
+    async def get_status(self, vin: str) -> VehicleData:
+        """Read the app screen and map it onto a VehicleData for this VIN.
+
+        A read that matches nothing returns a ``no_data`` VehicleData rather
+        than raising, so the coordinator's own no-data failsafe (keep
+        last-known-good visible) applies exactly as it does for a portal outage.
+        """
+        fields = await self._channel.read()
+        # None = the channel is in its post-failure cooldown. Return the last
+        # snapshot we actually took so the coordinator sees unchanged-but-valid
+        # data, not a no_data its poll loop would count as a failure (which
+        # would self-reinforce the cooldown). On the very first poll (nothing
+        # read yet) fall through to a no_data VehicleData.
+        if fields is None and self._last_data is not None:
+            return self._last_data
+        data = VehicleData(vin=vin.upper())
+        data.source_channel = "companion_adb"
+        if not fields:  # None (first-ever throttle) or {} (empty screen)
+            data.no_data = True
+            return data
+        for key, val in fields.items():
+            if hasattr(data, key):
+                setattr(data, key, val)
+        # A companion read is a two-way-capable source only when writes are on;
+        # expose that so the entity layer can reflect it.
+        data.companion_writes_enabled = self._channel.writes_enabled
+        self._last_data = data
+        return data
+
+    # -- the command surface --------------------------------------------------
+
+    async def _dispatch(self, command_name: str) -> None:
+        action = next(
+            (a for a, cmd in ACTION_TO_COMMAND.items() if cmd == command_name), None
+        )
+        if action is None:
+            from ..cariad.exceptions import VehicleCommandError  # noqa: PLC0415
+
+            raise VehicleCommandError(
+                command_name,
+                "this command is not available on the companion (ADB) channel",
+            )
+        try:
+            await self._channel.do_action(action)
+        except CompanionWriteBlocked as err:
+            from ..cariad.exceptions import VehicleCommandError  # noqa: PLC0415
+
+            raise VehicleCommandError(command_name, str(err)) from err
+
+    async def command_start_climate(self, vin: str, *_a: Any, **_k: Any) -> None:
+        await self._dispatch("command_start_climate")
+
+    async def command_start_climate_control(self, vin: str, *_a: Any, **_k: Any) -> None:
+        await self._dispatch("command_start_climate")
+
+    async def command_stop_climate(self, vin: str, *_a: Any, **_k: Any) -> None:
+        await self._dispatch("command_stop_climate")
+
+    async def command_start_charging(self, vin: str, *_a: Any, **_k: Any) -> None:
+        await self._dispatch("command_start_charging")
+
+    async def command_stop_charging(self, vin: str, *_a: Any, **_k: Any) -> None:
+        await self._dispatch("command_stop_charging")
+
+    async def close(self) -> None:
+        await self._transport.close()

--- a/custom_components/vag_connect/companion/presets.py
+++ b/custom_components/vag_connect/companion/presets.py
@@ -1,0 +1,274 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Per-brand screen presets for the companion (ADB) channel — v3.0.0-alpha.
+
+A preset says how to find a value or a button in one brand's app: which node in
+the accessibility tree, and how to turn its text into a number or a bool. The
+selector is deliberately layered so it survives small app changes:
+
+1. ``resource_id`` — the most stable handle when the app assigns one.
+2. ``content_desc_re`` — the accessibility description, next most stable.
+3. ``label_re`` + ``value_from`` — find a known localized label node, then read
+   the value from that node's text or a sibling. This is the fallback the
+   prior-art projects rely on, and it is why the app language must be German or
+   English for now.
+
+HONESTY: only ``volkswagen`` is verified against a real device (a Golf GTE).
+The other four are ``verified=False``. Their selectors are seeded from what the
+decoded apps and the VW shape suggest, but they are NOT confirmed. An unverified
+preset is allowed to read (a wrong read is a wrong number, recoverable) but must
+never write (a wrong tap is a physical action on the car). ``CompanionChannel``
+enforces that; see ``BrandPreset.writable``.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FieldSelector:
+    """How to locate one value in the accessibility tree and parse it.
+
+    At least one of ``resource_id`` / ``content_desc_re`` / ``label_re`` must be
+    set. They are tried in that order; the first that hits wins.
+    """
+
+    target: str  # the VehicleData field this fills, e.g. "battery_soc"
+    resource_id: str | None = None
+    content_desc_re: str | None = None
+    label_re: str | None = None
+    # When matched via ``label_re``, where the value text comes from:
+    #   "self"    → the label node's own text (e.g. "Ladung 74 %")
+    #   "sibling" → the next sibling node's text (label and value are separate)
+    value_from: str = "self"
+    # Turns the raw on-screen text into the typed value. Defaults to a plain
+    # string; the channel applies the field's own coercion on top.
+    parse: str = "str"  # one of: str, percent, int_km, bool_charging, kw
+
+
+@dataclass(frozen=True)
+class ActionSelector:
+    """How to find a button to tap for a write action."""
+
+    action: str  # logical action name, e.g. "start_climate"
+    resource_id: str | None = None
+    content_desc_re: str | None = None
+    label_re: str | None = None
+    # Some actions need to navigate to a screen first (tab labels, in order).
+    nav_labels: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BrandPreset:
+    """Everything the channel needs to read and (maybe) write one brand's app."""
+
+    brand: str
+    package: str  # the Android package name of the app
+    verified: bool  # True only when confirmed against a real device
+    # The app version this preset was built against. The channel refuses writes
+    # when the live app version differs (reads still run); mirrors the
+    # app-version quarantine idea from the prior-art projects.
+    verified_app_version: str | None
+    fields: tuple[FieldSelector, ...]
+    actions: tuple[ActionSelector, ...] = ()
+
+    @property
+    def writable(self) -> bool:
+        """Writes are only ever attempted on a verified preset with actions.
+
+        An unverified preset must not tap: a wrong selector on a read is a wrong
+        number, but a wrong selector on a tap is a physical command sent to the
+        wrong control on the car.
+        """
+        return self.verified and bool(self.actions)
+
+
+# ── Volkswagen — the one brand verified in-house (Golf GTE, app 4.2.1) ───────
+
+_VW = BrandPreset(
+    brand="volkswagen",
+    package="com.volkswagen.weconnect",
+    verified=True,
+    verified_app_version="4.2.1",
+    fields=(
+        FieldSelector(
+            target="battery_soc",
+            content_desc_re=r"(?:Ladezustand|State of charge|Ladung)\D*(\d{1,3})\s*%",
+            label_re=r"^(?:Ladung|Charge|Ladezustand|State of charge)$",
+            value_from="sibling",
+            parse="percent",
+        ),
+        FieldSelector(
+            target="electric_range_km",
+            content_desc_re=r"(?:Reichweite|Range)\D*(\d{1,4})\s*km",
+            label_re=r"^(?:Reichweite|Range)$",
+            value_from="sibling",
+            parse="int_km",
+        ),
+        FieldSelector(
+            target="charging_state",
+            content_desc_re=r"(?:Lädt|Charging|Wird geladen|Nicht verbunden|Not connected|Bereit|Ready)",
+            parse="str",
+        ),
+        FieldSelector(
+            target="is_charging",
+            content_desc_re=r"(?:Lädt|Wird geladen|Charging)",
+            parse="bool_charging",
+        ),
+        FieldSelector(
+            target="target_soc",
+            label_re=r"^(?:Zielladung|Ziel-Ladung|Target|Zielwert)$",
+            value_from="sibling",
+            parse="percent",
+        ),
+        FieldSelector(
+            target="remaining_charge_time_min",
+            content_desc_re=r"(?:noch|remaining)\D*(\d{1,4})\s*min",
+            parse="int_km",  # reuse the "first integer" parser
+        ),
+    ),
+    actions=(
+        ActionSelector(
+            action="start_climate",
+            content_desc_re=r"(?:Klima\w*\s*(?:starten|ein)|Start climate|Climatisation on)",
+            label_re=r"^(?:Klimatisierung|Climate|Klima)$",
+        ),
+        ActionSelector(
+            action="stop_climate",
+            content_desc_re=r"(?:Klima\w*\s*(?:stoppen|aus)|Stop climate|Climatisation off)",
+        ),
+        ActionSelector(
+            action="start_charging",
+            content_desc_re=r"(?:Laden\s*starten|Start charging)",
+        ),
+        ActionSelector(
+            action="stop_charging",
+            content_desc_re=r"(?:Laden\s*stoppen|Stop charging)",
+        ),
+    ),
+)
+
+# ── The four unverified brands — structure present, selectors best-effort ────
+#
+# These read what they can and refuse writes (``verified=False`` → not
+# ``writable``). Each needs a tester's uiautomator dump to confirm the field
+# selectors and to promote it to verified with real actions. The label
+# alternations below are seeded from the German/English wording the apps use;
+# they are a starting point for a tester, NOT a validated map.
+
+def _readonly_soc_range_fields(soc_label: str, range_label: str) -> tuple[FieldSelector, ...]:
+    return (
+        FieldSelector(
+            target="battery_soc",
+            label_re=soc_label,
+            value_from="sibling",
+            parse="percent",
+        ),
+        FieldSelector(
+            target="electric_range_km",
+            label_re=range_label,
+            value_from="sibling",
+            parse="int_km",
+        ),
+        FieldSelector(
+            target="charging_state",
+            content_desc_re=r"(?:Lädt|Charging|Wird geladen|Nicht verbunden|Not connected)",
+            parse="str",
+        ),
+        FieldSelector(
+            target="is_charging",
+            content_desc_re=r"(?:Lädt|Wird geladen|Charging)",
+            parse="bool_charging",
+        ),
+    )
+
+
+_AUDI = BrandPreset(
+    brand="audi",
+    package="de.myaudi.mobile.assistant",
+    verified=False,
+    verified_app_version=None,
+    fields=_readonly_soc_range_fields(
+        r"^(?:Ladezustand|State of charge)$", r"^(?:Reichweite|Range)$"
+    ),
+)
+
+_SKODA = BrandPreset(
+    brand="skoda",
+    package="cz.skodaauto.connect",
+    verified=False,
+    verified_app_version=None,
+    fields=_readonly_soc_range_fields(
+        r"^(?:Ladestand|Ladezustand|State of charge)$", r"^(?:Reichweite|Range)$"
+    ),
+)
+
+_SEAT = BrandPreset(
+    brand="seat",
+    package="com.seat.myseat.ola",
+    verified=False,
+    verified_app_version=None,
+    fields=_readonly_soc_range_fields(
+        r"^(?:Ladezustand|State of charge)$", r"^(?:Reichweite|Range)$"
+    ),
+)
+
+_CUPRA = BrandPreset(
+    brand="cupra",
+    package="com.cupra.mycupra",
+    verified=False,
+    verified_app_version=None,
+    fields=_readonly_soc_range_fields(
+        r"^(?:Ladezustand|State of charge)$", r"^(?:Reichweite|Range)$"
+    ),
+)
+
+
+PRESETS: dict[str, BrandPreset] = {
+    p.brand: p for p in (_VW, _AUDI, _SKODA, _SEAT, _CUPRA)
+}
+
+
+# ── value parsers ────────────────────────────────────────────────────────────
+
+_FIRST_INT_RE = re.compile(r"-?\d+")
+
+
+def _first_int(text: str) -> int | None:
+    m = _FIRST_INT_RE.search(text or "")
+    return int(m.group()) if m else None
+
+
+def coerce(parse: str, raw: str | None) -> object | None:
+    """Turn a matched raw string into the typed value the field expects."""
+    if raw is None:
+        return None
+    raw = raw.strip()
+    if not raw:
+        return None
+    if parse == "str":
+        return raw
+    if parse in ("percent", "int_km"):
+        val = _first_int(raw)
+        if val is None:
+            return None
+        if parse == "percent" and not (0 <= val <= 100):
+            return None  # a "%" that is not a plausible SoC is a mis-match
+        return val
+    if parse == "bool_charging":
+        return bool(re.search(r"(?:Lädt|Wird geladen|Charging)", raw, re.I))
+    if parse == "kw":
+        m = re.search(r"(\d+(?:[.,]\d+)?)", raw)
+        return float(m.group(1).replace(",", ".")) if m else None
+    return raw
+
+
+# The logical write actions the channel understands, mapped to the coordinator
+# command names. Only actions listed here can ever be dispatched.
+ACTION_TO_COMMAND: dict[str, str] = {
+    "start_climate": "command_start_climate",
+    "stop_climate": "command_stop_climate",
+    "start_charging": "command_start_charging",
+    "stop_charging": "command_stop_charging",
+}

--- a/custom_components/vag_connect/companion/screen.py
+++ b/custom_components/vag_connect/companion/screen.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Parse a ``uiautomator dump`` and resolve preset selectors against it.
+
+Pure, hardware-free, and therefore the part with the real test coverage. The
+transport hands us the XML string that ``uiautomator dump`` produces; from here
+on there is no device involved. Keeping the parse/match logic isolated like
+this is what lets the fragile bit (ADB itself) stay a thin shell.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from xml.etree import ElementTree as ET
+
+from .presets import BrandPreset, FieldSelector, coerce
+
+
+@dataclass(frozen=True)
+class UiNode:
+    """One node of the accessibility tree, flattened to what we match on."""
+
+    resource_id: str
+    content_desc: str
+    text: str
+    clazz: str
+    clickable: bool
+    bounds: tuple[int, int, int, int] | None  # (l, t, r, b) in device px
+
+    @property
+    def tap_point(self) -> tuple[int, int] | None:
+        """Centre of the node, the point ``input tap`` would target."""
+        if self.bounds is None:
+            return None
+        left, top, right, bottom = self.bounds
+        return ((left + right) // 2, (top + bottom) // 2)
+
+
+_BOUNDS_RE = re.compile(r"\[(\d+),(\d+)\]\[(\d+),(\d+)\]")
+
+
+def _parse_bounds(raw: str | None) -> tuple[int, int, int, int] | None:
+    if not raw:
+        return None
+    m = _BOUNDS_RE.search(raw)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)), int(m.group(4)))
+
+
+def parse_ui_dump(xml: str) -> list[UiNode]:
+    """Flatten a uiautomator XML dump into an ordered list of ``UiNode``.
+
+    Order is document order (a pre-order walk), which is what the sibling-value
+    resolution below relies on: on these screens the value node follows its
+    label node.
+    """
+    if not xml or not xml.strip():
+        return []
+    try:
+        root = ET.fromstring(xml)
+    except ET.ParseError:
+        return []
+    out: list[UiNode] = []
+    for el in root.iter("node"):
+        a = el.attrib
+        out.append(
+            UiNode(
+                resource_id=a.get("resource-id", ""),
+                content_desc=a.get("content-desc", ""),
+                text=a.get("text", ""),
+                clazz=a.get("class", ""),
+                clickable=a.get("clickable", "false") == "true",
+                bounds=_parse_bounds(a.get("bounds")),
+            )
+        )
+    return out
+
+
+def _match_field_raw(nodes: list[UiNode], sel: FieldSelector) -> str | None:
+    """Return the raw string a selector resolves to, or None.
+
+    Tries resource-id, then content-description (with capture-group support),
+    then a localized label whose value is on the node itself or its sibling.
+    """
+    # 1) resource-id — the value is the node's own text.
+    if sel.resource_id:
+        for n in nodes:
+            if n.resource_id == sel.resource_id:
+                return n.text or n.content_desc or None
+
+    # 2) content-description — if the regex has a capture group, return it;
+    #    otherwise the whole content-desc is the value (used for state strings).
+    if sel.content_desc_re:
+        rx = re.compile(sel.content_desc_re, re.I)
+        for n in nodes:
+            if not n.content_desc:
+                continue
+            m = rx.search(n.content_desc)
+            if m:
+                return m.group(1) if m.groups() else n.content_desc
+
+    # 3) localized label — find the label node, then read the value.
+    if sel.label_re:
+        rx = re.compile(sel.label_re, re.I)
+        for i, n in enumerate(nodes):
+            hay = n.text or n.content_desc
+            if not hay or not rx.search(hay):
+                continue
+            if sel.value_from == "self":
+                return hay
+            # "sibling": the next node in document order that actually carries
+            # text and is not the label itself.
+            for sib in nodes[i + 1:i + 4]:
+                if sib.text and sib.text.strip() and sib.text != hay:
+                    return sib.text
+    return None
+
+
+def read_fields(nodes: list[UiNode], preset: BrandPreset) -> dict[str, object]:
+    """Resolve every field selector in the preset against the parsed screen.
+
+    Returns only the fields that actually matched and coerced to a value, so a
+    partial screen never writes a spurious ``None`` over anything downstream.
+    """
+    out: dict[str, object] = {}
+    for sel in preset.fields:
+        raw = _match_field_raw(nodes, sel)
+        val = coerce(sel.parse, raw if isinstance(raw, str) else None)
+        if val is not None:
+            out[sel.target] = val
+    return out
+
+
+def find_action_node(nodes: list[UiNode], preset: BrandPreset, action: str) -> UiNode | None:
+    """Find the tappable node for a logical action, or None if not present.
+
+    Prefers a clickable node; a matching but non-clickable node is returned only
+    if nothing clickable matched, so the caller can decide whether to tap its
+    centre anyway.
+    """
+    spec = next((a for a in preset.actions if a.action == action), None)
+    if spec is None:
+        return None
+    candidates: list[UiNode] = []
+    for n in nodes:
+        hit = False
+        if spec.resource_id and n.resource_id == spec.resource_id:
+            hit = True
+        elif spec.content_desc_re and n.content_desc and re.search(
+            spec.content_desc_re, n.content_desc, re.I
+        ):
+            hit = True
+        elif spec.label_re and (n.text or n.content_desc) and re.search(
+            spec.label_re, n.text or n.content_desc, re.I
+        ):
+            hit = True
+        if hit:
+            candidates.append(n)
+    if not candidates:
+        return None
+    clickable = [n for n in candidates if n.clickable and n.tap_point]
+    return clickable[0] if clickable else candidates[0]

--- a/custom_components/vag_connect/companion/transport.py
+++ b/custom_components/vag_connect/companion/transport.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Network-ADB transport for the companion channel — v3.0.0-alpha.
+
+Pure-python ``adb-shell`` over TCP, so no ``adb`` binary is needed inside the
+Home Assistant container. This is the only module that talks to the device, and
+it is deliberately thin: everything that can be reasoned about without hardware
+lives in ``screen.py`` and ``channel.py`` instead.
+
+``adb-shell`` is imported lazily inside the methods, so importing this module
+(and running the test suite) never requires the dependency to be present. The
+requirement is declared in the manifest for real installs.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# uiautomator writes the dump here, then we read it back over the same shell.
+_DUMP_PATH = "/sdcard/vag_connect_ui.xml"
+
+# Where adb-shell persists the RSA keypair that authorises this HA instance to
+# the phone (the phone shows the "allow USB debugging" prompt once, then trusts
+# this key). Kept under the config dir so it survives restarts.
+_ADBKEY_BASENAME = "vag_connect_adbkey"
+
+
+class CompanionTransportError(RuntimeError):
+    """A device-side / connection failure. Carries a human-readable reason."""
+
+
+class NetworkAdbTransport:
+    """Talks to one phone over TCP ADB. All methods are async and best-effort.
+
+    The device object and the blocking adb-shell calls are marshalled onto a
+    worker thread via ``asyncio.to_thread`` so nothing blocks the event loop.
+    """
+
+    def __init__(self, host: str, port: int, adbkey_path: str) -> None:
+        self._host = host
+        self._port = int(port)
+        self._adbkey_path = adbkey_path
+        self._device: Any = None
+
+    # -- connection -----------------------------------------------------------
+
+    async def connect(self, timeout_s: float = 10.0) -> None:
+        """Open (or reopen) the ADB connection, loading/creating the RSA key."""
+        await asyncio.to_thread(self._connect_blocking, timeout_s)
+
+    def _connect_blocking(self, timeout_s: float) -> None:
+        try:
+            from adb_shell.adb_device import AdbDeviceTcp  # noqa: PLC0415
+            from adb_shell.auth.sign_pythonrsa import PythonRSASigner  # noqa: PLC0415
+            from adb_shell.auth.keygen import keygen  # noqa: PLC0415
+        except ImportError as err:  # pragma: no cover - requires the dependency
+            raise CompanionTransportError(
+                "the adb-shell library is not installed; it ships as a "
+                "requirement of this integration, so this usually means the "
+                "install did not complete"
+            ) from err
+
+        import os  # noqa: PLC0415
+
+        if not os.path.exists(self._adbkey_path):
+            # First run on this HA instance: mint a keypair. The phone will show
+            # a one-time "allow USB debugging from this computer" prompt.
+            keygen(self._adbkey_path)
+        with open(self._adbkey_path, encoding="utf-8") as fh:
+            priv = fh.read()
+        with open(self._adbkey_path + ".pub", encoding="utf-8") as fh:
+            pub = fh.read()
+        signer = PythonRSASigner(pub, priv)
+
+        device = AdbDeviceTcp(self._host, self._port, default_transport_timeout_s=timeout_s)
+        try:
+            device.connect(rsa_keys=[signer], auth_timeout_s=timeout_s)
+        except Exception as err:  # noqa: BLE001 - adb-shell raises many types
+            raise CompanionTransportError(
+                f"could not reach the phone at {self._host}:{self._port} "
+                f"({type(err).__name__}); check it is on the network, that ADB "
+                "over Wi-Fi is enabled, and that you accepted the debugging "
+                "prompt"
+            ) from err
+        self._device = device
+
+    async def close(self) -> None:
+        if self._device is not None:
+            try:
+                await asyncio.to_thread(self._device.close)
+            except Exception:  # noqa: BLE001
+                pass
+            self._device = None
+
+    @property
+    def connected(self) -> bool:
+        return self._device is not None and getattr(self._device, "available", False)
+
+    # -- operations -----------------------------------------------------------
+
+    async def shell(self, cmd: str, timeout_s: float = 10.0) -> str:
+        if self._device is None:
+            raise CompanionTransportError("not connected")
+        return await asyncio.to_thread(self._device.shell, cmd, timeout_s)
+
+    async def dump_ui(self, timeout_s: float = 15.0) -> str:
+        """Run uiautomator, return the screen's accessibility XML.
+
+        Two steps on the same shell: dump to a file, then cat it back. The dump
+        command prints a status line to stdout, not the XML, so reading the file
+        is the reliable path.
+        """
+        await self.shell(f"uiautomator dump {_DUMP_PATH}", timeout_s)
+        xml = await self.shell(f"cat {_DUMP_PATH}", timeout_s)
+        if "<hierarchy" not in xml:
+            raise CompanionTransportError(
+                "uiautomator returned no screen dump; the phone may be asleep "
+                "or the app may not be in the foreground"
+            )
+        return xml
+
+    async def foreground_app(self, package: str, timeout_s: float = 10.0) -> None:
+        """Bring the app to the front (monkey launch) and let it settle."""
+        await self.shell(
+            f"monkey -p {package} -c android.intent.category.LAUNCHER 1", timeout_s
+        )
+        await asyncio.sleep(1.5)
+
+    async def current_app_version(self, package: str) -> str | None:
+        """Read the installed versionName of the app, for the write quarantine."""
+        out = await self.shell(f"dumpsys package {package} | grep versionName")
+        for line in (out or "").splitlines():
+            line = line.strip()
+            if line.startswith("versionName="):
+                return line.split("=", 1)[1].strip() or None
+        return None
+
+    async def tap(self, x: int, y: int, timeout_s: float = 10.0) -> None:
+        await self.shell(f"input tap {int(x)} {int(y)}", timeout_s)
+        await asyncio.sleep(0.6)

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -410,8 +410,110 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                     "Portal (E-Mail + Passwort) — Volkswagen EU / Porsche "
                     "(+ Toggle: MBB-Fahrzeug → Fernbefehle)"
                 ),
+                # v3.0.0-alpha — experimental fourth source. Drives the official
+                # app on a spare phone over ADB; last-resort two-way where the
+                # network side is read-only. Clearly flagged EXPERIMENTAL.
+                "companion_adb": (
+                    "Companion-Handy (ADB) — EXPERIMENTELL, alle Marken "
+                    "(zweites Handy mit eingeloggter App nötig)"
+                ),
             },
         )
+
+    async def async_step_companion_adb(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """v3.0.0-alpha — set up the companion (ADB) channel.
+
+        Collects the phone's network-ADB address, the brand, the VIN the app
+        shows, and an optional S-PIN, then validates the connection by opening
+        ADB and reading the app's version. No credentials are stored: the phone
+        is already signed in, and the only secret at rest is the ADB RSA key.
+        """
+        from .const import (  # noqa: PLC0415
+            CONF_ADB_HOST,
+            CONF_ADB_PORT,
+            CONF_STRATEGY,
+            CONF_VIN,
+            DEFAULT_ADB_PORT,
+            STRATEGY_COMPANION_ADB,
+        )
+        from .companion.presets import PRESETS  # noqa: PLC0415
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            brand = user_input[CONF_BRAND]
+            host = user_input[CONF_ADB_HOST].strip()
+            port = int(user_input.get(CONF_ADB_PORT, DEFAULT_ADB_PORT))
+            vin = user_input[CONF_VIN].strip().upper()
+            spin = (user_input.get(CONF_SPIN) or "").strip()
+
+            valid, reason = await self._companion_probe(brand, host, port)
+            if not valid:
+                errors["base"] = reason
+            else:
+                await self.async_set_unique_id(f"companion_{brand}_{vin}")
+                self._abort_if_unique_id_configured()
+                preset = PRESETS[brand]
+                title = f"{brand.title()} (Companion/ADB) {vin[-6:]}"
+                if not preset.verified:
+                    title += " [alpha, read-only]"
+                return self.async_create_entry(
+                    title=title,
+                    data={
+                        CONF_STRATEGY: STRATEGY_COMPANION_ADB,
+                        CONF_BRAND: brand,
+                        CONF_ADB_HOST: host,
+                        CONF_ADB_PORT: port,
+                        CONF_VIN: vin,
+                        CONF_SPIN: spin,
+                    },
+                )
+
+        brands = {b: b.title() for b in PRESETS}
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_BRAND, default="volkswagen"): vol.In(brands),
+                vol.Required(CONF_ADB_HOST): str,
+                vol.Optional(CONF_ADB_PORT, default=DEFAULT_ADB_PORT): int,
+                vol.Required(CONF_VIN): str,
+                vol.Optional(CONF_SPIN, default=""): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="companion_adb", data_schema=schema, errors=errors,
+        )
+
+    async def _companion_probe(
+        self, brand: str, host: str, port: int
+    ) -> tuple[bool, str]:
+        """Open ADB and read the app version; returns (ok, error_key)."""
+        from .companion.presets import PRESETS  # noqa: PLC0415
+        from .companion.transport import (  # noqa: PLC0415
+            CompanionTransportError,
+            NetworkAdbTransport,
+        )
+
+        preset = PRESETS.get(brand)
+        if preset is None:
+            return False, "companion_unknown_brand"
+        adbkey = self.hass.config.path(".storage", "vag_connect_adbkey")
+        transport = NetworkAdbTransport(host, port, adbkey)
+        try:
+            await transport.connect()
+            version = await transport.current_app_version(preset.package)
+        except CompanionTransportError as err:
+            _LOGGER.warning("Companion ADB probe failed: %s", err)
+            return False, "companion_cannot_connect"
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("Companion ADB probe error: %s", type(err).__name__)
+            return False, "companion_cannot_connect"
+        finally:
+            await transport.close()
+        if version is None:
+            return False, "companion_app_not_found"
+        return True, ""
 
     async def async_step_email_password(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -9,6 +9,16 @@ CONF_BRAND                    = "brand"
 CONF_USERNAME                 = "username"
 CONF_PASSWORD                 = "password"
 CONF_SPIN                     = "spin"
+# v3.0.0-alpha — companion (ADB) channel. A config entry whose CONF_STRATEGY is
+# "companion_adb" is served by the CompanionClient over network ADB instead of
+# a CARIAD network client. Host/port point at the spare phone; VIN is the car
+# the phone's app shows. EXPERIMENTAL, opt-in from the hub menu.
+CONF_STRATEGY                 = "strategy"
+STRATEGY_COMPANION_ADB        = "companion_adb"
+CONF_ADB_HOST                 = "adb_host"
+CONF_ADB_PORT                 = "adb_port"
+CONF_VIN                      = "vin"
+DEFAULT_ADB_PORT              = 5555
 # v2.17.5 (#759) — optional per-VIN S-PIN overrides: {vin: spin}. When a
 # vehicle has no entry here the shared CONF_SPIN is used, so existing
 # single-S-PIN setups are unchanged. Set via the Options flow.

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -747,8 +747,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         )
 
         brand    = self.entry.data[CONF_BRAND]
-        username = self.entry.data[CONF_USERNAME]
-        password = self.entry.data[CONF_PASSWORD]
+        # v3.0.0-alpha — a companion (ADB) entry carries no username/password
+        # (the phone is already signed in), so read these defensively rather
+        # than with a hard key access that would KeyError before the companion
+        # branch below is even reached.
+        username = self.entry.data.get(CONF_USERNAME, "")
+        password = self.entry.data.get(CONF_PASSWORD, "")
         spin     = self.entry.data.get(CONF_SPIN) or ""
 
         # v2.4.1 (#281+#282) — OLA defense-in-depth Layer 2: read the
@@ -770,16 +774,43 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             or ""
         ).strip() or None
 
-        session = async_get_clientsession(self.hass)
-        self._cariad_client = CariadClientFactory.create(
-            brand, session, username, password, spin,
-            # v2.15.1 (#503) — Volkswagen US/Canada region. Only the
-            # volkswagen_na client consumes it; every other brand ignores
-            # the kwarg. Default "us" for entries created before this field.
-            country=self.entry.data.get(CONF_COUNTRY, "us"),
-            ola_app_version_override=ola_app_v,
-            ola_user_agent_override=ola_ua,
-        )
+        # v3.0.0-alpha — companion (ADB) channel. A companion entry is served by
+        # the CompanionClient over network ADB, not a CARIAD network client. It
+        # duck-types the same read/command surface, so everything after this
+        # point (client_id override, first fetch, poll loop) treats it like any
+        # other client; the token/portal/MBB attributes it lacks are all read
+        # via getattr(..., default) elsewhere, so those paths no-op cleanly.
+        from .const import CONF_STRATEGY, STRATEGY_COMPANION_ADB  # noqa: PLC0415
+        if self.entry.data.get(CONF_STRATEGY) == STRATEGY_COMPANION_ADB:
+            import time  # noqa: PLC0415
+
+            from .companion import CompanionClient  # noqa: PLC0415
+            from .const import (  # noqa: PLC0415
+                CONF_ADB_HOST,
+                CONF_ADB_PORT,
+                CONF_VIN,
+                DEFAULT_ADB_PORT,
+            )
+
+            self._cariad_client = CompanionClient(
+                brand=brand,
+                vin=self.entry.data[CONF_VIN],
+                host=self.entry.data[CONF_ADB_HOST],
+                port=self.entry.data.get(CONF_ADB_PORT, DEFAULT_ADB_PORT),
+                adbkey_path=self.hass.config.path(".storage", "vag_connect_adbkey"),
+                time_fn=time.monotonic,
+            )
+        else:
+            session = async_get_clientsession(self.hass)
+            self._cariad_client = CariadClientFactory.create(
+                brand, session, username, password, spin,
+                # v2.15.1 (#503) — Volkswagen US/Canada region. Only the
+                # volkswagen_na client consumes it; every other brand ignores
+                # the kwarg. Default "us" for entries created before this field.
+                country=self.entry.data.get(CONF_COUNTRY, "us"),
+                ola_app_version_override=ola_app_v,
+                ola_user_agent_override=ola_ua,
+            )
         # v2.10.4 — push the user-supplied OAuth client_id override
         # onto the underlying IDKAuth instance so the AuthConfigResolver
         # prepends it to the chain. No-op when override is None.
@@ -2373,6 +2404,17 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 await close_supp()
             except Exception:  # noqa: BLE001
                 pass
+        # v3.0.0a1 — the companion (ADB) client holds a TCP/ADB socket and a
+        # worker thread that must be released on unload/reload, or a reconfigure
+        # orphans the connection and (since ADB allows one authed session) can
+        # block the freshly-built client from reconnecting until the phone times
+        # out. Network clients have no ``close`` and are skipped.
+        close = getattr(self._cariad_client, "close", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception:  # noqa: BLE001
+                pass
         self._cariad_client = None
         _LOGGER.debug("VAG Connect: shutdown complete")
 
@@ -3010,6 +3052,26 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 # fail-soft — strict gate keeps this VIN's commands hidden
                 pass
+
+    def command_method_available(self, command_id: str) -> bool:
+        """v3.0.0a1 — does the active client implement this command?
+
+        Separate from ``command_capability_supported`` on purpose: that answers
+        a BACKEND capability question, this answers a CLIENT-method question.
+        The dispatcher calls ``getattr(self._cariad_client, command_id)``, so a
+        command whose method is absent could only ever raise AttributeError on
+        press (the "Unexpected exception" traceback class). Command-entity spawn
+        sites gate on this in addition to the capability check, mirroring the
+        long-standing guard in ``switch.py``. Matters for the companion (ADB)
+        client, which implements only climate + charge; a full network client
+        has every command method, so this is a no-op for existing setups.
+        A missing/None client returns True so setup-time entity creation before
+        the client is built is unaffected (capability check still applies).
+        """
+        client = getattr(self, "_cariad_client", None)
+        if client is None:
+            return True
+        return hasattr(client, command_id)
 
     def command_capability_supported(
         self, vin: str, command_id: str
@@ -4737,6 +4799,23 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             _brand = ""
         if _brand in ("seat", "cupra"):
             return True
+        # v3.0.0a1 — a companion (ADB) entry whose brand preset is not verified
+        # is structurally read-only: writes are refused at the channel anyway
+        # (a wrong tap on an unconfirmed screen map could hit the wrong control
+        # on the car), so spawning command entities that can only ever return a
+        # clean "experimental, read-only" error is just noise. A verified brand
+        # (currently only Volkswagen) is NOT forced read-only, so its climate +
+        # charge controls appear.
+        from .const import (  # noqa: PLC0415
+            CONF_STRATEGY,
+            STRATEGY_COMPANION_ADB,
+        )
+        if self.entry.data.get(CONF_STRATEGY) == STRATEGY_COMPANION_ADB:
+            from .companion.presets import PRESETS  # noqa: PLC0415
+
+            _preset = PRESETS.get(_brand)
+            if _preset is None or not _preset.writable:
+                return True
         # v2.14.0 — the volkswagen.de website authproxy (opt-in beta) is a
         # read-only channel too: the confidential web OAuth client has no
         # command surface, so command entities could only ever fail. Force

--- a/custom_components/vag_connect/lock.py
+++ b/custom_components/vag_connect/lock.py
@@ -32,6 +32,10 @@ async def async_setup_entry(
         # catches at runtime via classify_command_failure).
         if coordinator.command_capability_supported(vin, "command_lock") is False:
             return []
+        # v3.0.0a1 — the client must actually implement the command, or the
+        # entity would raise AttributeError on press (companion/ADB has no lock).
+        if not coordinator.command_method_available("command_lock"):
+            return []
         return [VagDoorLock(coordinator, vin)]
 
     register_dynamic_spawner(entry, coordinator, async_add_entities, _build_for_vin)

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -16,7 +16,8 @@
   "quality_scale": "platinum",
   "requirements": [
     "firebase-messaging>=0.4.0",
-    "aiomqtt>=2.0.0"
+    "aiomqtt>=2.0.0",
+    "adb-shell==0.4.4"
   ],
-  "version": "2.24.2"
+  "version": "3.0.0a1"
 }

--- a/custom_components/vag_connect/number.py
+++ b/custom_components/vag_connect/number.py
@@ -215,6 +215,10 @@ async def async_setup_entry(
             cmd_id = _CMD_ID.get(desc.key)
             if cmd_id and coordinator.command_capability_supported(vin, cmd_id) is False:
                 continue
+            # v3.0.0a1 — the client must implement the command, else the number
+            # raises AttributeError on set (companion/ADB has no target-SoC etc.).
+            if cmd_id and not coordinator.command_method_available(cmd_id):
+                continue
             entities.append(VagConnectNumber(coordinator, vin, desc))
         return entities
 

--- a/custom_components/vag_connect/select.py
+++ b/custom_components/vag_connect/select.py
@@ -148,9 +148,15 @@ async def async_setup_entry(
     def _build_for_vin(vin: str, vehicle: dict) -> list:
         entities: list = []
         if vehicle.get("has_battery"):
-            entities.append(VagChargeModeSelect(coordinator, vin))
+            # v3.0.0a1 — only if the client implements the command, else the
+            # select raises AttributeError on change (companion/ADB has no
+            # charge-mode command).
+            if coordinator.command_method_available("command_set_charge_mode"):
+                entities.append(VagChargeModeSelect(coordinator, vin))
             # v2.15.10 — Skoda-only max-charging-current select (enum plane).
-            if is_skoda:
+            if is_skoda and coordinator.command_method_available(
+                "command_update_charging_settings"
+            ):
                 entities.append(VagSkodaChargeCurrentSelect(coordinator, vin))
         return entities
 

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -132,6 +132,22 @@
           "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, not a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
       "portal_interaction_required": "The EU Data Act portal needs a one-time action in your browser or brand app (e.g. accept terms, confirm consent, finish onboarding/region selection) before headless access works. This is NOT a wrong-password problem — open the portal once in a browser, complete the prompt, then try again.",
-      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "This account is already configured.",

--- a/custom_components/vag_connect/time.py
+++ b/custom_components/vag_connect/time.py
@@ -51,6 +51,9 @@ async def async_setup_entry(
             is False
         ):
             return []
+        # v3.0.0a1 — client must implement it (companion/ADB does not).
+        if not coordinator.command_method_available("command_set_departure_timer"):
+            return []
         return [VagDepartureTimerTime(coordinator, vin, tid) for tid in (1, 2, 3)]
 
     register_dynamic_spawner(entry, coordinator, async_add_entities, _build_for_vin)

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -132,6 +132,22 @@
           "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "portal_interaction_required": "Portál EU Data Act vyžaduje jednorázovou akci ve vašem prohlížeči nebo aplikaci značky (např. přijmout podmínky, potvrdit souhlas, dokončit onboarding/výběr regionu), než začne fungovat bezhlavý přístup. Toto NENÍ problém se špatným heslem — otevřete portál jednou v prohlížeči, dokončete výzvu a zkuste to znovu.",
       "upstream_unavailable": "Backend VW dočasně nedostupný. Toto je problém na straně serveru VW, NIKOLI chyba přihlášení. Počkejte 5–15 minut a zkuste to znovu. Integraci znovu NEKONFIGURUJTE.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
-      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Tento účet je již nastaven.",

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -132,6 +132,22 @@
           "user_code": "Efter login skal du bekræfte denne kode i browseren for at godkende Home Assistant.",
           "approved_in_browser": "Lad fluebenet stå. Klik først på Send, når du har logget ind og bekræftet koden i browseren."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "upstream_unavailable": "VW-backendet er midlertidigt utilgængeligt. Dette er et serverproblem hos VW, IKKE et problem med loginoplysninger. Vent venligst 5-15 minutter, og prøv igen. Konfigurer IKKE integrationen igen.",
       "brand_not_dag_eligible": "Det valgte mærke understøtter ikke browser-login. Brug flowet med e-mail + adgangskode i stedet.",
       "portal_interaction_required": "EU Data Act-portalen kræver en engangshandling i din browser eller mærke-app (f.eks. accepter vilkår, bekræft samtykke, fuldfør onboarding/regionsvalg), før headless-adgang virker. Dette er IKKE et problem med forkert adgangskode — åbn portalen én gang i en browser, fuldfør anmodningen, og prøv igen.",
-      "still_waiting_browser": "Venter stadig på browser-godkendelse. Åbn URL'en ovenfor, log ind, bekræft koden, og klik på Send igen."
+      "still_waiting_browser": "Venter stadig på browser-godkendelse. Åbn URL'en ovenfor, log ind, bekræft koden, og klik på Send igen.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Denne konto er allerede konfigureret.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -132,6 +132,22 @@
           "user_code": "Nach dem Anmelden diesen Code im Browser bestätigen um Home Assistant freizugeben.",
           "approved_in_browser": "Haken gesetzt lassen. Erst auf Senden klicken nachdem du im Browser angemeldet und den Code bestätigt hast."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "portal_interaction_required": "Das EU-Data-Act-Portal benötigt eine einmalige Aktion in deinem Browser oder der Marken-App (z. B. AGB akzeptieren, Einwilligung bestätigen, Onboarding/Region-Auswahl abschließen), bevor der headless-Zugriff funktioniert. Das ist KEIN Passwort-Problem — öffne das Portal einmal im Browser, schließe die Abfrage ab und versuche es erneut.",
       "upstream_unavailable": "VW-Backend vorübergehend nicht erreichbar. Das ist ein Server-Problem bei VW, KEIN Anmeldefehler. Bitte 5–15 Minuten warten und nochmal versuchen. Die Integration NICHT neu konfigurieren.",
       "brand_not_dag_eligible": "Diese Marke unterstützt kein Browser-Login. Nutze stattdessen E-Mail + Passwort.",
-      "still_waiting_browser": "Warte noch auf die Browser-Bestätigung. Öffne die URL oben, melde dich an, bestätige den Code und klick dann nochmal auf Senden."
+      "still_waiting_browser": "Warte noch auf die Browser-Bestätigung. Öffne die URL oben, melde dich an, bestätige den Code und klick dann nochmal auf Senden.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Dieses Konto ist bereits eingerichtet.",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -132,6 +132,22 @@
           "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, NOT a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
       "portal_interaction_required": "The EU Data Act portal needs a one-time action in your browser or brand app (e.g. accept terms, confirm consent, finish onboarding/region selection) before headless access works. This is NOT a wrong-password problem — open the portal once in a browser, complete the prompt, then try again.",
-      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "This account is already configured.",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -132,6 +132,22 @@
           "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "portal_interaction_required": "El portal de la EU Data Act necesita una acción única en tu navegador o en la app de la marca (p. ej. aceptar los términos, confirmar el consentimiento, completar el onboarding/selección de región) antes de que funcione el acceso sin interfaz. Esto NO es un problema de contraseña: abre el portal una vez en un navegador, completa el aviso y vuelve a intentarlo.",
       "upstream_unavailable": "Backend de VW temporalmente no disponible. Es un problema del servidor de VW, NO un problema de credenciales. Espera 5–15 minutos e inténtalo de nuevo. NO reconfigures la integración.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
-      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Esta cuenta ya está configurada.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -132,6 +132,22 @@
           "user_code": "Kirjautumisen jälkeen vahvista tämä koodi selaimessa hyväksyäksesi Home Assistantin.",
           "approved_in_browser": "Jätä rastitetuksi. Napsauta Lähetä vasta, kun olet kirjautunut sisään ja vahvistanut koodin selaimessa."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "upstream_unavailable": "VW-taustajärjestelmä tilapäisesti tavoittamattomissa. Tämä on palvelinpuolen ongelma VW:llä, EI kirjautumistieto-ongelma. Odota 5–15 minuuttia ja yritä uudelleen. ÄLÄ määritä integraatiota uudelleen.",
       "brand_not_dag_eligible": "Valittu merkki ei tue selainkirjautumista. Käytä sen sijaan sähköposti + salasana -kirjautumista.",
       "portal_interaction_required": "EU Data Act -portaali vaatii kertaluonteisen toimenpiteen selaimessasi tai merkin sovelluksessa (esim. käyttöehtojen hyväksyminen, suostumuksen vahvistaminen, käyttöönoton/alueen valinnan viimeistely) ennen kuin selaimeton pääsy toimii. Tämä EI ole väärän salasanan ongelma — avaa portaali kerran selaimessa, suorita kehote loppuun ja yritä sitten uudelleen.",
-      "still_waiting_browser": "Odotetaan yhä selaimen hyväksyntää. Avaa yllä oleva URL-osoite, kirjaudu sisään, vahvista koodi ja napsauta sitten Lähetä uudelleen."
+      "still_waiting_browser": "Odotetaan yhä selaimen hyväksyntää. Avaa yllä oleva URL-osoite, kirjaudu sisään, vahvista koodi ja napsauta sitten Lähetä uudelleen.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Tämä tili on jo määritetty.",

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -132,6 +132,22 @@
           "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "portal_interaction_required": "Le portail EU Data Act nécessite une action ponctuelle dans votre navigateur ou l'application de la marque (par ex. accepter les conditions, confirmer le consentement, terminer l'intégration / la sélection de région) avant que l'accès sans interface ne fonctionne. Ce n'est PAS un problème de mot de passe — ouvrez le portail une fois dans un navigateur, complétez l'invite, puis réessayez.",
       "upstream_unavailable": "Backend VW temporairement indisponible. C'est un problème côté serveur chez VW, PAS un problème d'identifiants. Veuillez patienter 5 à 15 minutes puis réessayer. NE reconfigurez PAS l'intégration.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
-      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Ce compte est déjà configuré.",

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -132,6 +132,22 @@
           "user_code": "Dopo aver effettuato l'accesso, conferma questo codice nel browser per approvare Home Assistant.",
           "approved_in_browser": "Lascia la casella selezionata. Clicca su Invia solo dopo aver effettuato l'accesso e confermato il codice nel browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "upstream_unavailable": "Backend VW temporaneamente non disponibile. Si tratta di un problema lato server di VW, NON di un problema di credenziali. Attendi 5–15 minuti e riprova. NON riconfigurare l'integrazione.",
       "brand_not_dag_eligible": "La marca selezionata non supporta il login via browser. Usa invece la procedura con email + password.",
       "portal_interaction_required": "Il portale EU Data Act richiede un'azione una tantum nel tuo browser o nell'app della marca (ad es. accettare i termini, confermare il consenso, completare l'onboarding/la selezione della regione) prima che l'accesso headless funzioni. Questo NON è un problema di password errata — apri il portale una volta in un browser, completa la richiesta, poi riprova.",
-      "still_waiting_browser": "In attesa dell'approvazione dal browser. Apri l'URL qui sopra, accedi, conferma il codice, poi clicca di nuovo su Invia."
+      "still_waiting_browser": "In attesa dell'approvazione dal browser. Apri l'URL qui sopra, accedi, conferma il codice, poi clicca di nuovo su Invia.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Questo account è già configurato.",

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -132,6 +132,22 @@
           "user_code": "Etter innlogging bekrefter du denne koden i nettleseren for å godkjenne Home Assistant.",
           "approved_in_browser": "La den være avkrysset. Klikk Send inn først etter at du har logget inn og bekreftet koden i nettleseren."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "upstream_unavailable": "VW-baksystemet er midlertidig utilgjengelig. Dette er et problem på VWs side, IKKE et problem med påloggingsinformasjonen. Vent 5–15 minutter og prøv igjen. IKKE konfigurer integrasjonen på nytt.",
       "brand_not_dag_eligible": "Det valgte merket støtter ikke nettleserpålogging. Bruk e-post + passord-flyten i stedet.",
       "portal_interaction_required": "EU Data Act-portalen trenger en engangshandling i nettleseren din eller merkeappen (f.eks. godta vilkår, bekrefte samtykke, fullføre onboarding/regionvalg) før tilgang uten nettleser fungerer. Dette er IKKE et problem med feil passord — åpne portalen én gang i en nettleser, fullfør oppgaven, og prøv igjen.",
-      "still_waiting_browser": "Venter fortsatt på godkjenning i nettleseren. Åpne URL-en ovenfor, logg inn, bekreft koden, og klikk Send inn igjen."
+      "still_waiting_browser": "Venter fortsatt på godkjenning i nettleseren. Åpne URL-en ovenfor, logg inn, bekreft koden, og klikk Send inn igjen.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Denne kontoen er allerede konfigurert.",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -132,6 +132,22 @@
           "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "portal_interaction_required": "Het EU Data Act-portaal vereist een eenmalige actie in je browser of merk-app (bijv. voorwaarden accepteren, toestemming bevestigen, onboarding/regiokeuze voltooien) voordat headless-toegang werkt. Dit is GEEN wachtwoordprobleem — open het portaal één keer in een browser, voltooi de melding en probeer het opnieuw.",
       "upstream_unavailable": "VW backend tijdelijk onbereikbaar. Dit is een serverprobleem bij VW, GEEN inlogfout. Wacht 5–15 minuten en probeer opnieuw. Configureer de integratie NIET opnieuw.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
-      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Dit account is al geconfigureerd.",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -132,6 +132,22 @@
           "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "portal_interaction_required": "Portal EU Data Act wymaga jednorazowej czynności w przeglądarce lub aplikacji marki (np. zaakceptowania warunków, potwierdzenia zgody, dokończenia onboardingu/wyboru regionu), zanim zadziała dostęp bez interfejsu. To NIE jest problem z hasłem — otwórz portal raz w przeglądarce, wykonaj polecenie i spróbuj ponownie.",
       "upstream_unavailable": "Backend VW chwilowo niedostępny. To problem po stronie serwera VW, a NIE błąd uwierzytelniania. Poczekaj 5–15 minut i spróbuj ponownie. NIE konfiguruj integracji ponownie.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
-      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "To konto jest już skonfigurowane.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -132,6 +132,22 @@
           "user_code": "After signing in, confirm this code in the browser to approve Home Assistant.",
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
+      },
+      "companion_adb": {
+        "title": "Companion phone (ADB) — experimental",
+        "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
+        "data": {
+          "brand": "Vehicle brand",
+          "adb_host": "Phone IP address",
+          "adb_port": "ADB port",
+          "vin": "VIN (the car the app shows)",
+          "spin": "S-PIN (optional)"
+        },
+        "data_description": {
+          "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
+          "adb_port": "Usually 5555 for ADB over Wi-Fi.",
+          "vin": "The 17-character VIN of the car shown in the app."
+        }
       }
     },
     "error": {
@@ -146,7 +162,10 @@
       "portal_interaction_required": "EU Data Act-portalen kräver en engångsåtgärd i din webbläsare eller varumärkesapp (t.ex. godkänna villkor, bekräfta samtycke, slutföra onboarding/regionval) innan huvudlös åtkomst fungerar. Detta är INTE ett lösenordsproblem — öppna portalen en gång i en webbläsare, slutför uppmaningen och försök igen.",
       "upstream_unavailable": "VW backend tillfälligt otillgänglig. Detta är ett serverproblem hos VW, INTE ett autentiseringsfel. Vänta 5–15 minuter och försök igen. Konfigurera INTE om integrationen.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
-      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again."
+      "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
+      "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
+      "companion_unknown_brand": "That brand has no companion preset yet."
     },
     "abort": {
       "already_configured": "Det här kontot är redan konfigurerat.",

--- a/tests/test_v2150b12_setup_menu_mbb_toggle.py
+++ b/tests/test_v2150b12_setup_menu_mbb_toggle.py
@@ -41,11 +41,14 @@ def _flow() -> VagConnectConfigFlow:
 
 # ── menu trimmed to 2 ────────────────────────────────────────────────────────
 
-def test_menu_has_exactly_two_login_paths() -> None:
+def test_menu_has_the_expected_sources() -> None:
+    # b12 collapsed the old standalone mbb_login / website_authproxy entries into
+    # the Portal toggle. v3.0.0a1 added the experimental companion (ADB) source
+    # as a third entry. The two removed ones must stay gone.
     result = asyncio.run(_flow().async_step_user(None))
     assert result["type"] == "menu"
     opts = set(result["menu_options"])
-    assert opts == {"browser_login", "email_password"}
+    assert opts == {"browser_login", "email_password", "companion_adb"}
     assert "mbb_login" not in opts
     assert "website_authproxy" not in opts
 

--- a/tests/test_v300a1_companion_adb.py
+++ b/tests/test_v300a1_companion_adb.py
@@ -1,0 +1,466 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v3.0.0-alpha — companion (ADB) channel.
+
+The device-touching layer (``transport``) is not tested here; it needs a phone.
+Everything above it is pure and is tested hard, because that is where a wrong
+decision would ship a bad read or, worse, a tap onto the wrong control:
+
+- screen parsing and selector resolution (resource-id / content-desc / label);
+- the value coercions (percent bounds, first-int, charging bool);
+- the write quarantine: unverified brand never writes, version drift disables
+  writes but not reads, unknown version disables writes;
+- the post-failure cooldown clock (no per-read throttle: scan_interval is the
+  cadence, and a cooldown read must not itself count as a failed poll);
+- the client adapter mapping a screen read onto VehicleData, and refusing
+  commands with a clean VehicleCommandError rather than a raw crash;
+- every brand preset is structurally complete, and exactly one is verified.
+"""
+from __future__ import annotations
+
+
+import pytest
+
+from custom_components.vag_connect.companion.channel import (
+    CompanionChannel,
+    CompanionWriteBlocked,
+)
+from custom_components.vag_connect.companion.presets import (
+    ACTION_TO_COMMAND,
+    PRESETS,
+    coerce,
+)
+from custom_components.vag_connect.companion.screen import (
+    parse_ui_dump,
+    read_fields,
+)
+
+
+# ── a realistic uiautomator dump fragment for the VW app ────────────────────
+
+def _dump(nodes_xml: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<hierarchy rotation="0">' + nodes_xml + "</hierarchy>"
+    )
+
+
+VW_SCREEN = _dump(
+    '<node resource-id="" content-desc="Ladezustand 74 %" text="" '
+    'class="android.widget.TextView" clickable="false" bounds="[0,0][100,50]" />'
+    '<node resource-id="" content-desc="Reichweite 312 km" text="" '
+    'class="android.widget.TextView" clickable="false" bounds="[0,60][100,110]" />'
+    '<node resource-id="" content-desc="Wird geladen" text="" '
+    'class="android.widget.TextView" clickable="false" bounds="[0,120][100,170]" />'
+    '<node resource-id="" content-desc="Klimatisierung starten" text="Klima" '
+    'class="android.widget.Button" clickable="true" bounds="[0,200][200,260]" />'
+)
+
+
+class TestScreenParsing:
+    def test_empty_and_garbage_dumps_do_not_raise(self) -> None:
+        assert parse_ui_dump("") == []
+        assert parse_ui_dump("not xml") == []
+        assert parse_ui_dump("<hierarchy></hierarchy>") == []
+
+    def test_bounds_and_tap_point(self) -> None:
+        nodes = parse_ui_dump(VW_SCREEN)
+        btn = next(n for n in nodes if n.clazz.endswith("Button"))
+        assert btn.bounds == (0, 200, 200, 260)
+        assert btn.tap_point == (100, 230)
+
+    def test_vw_read_pulls_soc_range_and_state(self) -> None:
+        fields = read_fields(parse_ui_dump(VW_SCREEN), PRESETS["volkswagen"])
+        assert fields["battery_soc"] == 74
+        assert fields["electric_range_km"] == 312
+        assert fields["is_charging"] is True
+        assert "Wird geladen" in str(fields["charging_state"])
+
+    def test_partial_screen_yields_only_what_matched(self) -> None:
+        # No range node → range simply absent, never a spurious None/0.
+        screen = _dump(
+            '<node resource-id="" content-desc="Ladezustand 55 %" text="" '
+            'class="TextView" clickable="false" bounds="[0,0][10,10]" />'
+        )
+        fields = read_fields(parse_ui_dump(screen), PRESETS["volkswagen"])
+        assert fields == {"battery_soc": 55}
+
+
+class TestCoercion:
+    def test_percent_rejects_implausible_values(self) -> None:
+        assert coerce("percent", "74 %") == 74
+        assert coerce("percent", "0 %") == 0
+        assert coerce("percent", "100 %") == 100
+        assert coerce("percent", "312 km") is None  # a range wrongly matched
+
+    def test_int_km_takes_the_first_integer(self) -> None:
+        assert coerce("int_km", "312 km") == 312
+        assert coerce("int_km", "noch 45 min") == 45
+
+    def test_bool_charging(self) -> None:
+        assert coerce("bool_charging", "Wird geladen") is True
+        assert coerce("bool_charging", "Nicht verbunden") is False
+
+    def test_blank_is_none(self) -> None:
+        assert coerce("percent", "") is None
+        assert coerce("str", None) is None
+
+
+# ── the write quarantine — the part that must never tap in the dark ─────────
+
+class _FakeTransport:
+    """A transport stub: canned dump + version, records taps. No device."""
+
+    def __init__(self, *, version: str | None, dump: str) -> None:
+        self._version = version
+        self._dump = dump
+        self.taps: list[tuple[int, int]] = []
+        self.connected = True
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def foreground_app(self, package: str) -> None:  # noqa: ARG002
+        return None
+
+    async def current_app_version(self, package: str) -> str | None:  # noqa: ARG002
+        return self._version
+
+    async def dump_ui(self) -> str:
+        return self._dump
+
+    async def tap(self, x: int, y: int) -> None:
+        self.taps.append((x, y))
+
+
+def _clock():
+    t = {"v": 10_000.0}
+
+    def now() -> float:
+        return t["v"]
+
+    def advance(dt: float) -> None:
+        t["v"] += dt
+
+    return now, advance
+
+
+class TestWriteQuarantine:
+    @pytest.mark.asyncio
+    async def test_verified_matching_version_allows_a_tap(self) -> None:
+        now, _ = _clock()
+        t = _FakeTransport(version="4.2.1", dump=VW_SCREEN)
+        ch = CompanionChannel(t, PRESETS["volkswagen"], time_fn=now)
+        await ch.read()
+        assert ch.writes_enabled is True
+        await ch.do_action("start_climate")
+        assert t.taps == [(100, 230)]
+
+    @pytest.mark.asyncio
+    async def test_version_drift_disables_writes_but_not_reads(self) -> None:
+        now, _ = _clock()
+        t = _FakeTransport(version="4.3.0", dump=VW_SCREEN)
+        ch = CompanionChannel(t, PRESETS["volkswagen"], time_fn=now)
+        fields = await ch.read()
+        assert fields["battery_soc"] == 74, "reads must keep working on drift"
+        assert ch.writes_enabled is False
+        with pytest.raises(CompanionWriteBlocked):
+            await ch.do_action("start_climate")
+        assert t.taps == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_version_disables_writes(self) -> None:
+        now, _ = _clock()
+        t = _FakeTransport(version=None, dump=VW_SCREEN)
+        ch = CompanionChannel(t, PRESETS["volkswagen"], time_fn=now)
+        await ch.read()
+        assert ch.writes_enabled is False
+
+    @pytest.mark.asyncio
+    async def test_unverified_brand_never_writes(self) -> None:
+        # Even with a matching version, an unverified preset must refuse to tap.
+        now, _ = _clock()
+        t = _FakeTransport(version="anything", dump=VW_SCREEN)
+        ch = CompanionChannel(t, PRESETS["audi"], time_fn=now)
+        await ch.read()
+        assert ch.writes_enabled is False
+        with pytest.raises(CompanionWriteBlocked):
+            await ch.do_action("start_climate")
+
+
+class TestFailureCooldown:
+    """No per-read throttle anymore (scan_interval is the cadence); only a
+    post-failure cooldown, which must NOT read as a failed poll while active."""
+
+    @pytest.mark.asyncio
+    async def test_back_to_back_reads_are_not_throttled(self) -> None:
+        # Two reads with no failure in between both run — the old 15-min budget
+        # (which mis-counted the second as a failure) is gone.
+        now, _ = _clock()
+        t = _FakeTransport(version="4.2.1", dump=VW_SCREEN)
+        ch = CompanionChannel(t, PRESETS["volkswagen"], time_fn=now)
+        assert await ch.read()
+        assert await ch.read()  # not None, not throttled
+
+    @pytest.mark.asyncio
+    async def test_a_transport_failure_trips_a_cooldown(self) -> None:
+        from custom_components.vag_connect.companion.transport import (
+            CompanionTransportError,
+        )
+
+        now, advance = _clock()
+
+        class _Flaky(_FakeTransport):
+            async def dump_ui(self) -> str:
+                raise CompanionTransportError("phone asleep")
+
+        t = _Flaky(version="4.2.1", dump=VW_SCREEN)
+        ch = CompanionChannel(t, PRESETS["volkswagen"], time_fn=now)
+        with pytest.raises(CompanionTransportError):
+            await ch.read()
+        # next read inside the cooldown window returns None (not a re-raise, not
+        # a blank) so the coordinator does not stack failures
+        assert await ch.read() is None
+
+    @pytest.mark.asyncio
+    async def test_cooldown_clears_after_the_window(self) -> None:
+        from custom_components.vag_connect.companion.channel import (
+            _FAILURE_COOLDOWN_S,
+        )
+        from custom_components.vag_connect.companion.transport import (
+            CompanionTransportError,
+        )
+
+        now, advance = _clock()
+        state = {"fail": True}
+
+        class _Recovers(_FakeTransport):
+            async def dump_ui(self) -> str:
+                if state["fail"]:
+                    raise CompanionTransportError("phone asleep")
+                return VW_SCREEN
+
+        t = _Recovers(version="4.2.1", dump=VW_SCREEN)
+        ch = CompanionChannel(t, PRESETS["volkswagen"], time_fn=now)
+        with pytest.raises(CompanionTransportError):
+            await ch.read()
+        state["fail"] = False
+        assert await ch.read() is None  # still cooling down
+        advance(_FAILURE_COOLDOWN_S + 1)
+        assert await ch.read()  # window elapsed, reads again
+
+
+# ── the client adapter ──────────────────────────────────────────────────────
+
+class TestCompanionClient:
+    def _client(self, transport, brand="volkswagen"):
+        from custom_components.vag_connect.companion.client import CompanionClient
+
+        c = CompanionClient.__new__(CompanionClient)
+        # wire the internals without touching a real transport
+        import time
+
+        from custom_components.vag_connect.companion.channel import CompanionChannel
+
+        c._brand = brand
+        c._vin = "WVWZZZAUZFW805377"
+        c._transport = transport
+        c._channel = CompanionChannel(transport, PRESETS[brand], time_fn=time.monotonic)
+        c.on_tokens_changed = None
+        c._eu_portal = None
+        c._tokens = None
+        c._last_data = None
+        return c
+
+    @pytest.mark.asyncio
+    async def test_get_status_maps_a_read_onto_vehicledata(self) -> None:
+        t = _FakeTransport(version="4.2.1", dump=VW_SCREEN)
+        c = self._client(t)
+        data = await c.get_status("WVWZZZAUZFW805377")
+        assert data.battery_soc == 74
+        assert data.electric_range_km == 312
+        assert data.source_channel == "companion_adb"
+        assert data.no_data is False
+
+    @pytest.mark.asyncio
+    async def test_empty_read_returns_no_data_not_a_raise(self) -> None:
+        t = _FakeTransport(version="4.2.1", dump=_dump(""))
+        c = self._client(t)
+        data = await c.get_status("WVWZZZAUZFW805377")
+        assert data.no_data is True
+
+    @pytest.mark.asyncio
+    async def test_get_vehicles_returns_the_configured_vin(self) -> None:
+        t = _FakeTransport(version="4.2.1", dump=VW_SCREEN)
+        c = self._client(t)
+        assert await c.get_vehicles() == ["WVWZZZAUZFW805377"]
+
+    @pytest.mark.asyncio
+    async def test_cooldown_poll_returns_last_data_not_no_data(self) -> None:
+        # S3: a poll during the post-failure cooldown must not read as a failed
+        # poll. The client hands back the last real snapshot, unchanged.
+        from custom_components.vag_connect.companion.transport import (
+            CompanionTransportError,
+        )
+
+        state = {"fail": False}
+
+        class _Flaky(_FakeTransport):
+            async def dump_ui(self) -> str:
+                if state["fail"]:
+                    raise CompanionTransportError("asleep")
+                return VW_SCREEN
+
+        t = _Flaky(version="4.2.1", dump=VW_SCREEN)
+        c = self._client(t)
+        first = await c.get_status("WVWZZZAUZFW805377")
+        assert first.battery_soc == 74 and first.no_data is False
+        # trip the cooldown, then poll again while it is active
+        state["fail"] = True
+        try:
+            await c.get_status("WVWZZZAUZFW805377")
+        except CompanionTransportError:
+            pass
+        during = await c.get_status("WVWZZZAUZFW805377")
+        assert during is first, "cooldown poll should hand back the last snapshot"
+        assert during.no_data is False
+
+    @pytest.mark.asyncio
+    async def test_cooldown_with_no_history_is_no_data(self) -> None:
+        # If the very first poll fails and there is nothing cached, a subsequent
+        # cooldown poll returns a clean no_data rather than None.
+        from custom_components.vag_connect.companion.transport import (
+            CompanionTransportError,
+        )
+
+        class _DeadOnArrival(_FakeTransport):
+            async def dump_ui(self) -> str:
+                raise CompanionTransportError("asleep")
+
+        t = _DeadOnArrival(version="4.2.1", dump=VW_SCREEN)
+        c = self._client(t)
+        try:
+            await c.get_status("WVWZZZAUZFW805377")
+        except CompanionTransportError:
+            pass
+        data = await c.get_status("WVWZZZAUZFW805377")  # in cooldown, no history
+        assert data.no_data is True
+
+    @pytest.mark.asyncio
+    async def test_command_before_first_poll_still_works_on_verified_vw(self) -> None:
+        # S4: a command issued before any scheduled read must decide the write
+        # gate itself, not reject on the initial None.
+        t = _FakeTransport(version="4.2.1", dump=VW_SCREEN)
+        c = self._client(t)  # no get_status called yet
+        await c.command_start_climate("WVWZZZAUZFW805377")
+        assert t.taps == [(100, 230)]
+
+    @pytest.mark.asyncio
+    async def test_unverified_brand_command_raises_clean_vehiclecommanderror(self) -> None:
+        from custom_components.vag_connect.cariad.exceptions import VehicleCommandError
+
+        t = _FakeTransport(version="x", dump=VW_SCREEN)
+        c = self._client(t, brand="audi")
+        await c.get_status("WVWZZZAUZFW805377")  # decide writes
+        with pytest.raises(VehicleCommandError):
+            await c.command_start_climate("WVWZZZAUZFW805377")
+
+
+# ── coordinator integration: B1 (spawn guard) + S1 (read-only) ──────────────
+
+class TestCoordinatorGuards:
+    def _coord(self, *, brand: str, client: object):
+        from unittest.mock import MagicMock
+
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        from custom_components.vag_connect.const import STRATEGY_COMPANION_ADB
+
+        c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        c._cariad_client = client
+        c.entry = MagicMock()
+        c.entry.data = {"brand": brand, "strategy": STRATEGY_COMPANION_ADB}
+        c.entry.options = {}
+        c.vehicles = {}
+        return c
+
+    def _companion_client(self, brand: str):
+
+        from custom_components.vag_connect.companion.client import CompanionClient
+
+        cl = CompanionClient.__new__(CompanionClient)
+        cl._brand = brand
+        cl._vin = "V"
+        # only the methods a real CompanionClient has
+        return cl
+
+    def test_b1_missing_command_method_reported_unavailable(self) -> None:
+        # command_lock/flash/wake are not implemented by CompanionClient → the
+        # spawn-site guard hides them, so no entity spawns to crash on press.
+        c = self._coord(brand="volkswagen", client=self._companion_client("volkswagen"))
+        assert c.command_method_available("command_lock") is False
+        assert c.command_method_available("command_flash") is False
+        assert c.command_method_available("command_wake") is False
+        assert c.command_method_available("command_set_target_soc") is False
+        assert c.command_method_available("command_set_climate_temperature") is False
+
+    def test_b1_present_command_method_reported_available(self) -> None:
+        # climate + charge ARE implemented by the companion adapter.
+        c = self._coord(brand="volkswagen", client=self._companion_client("volkswagen"))
+        assert c.command_method_available("command_start_climate") is True
+        assert c.command_method_available("command_stop_climate") is True
+        assert c.command_method_available("command_start_charging") is True
+
+    def test_b1_no_client_defers_to_capability(self) -> None:
+        # Before the client is built, the method-availability guard must not
+        # hide entities (the capability check still applies).
+        c = self._coord(brand="volkswagen", client=None)
+        c._cariad_client = None
+        assert c.command_method_available("command_lock") is True
+
+    def test_s1_unverified_brand_is_read_only(self) -> None:
+        c = self._coord(brand="audi", client=self._companion_client("audi"))
+        assert c.is_read_only() is True
+
+    def test_s1_verified_vw_is_not_forced_read_only(self) -> None:
+        c = self._coord(brand="volkswagen", client=self._companion_client("volkswagen"))
+        assert c.is_read_only() is False
+
+
+# ── preset integrity ────────────────────────────────────────────────────────
+
+class TestPresetIntegrity:
+    def test_all_five_brands_present(self) -> None:
+        assert set(PRESETS) == {"volkswagen", "audi", "skoda", "seat", "cupra"}
+
+    def test_exactly_one_brand_is_verified(self) -> None:
+        verified = [b for b, p in PRESETS.items() if p.verified]
+        assert verified == ["volkswagen"], (
+            "only the brand actually tested on hardware may be verified; "
+            f"got {verified}"
+        )
+
+    def test_only_verified_presets_are_writable(self) -> None:
+        for brand, p in PRESETS.items():
+            if p.writable:
+                assert p.verified, f"{brand} is writable without being verified"
+
+    def test_unverified_presets_have_no_actions(self) -> None:
+        for brand, p in PRESETS.items():
+            if not p.verified:
+                assert p.actions == (), f"{brand} ships tap actions unverified"
+
+    def test_every_preset_reads_soc_and_range(self) -> None:
+        for brand, p in PRESETS.items():
+            targets = {f.target for f in p.fields}
+            assert "battery_soc" in targets, brand
+            assert "electric_range_km" in targets, brand
+
+    def test_every_action_maps_to_a_known_command(self) -> None:
+        for brand, p in PRESETS.items():
+            for a in p.actions:
+                assert a.action in ACTION_TO_COMMAND, f"{brand}:{a.action}"
+
+    def test_packages_are_distinct_and_plausible(self) -> None:
+        pkgs = {p.package for p in PRESETS.values()}
+        assert len(pkgs) == len(PRESETS)
+        assert PRESETS["volkswagen"].package == "com.volkswagen.weconnect"


### PR DESCRIPTION
Pre-release, experimental. Adds one opt-in source and changes nothing for existing setups (lazy dependency import, no entry-type changes, the channel only exists if the user picks it).

## What it is

A fourth source in the hub menu that drives the official manufacturer app on a spare Android phone over network ADB and reads the values off the screen. No separate login, no stored credentials, no root, no token reads — screen in via `uiautomator dump`, taps out via `input tap`. A last-resort two-way path on cars where every network channel is read-only.

- **Volkswagen is verified** against a real Golf GTE (We Connect 4.2.1): SoC, range, charging state; start/stop climate and charging.
- **Audi, Škoda, SEAT, CUPRA ship structurally read-only.** The screen maps are best-effort until a tester confirms them; an unverified preset reads what it can and refuses to tap rather than risk the wrong control.

## Architecture

`companion/` is self-contained (`transport / screen / presets / channel / client`). The client duck-types the coordinator's existing read + command surface, so a companion entry flows through the same setup and poll loop as any network client; the token/portal/MBB attributes it lacks are read via `getattr(..., default)` and no-op cleanly.

## Pre-release triage (fixed before the first commit, not as follow-ups)

An adversarial triage ran over the whole thing before release. It found and this PR fixes:
- **Blocker:** command entities whose method the client doesn't implement would AttributeError on press (the v2.24.2 traceback class, through a new door). Now hidden at spawn via `command_method_available()`, mirroring `switch.py`. Universally correct, no-op for full network clients.
- **Blocker:** missing CHANGELOG entry (would fail the commit hook and CI).
- Unverified companion brands are structurally read-only.
- The ADB socket is closed on unload/reload (was a leak).
- No private read throttle (a uiautomator dump reads the local screen, no backend traffic — `scan_interval` is the only cadence); a transport failure trips a short cooldown that does not count as a failed poll and clears on restart.
- Write quarantine disables taps on app-version drift; reads keep working.
- `adb-shell` pinned `==0.4.4` (matches HA core's androidtv; no `[async]` extra, sync `AdbDeviceTcp` via `asyncio.to_thread`).

The safety invariant — an unverified brand can never send a tap — was independently confirmed to hold.

## Verification

- Full suite: **4164 passed**, 15 skipped.
- 34 companion tests (screen parse, selector resolution, coercion bounds, write quarantine, failure cooldown, client adapter, preset integrity) plus coordinator spawn-guard and read-only tests.
- The device-touching transport is not unit-tested (needs a phone); everything above it is.
- ruff + mypy strict clean via pre-commit.

## Not in this alpha (needs a tester's phone)

The four unverified brands' selectors, poll/command concurrency lock + unique dump filename, and a few display-only selector hardenings. Tracked separately. Testers with Audi / Škoda / SEAT / CUPRA welcome.