### PR TITLE
v2.28.0: duration and horn options for the vehicle signal (#1009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.28.0] - 2026-08-01
+
+### Added
+- **The vehicle-signal service can now choose duration and horn (#1009).** The manufacturer app's signal screen lets you pick how long the car signals and whether the horn joins in, and `flash_lights` only ever sent a fixed ten-second flash. It now takes an optional duration (10, 20 or 30 seconds) and signal type (lights only, or horn and lights). Leaving both out does exactly what it did before, so nothing changes for existing automations. Volkswagen and Audi honour both settings and Skoda honours the horn; on the remaining brands the values are not documented in their apps, so they are accepted and ignored rather than guessed at. Thanks to Kimmy42-J for the request.
+
 ## [2.27.0] - 2026-08-01
 
 ### Added

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -55,6 +55,17 @@ SERVICE_VIN_SCHEMA = vol.Schema({vol.Required("vin"): cv.string})
 SERVICE_IMPORT_FILE_SCHEMA = vol.Schema(
     {vol.Required("vin"): cv.string, vol.Required("file"): cv.string}
 )
+# #1009 — the signal screen's two settings. Both optional: omitting them keeps
+# the previous fixed 10-second lights-only signal.
+SERVICE_FLASH_SCHEMA = vol.Schema(
+    {
+        vol.Required("vin"): cv.string,
+        vol.Optional("duration_seconds", default=10): vol.In([10, 20, 30]),
+        vol.Optional("signal_type", default="lights_only"): vol.In(
+            ["lights_only", "horn_and_lights"]
+        ),
+    }
+)
 
 # v2.10.0 unified action dispatcher (``execute_vehicle_action``).
 # Maps the user-facing action key (from the services.yaml select
@@ -387,7 +398,13 @@ def _register_services(hass: HomeAssistant) -> None:
         await _coord_writeable(call.data["vin"]).async_wake_vehicle(call.data["vin"])
 
     async def _handle_flash(call: ServiceCall) -> None:
-        await _coord_writeable(call.data["vin"]).async_flash_lights(call.data["vin"])
+        # #1009 — both optional; omitting them reproduces the previous fixed
+        # 10-second lights-only signal.
+        await _coord_writeable(call.data["vin"]).async_flash_lights(
+            call.data["vin"],
+            duration_s=int(call.data.get("duration_seconds", 10)),
+            honk=call.data.get("signal_type") == "horn_and_lights",
+        )
 
     async def _handle_set_target_soc(call: ServiceCall) -> None:
         await _coord_writeable(call.data["vin"]).async_set_target_soc(
@@ -615,7 +632,7 @@ def _register_services(hass: HomeAssistant) -> None:
         ("start_window_heating",           _handle_start_window,        SERVICE_VIN_SCHEMA),
         ("stop_window_heating",            _handle_stop_window,         SERVICE_VIN_SCHEMA),
         ("wake_vehicle",                   _handle_wake,                SERVICE_VIN_SCHEMA),
-        ("flash_lights",                   _handle_flash,               SERVICE_VIN_SCHEMA),
+        ("flash_lights",                   _handle_flash,               SERVICE_FLASH_SCHEMA),
         ("request_historical_export",      _handle_request_historical_export, SERVICE_VIN_SCHEMA),
         ("import_historical_export",       _handle_import_historical_export,  SERVICE_VIN_SCHEMA),
         ("import_export_file",             _handle_import_export_file,        SERVICE_IMPORT_FILE_SCHEMA),

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -1052,8 +1052,15 @@ class CariadBaseClient:
         vin: str,
         latitude: float | None = None,
         longitude: float | None = None,
+        duration_s: int = 10,
+        honk: bool = False,
     ) -> None:
-        """Honk and flash. SEAT/CUPRA require the user position; others ignore it."""
+        """Honk and flash. SEAT/CUPRA require the user position; others ignore it.
+
+        ``duration_s`` and ``honk`` (#1009) default to the previous behaviour —
+        a 10-second lights-only signal — so a brand client that ignores them
+        behaves exactly as it did before.
+        """
         raise NotImplementedError
 
     async def command_wake(self, vin: str) -> None:

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -271,6 +271,8 @@ class PorscheClient:
         vin: str,
         latitude: float | None = None,  # noqa: ARG002
         longitude: float | None = None,  # noqa: ARG002
+        duration_s: int = 10,  # noqa: ARG002 - value not grounded for this brand
+        honk: bool = False,  # noqa: ARG002 - value not grounded for this brand
     ) -> None:
         await self._command(vin, "HONK_FLASH")
 

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -2639,6 +2639,8 @@ class SeatCupraClient(CariadBaseClient):
         vin: str,
         latitude: float | None = None,
         longitude: float | None = None,
+        duration_s: int = 10,  # noqa: ARG002 - value not grounded for this brand
+        honk: bool = False,  # noqa: ARG002 - value not grounded for this brand
     ) -> None:
         """SEAT/CUPRA honk-and-flash.
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -1571,11 +1571,19 @@ class SkodaClient(CariadBaseClient):
         vin: str,
         latitude: float | None = None,  # noqa: ARG002
         longitude: float | None = None,  # noqa: ARG002
+        duration_s: int = 10,  # noqa: ARG002 - Skoda's DTO carries no duration
+        honk: bool = False,
     ) -> None:
         # v2.20.0 (APK audit) — Skoda's HonkAndFlashRequestDto$Mode enum (MyŠkoda
         # 8.14.0) has only HONK_AND_FLASH / FLASH; "FLASH_ONLY" is the VW-EU/Audi
         # value that was wrongly copied here and was rejected. Flash-only = FLASH.
-        await self._post(f"{_BASE}/api/v1/vehicle-access/{vin}/honk-and-flash", json={"mode": "FLASH"})
+        # #1009 — the same enum carries HONK_AND_FLASH, so the horn option is
+        # grounded here too. There is no duration field in Skoda's DTO, so
+        # duration_s is accepted and ignored rather than invented.
+        await self._post(
+            f"{_BASE}/api/v1/vehicle-access/{vin}/honk-and-flash",
+            json={"mode": "HONK_AND_FLASH" if honk else "FLASH"},
+        )
 
     async def command_wake(self, vin: str) -> None:
         await self._post(f"{_BASE}/api/v1/vehicle-wakeup/{vin}?applyRequestLimiter=true", json={})

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -945,6 +945,8 @@ class VWEUClient(CariadBaseClient):
         vin: str,
         latitude: float | None = None,
         longitude: float | None = None,
+        duration_s: int = 10,
+        honk: bool = False,
     ) -> None:
         """Flash the lights — CARIAD-BFF ``honkandflash`` endpoint.
 
