### PR TITLE
v2.26.3: resilience pass (staleness, type drift, portal retries, charge target)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.26.3] - 2026-08-01
+
+### Fixed
+- **A backend hiccup no longer makes every entity look broken.** The integration has always been meant to keep showing a car's last known values through a short outage, with the "last updated" timestamp telling you how old they are. That tolerance never actually applied when the whole poll failed, which on a single-car account is any brief error at all, so entities went unavailable immediately instead. They now stay visible with their last known values, exactly as intended, and still disappear once the data is genuinely too old.
+- **A sensor whose value changes type no longer breaks.** When a manufacturer turns a number into a text value (CUPRA once changed the max charge current to "maximum"/"reduced"), the affected sensor used to break outright. Each case was patched individually after someone had already hit it. Any sensor that expects a number now simply reports unknown and logs why, so one changed field cannot take an entity down.
+- **A brief portal error during startup no longer costs you the setup.** Listing your cars gave up on the first server error, while the very same call already retried three times if the connection timed out instead. Both are now retried the same way. If the portal is genuinely down the result is unchanged.
+
+### Added
+- **A charge target for cars that only report a battery-care limit.** Some cars (the Audi Q4 e-tron is the known one) send a battery-care charge ceiling and no separate charge target, so the target sensor stayed empty even though the car does have a limit. That ceiling now fills the target when nothing else provides one, and it is still shown separately as before.
+
 ## [2.26.2] - 2026-08-01
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1797,6 +1797,15 @@ def map_dataset_to_vehicle_data(
                           "charge_bcam_threshold"))
     if _bcam is not None:
         d.battery_care_target_soc_pct = _bcam
+        # Some cars (the Audi Q4 e-tron is the known one) ship this threshold
+        # and no settings.target_soc at all, so the headline charge-target
+        # sensor was never created for them even though the car does have a
+        # ceiling. When battery care is the only limit reported, it IS the
+        # effective charge target, so fill the gap with it. Gap-fill only: an
+        # explicit target_soc above always wins, and the battery-care value
+        # stays available in its own sensor either way.
+        if d.target_soc is None:
+            d.target_soc = _bcam
 
     # energy_contents.{current,maximal}_energy_content.physical_value gated on
     # the companion value_type being valid.
@@ -3086,13 +3095,22 @@ class EUDataActConnector:
                     url, headers=eff_headers, timeout=ClientTimeout(total=_TIMEOUT_S),
                 ) as resp:
                     if resp.status >= 400:
+                        # Retry a retriable 5xx regardless of ``soft``. This
+                        # used to sit inside the soft branch, so a HARD call
+                        # (VIN enumeration is one) raised on the first portal
+                        # hiccup with no retry at all, while a transport
+                        # timeout on the very same call retried three times.
+                        # The outcome after the retries is unchanged: soft
+                        # gives up as "no data", hard still raises — which
+                        # matters, because an empty VIN list is read as "this
+                        # account has no cars" and fails setup outright.
+                        if (
+                            resp.status in _RETRIABLE_STATUSES
+                            and attempt < len(_PORTAL_RETRY_DELAYS)
+                        ):
+                            await asyncio.sleep(_PORTAL_RETRY_DELAYS[attempt])
+                            continue
                         if soft and resp.status in _TRANSIENT_STATUSES:
