### PR TITLE
fix: persist vw.de supplementary session (#966/#632) + stop sentinel Scout spam (#958/#969/#970) — v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,17 +38,22 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [3.0.0a1] - 2026-07-27
+## [2.25.0] - 2026-07-27
 
-> **Pre-release, experimental.** This alpha adds one new opt-in source and changes nothing for existing setups. It only appears in HACS if you have beta versions enabled. If you do not set up the companion channel, the integration behaves exactly like 2.24.2.
+> The companion (ADB) channel that was briefly pre-released as 3.0.0a1 ships here in the stable line instead. It is still opt-in and experimental, and it changes nothing unless you set it up: if you do not pick it in the hub menu, the integration behaves exactly like 2.24.2.
 
 ### Added
 
 - **Companion phone (ADB) channel — experimental, opt-in.** A fourth source in the hub menu at the start of setup, next to the QR login, the portal login, and MBB. It drives the official manufacturer app on a spare Android phone over ADB and reads the values off the screen, so it works as a last-resort two-way path on cars where the network side is read-only. There is no separate login and no credentials are stored: the phone is already signed in, nothing is rooted, and no app tokens are read. The integration only reads the screen and taps buttons.
   - **Volkswagen is verified** (built and tested against the We Connect app 4.2.1): it reads state of charge, range and charging state, and can start/stop climate and charging.
   - **Audi, Škoda, SEAT and CUPRA ship read-only for now.** The structure is there, but their on-screen maps are not yet confirmed against a real device, so they read what they can and refuse to tap a button rather than risk hitting the wrong control. They switch to two-way once a tester with that car confirms the screen map.
-  - Safety built in: a conservative read budget so it never looks like abuse to the backend, and a write quarantine that disables taps whenever the app version on the phone differs from the one a preset was verified against (reads keep working).
-  - Needs a spare Android phone signed into the brand app with ADB over Wi-Fi, and the app language set to German or English. See the tracking issue for setup and to volunteer as a tester for the non-VW brands.
+  - Safety built in: a write quarantine that disables taps whenever the app version on the phone differs from the one a preset was verified against (reads keep working), and a cooldown after a connection failure so a sleeping phone never turns into an error storm.
+  - Needs a spare Android phone signed into the brand app with ADB over Wi-Fi, and the app language set to German or English. See the tracking issue to set it up and to volunteer as a tester for the non-VW brands.
+
+### Fixed
+
+- **The extra volkswagen.de channel no longer loses its session on every restart (#966, #632).** After you added the channel with the email code, its sign-in cookies were never saved back as they refreshed, so every restart replayed the original ones until they expired and the channel reported "SSO session expired, full re-login required" even though it had been working moments earlier. The refreshed cookies are now stored the same way the standalone volkswagen.de mode already did, so the session carries across restarts. (This is the standalone channel's twin; the main channel was already fine.)
+- **A car that is currently sending a "no reading" placeholder no longer re-reports the same field as new on every poll (#958, #969, #970).** Some readings, most visibly tyre pressures, come through as a placeholder meaning "no value right now" when the car has nothing to report. Those fields are already mapped, so the placeholder was being flagged as an undiscovered field over and over. It is now recognised as the mapped field it is: the sensor stays unavailable until a real value arrives, and the repeated reports stop. Genuinely unknown fields still surface for mapping exactly as before.
 
 ## [2.24.2] - 2026-07-27
 

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -858,6 +858,26 @@ class CariadBaseClient:
         result: list[dict[str, Any]] = cookies if isinstance(cookies, list) else []
         return result
 
+    def get_supplementary_proxy_cookies(self) -> list[dict[str, Any]]:
+        """v2.25.0 — export the live SUPPLEMENTARY vw.de session cookies.
+
+        The twin of ``get_website_proxy_cookies`` for the supplementary slot
+        (``_supplementary_authproxy``), which had no export path at all. Without
+        it the coordinator could never write the rotated cookies back, so every
+        restart replayed the original OTP cookies from the entry until they went
+        stale and ``refresh()`` reported "SSO session expired" (#966/#632).
+        Same fail-soft contract: empty list, never raises.
+        """
+        connector = self._supplementary_authproxy
+        if connector is None:
+            return []
+        try:
+            cookies = connector.export_cookies()
+        except Exception:  # noqa: BLE001
+            return []
+        result: list[dict[str, Any]] = cookies if isinstance(cookies, list) else []
+        return result
+
     def set_persisted_tokens(self, tokens: TokenSet | None) -> None:
         """v1.19.2 (#118) — inject tokens loaded from HA storage at
         coordinator setup, before the first API call. If valid, the

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1092,11 +1092,27 @@ def map_dataset_to_vehicle_data(
         for n in names:
             if n in fields:
                 val = fields[n]
-                # NO-SUPPRESSION: a sentinel ("no reading") value must never be
-                # assigned to a mapped target, but the field stays Scout-visible.
-                # We skip it WITHOUT marking it used, so it still appears in
-                # raw_unmapped_fields for discovery/mapping later.
+                # A sentinel ("no reading") value must never be assigned to a
+                # mapped target.
+                #
+                # v2.25.0 — but it must still be CONSUMED. A field first() is
+                # asked for is, by definition, a mapped field (only mapped names
+                # are ever passed here), so a sentinel on it is "this mapped
+                # field has no current value", NOT an undiscovered field. Leaving
+                # it Scout-visible (the pre-2.25.0 behaviour) made every mapped
+                # field re-report to the Scout on every poll for as long as the
+                # car sent the sentinel — e.g. tyre pressure reading "1"=invalid
+                # re-filed #958/#969/#970 endlessly. Same class as the v2.24.2
+                # value_type reclaim. Consume it (and its walker synonyms) so it
+                # stops re-surfacing; the sensor simply stays unavailable until a
+                # real value arrives. UNmapped fields never reach first(), so
+                # their sentinels still surface for discovery — the
+                # no-suppression policy for genuinely-new fields is intact.
                 if _is_sentinel(n, val):
+                    used.add(n)
+                    for other in syn.get(n, frozenset()):
+                        if other in fields:
+                            used.add(other)
                     continue
                 used.add(n)
                 # v2.15.4 synonym-collapse (no-suppression-safe): bare / dotted /

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1717,6 +1717,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     "VAG Connect: supplementary vw.de arming failed (%s)"
                     " — primary channel unaffected.", type(err).__name__,
                 )
+            # v2.25.0 (#966/#632) — arming runs refresh(), which rotates the
+            # cookie jar. Write the fresh cookies back so the NEXT restart
+            # resumes from a current session instead of replaying the original
+            # OTP cookies until they expire. No-op guarded inside.
+            if armed:
+                self._persist_supplementary_cookies()
             # v2.15.0b5 — graceful "re-login" Repair when the OTP-bound vw.de
             # session can't resume; cleared once it arms again.
             from .repairs import (  # noqa: PLC0415
@@ -2226,6 +2232,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     self._save_vehicle_cache()
                 except Exception:  # noqa: BLE001
                     pass
+                # v2.25.0 (#966/#632) — the per-VIN _merge_supplementary above
+                # may have refreshed the vw.de session on a mid-poll 401,
+                # rotating its cookie jar. Persist the rotated cookies here (once
+                # per poll, after the loop) so a long-uptime instance that never
+                # hits a manual refresh still carries a CURRENT session across a
+                # restart, not the aging setup-time snapshot. Idempotent: the
+                # equality guard makes it a no-op unless the jar actually moved.
+                self._persist_supplementary_cookies()
                 # v1.9.0 — Refresh the two reporter repair issues. Cheap to
                 # call: ``ensure_*_issue`` deletes when empty and updates
                 # in-place when the IDs already exist.
@@ -4192,6 +4206,9 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # fresh cookies so the next restart keeps skipping the OTP prompt.
             # No-op (and cheap) for every non-website-authproxy entry.
             self._persist_website_cookies()
+            # v2.25.0 (#966/#632) — same for the SUPPLEMENTARY vw.de channel,
+            # whose jar the merge above may also have rotated. Idempotent.
+            self._persist_supplementary_cookies()
             _LOGGER.debug("VAG Connect: Manual refresh OK")
             return dict(self.vehicles)
         except Exception as err:  # noqa: BLE001
@@ -4757,6 +4774,57 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(
                 "VAG Connect: could not persist website-authproxy cookies "
                 "(%s) — will retry next login.", type(err).__name__,
+            )
+
+    def _persist_supplementary_cookies(self) -> None:
+        """v2.25.0 (#966/#632) — write the SUPPLEMENTARY vw.de cookies back.
+
+        The twin of ``_persist_website_cookies`` for the supplementary slot. It
+        was missing entirely: the supplementary connector's ``refresh()`` rotates
+        its cookie jar every poll, but nothing exported those back, so the entry
+        kept the original OTP cookies from setup. On the next restart the arm
+        replayed those stale cookies, ``refresh()`` bounced to the login page,
+        and the channel reported "SSO session expired — full re-login required"
+        even though a live session had existed moments before. Same guards as the
+        sole-mode twin: no-op unless this is a supplementary-authproxy entry with
+        a non-empty export, writes only when the cookies actually changed, and
+        never raises (a persistence hiccup must not break the poll).
+        """
+        from .const import (  # noqa: PLC0415
+            CONF_SUPPLEMENTARY_AUTHPROXY,
+            CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES,
+        )
+
+        if not self.entry.data.get(CONF_SUPPLEMENTARY_AUTHPROXY):
+            return
+        client = getattr(self, "_cariad_client", None)
+        if client is None or not hasattr(client, "get_supplementary_proxy_cookies"):
+            return
+        try:
+            fresh: list[dict[str, Any]] = client.get_supplementary_proxy_cookies()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "VAG Connect: supplementary vw.de cookie export failed (%s) "
+                "— session still valid in-memory", type(err).__name__,
+            )
+            return
+        if not fresh:
+            return
+        if fresh == (self.entry.data.get(CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES) or []):
+            return
+        try:
+            self.hass.config_entries.async_update_entry(
+                self.entry,
+                data={**self.entry.data, CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES: fresh},
+            )
+            _LOGGER.debug(
+                "VAG Connect: persisted %d refreshed supplementary vw.de "
+                "cookie(s) back to the entry.", len(fresh),
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "VAG Connect: could not persist supplementary vw.de cookies "
+                "(%s) — will retry next poll.", type(err).__name__,
             )
 
     def is_read_only(self) -> bool:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "3.0.0a1"
+  "version": "2.25.0"
 }

--- a/tests/test_v2151_scout_mapping.py
+++ b/tests/test_v2151_scout_mapping.py
@@ -199,15 +199,17 @@ class TestEUNewFields:
             "battery_state_report": {"remaining_charging_time_bulk": -1},
         }
         flat = _walk_fields(payload)
-        # kept on the flattened surface (no-suppress)…
+        # kept on the flattened surface by the walker (pre-first())…
         assert "battery_state_report.remaining_charging_time_bulk" in flat
         d = map_dataset_to_vehicle_data(flat, VehicleData(vin="X"))
-        # …but the sentinel value never lands on the mapped target…
+        # …the sentinel value never lands on the mapped target…
         assert d.remaining_charge_time_bulk_min is None
-        # …and it remains Scout-visible for discovery.
+        # …and v2.25.0: it is CONSUMED, not left Scout-visible. This is a mapped
+        # field with no current reading, not an undiscovered field, so it must
+        # not re-report to the Scout every poll.
         assert (
             "battery_state_report.remaining_charging_time_bulk"
-            in d.raw_unmapped_fields
+            not in d.raw_unmapped_fields
         )
 
     def test_bulk_real_value_maps(self) -> None:

--- a/tests/test_v2153_eu_new_fields.py
+++ b/tests/test_v2153_eu_new_fields.py
@@ -167,15 +167,16 @@ def test_tyre_pressure_diff_valid_value() -> None:
     assert d.tyre_pressure_diff_fl == 7
 
 
-def test_tyre_pressure_diff_sentinel_not_mapped_but_scout_visible() -> None:
-    # 0=unsupported / 1=invalid → NO-SUPPRESSION: the value is never mapped to
-    # the target, but the field stays Scout-visible (raw_unmapped).
+def test_tyre_pressure_diff_sentinel_not_mapped_and_consumed() -> None:
+    # 0=unsupported / 1=invalid → never mapped to the target. v2.25.0: this is a
+    # MAPPED field with no reading, so it is now CONSUMED rather than left
+    # Scout-visible — it must not re-file #958/#969/#970 on every poll.
     d_fl = _map_flatlog(("tyre_pressure_differential_front_left", "1"))
     assert d_fl.tyre_pressure_diff_fl is None
-    assert "tyre_pressure_differential_front_left" in d_fl.raw_unmapped_fields
+    assert "tyre_pressure_differential_front_left" not in d_fl.raw_unmapped_fields
     d_fr = _map_flatlog(("tyre_pressure_differential_front_right", "0"))
     assert d_fr.tyre_pressure_diff_fr is None
-    assert "tyre_pressure_differential_front_right" in d_fr.raw_unmapped_fields
+    assert "tyre_pressure_differential_front_right" not in d_fr.raw_unmapped_fields
 
 
 # ── F. Lights / energy / misc ────────────────────────────────────────────────

--- a/tests/test_v2155_eu_bidi_sunroof_aux.py
+++ b/tests/test_v2155_eu_bidi_sunroof_aux.py
@@ -50,11 +50,12 @@ def test_bidi_consumed_not_in_raw() -> None:
     assert "bidirectional_charging_mode.bidi_max_Soc" not in d.raw_unmapped_fields
 
 
-def test_bidi_sentinel_dropped_but_scout_visible() -> None:
-    # 65535 uint16 not-available sentinel → None, but stays Scout-visible.
+def test_bidi_sentinel_dropped_and_consumed() -> None:
+    # 65535 uint16 not-available sentinel → None. v2.25.0: mapped field, no
+    # reading → consumed, not left Scout-visible.
     d = _map_flatlog(("bidirectional_charging_mode.bidi_max_Soc", "65535"))
     assert d.bidi_max_charge_level_pct is None
-    assert "bidirectional_charging_mode.bidi_max_Soc" in d.raw_unmapped_fields
+    assert "bidirectional_charging_mode.bidi_max_Soc" not in d.raw_unmapped_fields
 
 
 # ── #544 — sunroof motor hood 1 POSITION (distinct from STATE) ───────────────
@@ -80,10 +81,11 @@ def test_sunroof_position_distinct_from_state() -> None:
     assert d.sunroof_position_pct == 30
 
 
-def test_sunroof_position_sentinel_dropped_but_scout_visible() -> None:
+def test_sunroof_position_sentinel_dropped_and_consumed() -> None:
     d = _map_flatlog(("position_sunroof_motor_hood_1", "65535"))
     assert d.sunroof_position_pct is None
-    assert "position_sunroof_motor_hood_1" in d.raw_unmapped_fields
+    # v2.25.0: mapped field, sentinel reading → consumed, not Scout-visible.
+    assert "position_sunroof_motor_hood_1" not in d.raw_unmapped_fields
 
 
 # ── #544 — aux-consumer consumption 65535 SENTINEL fix ───────────────────────
@@ -96,14 +98,15 @@ def test_aux_consumption_65535_sentinel_dropped() -> None:
     )
     assert d.lifetime_avg_aux_consumption_kwh_100km is None
     assert d.last_trip_avg_aux_consumption_kwh_100km is None
-    # No-suppression: the sentinel field stays Scout-visible.
+    # v2.25.0: mapped fields with a sentinel reading are consumed, not left
+    # Scout-visible (they must not re-report every poll).
     assert (
         "long_term_data_average_aux_consumer_consumption"
-        in d.raw_unmapped_fields
+        not in d.raw_unmapped_fields
     )
     assert (
         "short_term_data_average_aux_consumer_consumption"
-        in d.raw_unmapped_fields
+        not in d.raw_unmapped_fields
     )
 
 

--- a/tests/test_v2250_sentinel_consume.py
+++ b/tests/test_v2250_sentinel_consume.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.25.0 — a sentinel on a MAPPED field is consumed, not re-reported forever.
+
+A field ``first()`` is asked for is, by definition, mapped (only mapped names
+are ever passed to it). A sentinel value on such a field means "this mapped
+field has no current reading", NOT "an undiscovered field". The pre-2.25.0
+behaviour skipped the sentinel WITHOUT consuming it, so every mapped field
+whose car was sending a sentinel re-filed a Scout report on every single poll —
+that is what kept #958/#969/#970 (tyre pressure "1"=invalid) coming back.
+
+This is the same class as the v2.24.2 value_type reclaim. The fix consumes the
+sentinel so it stops re-surfacing; the sensor stays unavailable until a real
+value arrives, at which point it maps normally.
+
+The no-suppression policy is preserved for GENUINELY-NEW fields: an unmapped
+field never reaches ``first()``, so a sentinel-shaped value on an unknown field
+still surfaces in raw_unmapped_fields for discovery. That invariant is the last
+test here and is the one that must never regress.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(fields: dict) -> VehicleData:
+    from custom_components.vag_connect.cariad.auth._eu_data_act import (
+        map_dataset_to_vehicle_data,
+    )
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_mapped_field_sentinel_is_consumed() -> None:
+    # tyre pressure "1" = invalid: mapped target stays None, and the field is
+    # gone from the Scout surface.
+    d = _map({"tyre_pressure_actual_front_left": "1"})
+    assert d.tyre_pressure_actual_fl is None
+    assert "tyre_pressure_actual_front_left" not in d.raw_unmapped_fields
+
+
+def test_mapped_field_real_value_still_maps() -> None:
+    d = _map({"tyre_pressure_actual_front_left": "230"})
+    assert d.tyre_pressure_actual_fl == 230
+    assert "tyre_pressure_actual_front_left" not in d.raw_unmapped_fields
+
+
+def test_all_wheels_sentinel_all_consumed() -> None:
+    # the exact #958/#970 shape: every wheel reporting the invalid sentinel
+    payload = {
+        "tyre_pressure_actual_front_left": "1",
+        "tyre_pressure_actual_front_right": "1",
+        "tyre_pressure_actual_rear_left": "1",
+        "tyre_pressure_actual_rear_right": "1",
+        "tyre_pressure_actual_spare_tyre": "1",
+    }
+    d = _map(payload)
+    for name in payload:
+        assert name not in d.raw_unmapped_fields, f"{name} still re-reports"
+
+
+def test_sentinel_synonyms_are_consumed_too() -> None:
+    # both the bare and container-qualified spellings of a sentinel'd mapped
+    # field must be consumed, or the twin keeps re-reporting.
+    d = _map({
+        "battery_state_report.remaining_charging_time_bulk": "-1",
+        "remaining_charging_time_bulk": "-1",
+    })
+    assert d.remaining_charge_time_bulk_min is None
+    raw = d.raw_unmapped_fields
+    assert "battery_state_report.remaining_charging_time_bulk" not in raw
+    assert "remaining_charging_time_bulk" not in raw
+
+
+def test_UNMAPPED_field_sentinel_stays_scout_visible() -> None:
+    # THE POLICY GUARD. A field the parser does not know (never passed to
+    # first()) must keep surfacing for discovery, even with a sentinel-shaped
+    # value — otherwise the fix would suppress genuinely-new fields.
+    d = _map({"some_brand_new_unknown_field": "65535"})
+    assert "some_brand_new_unknown_field" in d.raw_unmapped_fields

--- a/tests/test_v2250_supplementary_cookie_persist.py
+++ b/tests/test_v2250_supplementary_cookie_persist.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#966 / #632 — the supplementary vw.de channel now persists its rotated cookies.
+
+The sole-mode website-authproxy has persisted its rotated cookies since v2.14.3
+(_persist_website_cookies + get_website_proxy_cookies). The SUPPLEMENTARY slot
+never did: get_website_proxy_cookies reads _website_proxy, _persist_website_cookies
+is gated on the sole-mode CONF_WEBSITE_AUTHPROXY key, and
+CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES was only ever written once at OTP setup.
+
+So the arm ran refresh() (which rotates the jar) every poll, but the entry kept
+the original OTP cookies forever. On the next restart the arm replayed those
+stale cookies, refresh() bounced to the login page, and the channel reported
+"SSO session expired — full re-login required" even though a live session had
+existed moments earlier. This is exactly the loop the reporter of #966 (and
+shaarkys in #632, since 2026-07-09) was stuck in.
+
+The fix is the twin of the sole-mode path, scoped to its own storage key so the
+two never clobber each other.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.const import (
+    CONF_SUPPLEMENTARY_AUTHPROXY,
+    CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES,
+)
+
+
+# ── the export side (base client) ───────────────────────────────────────────
+
+class _FakeConnector:
+    def __init__(self, cookies):
+        self._cookies = cookies
+
+    def export_cookies(self):
+        return self._cookies
+
+
+class TestSupplementaryCookieExport:
+    def _client(self):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+
+        c = VWEUClient.__new__(VWEUClient)
+        c._website_proxy = None
+        c._supplementary_authproxy = None
+        return c
+
+    def test_exports_the_supplementary_connector_not_the_sole_mode_one(self) -> None:
+        c = self._client()
+        # sole-mode connector present, supplementary present with DIFFERENT cookies
+        c._website_proxy = _FakeConnector([{"name": "sole", "value": "x"}])
+        c._supplementary_authproxy = _FakeConnector([{"name": "supp", "value": "y"}])
+        got = c.get_supplementary_proxy_cookies()
+        assert got == [{"name": "supp", "value": "y"}], (
+            "must read _supplementary_authproxy, not _website_proxy"
+        )
+
+    def test_unarmed_returns_empty(self) -> None:
+        c = self._client()
+        assert c.get_supplementary_proxy_cookies() == []
+
+    def test_export_failure_is_soft(self) -> None:
+        class _Boom:
+            def export_cookies(self):
+                raise RuntimeError("jar gone")
+
+        c = self._client()
+        c._supplementary_authproxy = _Boom()
+        assert c.get_supplementary_proxy_cookies() == []
+
+
+# ── the persist side (coordinator) ──────────────────────────────────────────
+
+class TestSupplementaryCookiePersist:
+    def _coord(self, *, entry_data, exported):
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+        c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+        c.entry = MagicMock()
+        c.entry.data = dict(entry_data)
+        c.hass = MagicMock()
+        c.hass.config_entries = MagicMock()
+        client = MagicMock()
+        client.get_supplementary_proxy_cookies = MagicMock(return_value=exported)
+        c._cariad_client = client
+        return c
+
+    def _updated_data(self, c):
+        call = c.hass.config_entries.async_update_entry.call_args
+        return call.kwargs["data"] if call else None
+
+    def test_writes_rotated_cookies_back(self) -> None:
+        c = self._coord(
+            entry_data={
+                CONF_SUPPLEMENTARY_AUTHPROXY: True,
+                CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES: [{"name": "old", "value": "1"}],
+            },
+            exported=[{"name": "new", "value": "2"}],
+        )
+        c._persist_supplementary_cookies()
+        data = self._updated_data(c)
+        assert data is not None
+        assert data[CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES] == [{"name": "new", "value": "2"}]
+
+    def test_noop_when_unchanged(self) -> None:
+        same = [{"name": "same", "value": "1"}]
+        c = self._coord(
+            entry_data={
+                CONF_SUPPLEMENTARY_AUTHPROXY: True,
+                CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES: same,
+            },
+            exported=list(same),
+        )
+        c._persist_supplementary_cookies()
+        c.hass.config_entries.async_update_entry.assert_not_called()
+
+    def test_noop_when_not_a_supplementary_entry(self) -> None:
+        c = self._coord(
+            entry_data={CONF_SUPPLEMENTARY_AUTHPROXY: False},
+            exported=[{"name": "new", "value": "2"}],
+        )
+        c._persist_supplementary_cookies()
+        c.hass.config_entries.async_update_entry.assert_not_called()
+
+    def test_noop_on_empty_export(self) -> None:
+        c = self._coord(
+            entry_data={
+                CONF_SUPPLEMENTARY_AUTHPROXY: True,
+                CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES: [{"name": "old", "value": "1"}],
+            },
+            exported=[],
+        )
+        c._persist_supplementary_cookies()
+        c.hass.config_entries.async_update_entry.assert_not_called()
+
+    def test_does_not_touch_the_sole_mode_key(self) -> None:
+        from custom_components.vag_connect.const import CONF_WEBSITE_COOKIES
+
+        c = self._coord(
+            entry_data={
+                CONF_SUPPLEMENTARY_AUTHPROXY: True,
+                CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES: [{"name": "old", "value": "1"}],
+                CONF_WEBSITE_COOKIES: [{"name": "sole", "value": "keep"}],
+            },
+            exported=[{"name": "new", "value": "2"}],
+        )
+        c._persist_supplementary_cookies()
+        data = self._updated_data(c)
+        # sole-mode cookies untouched
+        assert data[CONF_WEBSITE_COOKIES] == [{"name": "sole", "value": "keep"}]


### PR DESCRIPTION
Two fixes. The version settles the companion (ADB) channel onto the stable 2.25.0 line (the brief 3.0.0a1 pre-release is being withdrawn) — it stays opt-in and experimental, and changes nothing unless you set it up.

## vw.de supplementary cookie persistence (#966 / #632)

The standalone website-authproxy has persisted its rotated cookies since v2.14.3. The **supplementary** slot never did: `get_website_proxy_cookies` reads the sole-mode connector, `_persist_website_cookies` gates on the sole-mode key, and `CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES` was only ever written once, at OTP setup.

So the supplementary connector's `refresh()` rotated its jar every poll, but nothing wrote it back. Every restart replayed the original OTP cookies until they went stale, and the channel reported "SSO session expired, full re-login required" even though a live session had existed moments before. That is the exact loop in #966 (and shaarkys in #632, since 2026-07-09).

Added the twin path: `get_supplementary_proxy_cookies()` reads the supplementary connector, `_persist_supplementary_cookies()` writes its **own** storage key (never touching the sole-mode key), and it runs at all three points the jar can rotate: the setup-time arm, the poll loop after the per-VIN supplementary merge, and the manual refresh. Idempotent (equality-guarded), fail-soft. The poll-loop/refresh calls close a long-uptime gap an adversarial review flagged: persisting only at setup would leave an instance that rotated forward mid-session, then restarted, back on stale cookies.

## Sentinel Scout spam (#958 / #969 / #970)

`first()` skipped a sentinel ("no reading") value **without consuming it**, on the theory the field stays visible "for discovery later". But every name `first()` is asked for is already mapped, so a sentinel there is a mapped field with no current value, not an undiscovered field. Leaving it Scout-visible made every such field re-report as new on every poll for as long as the car sent the sentinel — that is what kept #958/#969/#970 (tyre pressure "1"=invalid) coming back. Same class as the v2.24.2 value_type reclaim.

The sentinel is now consumed (with its walker synonyms), symmetric with the real-value path; the sensor stays unavailable until a real value arrives. Genuinely-new fields are untouched: they never reach `first()`, and a synonym is always a same-node twin, so no unmapped field can be consumed. A dedicated test asserts an unknown field with a sentinel-shaped value still surfaces for discovery — the no-suppression policy is provably intact.

## Verification

- Full suite: **4177 passed**, 15 skipped.
- New: 8 tests for the supplementary cookie path (export reads the right connector, separate storage key, equality guard, fail-soft) + 5 for sentinel consumption including the no-suppression policy guard. 5 existing sentinel tests updated to the new (intended) behaviour.
- Both fixes independently adversarially reviewed; the no-suppression invariant was proven to hold by construction of the synonym map.
- ruff + mypy strict clean.