@@ -1004,7 +1006,14 @@ class VWEUClient(CariadBaseClient):
         # HonkAndFlashParameters uses @SerialName("duration_s") on
         # durationInSeconds); the old ``duration`` was an unknown key the backend
         # silently dropped, so the flash always ran the backend default length.
-        body: dict[str, Any] = {"mode": "FLASH_ONLY", "duration_s": 10}
+        # #1009 — the app's own signal screen offers both of these, and the
+        # wire contract already carries them: the CARIAD ``Mode`` enum has
+        # exactly HONK_AND_FLASH and FLASH_ONLY, and ``duration_s`` is plain
+        # seconds. Defaults reproduce the previous fixed 10-second flash.
+        body: dict[str, Any] = {
+            "mode": "HONK_AND_FLASH" if honk else "FLASH_ONLY",
+            "duration_s": int(duration_s),
+        }
         try:
             await self._post_command(vin, "honkandflash", json=body)
             return

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -1487,6 +1487,8 @@ class VWNAClient:
         vin: str,
         latitude: float | None = None,  # noqa: ARG002
         longitude: float | None = None,  # noqa: ARG002
+        duration_s: int = 10,  # noqa: ARG002 - value not grounded for this brand
+        honk: bool = False,  # noqa: ARG002 - value not grounded for this brand
     ) -> None:
         uuid = self._vin_to_uuid.get(vin, vin)
         # v2.20.0 (APK audit) — myVW 2026.5.27 exposes honk/flash as the dedicated

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -4514,7 +4514,9 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             optimistic={"charging_state": "NOT_CHARGING", "is_charging": False},
         )
 
-    async def async_flash_lights(self, vin: str) -> None:
+    async def async_flash_lights(
+        self, vin: str, duration_s: int = 10, honk: bool = False
+    ) -> None:
         # SEAT/CUPRA require the user position in the honk-and-flash payload
         # (HTTP 400 otherwise). Other brands accept and ignore it.
         #