-                            if (
-                                resp.status in _RETRIABLE_STATUSES
-                                and attempt < len(_PORTAL_RETRY_DELAYS)
-                            ):
-                                await asyncio.sleep(_PORTAL_RETRY_DELAYS[attempt])
-                                continue
                             return None
                         raise AuthenticationError(
                             f"EU Data Act GET {url} → HTTP {resp.status}"

--- a/custom_components/vag_connect/entity_base.py
+++ b/custom_components/vag_connect/entity_base.py
@@ -80,7 +80,21 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
         definitive "command not supported" outcome from a previous attempt.
         """
         if not super().available:
-            return False
+            # Connector-level failure (``last_update_success``). That is a
+            # statement about the poll, not about this car: a single-vehicle
+            # account hits it on any transient 5xx or timeout, and every
+            # account hits it during a backend-wide outage. Returning here
+            # made the coordinator's own two-stage tolerance unreachable for
+            # exactly those cases, even though the poll-failure path promises
+            # it (coordinator.py, "is_vehicle_available still tolerates this").
+            # Fall through to that policy, but only when we actually hold a
+            # last-known-good snapshot for this VIN, so a car that has never
+            # polled successfully still reports unavailable as before.
+            last_good = (
+                getattr(self.coordinator, "vehicle_last_good_at", {}) or {}
+            ).get(self._vin)
+            if last_good is None:
+                return False
         if not self.coordinator.is_vehicle_available(self._vin):
             return False
         if self._command_id is not None:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.26.2"
+  "version": "2.26.3"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -10,6 +10,7 @@ The VagSensorDescription.condition field gates sensor creation:
 charging_rate_kmh uses SensorDeviceClass.SPEED so HA auto-converts km/h ↔ mph
 based on the user's unit system preference.
 """
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -37,6 +38,27 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity, register_dynamic_spawner
+
+_LOGGER = logging.getLogger(__name__)
+
+# Device classes whose state Home Assistant parses as a number. DATE and
+# TIMESTAMP are deliberately absent: they are datetimes and have their own
+# handling in native_value above. Used by the schema-drift guard there.
+_NUMERIC_DEVICE_CLASSES = frozenset({
+    SensorDeviceClass.BATTERY,
+    SensorDeviceClass.CURRENT,
+    SensorDeviceClass.DISTANCE,
+    SensorDeviceClass.DURATION,
+    SensorDeviceClass.ENERGY,
+    SensorDeviceClass.ENERGY_STORAGE,
+    SensorDeviceClass.POWER,
+    SensorDeviceClass.PRESSURE,
+    SensorDeviceClass.SPEED,
+    SensorDeviceClass.TEMPERATURE,
+    SensorDeviceClass.VOLTAGE,
+    SensorDeviceClass.VOLUME,
+    SensorDeviceClass.VOLUME_STORAGE,
+})
 
 
 @dataclass(frozen=True)
@@ -3689,6 +3711,36 @@ class VagConnectSensor(VagConnectEntity, SensorEntity):
                 if parsed.tzinfo is None:
                     parsed = parsed.replace(tzinfo=timezone.utc)
                 return parsed
+
+        # Schema-drift safety net. A backend field that turns from a number
+        # into an enum string raises inside Home Assistant's state write, which
+        # is outside the coordinator's parse guard, so it cannot be caught
+        # there. It has happened for real: CUPRA firmware turned the max charge
+        # current into "maximum"/"reduced" and the amp sensor blew up with
+        # "could not convert string to float" (#392). That was patched per
+        # field, in whichever parser had already been burned; this catches the
+        # whole class once, at the boundary. Reports unknown instead of raising.
+        # No-op for every field that is already numeric today, and untouched
+        # for text sensors (no state class, no numeric device class).
+        if (
+            val is not None
+            and not isinstance(val, (int, float))
+            and (
+                self.entity_description.state_class is not None
+                or self.entity_description.device_class in _NUMERIC_DEVICE_CLASSES
+            )
+        ):
+            from .cariad._util import safe_float  # noqa: PLC0415
+
+            coerced = safe_float(val)
+            if coerced is None:
+                _LOGGER.warning(
+                    "VAG Connect: %s received the non-numeric value %r, so it "
+                    "reports unknown. This usually means the backend changed "
+                    "the field's type.",
+                    self.entity_description.key, val,
+                )
+            return coerced
 
         return val
 

--- a/tests/test_v2131_portal_backoff.py
+++ b/tests/test_v2131_portal_backoff.py
@@ -68,10 +68,29 @@ class TestPortalBackoff:
         assert sess.get.call_count == 1  # 404 is a stable state, not retried
         sleep.assert_not_awaited()
 
-    def test_non_soft_raises_immediately(self):
-        sess = _session_seq([_resp(500)])
+    def test_non_soft_retries_then_raises(self):
+        """A hard call retries a retriable 5xx, then still raises.
+
+        The retry used to sit inside the soft branch, so a hard call gave up on
+        the first hiccup while a transport timeout on the same call retried
+        three times. VIN enumeration is a hard call, and an empty VIN list is
+        read as "this account has no cars", so failing fast there costs a
+        working setup. What must NOT change is the ending: a hard call still
+        raises rather than returning an empty result.
+        """
+        sess = _session_seq([_resp(500), _resp(500), _resp(500)])
         conn = _conn(sess)
         with patch(_SLEEP, new=AsyncMock()):
             with pytest.raises(AuthenticationError):
                 asyncio.run(conn._get_json("https://x/y", soft=False))
-        assert sess.get.call_count == 1
+        assert sess.get.call_count == 3  # 1 try + 2 retries, same as soft
+
+    def test_non_soft_recovers_when_a_retry_succeeds(self):
+        """The point of retrying: a one-off 500 no longer kills the call."""
+        ok = _resp(200)
+        ok.json = AsyncMock(return_value={"vehicles": []})
+        sess = _session_seq([_resp(500), ok])
+        conn = _conn(sess)
+        with patch(_SLEEP, new=AsyncMock()):
+            out = asyncio.run(conn._get_json("https://x/y", soft=False))
+        assert out == {"vehicles": []}

--- a/tests/test_v2148_portal_timeout_retry.py
+++ b/tests/test_v2148_portal_timeout_retry.py
@@ -96,16 +96,24 @@ class TestPortalTimeoutRetry:
                 asyncio.run(conn._get_json("https://x/y", soft=False))
         assert sess.get.call_count == _ATTEMPTS
 
-    def test_status_5xx_path_still_works(self) -> None:
-        """Regression shield: the existing HTTP-status retry path is untouched —
-        a non-soft 5xx still raises AuthenticationError immediately."""
-        r = AsyncMock()
-        r.status = 500
-        r.__aenter__ = AsyncMock(return_value=r)
-        r.__aexit__ = AsyncMock(return_value=False)
-        sess = _session_seq([r])
+    def test_status_5xx_path_matches_the_timeout_path(self) -> None:
+        """A non-soft 5xx now retries like a non-soft timeout already did.
+
+        This test used to assert the opposite (raise on the first 5xx) purely
+        because the retry was nested in the soft branch, which made the two
+        transient-failure kinds behave differently on the same call. The end
+        state is unchanged: after the retries a hard call still raises.
+        """
+        def _r() -> AsyncMock:
+            r = AsyncMock()
+            r.status = 500
+            r.__aenter__ = AsyncMock(return_value=r)
+            r.__aexit__ = AsyncMock(return_value=False)
+            return r
+
+        sess = _session_seq([_r() for _ in range(_ATTEMPTS)])
         conn = _conn(sess)
         with patch(_SLEEP, new=AsyncMock()):
             with pytest.raises(AuthenticationError):
                 asyncio.run(conn._get_json("https://x/y", soft=False))
-        assert sess.get.call_count == 1
+        assert sess.get.call_count == _ATTEMPTS

--- a/tests/test_v2263_health_vs_staleness.py
+++ b/tests/test_v2263_health_vs_staleness.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Connector health and vehicle-data staleness are two different things.
+
+The coordinator has always carried a two-stage tolerance for a car whose poll
+fails: up to ``_FAILURE_TOLERANCE`` consecutive failures are ignored, and even
+past that the car stays visible while the last good poll is inside
+``_STALE_CACHE_WINDOW`` (old but visible, with ``last_updated_at`` telling the
+truth about the age). The poll-failure path says so in as many words.
+
+It could not actually happen. ``VagConnectEntity.available`` checked the
+CONNECTOR-level ``last_update_success`` first and returned, so the per-vehicle
+policy was unreachable whenever the whole poll failed. On a single-vehicle
+account that is every transient 5xx or timeout; on any account it is every
+backend-wide outage, which is precisely what the tolerance was written for.
+
+The fall-through is deliberately narrow: only a VIN that has polled
+successfully at least once (it has a ``vehicle_last_good_at`` stamp) AND still
+passes ``is_vehicle_available`` may stay available. A car that never polled is
+unavailable exactly as before.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.coordinator import (
+    _FAILURE_TOLERANCE,
+    _STALE_CACHE_WINDOW,
+    VagConnectCoordinator,
+)
+from custom_components.vag_connect.entity_base import VagConnectEntity
+
+_VIN = "VIN123"
+
+
+def _entity(
+    *,
+    connector_ok: bool,
+    failures: int,
+    last_good_ago: timedelta | None,
+) -> VagConnectEntity:
+    coord = MagicMock(spec=VagConnectCoordinator)
+    coord.last_update_success = connector_ok
+    coord.data = {_VIN: {"vin": _VIN}}
+    coord.vehicles = {_VIN: {"vin": _VIN}}
+    coord.vehicle_failure_count = {_VIN: failures}
+    coord.vehicle_last_good_at = (
+        {} if last_good_ago is None
+        else {_VIN: datetime.now(tz=timezone.utc) - last_good_ago}
+    )
+    # Use the real policy, not a mock, so the test pins actual behaviour.
+    coord.is_vehicle_available = lambda vin: (
+        VagConnectCoordinator.is_vehicle_available(coord, vin)
+    )
+    ent = VagConnectEntity(coord, _VIN, "test_key")
+    return ent
+
+
+class TestStaleButVisible:
+    def test_connector_failure_keeps_a_recently_good_car_visible(self) -> None:
+        """THE regression: the documented tolerance now actually applies."""
+        ent = _entity(
+            connector_ok=False,
+            failures=_FAILURE_TOLERANCE + 5,  # well past the failure tolerance
+            last_good_ago=timedelta(minutes=30),  # but recent good data
+        )
+        assert ent.available is True
+
+    def test_connector_failure_within_failure_tolerance_stays_visible(self) -> None:
+        ent = _entity(
+            connector_ok=False, failures=1, last_good_ago=timedelta(minutes=5)
+        )
+        assert ent.available is True
+
+    def test_a_car_that_never_polled_is_still_unavailable(self) -> None:
+        """The narrow guard: no last-known-good means no free pass."""
+        ent = _entity(connector_ok=False, failures=1, last_good_ago=None)
+        assert ent.available is False
+
+    def test_data_older_than_the_stale_window_goes_unavailable(self) -> None:
+        """Old but visible has a limit; past the window the car is gone."""
+        ent = _entity(
+            connector_ok=False,
+            failures=_FAILURE_TOLERANCE + 1,
+            last_good_ago=_STALE_CACHE_WINDOW + timedelta(hours=1),
+        )
+        assert ent.available is False
+
+    def test_healthy_connector_is_unaffected(self) -> None:
+        ent = _entity(
+            connector_ok=True, failures=0, last_good_ago=timedelta(minutes=1)
+        )
+        assert ent.available is True
+
+    def test_healthy_connector_still_hides_a_truly_dead_car(self) -> None:
+        """Per-VIN policy keeps working on the healthy-connector path."""
+        ent = _entity(
+            connector_ok=True,
+            failures=_FAILURE_TOLERANCE + 1,
+            last_good_ago=_STALE_CACHE_WINDOW + timedelta(hours=2),
+        )
+        assert ent.available is False

--- a/tests/test_v2263_sensor_type_guard.py
+++ b/tests/test_v2263_sensor_type_guard.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""A backend field changing type must not break entity rendering.
+
+This has happened for real: CUPRA firmware turned ``settings.maxChargeCurrentAc``
+from an integer into the enum "maximum"/"reduced", and the amp sensor blew up
+with ``could not convert string to float: 'maximum'`` (#392). That was patched
+inside the SEAT/CUPRA parser, and later inside the Skoda one, each time after
+somebody's entity had already broken.
+
+The raise happens in Home Assistant's state write, which is OUTSIDE the
+coordinator's parse guard, so no amount of coordinator-side hardening can catch
+it. The guard therefore lives at the entity boundary, where it covers the whole
+class once: a non-numeric value on a numeric sensor reports unknown.
+
+Text sensors (no state class, no numeric device class) must keep passing their
+strings through untouched.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+from custom_components.vag_connect.sensor import (
+    VagSensorDescription,
+    VagConnectSensor,
+)
+
+_VIN = "VIN123"
+
+
+def _sensor(desc: VagSensorDescription, raw_value: object) -> VagConnectSensor:
+    coord = MagicMock()
+    coord.data = {_VIN: {desc.data_key: raw_value}}
+    coord.vehicles = coord.data
+    ent = VagConnectSensor(coord, _VIN, desc)
+    # _vehicle is what native_value reads.
+    type(ent)._vehicle = property(lambda self: coord.data[_VIN])  # type: ignore[assignment]
+    return ent
+
+
+_NUMERIC = VagSensorDescription(
+    key="max_charge_current",
+    data_key="max_charge_current",
+    device_class=SensorDeviceClass.CURRENT,
+    state_class=SensorStateClass.MEASUREMENT,
+)
+_TEXT = VagSensorDescription(key="charging_state", data_key="charging_state")
+
+
+class TestSensorTypeGuard:
+    def test_enum_string_on_a_numeric_sensor_reports_unknown(self) -> None:
+        """#392's exact shape: an int field starts arriving as an enum."""
+        assert _sensor(_NUMERIC, "maximum").native_value is None
+
+    def test_numeric_values_are_untouched(self) -> None:
+        assert _sensor(_NUMERIC, 16).native_value == 16
+        assert _sensor(_NUMERIC, 16.5).native_value == 16.5
+
+    def test_stringified_number_still_works(self) -> None:
+        """Firmware that sends "85" kept working before the guard and must
+        keep working after it — HA's own float() accepted those too."""
+        assert _sensor(_NUMERIC, "85").native_value == 85.0
+
+    def test_none_stays_none(self) -> None:
+        assert _sensor(_NUMERIC, None).native_value is None
+
+    def test_text_sensor_passes_its_string_through(self) -> None:
+        """The guard must not turn a legitimate text sensor into unknown."""
+        assert _sensor(_TEXT, "CHARGING").native_value == "CHARGING"
+
+    def test_case_variant_enum_does_not_raise(self) -> None:
+        """Backends have been seen sending the same enum in different cases;
+        neither may reach HA as a numeric state."""
+        for variant in ("Maximum", "MAXIMUM", "reduced"):
+            assert _sensor(_NUMERIC, variant).native_value is None
+
+
+# ── target-SoC gap-fill from the battery-care threshold ─────────────────────
+
+class TestTargetSocFallback:
+    """Cars that report only a battery-care ceiling still get a charge target.
+
+    Some exports (the Audi Q4 e-tron is the known case) carry
+    battery_care_mode.charge_bcam_threshold and no settings.target_soc, so the
+    headline target sensor was never populated even though the car has a
+    ceiling. Gap-fill only: an explicit target always wins.
+    """
+
+    @staticmethod
+    def _map(fields: dict[str, str]):
+        from custom_components.vag_connect.cariad.auth._eu_data_act import (
+            map_dataset_to_vehicle_data,
+        )
+        from custom_components.vag_connect.cariad.models import VehicleData
+
+        return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+    def test_threshold_fills_an_empty_target(self) -> None:
+        d = self._map({"battery_care_mode.charge_bcam_threshold": "80"})
+        assert d.target_soc == 80
+        assert d.battery_care_target_soc_pct == 80  # still exposed separately
+
+    def test_explicit_target_wins(self) -> None:
+        d = self._map({
+            "settings.target_soc": "90",
+            "battery_care_mode.charge_bcam_threshold": "80",
+        })
+        assert d.target_soc == 90
+        assert d.battery_care_target_soc_pct == 80
+
+    def test_no_threshold_leaves_target_empty(self) -> None:
+        d = self._map({"battery_state_report.soc": "55"})
+        assert d.target_soc is None


### PR DESCRIPTION
Four items from the competitor audit, each grounded against our own source and each additive.

**Connector health no longer overrides the staleness policy.** Entity availability checked the connector-level `last_update_success` first and returned, so the coordinator's two-stage per-VIN tolerance was unreachable whenever the whole poll failed. That is every transient error on a single-car account and every backend-wide outage, which is exactly the case the tolerance was written for; the poll-failure path even says so in a comment. Availability now falls through to that policy, guarded so only a VIN with a last-known-good stamp qualifies. A regression test proves the old code fails it.

**A type change in one field can no longer break an entity.** A field that turns from a number into an enum raises inside HA's state write, outside the coordinator's parse guard, so it was only ever patched per field after a user hit it (#392, CUPRA's max charge current). Numeric sensors now coerce or report unknown, once, for the whole class. Stringified numbers keep working; text sensors are untouched.

**A hard portal call retries a transient 5xx.** The retry sat inside the soft branch, so VIN enumeration gave up on the first hiccup while a transport timeout on the same call retried three times. Now symmetric. A hard call still raises rather than returning an empty list, which matters because an empty VIN list is read as 'this account has no cars' and fails setup.

**Charge target for battery-care-only cars.** Cars that ship only `battery_care_mode.charge_bcam_threshold` (Audi Q4 e-tron) had an empty target. Gap-filled from that threshold; an explicit target always wins.

Also audited and found already safe: sensor units are static, so the 'unit changed' repair that offers to delete history cannot trigger.

Full suite 4302 passed, ruff + mypy strict clean.