### PR TITLE
v2.27.0: run the companion channel through the ADB Bridge add-on (#968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.27.0] - 2026-08-01
+
+### Added
+- **The companion channel can now run through the ADB Bridge add-on (#968).** On a phone running Android 11 or newer, the only way in is wireless debugging, which needs a TLS handshake and a pairing step that the built-in connection cannot do. It reaches the phone and fails, which is as far as most people got. The [ADB Bridge add-on](https://github.com/its-me-prash/vwgroup-app-adb-bridge) bundles the real tooling and does the pairing, and the integration can now talk to it instead: tick "Connect through the ADB Bridge add-on" when you add the companion channel, and give the add-on's address instead of the phone's. Everything after that is unchanged, including the read-only quarantine, so an older phone still connects directly exactly as before. Thanks to plainmad for testing the add-on and reporting precisely where it stopped.
+
 ## [2.26.3] - 2026-08-01
 
 ### Fixed

--- a/custom_components/vag_connect/companion/addon_transport.py
+++ b/custom_components/vag_connect/companion/addon_transport.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Companion transport that talks to the ADB Bridge add-on instead of a phone.
+
+Why this exists: the direct transport (``NetworkAdbTransport``) speaks classic
+ADB with the pure-python ``adb-shell`` library, which cannot do the TLS +
+pairing handshake Android 11 and newer require for wireless debugging. On a
+modern phone it reaches the port and fails. The add-on bundles the real ``adb``
+binary, does the pairing, and exposes two endpoints:
+
+    GET  /health  -> {"connected": bool, "serial": str|None, ...}
+    POST /shell   -> body is a shell command, returns {"stdout", "stderr", "rc"}
+
+Both take an ``X-Token`` header when the add-on has an ``api_token`` set.
+
+Everything above the wire is unchanged: ``dump_ui``, ``foreground_app``,
+``tap``, ``wake`` and the rest are all built on ``shell()`` in the base class,
+so subclassing and replacing the four connection primitives is enough. The
+screen parsing, the presets and the write quarantine never learn which
+transport they are running on.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from .transport import CompanionTransportError, NetworkAdbTransport
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_PORT = 8129
+
+
+class AddOnAdbTransport(NetworkAdbTransport):
+    """Runs shell commands through the add-on's local HTTP API."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int = _DEFAULT_PORT,
+        *,
+        token: str = "",
+        session: object | None = None,
+        wake_sleep: bool = False,
+    ) -> None:
+        # The base class stores host/port and the wake_sleep opt-in; the adbkey
+        # path is meaningless here (the add-on owns the key), so it is blank.
+        super().__init__(host, port or _DEFAULT_PORT, "", wake_sleep=wake_sleep)
+        self._token = token or ""
+        self._session = session
+        self._serial: str | None = None
+
+    # -- helpers --------------------------------------------------------------
+
+    @property
+    def _base(self) -> str:
+        return f"http://{self._host}:{self._port}"
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-Token": self._token} if self._token else {}
+
+    async def _get_session(self) -> object:
+        if self._session is None:
+            from aiohttp import ClientSession  # noqa: PLC0415
+
+            self._session = ClientSession()
+            self._owns_session = True
+        return self._session
+
+    # -- connection -----------------------------------------------------------
+
+    async def connect(self, timeout_s: float = 10.0) -> None:
+        """Ask the add-on whether it currently has a phone.
+
+        There is no socket for us to open: the add-on holds the ADB connection.
+        "Connected" therefore means the add-on reports a phone in device state,
+        and the failure messages point at the add-on rather than at the phone,
+        because that is where the user has to look.
+        """
+        from aiohttp import ClientError, ClientTimeout  # noqa: PLC0415
+
+        session = await self._get_session()
+        try:
+            async with session.get(  # type: ignore[attr-defined]
+                f"{self._base}/health",
+                headers=self._headers(),
+                timeout=ClientTimeout(total=timeout_s),
+            ) as resp:
+                if resp.status == 403:
+                    raise CompanionTransportError(
+                        "the add-on rejected the token; check that the token "
+                        "here matches api_token in the add-on configuration"
+                    )
+                if resp.status >= 400:
+                    raise CompanionTransportError(
+                        f"the add-on answered HTTP {resp.status} on /health"
+                    )
+                payload = await resp.json(content_type=None)
+        except (TimeoutError, ClientError, OSError) as err:
+            raise CompanionTransportError(
+                f"could not reach the ADB Bridge add-on at {self._base} "
+                f"({type(err).__name__}); check the add-on is started and that "
+                "the host and port match its configuration"
+            ) from err
+
+        if not isinstance(payload, dict) or not payload.get("connected"):
+            reason = ""
+            if isinstance(payload, dict):
+                reason = str(payload.get("last_error") or "")
+            raise CompanionTransportError(
+                "the add-on is running but has no phone connected"
+                + (f": {reason}" if reason else "")
+            )
+        self._serial = payload.get("serial") or None
+        # The base class treats a non-None _device as "connected"; there is no
+        # adb-shell device here, so the serial stands in for it.
+        self._device = self._serial or True
+
+    async def close(self) -> None:
+        self._device = None
+        self._serial = None
+        if getattr(self, "_owns_session", False) and self._session is not None:
+            try:
+                await self._session.close()  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                pass
+            self._session = None
+            self._owns_session = False
+
+    @property
+    def connected(self) -> bool:
+        return self._device is not None
+
+    # -- operations -----------------------------------------------------------
+
+    async def shell(self, cmd: str, timeout_s: float = 10.0) -> str:
+        """Run one shell command on the phone via the add-on.
+
+        Returns stdout, matching the base class. A non-zero exit code is NOT an
+        error here for the same reason it is not over raw ADB: several of the
+        commands we run (``grep`` with no match, ``rm -f`` on a missing file)
+        exit non-zero as a normal outcome, and the callers judge the output.
+        """
+        if self._device is None:
+            raise CompanionTransportError("not connected")
+
+        from aiohttp import ClientError, ClientTimeout  # noqa: PLC0415
+
+        session = await self._get_session()
+        try:
+            async with session.post(  # type: ignore[attr-defined]
+                f"{self._base}/shell",
+                data=cmd.encode("utf-8"),
+                headers=self._headers(),
+                timeout=ClientTimeout(total=timeout_s + 5),
+            ) as resp:
+                if resp.status == 503:
+                    # The add-on lost the phone underneath us.
+                    self._device = None
+                    raise CompanionTransportError(
+                        "the add-on reports no phone connected"
+                    )
+                if resp.status == 403:
+                    raise CompanionTransportError(
+                        "the add-on rejected the token"
+                    )
+                if resp.status >= 400:
+                    raise CompanionTransportError(
+                        f"the add-on answered HTTP {resp.status} running a command"
+                    )
+                payload = await resp.json(content_type=None)
+        except (TimeoutError, ClientError, OSError) as err:
+            raise CompanionTransportError(
+                f"the ADB Bridge add-on became unreachable ({type(err).__name__})"
+            ) from err
+
+        if not isinstance(payload, dict):
+            raise CompanionTransportError(
+                "the add-on returned an unexpected response running a command"
+            )
+        return str(payload.get("stdout") or "")
+
+
+async def probe_addon(
+    host: str, port: int, token: str, *, session: object | None = None
+) -> tuple[bool, str]:
+    """Check an add-on address for the config flow. Returns (ok, reason).
+
+    Never raises: the config flow turns the reason into a form error.
+    """
+    transport = AddOnAdbTransport(host, port, token=token, session=session)
+    try:
+        await transport.connect(timeout_s=10.0)
+    except CompanionTransportError as err:
+        return False, str(err)
+    except Exception as err:  # noqa: BLE001 - a probe must never crash setup
+        _LOGGER.debug("Companion add-on probe failed: %s", err, exc_info=True)
+        return False, str(err)
+    finally:
+        with_close = transport.close()
+        try:
+            await asyncio.wait_for(with_close, timeout=5)
+        except Exception:  # noqa: BLE001
+            pass
+    return True, ""

--- a/custom_components/vag_connect/companion/client.py
+++ b/custom_components/vag_connect/companion/client.py
@@ -40,13 +40,27 @@ class CompanionClient:
         time_fn: Callable[[], float],
         read_charge_detail: bool = False,
         wake_sleep: bool = False,
+        use_addon: bool = False,
+        addon_token: str = "",
     ) -> None:
         self._brand = brand.lower()
         self._vin = vin.upper()
         preset = PRESETS.get(self._brand)
         if preset is None:
             raise ValueError(f"no companion preset for brand {brand!r}")
-        self._transport = NetworkAdbTransport(host, port, adbkey_path, wake_sleep=wake_sleep)
+        if use_addon:
+            # host/port address the ADB Bridge add-on, which owns the phone
+            # connection. Everything above the wire is identical, so the
+            # channel below neither knows nor cares which transport it got.
+            from .addon_transport import AddOnAdbTransport  # noqa: PLC0415
+
+            self._transport: NetworkAdbTransport = AddOnAdbTransport(
+                host, port, token=addon_token, wake_sleep=wake_sleep
+            )
+        else:
+            self._transport = NetworkAdbTransport(
+                host, port, adbkey_path, wake_sleep=wake_sleep
+            )
         self._channel = CompanionChannel(
             self._transport, preset, time_fn=time_fn,
             read_charge_detail=read_charge_detail,

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -433,9 +433,12 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         from .const import (  # noqa: PLC0415
             CONF_ADB_HOST,
             CONF_ADB_PORT,
+            CONF_COMPANION_ADDON_TOKEN,
+            CONF_COMPANION_USE_ADDON,
             CONF_STRATEGY,
             CONF_VIN,
             DEFAULT_ADB_PORT,
+            DEFAULT_COMPANION_ADDON_PORT,
             STRATEGY_COMPANION_ADB,
         )
         from .companion.presets import PRESETS  # noqa: PLC0415
@@ -445,11 +448,22 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         if user_input is not None:
             brand = user_input[CONF_BRAND]
             host = user_input[CONF_ADB_HOST].strip()
-            port = int(user_input.get(CONF_ADB_PORT, DEFAULT_ADB_PORT))
+            use_addon = bool(user_input.get(CONF_COMPANION_USE_ADDON))
+            addon_token = (user_input.get(CONF_COMPANION_ADDON_TOKEN) or "").strip()
+            # The add-on serves its API on its own port, so a user who ticked
+            # the box and left the ADB default in place gets the right one.
+            _default_port = (
+                DEFAULT_COMPANION_ADDON_PORT if use_addon else DEFAULT_ADB_PORT
+            )
+            port = int(user_input.get(CONF_ADB_PORT) or _default_port)
+            if use_addon and port == DEFAULT_ADB_PORT:
+                port = DEFAULT_COMPANION_ADDON_PORT
             vin = user_input[CONF_VIN].strip().upper()
             spin = (user_input.get(CONF_SPIN) or "").strip()
 
-            valid, reason = await self._companion_probe(brand, host, port)
+            valid, reason = await self._companion_probe(
+                brand, host, port, use_addon=use_addon, addon_token=addon_token
+            )
             if not valid:
                 errors["base"] = reason
             else:
@@ -468,6 +482,8 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                         CONF_ADB_PORT: port,
                         CONF_VIN: vin,
                         CONF_SPIN: spin,
+                        CONF_COMPANION_USE_ADDON: use_addon,
+                        CONF_COMPANION_ADDON_TOKEN: addon_token,
                     },
                 )
 
@@ -479,6 +495,12 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 vol.Optional(CONF_ADB_PORT, default=DEFAULT_ADB_PORT): int,
                 vol.Required(CONF_VIN): str,
                 vol.Optional(CONF_SPIN, default=""): str,
+                # #968 — on Android 11+ the phone only speaks wireless debugging
+                # (TLS + pairing), which the built-in transport cannot do. Tick
+                # this and give the ADD-ON's address above instead of the
+                # phone's; the add-on holds the phone connection.
+                vol.Optional(CONF_COMPANION_USE_ADDON, default=False): bool,
+                vol.Optional(CONF_COMPANION_ADDON_TOKEN, default=""): str,
             }
         )
         return self.async_show_form(
@@ -486,7 +508,13 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         )
 
     async def _companion_probe(
-        self, brand: str, host: str, port: int
+        self,
+        brand: str,
+        host: str,
+        port: int,
+        *,
+        use_addon: bool = False,
+        addon_token: str = "",
     ) -> tuple[bool, str]:
         """Open ADB and read the app version; returns (ok, error_key)."""
         from .companion.presets import PRESETS  # noqa: PLC0415
@@ -498,8 +526,16 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         preset = PRESETS.get(brand)
         if preset is None:
             return False, "companion_unknown_brand"
-        adbkey = self.hass.config.path(".storage", "vag_connect_adbkey")
-        transport = NetworkAdbTransport(host, port, adbkey)
+        transport: NetworkAdbTransport
+        if use_addon:
+            # host/port address the add-on; it owns the phone connection, so
+            # there is no local RSA key involved.
+            from .companion.addon_transport import AddOnAdbTransport  # noqa: PLC0415
+
+            transport = AddOnAdbTransport(host, port, token=addon_token)
+        else:
+            adbkey = self.hass.config.path(".storage", "vag_connect_adbkey")
+            transport = NetworkAdbTransport(host, port, adbkey)
         try:
             await transport.connect()
             version = await transport.current_app_version(preset.package)

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -33,6 +33,14 @@ CONF_COMPANION_READ_CHARGE_DETAIL = "companion_read_charge_detail"
 # to sleep afterwards, so a locked/asleep phone shows the app (not the keyguard)
 # without needing "Stay awake" on permanently. OFF by default.
 CONF_COMPANION_WAKE_SLEEP        = "companion_wake_sleep"
+# v2.27.0 (#968) — route the companion channel through the ADB Bridge add-on
+# instead of talking ADB to the phone directly. Android 11+ wireless debugging
+# needs TLS + pairing, which the pure-python transport cannot do, so a modern
+# phone can only be driven via the add-on (it bundles the real adb binary).
+# When set, CONF_ADB_HOST/PORT address the ADD-ON, not the phone.
+CONF_COMPANION_USE_ADDON         = "companion_use_addon"
+CONF_COMPANION_ADDON_TOKEN       = "companion_addon_token"
+DEFAULT_COMPANION_ADDON_PORT     = 8129
 # v2.17.5 (#759) — optional per-VIN S-PIN overrides: {vin: spin}. When a
 # vehicle has no entry here the shared CONF_SPIN is used, so existing
 # single-S-PIN setups are unchanged. Set via the Options flow.

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -793,7 +793,9 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             )
 
             from .const import (  # noqa: PLC0415
+                CONF_COMPANION_ADDON_TOKEN,
                 CONF_COMPANION_READ_CHARGE_DETAIL,
+                CONF_COMPANION_USE_ADDON,
                 CONF_COMPANION_WAKE_SLEEP,
             )
             self._cariad_client = CompanionClient(
@@ -808,6 +810,15 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 ),
                 wake_sleep=bool(
                     self.entry.data.get(CONF_COMPANION_WAKE_SLEEP, False)
+                ),
+                # #968 — when set, host/port above address the ADB Bridge
+                # add-on rather than the phone (Android 11+ wireless debugging
+                # needs the real adb binary, which the add-on bundles).
+                use_addon=bool(
+                    self.entry.data.get(CONF_COMPANION_USE_ADDON, False)
+                ),
+                addon_token=str(
+                    self.entry.data.get(CONF_COMPANION_ADDON_TOKEN, "") or ""
                 ),
             )
             # v2.26.0 (ckomma #21) — re-apply a rate-limit backoff persisted

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.26.3"
+  "version": "2.27.0"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Connect through the ADB Bridge add-on",
+          "companion_addon_token": "Add-on token"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Tick this for an Android 11 or newer phone, which only offers wireless debugging. Then enter the ADD-ON's address above instead of the phone's.",
+          "companion_addon_token": "Only needed if you set api_token in the add-on."
         }
       }
     },

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Über das ADB-Bridge-Add-on verbinden",
+          "companion_addon_token": "Add-on-Token"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Für Handys ab Android 11 ankreuzen, die nur noch Wireless-Debugging anbieten. Dann oben die Adresse des ADD-ONS eintragen, nicht die des Handys.",
+          "companion_addon_token": "Nur nötig, wenn im Add-on api_token gesetzt ist."
         }
       }
     },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Connect through the ADB Bridge add-on",
+          "companion_addon_token": "Add-on token"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Tick this for an Android 11 or newer phone, which only offers wireless debugging. Then enter the ADD-ON's address above instead of the phone's.",
+          "companion_addon_token": "Only needed if you set api_token in the add-on."
         }
       }
     },

--- a/tests/test_v2270_addon_transport.py
+++ b/tests/test_v2270_addon_transport.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#968 Phase 1 — the companion channel can run through the ADB Bridge add-on.
+
+Android 11+ only offers wireless debugging (TLS + SPAKE2 pairing), which the
+pure-python transport cannot speak: it reaches the port and fails. The add-on
+bundles the real adb binary and exposes ``/health`` and ``/shell``, so the
+integration talks HTTP to it instead of ADB to the phone.
+
+The point of the design is that ONLY the four connection primitives change.
+``dump_ui``, ``foreground_app``, ``tap``, ``wake`` and the write quarantine are
+all built on ``shell()`` in the base class, so they are inherited untouched and
+the screen layer never learns which transport it got.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.companion.addon_transport import (
+    AddOnAdbTransport,
+    probe_addon,
+)
+from custom_components.vag_connect.companion.transport import (
+    CompanionTransportError,
+    NetworkAdbTransport,
+)
+
+
+class _Resp:
+    def __init__(self, status: int, payload: Any = None) -> None:
+        self.status = status
+        self._payload = payload
+
+    async def json(self, content_type: Any = None) -> Any:
+        return self._payload
+
+    async def __aenter__(self) -> _Resp:
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+
+class _Session:
+    """Records calls and replays queued responses."""
+
+    def __init__(self, health: Any = None, shell: Any = None) -> None:
+        self._health = health
+        self._shell = shell
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def get(self, url: str, **kw: Any) -> Any:
+        self.calls.append(("GET", url, kw))
+        if isinstance(self._health, Exception):
+            raise self._health
+        return self._health
+
+    def post(self, url: str, **kw: Any) -> Any:
+        self.calls.append(("POST", url, kw))
+        if isinstance(self._shell, Exception):
+            raise self._shell
+        return self._shell
+
+    async def close(self) -> None:
+        return None
+
+
+def _t(session: _Session, token: str = "") -> AddOnAdbTransport:
+    return AddOnAdbTransport("1.2.3.4", 8129, token=token, session=session)
+
+
+class TestConnect:
+    def test_connect_succeeds_when_the_addon_has_a_phone(self) -> None:
+        sess = _Session(health=_Resp(200, {"connected": True, "serial": "ph:1"}))
+        t = _t(sess)
+        asyncio.run(t.connect())
+        assert t.connected is True
+        assert "/health" in sess.calls[0][1]
+
+    def test_addon_without_a_phone_is_a_clear_error(self) -> None:
+        sess = _Session(health=_Resp(200, {"connected": False, "last_error": "no phone found"}))
+        t = _t(sess)
+        with pytest.raises(CompanionTransportError, match="no phone"):
+            asyncio.run(t.connect())
+        assert t.connected is False
+
+    def test_bad_token_names_the_token(self) -> None:
+        sess = _Session(health=_Resp(403, {}))
+        with pytest.raises(CompanionTransportError, match="token"):
+            asyncio.run(_t(sess, token="wrong").connect())
+
+    def test_unreachable_addon_points_at_the_addon(self) -> None:
+        sess = _Session(health=OSError("refused"))
+        with pytest.raises(CompanionTransportError, match="add-on"):
+            asyncio.run(_t(sess).connect())
+
+    def test_token_is_sent_when_configured(self) -> None:
+        sess = _Session(health=_Resp(200, {"connected": True, "serial": "s"}))
+        asyncio.run(_t(sess, token="secret").connect())
+        assert sess.calls[0][2]["headers"]["X-Token"] == "secret"
+
+    def test_no_token_header_when_blank(self) -> None:
+        sess = _Session(health=_Resp(200, {"connected": True, "serial": "s"}))
+        asyncio.run(_t(sess).connect())
+        assert "X-Token" not in sess.calls[0][2]["headers"]
+
+
+class TestShell:
+    def _connected(self, shell_resp: Any) -> tuple[AddOnAdbTransport, _Session]:
+        sess = _Session(
+            health=_Resp(200, {"connected": True, "serial": "s"}), shell=shell_resp
+        )
+        t = _t(sess)
+        asyncio.run(t.connect())
+        return t, sess
+
+    def test_shell_returns_stdout(self) -> None:
+        t, sess = self._connected(_Resp(200, {"stdout": "ok\n", "stderr": "", "rc": 0}))
+        assert asyncio.run(t.shell("echo ok")) == "ok\n"
+        assert sess.calls[-1][0] == "POST"
+        assert "/shell" in sess.calls[-1][1]
+
+    def test_nonzero_exit_is_not_an_error(self) -> None:
+        """grep with no match and rm -f on a missing file both exit non-zero
+        as a normal outcome; the callers judge the output, exactly as over
+        raw ADB."""
+        t, _ = self._connected(_Resp(200, {"stdout": "", "stderr": "", "rc": 1}))
+        assert asyncio.run(t.shell("grep nothing")) == ""
+
+    def test_phone_lost_mid_session_marks_disconnected(self) -> None:
+        t, _ = self._connected(_Resp(503, {"error": "phone not connected"}))
+        with pytest.raises(CompanionTransportError):
+            asyncio.run(t.shell("echo hi"))
+        assert t.connected is False  # so the channel reconnects next time
+
+    def test_shell_before_connect_raises(self) -> None:
+        sess = _Session()
+        with pytest.raises(CompanionTransportError, match="not connected"):
+            asyncio.run(_t(sess).shell("echo hi"))
+
+
+class TestInheritedBehaviour:
+    """The whole point: everything above shell() is untouched."""
+
+    def test_it_is_a_network_transport(self) -> None:
+        assert issubclass(AddOnAdbTransport, NetworkAdbTransport)
+
+    def test_dump_ui_runs_the_same_commands_over_http(self) -> None:
+        """dump_ui is inherited, so it must work unchanged through the add-on:
+        remove the stale dump, run uiautomator, cat the file back."""
+        xml = '<?xml version="1.0"?><hierarchy rotation="0"></hierarchy>'
+        sess = _Session(
+            health=_Resp(200, {"connected": True, "serial": "s"}),
+            shell=_Resp(200, {"stdout": xml, "stderr": "", "rc": 0}),
+        )
+        t = _t(sess)
+        asyncio.run(t.connect())
+        assert "<hierarchy" in asyncio.run(t.dump_ui())
+        posts = [c for c in sess.calls if c[0] == "POST"]
+        assert len(posts) == 3  # rm, uiautomator dump, cat
+        assert b"uiautomator dump" in posts[1][2]["data"]
+
+    def test_a_failed_dump_is_still_honest(self) -> None:
+        """The stale-dump guard is inherited too: no hierarchy means no data,
+        never a silently reused previous screen."""
+        sess = _Session(
+            health=_Resp(200, {"connected": True, "serial": "s"}),
+            shell=_Resp(200, {"stdout": "", "stderr": "", "rc": 0}),
+        )
+        t = _t(sess)
+        asyncio.run(t.connect())
+        with pytest.raises(CompanionTransportError):
+            asyncio.run(t.dump_ui())
+
+
+class TestProbe:
+    def test_probe_reports_ok(self) -> None:
+        sess = _Session(health=_Resp(200, {"connected": True, "serial": "s"}))
+        ok, reason = asyncio.run(probe_addon("1.2.3.4", 8129, "", session=sess))
+        assert ok is True and reason == ""
+
+    def test_probe_never_raises(self) -> None:
+        sess = _Session(health=OSError("boom"))
+        ok, reason = asyncio.run(probe_addon("1.2.3.4", 8129, "", session=sess))
+        assert ok is False and reason


### PR DESCRIPTION
Android 11 and newer only offer wireless debugging, which needs a TLS handshake and a pairing step that the pure-python transport cannot do: it reaches the port and fails. That is where testers with a modern phone stopped, including one who had the add-on itself working perfectly and correctly reported that the integration could not use it.

`AddOnAdbTransport` subclasses `NetworkAdbTransport` and replaces only the four connection primitives (connect / close / connected / shell) with calls to the add-on's `/health` and `/shell`. Everything above the wire is inherited unchanged: `dump_ui`, `foreground_app`, `tap`, `wake` and the write quarantine are all built on `shell()`, so the screen layer, the presets and the read-only gating never learn which transport they got. A non-zero exit code stays a normal outcome (grep with no match, rm -f on a missing file) and the stale-dump guard still turns a failed dump into honest no-data.

Opt-in per entry from the config flow: tick the box, give the add-on's address instead of the phone's, and the default port follows. An older phone keeps connecting directly with no change at all.

15 tests, including that `dump_ui` issues its three commands over HTTP and that a failed dump is still reported honestly. Full suite 4317 passed, ruff + mypy strict clean.