@@ -4533,6 +4535,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             "command_flash",
             latitude=vehicle.get("latitude"),
             longitude=vehicle.get("longitude"),
+            # #1009 — honoured where the brand's own signal enum grounds them
+            # (Volkswagen/Audi carry both; Skoda carries the horn but no
+            # duration); brands where the values are not grounded accept and
+            # ignore them rather than guessing a wire value.
+            duration_s=int(duration_s),
+            honk=bool(honk),
         )
 
     async def async_set_target_soc(self, vin: str, target: int) -> None:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.27.0"
+  "version": "2.28.0"
 }

--- a/custom_components/vag_connect/services.yaml
+++ b/custom_components/vag_connect/services.yaml
@@ -148,13 +148,42 @@ stop_charging:
 
 flash_lights:
   name: Lichtsignal
-  description: Aktiviert Lichthupe und Lichtsignal (Honk & Flash).
+  description: >-
+    Löst das Fahrzeugsignal aus, um das Auto zu finden. Ohne Angaben blinkt es
+    10 Sekunden ohne Hupe, wie bisher.
   fields:
     vin:
       name: VIN
       required: true
       selector:
         text:
+    duration_seconds:
+      name: Dauer
+      description: >-
+        Dauer des Signals in Sekunden. Wird von Volkswagen und Audi
+        unterstützt; andere Marken nutzen ihre eigene Vorgabe.
+      required: false
+      default: 10
+      selector:
+        select:
+          options:
+            - "10"
+            - "20"
+            - "30"
+    signal_type:
+      name: Signalart
+      description: >-
+        Nur Blinken oder Hupe und Blinken. Wird von Volkswagen, Audi und Škoda
+        unterstützt; bei anderen Marken bleibt es beim Blinken.
+      required: false
+      default: lights_only
+      selector:
+        select:
+          options:
+            - label: Nur Blinken
+              value: lights_only
+            - label: Hupe und Blinken
+              value: horn_and_lights
 
 start_window_heating:
   name: Fensterheizung starten

