### PR TITLE
v2.26.1: VW Canada auth host fix (#990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.26.1] - 2026-07-29
+
+### Fixed
+- **Volkswagen Canada sign-in reaches the right host again (#990, #915).** v2.26.0 sent Canada to its own regional host (ca00) for everything, including the login. That was half right: the vehicle data does live on ca00, but the login does not, and ca00 has no working authorize endpoint, so Canadian setup started failing at the login step with an HTTP 400 (before v2.26.0 it got past the login and failed later with a 500). A Canadian owner confirmed the official app signs in on the shared North America identity host, so the login now goes back there (as it did in 2.25.0) while only the vehicle data stays on ca00. Thanks to vrouleau for the capture and the details.
+
 ## [2.26.0] - 2026-07-27
 
 > This release is about the companion (ADB) channel from 2.25.0, and it changes nothing for anyone not using it. Two things stand out: the Volkswagen screen-reading is now grounded against a real, independently verified reference instead of our own guesses, and CUPRA reads real data for the first time thanks to a contributor's screen dump. Command sending on the companion channel is paused for now — see below.

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -111,6 +111,18 @@ _COUNTRY_BASES: dict[str, str] = {
     "ca": "https://b-h-s.spr.ca00.p.con-veh.net",
 }
 
+# v2.26.1 (#990/#915) — OIDC authorize/token PROXY host for every NA country.
+# vrouleau confirmed the myVW app signs in on identity.na.vwgroup.io, and that
+# v2.25 (which sent every NA country through us00) authenticated fine; only the
+# vehicle-DATA host is per-country. The Canadian data host ca00 does NOT front a
+# working /oidc/v1/authorize (it returns HTTP 400 before any credentials are
+# submitted), so the auth flow must stay on the us00 con-veh proxy that 302s to
+# the NA IDP for ALL NA countries, while api_base (the vehicle reads/commands)
+# stays per-country from _COUNTRY_BASES above. This is the v2.26.0 regression:
+# routing CA auth to ca00 moved the failure from a late 500 (v2.25, us00 data
+# host wrong for a CA car) to an early 400 (ca00 has no authorize proxy).
+_NA_OIDC_PROXY_BASE = _COUNTRY_BASES["us"]
+
 BRAND_VW_NA = BrandConfig(
     name="volkswagen_na",
     client_id="59992128-69a9-42c3-8621-7942041ba824_MYVW_ANDROID",
@@ -183,14 +195,16 @@ class VWNAClient:
         # v2.3.0 (#269 roberttco, 2026-05-21) — VW NA auth requires four
         # IDP overrides vs the default identity.vwgroup.io (EU) flow:
         #
-        #   1. authorize_url_override → ``{api_base}/oidc/v1/authorize``
-        #      (per-country host b-h-s.spr.{us|ca}00.p.con-veh.net,
-        #      NOT identity.vwgroup.io). The MYVW_ANDROID client_id is
-        #      only registered against this host — sending it to the EU
-        #      IDP returns HTTP 400 (user's log on #269).
+        #   1. authorize_url_override → ``{_NA_OIDC_PROXY_BASE}/oidc/v1/authorize``
+        #      (the us00 con-veh proxy, NOT identity.vwgroup.io). The
+        #      MYVW_ANDROID client_id is only registered against this host —
+        #      sending it to the EU IDP returns HTTP 400 (user's log on #269).
+        #      v2.26.1 (#990): this is the us00 proxy for EVERY NA country, not
+        #      the per-country data host. The ca00 host has no working authorize
+        #      endpoint (it 400s), and vrouleau confirmed CA signs in here fine.
         #
-        #   2. token_url_override → ``{api_base}/oidc/v1/token`` — same
-        #      host for both code-exchange and refresh-token calls. The
+        #   2. token_url_override → ``{_NA_OIDC_PROXY_BASE}/oidc/v1/token`` — same
+        #      us00 host for both code-exchange and refresh-token calls. The
         #      default fallback (emea.bff.cariad.digital/login/v1/idk/
         #      token) does not know NA client_ids.
         #
@@ -232,8 +246,8 @@ class VWNAClient:
         self._auth = IDKAuth(
             session,
             brand,
-            authorize_url_override=f"{self._base}/oidc/v1/authorize",
-            token_url_override=f"{self._base}/oidc/v1/token",
+            authorize_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/authorize",
+            token_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/token",
             idk_base_override=_NA_IDP_BASE,
         )
         # UUID cache: VIN → UUID (returned by garage)

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.26.0"
+  "version": "2.26.1"
 }

--- a/tests/test_v2151_vwna_country.py
+++ b/tests/test_v2151_vwna_country.py
@@ -93,6 +93,21 @@ class TestCaUsesOwnHostSharedClient:
         assert 'client_id = BRAND_VW_NA.client_id' in src
         assert 'if self._country == "ca"' not in src
 
+    def test_auth_uses_us00_proxy_but_api_stays_per_country(self) -> None:
+        # v2.26.1 (#990) — vrouleau proved the myVW app signs in on identity.na
+        # and that CA auth works through the us00 proxy (v2.25 authenticated;
+        # only the later data call 500'd). The Canadian ca00 host has no working
+        # /oidc/v1/authorize (400s). So the OIDC authorize+token must go to the
+        # fixed us00 proxy for every NA country, while api_base stays per-country.
+        src = _VW_NA_PY.read_text(encoding="utf-8")
+        assert '_NA_OIDC_PROXY_BASE = _COUNTRY_BASES["us"]' in src
+        assert 'authorize_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/authorize"' in src
+        assert 'token_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/token"' in src
+        # the auth override must no longer be gated on the per-country data host
+        assert 'authorize_url_override=f"{self._base}' not in src
+        # but the vehicle API base must still be per-country (ca00 for CA)
+        assert 'api_base=self._base' in src
+
 
 class TestCountryConstAndSelector:
     """const.py defines CONF_COUNTRY; config_flow builds the dropdown."""

--- a/tests/test_v230_sprint_b.py
+++ b/tests/test_v230_sprint_b.py
@@ -132,13 +132,16 @@ class TestVWNAUsesNAOverrides:
 
     def test_idkauth_constructed_with_authorize_override(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        # The authorize URL must point at the per-country API base
-        # (b-h-s.spr.{us|ca}00.p.con-veh.net), NOT identity.vwgroup.io.
-        assert 'authorize_url_override=f"{self._base}/oidc/v1/authorize"' in src
+        # v2.26.1 (#990) — the authorize URL points at the fixed us00 OIDC proxy
+        # (_NA_OIDC_PROXY_BASE), NOT the per-country data host. ca00 has no
+        # working /oidc/v1/authorize (it 400s); the us00 proxy 302s to
+        # identity.na for every NA country, and vrouleau confirmed CA signs in
+        # there (v2.25 authenticated this way). Only api_base is per-country.
+        assert 'authorize_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/authorize"' in src
 
     def test_idkauth_constructed_with_token_override(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        assert 'token_url_override=f"{self._base}/oidc/v1/token"' in src
+        assert 'token_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/token"' in src
 
     def test_idkauth_constructed_with_idk_base_override(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes the #915 Canada regression reported in #990.

vrouleau confirmed the myVW app signs in on identity.na.vwgroup.io and that v2.25 authenticated fine through the us00 proxy (only the later data call 500'd). The ca00 host has no working `/oidc/v1/authorize` (it 400s), so v2.26.0 moved the failure from a late 500 to an early 400.

This decouples the two: `authorize`+`token` use the fixed us00 OIDC proxy for every NA country (302s to identity.na, works for CA), while `api_base` stays per-country (ca00 for CA data).

- 1 new test + 2 updated (they pinned the old, now-disproven invariant)
- full suite 4283 passed, pre-commit green
- manifest 2.26.1, CHANGELOG updated