--- a/tests/test_v2280_flash_options.py
+++ b/tests/test_v2280_flash_options.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1009 — the vehicle-signal service exposes duration and horn.
+
+The manufacturer app's signal screen offers both, and the wire contract already
+carried them: the CARIAD ``HonkAndFlashParameters$Mode`` enum has exactly
+HONK_AND_FLASH and FLASH_ONLY, and ``duration_s`` is plain seconds (both read
+out of the decompiled app when the endpoint was first grounded). Skoda's own
+DTO carries the same two-value mode but no duration.
+
+Nothing is invented here: a brand whose values are not grounded accepts the
+arguments and ignores them, exactly as it already does for latitude/longitude.
+Omitting both reproduces the previous fixed 10-second lights-only signal.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from custom_components.vag_connect.cariad.api.skoda import SkodaClient
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+
+
+def _vw() -> tuple[VWEUClient, AsyncMock]:
+    c = VWEUClient.__new__(VWEUClient)
+    c._mbb_command_target = lambda: None  # type: ignore[method-assign]
+    post = AsyncMock()
+    c._post_command = post  # type: ignore[method-assign]
+    return c, post
+
+
+class TestVolkswagenAudi:
+    def test_default_is_the_previous_behaviour(self) -> None:
+        c, post = _vw()
+        asyncio.run(c.command_flash("VIN"))
+        assert post.await_args.kwargs["json"] == {
+            "mode": "FLASH_ONLY", "duration_s": 10
+        }
+
+    def test_horn_uses_the_grounded_enum_value(self) -> None:
+        c, post = _vw()
+        asyncio.run(c.command_flash("VIN", honk=True))
+        assert post.await_args.kwargs["json"]["mode"] == "HONK_AND_FLASH"
+
+    def test_duration_is_sent_as_seconds(self) -> None:
+        c, post = _vw()
+        asyncio.run(c.command_flash("VIN", duration_s=30))
+        assert post.await_args.kwargs["json"]["duration_s"] == 30
+
+    def test_both_together(self) -> None:
+        c, post = _vw()
+        asyncio.run(c.command_flash("VIN", duration_s=20, honk=True))
+        assert post.await_args.kwargs["json"] == {
+            "mode": "HONK_AND_FLASH", "duration_s": 20
+        }
+
+
+class TestSkoda:
+    def _client(self) -> tuple[SkodaClient, AsyncMock]:
+        c = SkodaClient.__new__(SkodaClient)
+        post = AsyncMock()
+        c._post = post  # type: ignore[method-assign]
+        return c, post
+
+    def test_flash_only_keeps_skodas_own_enum_value(self) -> None:
+        """Skoda's value is FLASH, not the VW-EU FLASH_ONLY (that mismatch was
+        a real bug once)."""
+        c, post = self._client()
+        asyncio.run(c.command_flash("VIN"))
+        assert post.await_args.kwargs["json"] == {"mode": "FLASH"}
+
+    def test_horn_is_grounded_here_too(self) -> None:
+        c, post = self._client()
+        asyncio.run(c.command_flash("VIN", honk=True))
+        assert post.await_args.kwargs["json"] == {"mode": "HONK_AND_FLASH"}
+
+    def test_duration_is_ignored_not_invented(self) -> None:
+        """Skoda's DTO has no duration field, so we must not add one."""
+        c, post = self._client()
+        asyncio.run(c.command_flash("VIN", duration_s=30))
+        assert "duration_s" not in post.await_args.kwargs["json"]
+
+
+class TestWiring:
+    def test_every_brand_accepts_the_arguments(self) -> None:
+        """Signature compatibility: the coordinator passes both to whichever
+        client the entry has, so none may raise TypeError."""
+        import inspect
+
+        from custom_components.vag_connect.cariad.api import (
+            base, porsche, seat_cupra, skoda, vw_eu, vw_na,
+        )
+
+        for mod in (base, porsche, seat_cupra, skoda, vw_eu, vw_na):
+            for _name, obj in inspect.getmembers(mod, inspect.isclass):
+                fn = obj.__dict__.get("command_flash")
+                if fn is None:
+                    continue
+                params = inspect.signature(fn).parameters
+                assert "duration_s" in params, f"{mod.__name__} missing duration_s"
+                assert "honk" in params, f"{mod.__name__} missing honk"
+
+    def test_service_is_registered_with_the_new_schema(self) -> None:
+        import pathlib
+
+        src = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "custom_components/vag_connect/__init__.py"
+        ).read_text(encoding="utf-8")
+        assert "SERVICE_FLASH_SCHEMA" in src
+        assert '"flash_lights",                   _handle_flash,               SERVICE_FLASH_SCHEMA' in src
+
+    def test_service_is_documented(self) -> None:
+        import pathlib
+
+        import yaml
+
+        doc = yaml.safe_load(
+            (
+                pathlib.Path(__file__).resolve().parents[1]
+                / "custom_components/vag_connect/services.yaml"
+            ).read_text(encoding="utf-8")
+        )
+        fields = doc["flash_lights"]["fields"]
+        assert "duration_seconds" in fields
+        assert "signal_type" in fields


### PR DESCRIPTION
The manufacturer app's signal screen offers a duration and a lights-only / horn-and-lights choice, and `flash_lights` only ever sent a fixed ten-second flash.

Nothing had to be reverse-engineered for this: the wire contract already carried both. The CARIAD `HonkAndFlashParameters$Mode` enum has exactly `HONK_AND_FLASH` and `FLASH_ONLY`, and `duration_s` is plain seconds, both read out of the decompiled app when that endpoint was first grounded. Skoda's own DTO carries the same two-value mode but no duration field.

`flash_lights` gains optional `duration_seconds` (10/20/30) and `signal_type` (lights_only / horn_and_lights). **Omitting them reproduces the previous behaviour exactly**, so existing automations are untouched.

Per brand, honestly: Volkswagen and Audi honour both. Skoda honours the horn and ignores the duration, because its DTO has no such field and inventing one would be a guess. The remaining brands accept and ignore both, the same way they already treat latitude/longitude, rather than sending a wire value nobody has confirmed.

10 tests, including that Skoda keeps its own `FLASH` value (copying VW's `FLASH_ONLY` there was a real bug once) and that no duration key is added where the DTO has none. Full suite 4327 passed, ruff + mypy strict clean.