### PR TITLE
VW North America: send the play_integrity_token the token step now requires (#1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ## [Unreleased]
 
 ### Fixed
+- **Volkswagen US and Canada could not be added since 30 July (#1012).** Sign-in itself was working: it ran through to an authorization code and only the step that trades that code for a token was refused, with a 401 that read like a wrong password but was not one. On 30 July VW's North American token service began requiring a field that was not there before, and every request without it now bounces. That field is sent now, on both the initial token exchange and the refresh, so an affected account adds and stays signed in. Confirmed by three owners, whose reports all point at the same 04:00 UTC cut-over. Thanks to briancmoses, chrisspatrickk1 and savabg.
 - **Ten of the eleven translations were missing the companion-channel strings.** Home Assistant does not fall back to English for a custom integration, so a key that exists only in English renders as the raw key or as nothing at all. The twelve strings added with the companion channel and the export-file import had reached German only, which left the add-on checkbox, its error message, the two companion option toggles and the three import error messages blank for everyone running Home Assistant in French, Spanish, Italian, Dutch, Polish, Czech, Swedish, Danish, Norwegian or Finnish. All twelve are translated now, and a test fails the build if a language ever falls behind again.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **Ten of the eleven translations were missing the companion-channel strings.** Home Assistant does not fall back to English for a custom integration, so a key that exists only in English renders as the raw key or as nothing at all. The twelve strings added with the companion channel and the export-file import had reached German only, which left the add-on checkbox, its error message, the two companion option toggles and the three import error messages blank for everyone running Home Assistant in French, Spanish, Italian, Dutch, Polish, Czech, Swedish, Danish, Norwegian or Finnish. All twelve are translated now, and a test fails the build if a language ever falls behind again.
+
 ### Changed
 - **An identity token from the portal export no longer enters field discovery.** The export carries `idp_idt`, which identifies the account holder rather than anything about the car, and it was reaching the Vehicle Data Scout as an unmapped field. Only the token masker kept its value out of a public issue. It is now withheld from discovery entirely, so it can never end up in an entity attribute, a backup or a diagnostics download. This is a deliberate single exception to the rule that every discovered field stays visible until mapped, it is scoped to one named field, and each withholding is logged.
 

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -1679,7 +1679,14 @@ class VWNAClient:
     async def _refresh(self) -> None:
         if self._tokens and self._tokens.refresh_token:
             try:
-                self._tokens = await self._auth.refresh(self._tokens.refresh_token)
+                # #1012 — replay the login's PKCE verifier: the con-veh server
+                # binds the refresh to it. Empty on a token set from before the
+                # fix, in which case the refresh fails and we fall through to a
+                # full re-login below (which now carries the verifier again).
+                self._tokens = await self._auth.refresh(
+                    self._tokens.refresh_token,
+                    code_verifier=self._tokens.code_verifier,
+                )
                 return
             except TokenExpiredError:
                 pass

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -63,6 +63,14 @@ _AUTHORIZE_URL = f"{_IDK_BASE}/oidc/v1/authorize"
 # evcc PR #30277 / volkswagencarnet PR #331 / ioBroker.vw-connect):
 _CARIAD_TOKEN_URL = "https://emea.bff.cariad.digital/auth/v1/idk/oidc/token"
 
+# #1012 — the value sent in the ``play_integrity_token`` field VW NA's con-veh
+# token endpoint began requiring on 2026-07-30. VW checks presence, not that it
+# is a genuine Play Integrity attestation (which cannot be minted off-device),
+# so this placeholder is what the maintained third-party NA clients send too.
+# The moment VW starts validating it, the exchange 401s again and this is the
+# line to revisit — it is deliberately not a fabricated-looking real token.
+_NA_PLAY_INTEGRITY_PLACEHOLDER = "unavailable"
+
 # ── X-QMAuth signing for Audi + VW EU IDK token exchange ────────────────────
 # v2.5.4 (#313) — Audi/VW EU's IDK token endpoint validates an
 # ``x-qmauth`` HMAC-SHA256 header on both ``authorization_code`` and
@@ -1260,7 +1268,7 @@ class IDKAuth:
 
         return await self._exchange_code(auth_code, verifier)
 
-    async def refresh(self, refresh_token: str) -> TokenSet:
+    async def refresh(self, refresh_token: str, code_verifier: str = "") -> TokenSet:
         """Exchange a refresh token for a fresh token set.
 
         Refresh endpoints differ by brand:
@@ -1304,6 +1312,20 @@ class IDKAuth:
         }
         if self._brand.client_secret:
             data["client_secret"] = self._brand.client_secret
+
+        # #1012 — VW North America. The same con-veh server change that added
+        # play_integrity_token to the code exchange applies to refresh, and the
+        # server additionally binds the refresh to the original PKCE verifier,
+        # so both travel on the refresh too. Without the token the refresh 401s;
+        # without the verifier it 400s "Internal Service validation failure".
+        # Both are scoped to the con-veh endpoint so the CARIAD-BFF and OLA
+        # brands sharing this method are untouched. If the verifier was not
+        # preserved (e.g. a token set from before this change), the refresh
+        # falls through to the coordinator's full re-login rather than looping.
+        if "con-veh" in token_url:
+            data["play_integrity_token"] = _NA_PLAY_INTEGRITY_PLACEHOLDER
+            if code_verifier:
+                data["code_verifier"] = code_verifier
 
         # v2.5.4 (#313) — Audi + VW EU require the assertion header set
         # at the CARIAD BFF token endpoint AFTER the 2026-05-28 Azure
@@ -1705,6 +1727,22 @@ class IDKAuth:
             if self._brand.client_secret:
                 data["client_secret"] = self._brand.client_secret
 
+            # #1012 — VW North America. Since 2026-07-30 the con-veh token
+            # endpoint (which proxies to CarnetSPAuthorizationServer /azs) has
+            # required a ``play_integrity_token`` form field on the grant.
+            # Without it the exchange returns exactly HTTP 401
+            # {"errorCode":"INVALID_REQUEST","origin":"CarnetSPAuthorizationServer"},
+            # which is what two US owners reported after their sign-in itself
+            # succeeded. VW only checks the field is PRESENT, not that it is a
+            # valid Play Integrity attestation, so a placeholder satisfies it
+            # (confirmed against two independently-maintained live NA clients).
+            # Scoped to the con-veh host by the token-url marker so the other
+            # brands sharing this branch (Skoda/SEAT/CUPRA) are untouched, and
+            # so the day VW starts validating the token this simply 401s again
+            # rather than doing anything unsafe.
+            if "con-veh" in self._get_token_endpoint():
+                data["play_integrity_token"] = _NA_PLAY_INTEGRITY_PLACEHOLDER
+
             # v2.5.7 R2 — assertion headers signed with this attempt's qmauth.
             # v2.5.11 — per-brand x-android-package-name (was hardcoded to
             # Audi value pre-v2.5.11; latent VW-impersonation bug fixed).
@@ -1738,7 +1776,16 @@ class IDKAuth:
                                 qm_client_id or "n/a",
                             )
                         payload: dict[str, Any] = await resp.json()
-                        return self._parse_tokens(payload)
+                        # #1012 — persist the PKCE verifier on the token set for
+                        # the con-veh brands, whose refresh grant requires it
+                        # replayed. Left empty for everyone else.
+                        _keep_verifier = (
+                            verifier if "con-veh" in self._get_token_endpoint()
+                            else ""
+                        )
+                        return self._parse_tokens(
+                            payload, code_verifier=_keep_verifier
+                        )
                     body = await resp.text()
                     # v2.5.7 (#313 follow-on / 502 storm 2026-05-29) — 5xx
                     # responses from the CARIAD-BFF mean the VW backend is
@@ -1896,6 +1943,7 @@ class IDKAuth:
         self,
         payload: dict[str, Any],
         fallback_refresh: str = "",
+        code_verifier: str = "",
     ) -> TokenSet:
         """Parse token response into a TokenSet.
 
@@ -1924,7 +1972,15 @@ class IDKAuth:
             raise AuthenticationError(
                 f"Token response missing refresh_token (no fallback): {list(payload)}"
             )
-        return TokenSet(access_token=access, refresh_token=refresh, id_token=id_tok)
+        return TokenSet(
+            access_token=access,
+            refresh_token=refresh,
+            id_token=id_tok,
+            # #1012 — carried only when the caller (the con-veh exchange) passes
+            # it, or preserved across a refresh via fallback so it survives the
+            # whole token lifetime.
+            code_verifier=code_verifier,
+        )
 
     @staticmethod
     def _parse_csrf(html: str) -> _CSRFParser:

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -337,6 +337,15 @@ class TokenSet:
     #    "expires": ..., "secure": ..., "httponly": ...}
     auth_cookies: list[dict[str, Any]] = field(default_factory=list)
 
+    # #1012 — VW North America. Its con-veh token server binds the refresh
+    # grant to the ORIGINAL login's PKCE code_verifier: refreshing without it
+    # returns "400 Internal Service validation failure" (confirmed against two
+    # maintained NA clients). So the verifier has to survive from the initial
+    # exchange through to every later refresh, which means persisting it here
+    # with the token set. Empty for every other brand, whose servers do not
+    # want it on refresh.
+    code_verifier: str = ""
+
     def is_valid(self) -> bool:
         """Return True if the access_token + id_token are populated.
 

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -739,6 +739,9 @@
       "active_ventilation_remaining_time_min": {
         "name": "Active Ventilation Remaining"
       },
+      "battery_support_state": {
+        "name": "12V Battery Support"
+      },
       "connection_state_battery_power_level": {
         "name": "12V Battery Power Level"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Připojit přes doplněk ADB Bridge",
+          "companion_addon_token": "Token doplňku"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Zaškrtněte u telefonu s Androidem 11 nebo novějším, který nabízí jen bezdrátové ladění. Pak výše zadejte adresu DOPLŇKU místo adresy telefonu.",
+          "companion_addon_token": "Potřeba jen tehdy, pokud jste v doplňku nastavili api_token."
         }
       }
     },
@@ -164,6 +168,7 @@
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
       "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Vypadá to na telefon s Androidem 11+ používající bezdrátové ladění, které zdejší přímé připojení neumí (vyžaduje TLS a párování). Nainstalujte doplněk 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) a nasměrujte na něj companion. Starší telefony (Android 10 a starší) se připojí přímo zde.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Reverzní geokódování (adresa parkování)",
           "read_only_mode": "Režim jen pro čtení",
+          "companion_read_charge_detail": "Companion: číst cíl nabíjení (naviguje v aplikaci)",
+          "companion_wake_sleep": "Companion: probudit displej k dotazu, poté uspat",
           "force_ppe_climate": "Audi PPE/PPC klima-tělo (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push updates (MQTT, EXPERIMENTAL)",
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN pro zamykání dveří.",
           "enable_reverse_geocoding": "Odesílá GPS parkování do OpenStreetMap Nominatim pro získání ulice/města. Výchozí: vypnuto (soukromí).",
           "read_only_mode": "Když je povoleno, vytváří se pouze stavové senzory — žádné spínače, tlačítka, zámky, klima ani posuvníky odesílající příkazy. Užitečné, pokud chcete telemetrii vozidla bez rizika náhodného spuštění. Po přepnutí znovu načtěte integraci.",
+          "companion_read_charge_detail": "Pouze companion (ADB). Načítá navíc cíl nabíjení, výkon a zbývající čas, které jsou skryté za obrazovkou s detailem nabíjení. Kvůli tomu KLEPÁ do aplikace, aby se tam dostala (asi každých 15 minut), proto to zapínejte až po ověření, že postup na vašem telefonu funguje. Výchozí: vypnuto. Po přepnutí znovu načtěte integraci.",
+          "companion_wake_sleep": "Pouze companion (ADB). Před každým dotazem probudí displej telefonu a poté ho zase uspí, takže zamčený nebo spící telefon během čtení zobrazí aplikaci, aniž by displej svítil trvale. Výchozí: vypnuto. Po přepnutí znovu načtěte integraci.",
           "force_ppe_climate": "Pouze Audi. Vynucuje nový PPE/PPC formát těla (climatisationMode povinný, targetTemperature vynechaný) při startu klimatizace. Zapnout pouze pokud vlastníš Q6 e-tron, A6 e-tron, RS e-tron GT Facelift nebo A3 2024+ PHEV — jinak API vrátí 400. Po zapnutí znovu načti integraci.",
           "enable_push_mqtt": "EXPERIMENTAL: Skoda-only. Enables real-time MQTT push from Skoda mysmob backend (requires aiomqtt + firebase-messaging Python packages — currently lazy-imported, not pre-installed). Foundation phase in v1.18.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW blokuje vzdálené příkazy pro SEAT/CUPRA za ověřením zařízení od Googlu (Play Integrity / App Check), kterým projde jen oficiální aplikace na skutečném telefonu. Zamýkání, klimatizaci ani nabíjení proto odsud nelze odeslat. Jde o trvalé serverové omezení ze strany VW, nikoli o přepínatelné nastavení. Data vozidla se dál aktualizují přes portál EU Data Act."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant nemá povoleno číst {path}. Umístěte soubor s exportem do konfigurační složky (nebo do složky uvedené v allowlist_external_dirs) a zadejte cestu znovu."
+    },
+    "export_file_not_found": {
+      "message": "V umístění {path} nebyl nalezen žádný soubor. Zkontrolujte cestu. Relativní název se hledá v konfigurační složce."
+    },
+    "export_file_no_data": {
+      "message": "Soubor neobsahoval čitelnou datovou sadu EU Data Act. Ujistěte se, že jde o .zip stažený z datového portálu VW pro toto vozidlo."
     },
     "historical_portal_not_ready": {
       "message": "Portál EU Data Act ještě není připraven. Počkejte, až integrace po nastavení jednou provede dotaz, a poté zkuste historický export znovu."

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Forbind via ADB Bridge-tilføjelsen",
+          "companion_addon_token": "Tilføjelses-token"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Sæt flueben her, hvis telefonen kører Android 11 eller nyere og kun tilbyder trådløs fejlfinding. Indtast så TILFØJELSENS adresse ovenfor i stedet for telefonens.",
+          "companion_addon_token": "Kræves kun, hvis du har sat api_token i tilføjelsen."
         }
       }
     },
@@ -164,6 +168,7 @@
       "portal_interaction_required": "EU Data Act-portalen kræver en engangshandling i din browser eller mærke-app (f.eks. accepter vilkår, bekræft samtykke, fuldfør onboarding/regionsvalg), før headless-adgang virker. Dette er IKKE et problem med forkert adgangskode — åbn portalen én gang i en browser, fuldfør anmodningen, og prøv igen.",
       "still_waiting_browser": "Venter stadig på browser-godkendelse. Åbn URL'en ovenfor, log ind, bekræft koden, og klik på Send igen.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Dette ligner en telefon med Android 11 eller nyere, der bruger trådløs fejlfinding, som den direkte forbindelse her ikke kan bruge (den kræver TLS + parring). Installér tilføjelsen 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge), og lad Companion forbinde til den. Ældre telefoner (Android 10 eller tidligere) forbinder direkte her.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Omvendt geokodning (parkeringsadresse)",
           "read_only_mode": "Skrivebeskyttet tilstand",
+          "companion_read_charge_detail": "Companion: læs lademål (navigerer i appen)",
+          "companion_wake_sleep": "Companion: væk skærmen før hentning, sov bagefter",
           "force_ppe_climate": "Audi PPE/PPC-klimaformat (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push-opdateringer (MQTT, EKSPERIMENTEL)",
           "enable_push_fcm": "CUPRA/SEAT push-opdateringer (FCM, EKSPERIMENTEL)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN til dørlåsning. App → Sikkerhed → S-PIN.",
           "enable_reverse_geocoding": "Sender parkerings-GPS til OpenStreetMap Nominatim for at finde gade/by. Slået fra som standard af hensyn til privatliv.",
           "read_only_mode": "Når aktiveret, oprettes kun statussensorer — ingen kontakter, knapper, låse, klima eller skydere, der sender kommandoer. Nyttigt, hvis du vil have køretøjstelemetri uden nogen risiko for utilsigtet aktivering. Genindlæs integrationen efter ændring.",
+          "companion_read_charge_detail": "Kun Companion (ADB). Læser også lademål, ladeeffekt og resterende tid, som ligger bag ladedetalje-skærmen. Det kræver, at der TRYKKES i appen for at navigere derhen (cirka hvert 15. minut), så aktivér det først, når du har bekræftet, at flowet virker på din telefon. Slået fra som standard. Genindlæs efter ændring.",
+          "companion_wake_sleep": "Kun Companion (ADB). Vækker telefonens skærm før hver hentning og lader den sove igen bagefter, så en låst eller sovende telefon viser appen under aflæsningen uden at have skærmen tændt permanent. Slået fra som standard. Genindlæs efter ændring.",
           "force_ppe_climate": "Kun Audi. Gennemtvinger det nye PPE/PPC-format (climatisationMode obligatorisk, targetTemperature udeladt) ved klimastart. Aktivér kun, hvis du ejer en Q6 e-tron, A6 e-tron, RS e-tron GT Facelift eller A3 2024+ PHEV — ellers returnerer klimastart 400. Genindlæs integrationen efter ændring.",
           "enable_push_mqtt": "EKSPERIMENTEL: Kun Skoda. Aktiverer realtids-MQTT-push fra Skoda mysmob-backendet (kræver Python-pakkerne aiomqtt + firebase-messaging — pt. importeret dovent, ikke forudinstalleret). Grundlagsfase i v1.18.0; live-aktivering afventer validering fra community-testere. Hvis push ikke er tilgængelig, falder integrationen stille tilbage til polling. Genindlæs integrationen efter ændring.",
           "enable_push_fcm": "EKSPERIMENTEL: Kun CUPRA/SEAT. Aktiverer realtids-push via Firebase Cloud Messaging fra OLA-backendet (kræver Python-pakken firebase-messaging — samme dovne import som Skoda MQTT-kontakten i v1.18.0). Grundlagsfase i v1.19.0; live-aktivering afventer validering fra community-testere. Hvis push ikke er tilgængelig, falder integrationen stille tilbage til polling. Genindlæs integrationen efter ændring.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW blokerer fjernkommandoer til SEAT/CUPRA bag en Google-enhedskontrol (Play Integrity / App Check), som kun den officielle app på en rigtig telefon kan bestå. Lås, klima og opladning kan derfor ikke sendes herfra. Det er en permanent serverside-blokering fra VW, ikke en indstilling, du kan slå fra. Køretøjsdata opdateres stadig via EU Data Act-portalen."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant har ikke lov til at læse {path}. Læg eksportfilen i config-mappen (eller en mappe, der står under allowlist_external_dirs), og angiv stien igen."
+    },
+    "export_file_not_found": {
+      "message": "Der blev ikke fundet nogen fil på {path}. Tjek stien. Et relativt navn søges i config-mappen."
+    },
+    "export_file_no_data": {
+      "message": "Filen indeholdt ikke et læsbart EU Data Act-datasæt. Kontrollér, at det er den .zip, du har hentet fra VW's dataportal til denne bil."
     },
     "historical_portal_not_ready": {
       "message": "EU Data Act-portalen er ikke klar endnu. Vent, til integrationen har hentet data én gang efter opsætning, og prøv derefter det historiske eksport igen."

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Conectar mediante el complemento ADB Bridge",
+          "companion_addon_token": "Token del complemento"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Márcalo para un teléfono con Android 11 o superior, que solo ofrece depuración inalámbrica. Después introduce arriba la dirección del COMPLEMENTO, no la del teléfono.",
+          "companion_addon_token": "Solo es necesario si has definido api_token en el complemento."
         }
       }
     },
@@ -164,6 +168,7 @@
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
       "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Parece un teléfono con Android 11 o superior con depuración inalámbrica, que la conexión directa de aquí no admite (usa TLS y emparejamiento). Instala el complemento 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) e indica aquí su dirección. Los teléfonos más antiguos (Android 10 o anterior) se conectan aquí directamente.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Geocodificación inversa (dirección de aparcamiento)",
           "read_only_mode": "Modo solo lectura",
+          "companion_read_charge_detail": "Companion: leer el objetivo de carga (navega por la app)",
+          "companion_wake_sleep": "Companion: despertar la pantalla para consultar y apagarla después",
           "force_ppe_climate": "Climatización PPE/PPC Audi (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push updates (MQTT, EXPERIMENTAL)",
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN para bloqueo de puertas.",
           "enable_reverse_geocoding": "Envía GPS de aparcamiento a OpenStreetMap Nominatim para resolver calle/ciudad. Desactivado por defecto (privacidad).",
           "read_only_mode": "Cuando está activado, solo se crean sensores de estado — sin interruptores, botones, cerraduras, clima o deslizadores que envíen comandos. Útil si quieres telemetría del vehículo sin riesgo de actuación accidental. Recarga la integración tras activar.",
+          "companion_read_charge_detail": "Solo para Companion (ADB). Lee también el objetivo de carga, la potencia y el tiempo restante que están detrás de la pantalla de detalle de carga. Para llegar ahí PULSA en la app (cada 15 minutos aproximadamente), así que actívalo solo tras comprobar que el proceso funciona en tu teléfono. Desactivado por defecto. Recarga tras cambiarlo.",
+          "companion_wake_sleep": "Solo para Companion (ADB). Despierta la pantalla del teléfono antes de cada consulta y la vuelve a apagar después, para que un teléfono bloqueado o en reposo muestre la app durante la lectura sin dejar la pantalla encendida de forma permanente. Desactivado por defecto. Recarga tras cambiarlo.",
           "force_ppe_climate": "Solo para Audi. Fuerza el nuevo formato PPE/PPC (climatisationMode obligatorio, targetTemperature omitido) al iniciar la climatización. Activar solo si posees Q6 e-tron, A6 e-tron, RS e-tron GT Facelift o A3 2024+ PHEV — de lo contrario la API responde 400. Recarga la integración tras activar.",
           "enable_push_mqtt": "EXPERIMENTAL: Skoda-only. Enables real-time MQTT push from Skoda mysmob backend (requires aiomqtt + firebase-messaging Python packages — currently lazy-imported, not pre-installed). Foundation phase in v1.18.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW bloquea los comandos remotos de SEAT/CUPRA tras una verificación de dispositivo de Google (Play Integrity / App Check) que solo la app oficial en un teléfono real puede superar. Por eso no se pueden enviar desde aquí el cierre, la climatización ni la carga. Es un bloqueo permanente del lado del servidor de VW, no un ajuste que puedas desactivar. Los datos del vehículo siguen actualizándose mediante el portal de la Ley de Datos de la UE."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant no tiene permiso para leer {path}. Coloca el archivo de exportación en la carpeta de configuración (o en una carpeta incluida en allowlist_external_dirs) e indica su ruta de nuevo."
+    },
+    "export_file_not_found": {
+      "message": "No se encontró ningún archivo en {path}. Comprueba la ruta. Un nombre relativo se busca en la carpeta de configuración."
+    },
+    "export_file_no_data": {
+      "message": "Ese archivo no contenía un conjunto de datos legible de la Ley de Datos de la UE. Asegúrate de que sea el .zip que descargaste del portal de datos de VW para este coche."
     },
     "historical_portal_not_ready": {
       "message": "El portal de la Ley de Datos de la UE aún no está listo. Espera a que la integración haya consultado una vez tras la configuración e inténtalo de nuevo."

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Yhdistä ADB Bridge -lisäosan kautta",
+          "companion_addon_token": "Lisäosan tunniste"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Rastita tämä, jos puhelin on Android 11 tai uudempi ja tarjoaa vain langattoman virheenkorjauksen. Syötä sitten yllä LISÄOSAN osoite puhelimen osoitteen sijaan.",
+          "companion_addon_token": "Tarvitaan vain, jos olet asettanut lisäosassa api_token-arvon."
         }
       }
     },
@@ -164,6 +168,7 @@
       "portal_interaction_required": "EU Data Act -portaali vaatii kertaluonteisen toimenpiteen selaimessasi tai merkin sovelluksessa (esim. käyttöehtojen hyväksyminen, suostumuksen vahvistaminen, käyttöönoton/alueen valinnan viimeistely) ennen kuin selaimeton pääsy toimii. Tämä EI ole väärän salasanan ongelma — avaa portaali kerran selaimessa, suorita kehote loppuun ja yritä sitten uudelleen.",
       "still_waiting_browser": "Odotetaan yhä selaimen hyväksyntää. Avaa yllä oleva URL-osoite, kirjaudu sisään, vahvista koodi ja napsauta sitten Lähetä uudelleen.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Tämä näyttää Android 11 -puhelimelta tai uudemmalta, joka käyttää langatonta virheenkorjausta. Suora yhteys tästä ei toimi sen kanssa (se vaatii TLS:n ja parituksen). Asenna 'VW Group App ADB Bridge' -lisäosa (github.com/its-me-prash/vwgroup-app-adb-bridge) ja anna sen osoite tähän. Vanhemmat puhelimet (Android 10 tai vanhempi) yhdistyvät suoraan.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Käänteinen geokoodaus (pysäköintiosoite)",
           "read_only_mode": "Vain luku -tila",
+          "companion_read_charge_detail": "Companion: lue lataustavoite (navigoi sovelluksessa)",
+          "companion_wake_sleep": "Companion: herätä näyttö kyselyn ajaksi, nukuta sen jälkeen",
           "force_ppe_climate": "Audi PPE/PPC -ilmastoinnin runko (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push-päivitykset (MQTT, KOKEELLINEN)",
           "enable_push_fcm": "CUPRA/SEAT push-päivitykset (FCM, KOKEELLINEN)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN ovien lukitsemiseen. Sovellus → Turvallisuus → S-PIN.",
           "enable_reverse_geocoding": "Lähettää pysäköinnin GPS-sijainnin OpenStreetMap Nominatimille kadun/kaupungin selvittämiseksi. Oletuksena pois päältä yksityisyyden vuoksi.",
           "read_only_mode": "Käytössä ollessaan vain tilanantureita luodaan — ei kytkimiä, painikkeita, lukkoja, ilmastointia tai liukusäätimiä, jotka lähettävät komentoja. Hyödyllinen, jos haluat ajoneuvon telemetrian ilman tahattoman toiminnan riskiä. Lataa integraatio uudelleen vaihdon jälkeen.",
+          "companion_read_charge_detail": "Vain Companion (ADB). Lukee lisäksi lataustavoitteen, lataustehon ja jäljellä olevan ajan, jotka ovat latauksen tietonäytön takana. Tämä NAPAUTTAA sovellusta siirtyäkseen sinne (noin 15 minuutin välein), joten ota se käyttöön vasta kun olet varmistanut, että se toimii puhelimessasi. Oletuksena pois päältä. Lataa uudelleen vaihdon jälkeen.",
+          "companion_wake_sleep": "Vain Companion (ADB). Herättää puhelimen näytön ennen jokaista kyselyä ja nukuttaa sen jälkeen, jotta lukittu tai nukkuva puhelin näyttää sovelluksen luvun ajan ilman, että näyttö jää pysyvästi päälle. Oletuksena pois päältä. Lataa uudelleen vaihdon jälkeen.",
           "force_ppe_climate": "Vain Audi. Pakottaa uuden PPE/PPC-rungon muodon (climatisationMode pakollinen, targetTemperature jätetty pois) ilmastoinnin käynnistyksessä. Ota käyttöön vain, jos omistat Q6 e-tronin, A6 e-tronin, RS e-tron GT Faceliftin tai A3 2024+ PHEV:n — muutoin ilmastoinnin käynnistys palauttaa 400. Lataa integraatio uudelleen vaihdon jälkeen.",
           "enable_push_mqtt": "KOKEELLINEN: vain Skoda. Ottaa käyttöön reaaliaikaiset MQTT-push-päivitykset Skodan mysmob-taustajärjestelmästä (vaatii aiomqtt + firebase-messaging Python-paketit — tällä hetkellä lazy-imported, ei esiasennettu). Perustusvaihe versiossa v1.18.0; live-aktivointi odottaa yhteisötestaajien validointia. Jos push ei ole saatavilla, integraatio palautuu hiljaisesti kyselyyn. Lataa integraatio uudelleen vaihdon jälkeen.",
           "enable_push_fcm": "KOKEELLINEN: vain CUPRA/SEAT. Ottaa käyttöön reaaliaikaisen Firebase Cloud Messaging -pushin OLA-taustajärjestelmästä (vaatii firebase-messaging Python-paketin — sama lazy-import kuin v1.18.0 Skoda MQTT -kytkimessä). Perustusvaihe versiossa v1.19.0; live-aktivointi odottaa yhteisötestaajien validointia. Jos push ei ole saatavilla, integraatio palautuu hiljaisesti kyselyyn. Lataa integraatio uudelleen vaihdon jälkeen.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW estää SEAT/CUPRAn etäkomennot Googlen laitetarkistuksen (Play Integrity / App Check) taakse, jonka läpäisee vain virallinen sovellus aidolla puhelimella. Lukitusta, ilmastointia ja latausta ei siksi voi lähettää täältä. Kyseessä on VW:n pysyvä palvelinpuolen esto, ei asetus, jonka voi kytkeä pois. Ajoneuvon tiedot päivittyvät edelleen EU:n datasäädösportaalin kautta."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistantilla ei ole lupaa lukea polkua {path}. Siirrä vientitiedosto config-kansioon (tai kansioon, joka on listattu kohdassa allowlist_external_dirs) ja anna sen polku uudelleen."
+    },
+    "export_file_not_found": {
+      "message": "Polusta {path} ei löytynyt tiedostoa. Tarkista polku. Suhteellinen nimi haetaan config-kansiosta."
+    },
+    "export_file_no_data": {
+      "message": "Tiedosto ei sisältänyt luettavaa EU Data Act -tietojoukkoa. Varmista, että se on .zip, jonka latasit VW:n dataportaalista tälle autolle."
     },
     "historical_portal_not_ready": {
       "message": "EU:n datasäädösportaali ei ole vielä valmis. Odota, kunnes integraatio on hakenut tiedot kerran käyttöönoton jälkeen, ja yritä sitten uudelleen."

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Se connecter via le module complémentaire ADB Bridge",
+          "companion_addon_token": "Jeton du module complémentaire"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "À cocher pour un téléphone Android 11 ou plus récent, qui ne propose que le débogage sans fil. Saisissez ensuite ci-dessus l'adresse du MODULE COMPLÉMENTAIRE, pas celle du téléphone.",
+          "companion_addon_token": "Nécessaire uniquement si vous avez défini api_token dans le module complémentaire."
         }
       }
     },
@@ -164,6 +168,7 @@
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
       "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Ce téléphone semble être un Android 11 ou plus récent en débogage sans fil, que la connexion directe d'ici ne peut pas utiliser (TLS + appairage). Installez le module complémentaire « VW Group App ADB Bridge » (github.com/its-me-prash/vwgroup-app-adb-bridge) et indiquez son adresse ici. Les téléphones plus anciens (Android 10 ou antérieur) se connectent directement ici.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Géocodage inverse (adresse de stationnement)",
           "read_only_mode": "Mode lecture seule",
+          "companion_read_charge_detail": "Companion : lire l'objectif de charge (navigue dans l'application)",
+          "companion_wake_sleep": "Companion : réveiller l'écran pour interroger, puis le rendormir",
           "force_ppe_climate": "Climate Audi PPE/PPC (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push updates (MQTT, EXPERIMENTAL)",
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN pour le verrouillage des portes.",
           "enable_reverse_geocoding": "Envoie le GPS de stationnement à OpenStreetMap Nominatim pour obtenir rue/ville. Désactivé par défaut (confidentialité).",
           "read_only_mode": "Lorsqu'activé, seuls les capteurs d'état sont créés — pas d'interrupteurs, boutons, verrous, climat ou curseurs qui envoient des commandes. Utile si vous voulez la télémétrie véhicule sans risque d'actionnement accidentel. Rechargez l'intégration après activation.",
+          "companion_read_charge_detail": "Companion (ADB) uniquement. Lit aussi l'objectif de charge, la puissance et le temps restant qui se trouvent derrière l'écran de détail de la charge. Pour y accéder, l'application est PILOTÉE par appuis (environ toutes les 15 minutes) : n'activez cette option qu'après avoir vérifié que cela fonctionne sur votre téléphone. Désactivé par défaut. Rechargez l'intégration après activation.",
+          "companion_wake_sleep": "Companion (ADB) uniquement. Réveille l'écran du téléphone avant chaque interrogation et le rendort ensuite, pour qu'un téléphone verrouillé ou en veille affiche l'application pendant la lecture sans rester allumé en permanence. Désactivé par défaut. Rechargez l'intégration après activation.",
           "force_ppe_climate": "Audi uniquement. Force le nouveau format de payload PPE/PPC (climatisationMode obligatoire, targetTemperature omis) au démarrage du climat. À activer uniquement si vous possédez une Q6 e-tron, A6 e-tron, RS e-tron GT Facelift ou A3 2024+ PHEV — sinon l'API renvoie 400. Rechargez l'intégration après activation.",
           "enable_push_mqtt": "EXPERIMENTAL: Skoda-only. Enables real-time MQTT push from Skoda mysmob backend (requires aiomqtt + firebase-messaging Python packages — currently lazy-imported, not pre-installed). Foundation phase in v1.18.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW bloque les commandes à distance pour SEAT/CUPRA derrière une vérification d'appareil Google (Play Integrity / App Check) que seule l'application officielle sur un vrai téléphone peut passer. Le verrouillage, la climatisation et la charge ne peuvent donc pas être envoyés d'ici. C'est un blocage permanent côté serveur de VW, pas un réglage désactivable. Les données du véhicule continuent d'être mises à jour via le portail EU Data Act."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant n'est pas autorisé à lire {path}. Placez le fichier d'export dans le dossier de configuration (ou un dossier listé sous allowlist_external_dirs) et indiquez à nouveau son chemin."
+    },
+    "export_file_not_found": {
+      "message": "Aucun fichier n'a été trouvé à {path}. Vérifiez le chemin. Un nom relatif est recherché dans le dossier de configuration."
+    },
+    "export_file_no_data": {
+      "message": "Ce fichier ne contient pas de jeu de données EU Data Act lisible. Assurez-vous qu'il s'agit bien du .zip téléchargé depuis le portail de données VW pour cette voiture."
     },
     "historical_portal_not_ready": {
       "message": "Le portail EU Data Act n'est pas encore prêt. Attendez que l'intégration ait interrogé une fois après la configuration, puis réessayez l'export historique."

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Connetti tramite l'add-on ADB Bridge",
+          "companion_addon_token": "Token dell'add-on"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Seleziona questa opzione per un telefono con Android 11 o successivo, che offre solo il debug wireless. Poi inserisci qui sopra l'indirizzo dell'ADD-ON, non quello del telefono.",
+          "companion_addon_token": "Serve solo se hai impostato api_token nell'add-on."
         }
       }
     },
@@ -164,6 +168,7 @@
       "portal_interaction_required": "Il portale EU Data Act richiede un'azione una tantum nel tuo browser o nell'app della marca (ad es. accettare i termini, confermare il consenso, completare l'onboarding/la selezione della regione) prima che l'accesso headless funzioni. Questo NON è un problema di password errata — apri il portale una volta in un browser, completa la richiesta, poi riprova.",
       "still_waiting_browser": "In attesa dell'approvazione dal browser. Apri l'URL qui sopra, accedi, conferma il codice, poi clicca di nuovo su Invia.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Sembra un telefono con Android 11 o successivo che usa il debug wireless, che la connessione diretta qui non può utilizzare (richiede TLS + accoppiamento). Installa l'add-on 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) e fai puntare il companion a quello. I telefoni più vecchi (Android 10 o precedenti) si collegano qui direttamente.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Geocodifica inversa (indirizzo di parcheggio)",
           "read_only_mode": "Modalità sola lettura",
+          "companion_read_charge_detail": "Companion: leggi l'obiettivo di ricarica (naviga nell'app)",
+          "companion_wake_sleep": "Companion: accendi lo schermo per l'interrogazione, poi rimettilo in stop",
           "force_ppe_climate": "Body clima Audi PPE/PPC (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Aggiornamenti push Skoda (MQTT, SPERIMENTALE)",
           "enable_push_fcm": "Aggiornamenti push CUPRA/SEAT (FCM, SPERIMENTALE)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN per la chiusura delle porte. App → Sicurezza → S-PIN.",
           "enable_reverse_geocoding": "Invia le coordinate GPS del parcheggio a OpenStreetMap Nominatim per risolvere via/città. Disattivato per impostazione predefinita per motivi di privacy.",
           "read_only_mode": "Quando abilitata, vengono creati solo i sensori di stato — nessun interruttore, pulsante, blocco, clima o cursore che invii comandi. Utile se vuoi la telemetria del veicolo senza alcun rischio di attivazione accidentale. Ricarica l'integrazione dopo aver modificato l'impostazione.",
+          "companion_read_charge_detail": "Solo Companion (ADB). Legge anche l'obiettivo di ricarica, la potenza e il tempo rimanente che si trovano dietro la schermata di dettaglio della ricarica. Per arrivarci TOCCA l'app (circa ogni 15 minuti), quindi attivalo solo dopo aver verificato che la procedura funzioni sul tuo telefono. Disattivato per impostazione predefinita. Ricarica dopo aver modificato l'impostazione.",
+          "companion_wake_sleep": "Solo Companion (ADB). Accende lo schermo del telefono prima di ogni interrogazione e lo rimette in stop subito dopo, così un telefono bloccato o in stop mostra l'app durante la lettura senza tenere il display sempre acceso. Disattivato per impostazione predefinita. Ricarica dopo aver modificato l'impostazione.",
           "force_ppe_climate": "Solo per Audi. Forza il nuovo formato body PPE/PPC (climatisationMode obbligatorio, targetTemperature omesso) all'avvio del clima. Abilita solo se possiedi un Q6 e-tron, A6 e-tron, RS e-tron GT Facelift o A3 2024+ PHEV — altrimenti l'avvio del clima restituisce 400. Ricarica l'integrazione dopo aver modificato l'impostazione.",
           "enable_push_mqtt": "SPERIMENTALE: solo per Skoda. Abilita il push MQTT in tempo reale dal backend Skoda mysmob (richiede i pacchetti Python aiomqtt + firebase-messaging — attualmente importati in lazy, non preinstallati). Fase di fondamenta in v1.18.0; l'attivazione live è in attesa della validazione dei tester della community. Se il push non è disponibile, l'integrazione ripiega silenziosamente sul polling. Ricarica l'integrazione dopo aver modificato l'impostazione.",
           "enable_push_fcm": "SPERIMENTALE: solo CUPRA/SEAT. Abilita il push in tempo reale via Firebase Cloud Messaging dal backend OLA (richiede il pacchetto Python firebase-messaging — stesso lazy-import del toggle MQTT Skoda della v1.18.0). Fase di fondamenta in v1.19.0; l'attivazione live è in attesa della validazione dei tester della community. Se il push non è disponibile, l'integrazione ripiega silenziosamente sul polling. Ricarica l'integrazione dopo aver modificato l'impostazione.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW blocca i comandi a distanza per SEAT/CUPRA dietro una verifica del dispositivo di Google (Play Integrity / App Check) che solo l'app ufficiale su un telefono reale può superare. Blocco porte, climatizzazione e ricarica non possono quindi essere inviati da qui. È un blocco permanente lato server di VW, non un'impostazione disattivabile. I dati del veicolo continuano ad aggiornarsi tramite il portale EU Data Act."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant non è autorizzato a leggere {path}. Sposta il file di esportazione nella cartella di configurazione (o in una cartella elencata in allowlist_external_dirs) e indica di nuovo il suo percorso."
+    },
+    "export_file_not_found": {
+      "message": "Nessun file trovato in {path}. Controlla il percorso. Un nome relativo viene cercato nella cartella di configurazione."
+    },
+    "export_file_no_data": {
+      "message": "Il file non conteneva un set di dati EU Data Act leggibile. Assicurati che sia il .zip scaricato dal portale dati VW per questa auto."
     },
     "historical_portal_not_ready": {
       "message": "Il portale EU Data Act non è ancora pronto. Attendi che l'integrazione abbia effettuato un'interrogazione dopo la configurazione, poi riprova l'esportazione storica."

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Koble til via ADB Bridge-tillegget",
+          "companion_addon_token": "Token for tillegget"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Kryss av her for en telefon med Android 11 eller nyere, som bare tilbyr trådløs feilsøking. Skriv da inn adressen til TILLEGGET ovenfor, ikke telefonens.",
+          "companion_addon_token": "Trengs bare hvis du har satt api_token i tillegget."
         }
       }
     },
@@ -164,6 +168,7 @@
       "portal_interaction_required": "EU Data Act-portalen trenger en engangshandling i nettleseren din eller merkeappen (f.eks. godta vilkår, bekrefte samtykke, fullføre onboarding/regionvalg) før tilgang uten nettleser fungerer. Dette er IKKE et problem med feil passord — åpne portalen én gang i en nettleser, fullfør oppgaven, og prøv igjen.",
       "still_waiting_browser": "Venter fortsatt på godkjenning i nettleseren. Åpne URL-en ovenfor, logg inn, bekreft koden, og klikk Send inn igjen.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Dette ser ut som en telefon med Android 11 eller nyere som bruker trådløs feilsøking, noe den direkte tilkoblingen her ikke kan bruke (den krever TLS + paring). Installer tillegget «VW Group App ADB Bridge» (github.com/its-me-prash/vwgroup-app-adb-bridge) og pek Companion mot det. Eldre telefoner (Android 10 eller eldre) kobles til direkte her.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Omvendt geokoding (parkeringsadresse)",
           "read_only_mode": "Skrivebeskyttet modus",
+          "companion_read_charge_detail": "Companion: les lademål (navigerer i appen)",
+          "companion_wake_sleep": "Companion: vekk skjermen ved henting, sov etterpå",
           "force_ppe_climate": "Audi PPE/PPC-klimadata (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push-oppdateringer (MQTT, EKSPERIMENTELL)",
           "enable_push_fcm": "CUPRA/SEAT push-oppdateringer (FCM, EKSPERIMENTELL)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN for dørlåsing. App → Sikkerhet → S-PIN.",
           "enable_reverse_geocoding": "Sender parkerings-GPS til OpenStreetMap Nominatim for å finne gate/by. Av som standard av personvernhensyn.",
           "read_only_mode": "Når aktivert opprettes kun statussensorer — ingen brytere, knapper, låser, klima eller glidebrytere som sender kommandoer. Nyttig hvis du vil ha kjøretøytelemetri uten risiko for utilsiktet utløsing. Last inn integrasjonen på nytt etter endring.",
+          "companion_read_charge_detail": "Kun for Companion (ADB). Leser i tillegg lademål, ladeeffekt og gjenstående tid som ligger bak ladedetaljskjermen. Dette TRYKKER i appen for å navigere dit (omtrent hvert 15. minutt), så aktiver det bare etter at du har bekreftet at flyten fungerer på telefonen din. Av som standard. Last inn på nytt etter endring.",
+          "companion_wake_sleep": "Kun for Companion (ADB). Vekker telefonskjermen før hver henting og lar den sovne igjen etterpå, slik at en låst eller sovende telefon viser appen under avlesningen uten at skjermen står på hele tiden. Av som standard. Last inn på nytt etter endring.",
           "force_ppe_climate": "Kun for Audi. Tvinger frem den nye PPE/PPC-datastrukturen (climatisationMode obligatorisk, targetTemperature utelatt) ved klimastart. Aktiver kun hvis du eier en Q6 e-tron, A6 e-tron, RS e-tron GT Facelift eller A3 2024+ PHEV — ellers returnerer klimastart 400. Last inn integrasjonen på nytt etter endring.",
           "enable_push_mqtt": "EKSPERIMENTELL: Kun for Skoda. Aktiverer sanntids MQTT-push fra Skodas mysmob-baksystem (krever Python-pakkene aiomqtt + firebase-messaging — for tiden lazy-importert, ikke forhåndsinstallert). Grunnlagsfase i v1.18.0; live-aktivering avventer validering fra fellesskapstestere. Hvis push er utilgjengelig, faller integrasjonen stille tilbake til polling. Last inn integrasjonen på nytt etter endring.",
           "enable_push_fcm": "EKSPERIMENTELL: Kun for CUPRA/SEAT. Aktiverer sanntids Firebase Cloud Messaging-push fra OLA-baksystemet (krever Python-pakken firebase-messaging — samme lazy-import som Skoda MQTT-bryteren i v1.18.0). Grunnlagsfase i v1.19.0; live-aktivering avventer validering fra fellesskapstestere. Hvis push er utilgjengelig, faller integrasjonen stille tilbake til polling. Last inn integrasjonen på nytt etter endring.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW blokkerer fjernkommandoer for SEAT/CUPRA bak en Google-enhetskontroll (Play Integrity / App Check) som bare den offisielle appen på en ekte telefon kan bestå. Låsing, klima og lading kan derfor ikke sendes herfra. Dette er en permanent serverside-blokkering fra VW, ikke en innstilling du kan slå av. Kjøretøydata oppdateres fortsatt via EU Data Act-portalen."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant har ikke lov til å lese {path}. Legg eksportfilen i konfigurasjonsmappen (eller en mappe som er oppført under allowlist_external_dirs) og oppgi banen på nytt."
+    },
+    "export_file_not_found": {
+      "message": "Fant ingen fil på {path}. Sjekk banen. Et relativt navn slås opp i konfigurasjonsmappen."
+    },
+    "export_file_no_data": {
+      "message": "Filen inneholdt ikke et lesbart EU Data Act-datasett. Kontroller at det er .zip-filen du lastet ned fra VWs dataportal for denne bilen."
     },
     "historical_portal_not_ready": {
       "message": "EU Data Act-portalen er ikke klar ennå. Vent til integrasjonen har hentet data én gang etter oppsett, og prøv deretter det historiske eksporten på nytt."

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Verbinden via de ADB Bridge-add-on",
+          "companion_addon_token": "Add-on-token"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Aanvinken bij een telefoon met Android 11 of nieuwer, die alleen draadloos debuggen biedt. Vul hierboven dan het adres van de ADD-ON in, niet dat van de telefoon.",
+          "companion_addon_token": "Alleen nodig als je api_token in de add-on hebt ingesteld."
         }
       }
     },
@@ -164,6 +168,7 @@
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
       "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Dit lijkt een telefoon met Android 11 of nieuwer die draadloos debuggen gebruikt; de directe verbinding hier kan daar niet mee overweg (dat is TLS + koppelen). Installeer de add-on 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) en laat de companion daarnaar wijzen. Oudere telefoons (Android 10 of ouder) verbinden hier rechtstreeks.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Reverse geocoding (parkeeradres)",
           "read_only_mode": "Alleen-lezen modus",
+          "companion_read_charge_detail": "Companion: laaddoel lezen (navigeert in de app)",
+          "companion_wake_sleep": "Companion: scherm wekken om op te halen, daarna weer in slaap",
           "force_ppe_climate": "Audi PPE/PPC klimaat-body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push updates (MQTT, EXPERIMENTAL)",
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN voor deurvergrendeling.",
           "enable_reverse_geocoding": "Verzendt parkeer-GPS naar OpenStreetMap Nominatim om straat/stad te vinden. Standaard uit (privacy).",
           "read_only_mode": "Indien ingeschakeld worden alleen statussensoren aangemaakt — geen schakelaars, knoppen, sloten, klimaat of schuifregelaars die commando's verzenden. Handig als je voertuigtelemetrie wilt zonder risico op onbedoelde bediening. Herlaad de integratie na inschakelen.",
+          "companion_read_charge_detail": "Alleen voor Companion (ADB). Leest ook het laaddoel, het vermogen en de resterende tijd die achter het laaddetailscherm zitten. Hiervoor wordt er in de app GETIKT om daarheen te navigeren (ongeveer elke 15 minuten), dus schakel dit pas in als je hebt bevestigd dat dit op je telefoon werkt. Standaard uit. Herlaad de integratie na het wijzigen.",
+          "companion_wake_sleep": "Alleen voor Companion (ADB). Wekt het scherm van de telefoon vóór elke opvraging en laat het daarna weer slapen, zodat een vergrendelde of slapende telefoon de app toont tijdens het lezen zonder het scherm permanent aan te laten staan. Standaard uit. Herlaad de integratie na het wijzigen.",
           "force_ppe_climate": "Alleen voor Audi. Forceert het nieuwe PPE/PPC body-formaat (climatisationMode verplicht, targetTemperature weggelaten) bij klimaat-start. Alleen inschakelen als je een Q6 e-tron, A6 e-tron, RS e-tron GT Facelift of A3 2024+ PHEV bezit — anders geeft de API 400 terug. Integratie herladen na inschakelen.",
           "enable_push_mqtt": "EXPERIMENTAL: Skoda-only. Enables real-time MQTT push from Skoda mysmob backend (requires aiomqtt + firebase-messaging Python packages — currently lazy-imported, not pre-installed). Foundation phase in v1.18.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW blokkeert opdrachten op afstand voor SEAT/CUPRA achter een Google-apparaatcontrole (Play Integrity / App Check) die alleen de officiële app op een echte telefoon kan doorstaan. Vergrendeling, klimaat en laden kunnen daarom niet vanaf hier worden verstuurd. Dit is een permanente blokkering aan de serverkant van VW, geen instelling die je kunt uitschakelen. Voertuiggegevens worden nog steeds bijgewerkt via het EU Data Act-portaal."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant mag {path} niet lezen. Zet het exportbestand in de configuratiemap (of in een map die onder allowlist_external_dirs staat) en geef het pad opnieuw op."
+    },
+    "export_file_not_found": {
+      "message": "Er is geen bestand gevonden op {path}. Controleer het pad. Een relatieve naam wordt in de configuratiemap gezocht."
+    },
+    "export_file_no_data": {
+      "message": "Dat bestand bevatte geen leesbare EU Data Act-dataset. Controleer of het de .zip is die je voor deze auto uit het VW-dataportaal hebt gedownload."
     },
     "historical_portal_not_ready": {
       "message": "Het EU Data Act-portaal is nog niet gereed. Wacht tot de integratie na de installatie één keer heeft opgehaald en probeer de historische export dan opnieuw."

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Połącz przez dodatek ADB Bridge",
+          "companion_addon_token": "Token dodatku"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Zaznacz dla telefonu z Androidem 11 lub nowszym, który udostępnia tylko debugowanie bezprzewodowe. Wtedy wpisz powyżej adres DODATKU, a nie telefonu.",
+          "companion_addon_token": "Potrzebny tylko, jeśli ustawiłeś api_token w dodatku."
         }
       }
     },
@@ -164,6 +168,7 @@
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
       "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "To wygląda na telefon z Androidem 11 lub nowszym z debugowaniem bezprzewodowym, którego bezpośrednie połączenie stąd nie obsługuje (wymaga TLS i parowania). Zainstaluj dodatek „VW Group App ADB Bridge” (github.com/its-me-prash/vwgroup-app-adb-bridge) i wskaż go tutaj. Starsze telefony (Android 10 lub wcześniejszy) łączą się bezpośrednio.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Geokodowanie odwrotne (adres parkowania)",
           "read_only_mode": "Tryb tylko do odczytu",
+          "companion_read_charge_detail": "Companion: odczyt celu ładowania (nawiguje w aplikacji)",
+          "companion_wake_sleep": "Companion: wybudź ekran do odpytania, potem uśpij",
           "force_ppe_climate": "Audi PPE/PPC klimat-body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push updates (MQTT, EXPERIMENTAL)",
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN do blokowania drzwi.",
           "enable_reverse_geocoding": "Wysyła GPS parkowania do OpenStreetMap Nominatim, aby uzyskać ulicę/miasto. Domyślnie wyłączone (prywatność).",
           "read_only_mode": "Po włączeniu tworzone są tylko czujniki statusu — bez przełączników, przycisków, blokad, klimatu czy suwaków wysyłających polecenia. Przydatne gdy chcesz telemetrię pojazdu bez ryzyka przypadkowego uruchomienia. Przeładuj integrację po włączeniu.",
+          "companion_read_charge_detail": "Tylko Companion (ADB). Odczytuje dodatkowo cel ładowania, moc i pozostały czas, które są ukryte za ekranem szczegółów ładowania. Aby tam przejść, integracja DOTYKA ekranu aplikacji (mniej więcej co 15 minut), więc włącz to dopiero po sprawdzeniu, że taki przebieg działa na Twoim telefonie. Domyślnie wyłączone. Po zmianie przeładuj integrację.",
+          "companion_wake_sleep": "Tylko Companion (ADB). Wybudza ekran telefonu przed każdym odpytaniem i usypia go po nim, dzięki czemu zablokowany lub uśpiony telefon pokazuje aplikację podczas odczytu bez trzymania ekranu włączonego na stałe. Domyślnie wyłączone. Po zmianie przeładuj integrację.",
           "force_ppe_climate": "Tylko Audi. Wymusza nowy format PPE/PPC (climatisationMode obowiązkowy, targetTemperature pominięty) przy starcie klimatyzacji. Włącz tylko jeśli masz Q6 e-tron, A6 e-tron, RS e-tron GT Facelift lub A3 2024+ PHEV — w przeciwnym razie API zwraca 400. Po włączeniu przeładuj integrację.",
           "enable_push_mqtt": "EXPERIMENTAL: Skoda-only. Enables real-time MQTT push from Skoda mysmob backend (requires aiomqtt + firebase-messaging Python packages — currently lazy-imported, not pre-installed). Foundation phase in v1.18.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW blokuje zdalne polecenia dla SEAT/CUPRA za weryfikacją urządzenia Google (Play Integrity / App Check), którą przechodzi tylko oficjalna aplikacja na prawdziwym telefonie. Dlatego z tego miejsca nie można wysłać zamykania, klimatyzacji ani ładowania. To trwała blokada po stronie serwera VW, a nie ustawienie, które można wyłączyć. Dane pojazdu są nadal aktualizowane przez portal EU Data Act."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant nie ma uprawnień do odczytu {path}. Umieść plik eksportu w folderze konfiguracji (lub w folderze wymienionym w allowlist_external_dirs) i podaj jego ścieżkę ponownie."
+    },
+    "export_file_not_found": {
+      "message": "Nie znaleziono pliku w {path}. Sprawdź ścieżkę. Nazwa względna jest szukana w folderze konfiguracji."
+    },
+    "export_file_no_data": {
+      "message": "Ten plik nie zawierał czytelnego zestawu danych EU Data Act. Upewnij się, że to plik .zip pobrany z portalu danych VW dla tego auta."
     },
     "historical_portal_not_ready": {
       "message": "Portal EU Data Act nie jest jeszcze gotowy. Poczekaj, aż integracja wykona jedno odpytanie po konfiguracji, a następnie ponów eksport historyczny."

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -141,12 +141,16 @@
           "adb_host": "Phone IP address",
           "adb_port": "ADB port",
           "vin": "VIN (the car the app shows)",
-          "spin": "S-PIN (optional)"
+          "spin": "S-PIN (optional)",
+          "companion_use_addon": "Anslut via ADB Bridge-tillägget",
+          "companion_addon_token": "Tilläggets token"
         },
         "data_description": {
           "adb_host": "The phone's address on your network, e.g. 192.168.1.42.",
           "adb_port": "Usually 5555 for ADB over Wi-Fi.",
-          "vin": "The 17-character VIN of the car shown in the app."
+          "vin": "The 17-character VIN of the car shown in the app.",
+          "companion_use_addon": "Kryssa i detta för en telefon med Android 11 eller nyare, som bara erbjuder trådlös felsökning. Ange sedan TILLÄGGETS adress ovan i stället för telefonens.",
+          "companion_addon_token": "Behövs bara om du har satt api_token i tillägget."
         }
       }
     },
@@ -164,6 +168,7 @@
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
       "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
+      "companion_needs_addon": "Det här ser ut som en telefon med Android 11 eller nyare som använder trådlös felsökning, vilket den direkta anslutningen här inte klarar (den bygger på TLS och parkoppling). Installera tillägget 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) och peka companion-anslutningen mot tillägget. Äldre telefoner (Android 10 eller tidigare) ansluter direkt här.",
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet."
     },
@@ -187,6 +192,8 @@
           "spin": "S-PIN",
           "enable_reverse_geocoding": "Omvänd geokodning (parkeringsadress)",
           "read_only_mode": "Skrivskyddat läge",
+          "companion_read_charge_detail": "Companion: läs laddningsmål (navigerar i appen)",
+          "companion_wake_sleep": "Companion: väck skärmen för hämtning, släck efteråt",
           "force_ppe_climate": "Audi PPE/PPC klimat-body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda push updates (MQTT, EXPERIMENTAL)",
           "enable_push_fcm": "CUPRA/SEAT push updates (FCM, EXPERIMENTAL)",
@@ -209,6 +216,8 @@
           "spin": "S-PIN för dörrlåsning.",
           "enable_reverse_geocoding": "Skickar parkerings-GPS till OpenStreetMap Nominatim för att hämta gata/stad. Av som standard (integritet).",
           "read_only_mode": "När aktiverat skapas endast statussensorer — inga brytare, knappar, lås, klimat eller reglage som skickar kommandon. Användbart om du vill ha fordonstelemetri utan risk för oavsiktlig aktivering. Ladda om integrationen efter ändring.",
+          "companion_read_charge_detail": "Endast Companion (ADB). Läser även laddningsmål, effekt och återstående tid som ligger bakom laddningsdetaljvyn. Detta TRYCKER i appen för att navigera dit (ungefär var 15:e minut), så aktivera det först när du har bekräftat att flödet fungerar på din telefon. Av som standard. Ladda om efter ändring.",
+          "companion_wake_sleep": "Endast Companion (ADB). Väcker telefonens skärm före varje hämtning och släcker den igen efteråt, så att en låst eller sovande telefon visar appen under avläsningen utan att skärmen är tänd hela tiden. Av som standard. Ladda om efter ändring.",
           "force_ppe_climate": "Endast Audi. Tvingar det nya PPE/PPC body-formatet (climatisationMode obligatoriskt, targetTemperature utelämnat) vid klimatstart. Aktivera bara om du äger en Q6 e-tron, A6 e-tron, RS e-tron GT Facelift eller A3 2024+ PHEV — annars svarar API:t med 400. Ladda om integrationen efter aktivering.",
           "enable_push_mqtt": "EXPERIMENTAL: Skoda-only. Enables real-time MQTT push from Skoda mysmob backend (requires aiomqtt + firebase-messaging Python packages — currently lazy-imported, not pre-installed). Foundation phase in v1.18.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
           "enable_push_fcm": "EXPERIMENTAL: CUPRA/SEAT only. Enables real-time Firebase Cloud Messaging push from OLA backend (requires firebase-messaging Python package — same lazy-import as v1.18.0 Skoda MQTT toggle). Foundation phase in v1.19.0; live activation pending community-tester validation. If push is unavailable, the integration silently falls back to polling. Reload the integration after toggling.",
@@ -1849,6 +1858,15 @@
     },
     "read_only_attestation_blocked": {
       "message": "VW blockerar fjärrkommandon för SEAT/CUPRA bakom en enhetskontroll från Google (Play Integrity / App Check) som bara den officiella appen på en riktig telefon klarar. Lås, klimat och laddning kan därför inte skickas härifrån. Det är en permanent blockering på VW:s serversida, inte en inställning du kan stänga av. Fordonsdata uppdateras fortfarande via EU Data Act-portalen."
+    },
+    "export_file_not_allowed": {
+      "message": "Home Assistant får inte läsa {path}. Lägg exportfilen i konfigurationsmappen (eller en mapp som anges under allowlist_external_dirs) och ange sökvägen igen."
+    },
+    "export_file_not_found": {
+      "message": "Ingen fil hittades på {path}. Kontrollera sökvägen. Ett relativt namn söks i konfigurationsmappen."
+    },
+    "export_file_no_data": {
+      "message": "Filen innehöll ingen läsbar EU Data Act-datamängd. Kontrollera att det är den .zip du laddade ner från VW:s dataportal för den här bilen."
     },
     "historical_portal_not_ready": {
       "message": "EU Data Act-portalen är inte redo ännu. Vänta tills integrationen har hämtat data en gång efter installationen och försök sedan med den historiska exporten igen."

--- a/tests/test_translation_parity.py
+++ b/tests/test_translation_parity.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Every shipped language must carry every string, or the dialog breaks.
+
+Home Assistant does not fall back to English for a custom integration. A key
+that exists in ``en.json`` and is missing from ``fr.json`` does not quietly
+render in English for a French user, it renders as the raw key or as nothing at
+all. So a translation file that lags behind is not a cosmetic debt, it is a
+broken settings dialog for everyone using that language, and it fails silently:
+the tests pass, the integration loads, and only a user in that language ever
+sees it.
+
+That is exactly how twelve keys added with the companion channel reached ten of
+the eleven shipped translations as blanks. Nothing in the suite noticed, because
+nothing was looking.
+
+Placeholders are pinned for the same reason. ``{path}`` is not a word, it is a
+substitution the code performs, and a translation that drops it or renames it
+produces either a literal brace in the dialog or a KeyError at render time.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_TRANSLATIONS = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components" / "vag_connect" / "translations"
+)
+_STRINGS = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components" / "vag_connect" / "strings.json"
+)
+
+
+def _flatten(obj: object, prefix: str = "") -> dict[str, str]:
+    """Nested translation dict → {dotted.key: text}."""
+    out: dict[str, str] = {}
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            out.update(_flatten(value, f"{prefix}.{key}" if prefix else key))
+    elif isinstance(obj, str):
+        out[prefix] = obj
+    return out
+
+
+def _load(path: Path) -> dict[str, str]:
+    return _flatten(json.loads(path.read_text(encoding="utf-8")))
+
+
+def _placeholders(text: str) -> set[str]:
+    import re
+
+    return set(re.findall(r"\{(\w+)\}", text))
+
+
+_ENGLISH = _load(_TRANSLATIONS / "en.json")
+_LANGS = sorted(
+    p.stem for p in _TRANSLATIONS.glob("*.json") if p.stem != "en"
+)
+
+
+def test_there_are_translations_to_check() -> None:
+    """Guard against the whole file passing because a glob found nothing."""
+    assert len(_LANGS) >= 10, _LANGS
+    assert len(_ENGLISH) > 500, len(_ENGLISH)
+
+
+@pytest.mark.parametrize("lang", _LANGS)
+def test_no_string_is_missing(lang: str) -> None:
+    translated = _load(_TRANSLATIONS / f"{lang}.json")
+    missing = sorted(set(_ENGLISH) - set(translated))
+    assert not missing, (
+        f"{lang}.json is missing {len(missing)} string(s); a user running Home "
+        f"Assistant in this language sees the raw key instead:\n  "
+        + "\n  ".join(missing[:20])
+    )
+
+
+@pytest.mark.parametrize("lang", _LANGS)
+def test_no_string_is_orphaned(lang: str) -> None:
+    """A key no longer in English is dead weight, and usually a typo in a key
+    name, which reads as a missing translation from the other side."""
+    translated = _load(_TRANSLATIONS / f"{lang}.json")
+    extra = sorted(set(translated) - set(_ENGLISH))
+    assert not extra, f"{lang}.json has {len(extra)} key(s) English does not: {extra[:20]}"
+
+
+@pytest.mark.parametrize("lang", _LANGS)
+def test_placeholders_survive_translation(lang: str) -> None:
+    translated = _load(_TRANSLATIONS / f"{lang}.json")
+    drifted = {
+        key: (sorted(_placeholders(_ENGLISH[key])), sorted(_placeholders(translated[key])))
+        for key in set(_ENGLISH) & set(translated)
+        if _placeholders(_ENGLISH[key]) != _placeholders(translated[key])
+    }
+    assert not drifted, (
+        f"{lang}.json changes the substitutions the code performs: {drifted}"
+    )
+
+
+def test_strings_json_matches_the_english_translation() -> None:
+    """``strings.json`` is what Home Assistant validates the integration
+    against; letting it drift from the shipped English is how a key ends up
+    translated everywhere and rendered nowhere."""
+    strings = _load(_STRINGS)
+    only_en = sorted(set(_ENGLISH) - set(strings))
+    only_strings = sorted(set(strings) - set(_ENGLISH))
+    assert not only_en and not only_strings, (
+        f"only in en.json: {only_en[:10]}\nonly in strings.json: {only_strings[:10]}"
+    )

--- a/tests/test_v2290_vwna_play_integrity.py
+++ b/tests/test_v2290_vwna_play_integrity.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1012 — VW North America needs a play_integrity_token on the token exchange.
+
+Two US owners could not add the integration. Their debug logs show the sign-in
+completing all the way to an authorization code, and only the code->token POST
+failing, with HTTP 401 {"errorCode":"INVALID_REQUEST",
+"origin":"CarnetSPAuthorizationServer"}.
+
+On 2026-07-30 VW's con-veh token endpoint began requiring a ``play_integrity_token``
+form field on the grant. It checks the field is present, not that it is a valid
+attestation, so the maintained third-party NA clients send the literal string
+``"unavailable"``. Our request matched the working clients byte-for-byte except
+for this one missing field, which is why our own note records that v2.25 (before
+the server change) authenticated fine.
+
+These tests pin two things: the field IS sent when the token endpoint is a
+con-veh host, and it is NOT sent for the other brands that share the same
+code path (Skoda / SEAT / CUPRA / VW EU), whose servers do not want it.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.vag_connect.cariad.api.vw_na import BRAND_VW_NA
+from custom_components.vag_connect.cariad.auth.idk import IDKAuth
+
+_US_TOKEN_URL = "https://b-h-s.spr.us00.p.con-veh.net/oidc/v1/token"
+_NON_CONVEH_URL = "https://emea.bff.cariad.digital/oidc/v1/token"
+
+
+def _capturing_session() -> tuple[MagicMock, dict]:
+    """A session whose POST records its ``data`` and returns a 200 token body."""
+    captured: dict = {}
+
+    def _post(url, **kwargs):
+        captured["url"] = url
+        captured["data"] = kwargs.get("data")
+        resp = AsyncMock()
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        resp.status = 200
+        resp.json = AsyncMock(return_value={
+            "access_token": "a", "refresh_token": "r", "id_token": "i",
+        })
+        resp.text = AsyncMock(return_value="{}")
+        return resp
+
+    session = MagicMock()
+    session.post = MagicMock(side_effect=_post)
+    return session, captured
+
+
+def test_na_exchange_sends_play_integrity_token() -> None:
+    session, captured = _capturing_session()
+    auth = IDKAuth(session, BRAND_VW_NA, token_url_override=_US_TOKEN_URL)
+    asyncio.run(auth._exchange_code("thecode", "theverifier"))
+
+    data = captured["data"]
+    assert data["play_integrity_token"] == "unavailable"
+    # everything else the working clients send must still be there, unchanged
+    assert data["grant_type"] == "authorization_code"
+    assert data["code"] == "thecode"
+    assert data["code_verifier"] == "theverifier"
+    assert data["redirect_uri"] == BRAND_VW_NA.redirect_uri
+    # public client: no secret, no basic auth
+    assert "client_secret" not in data
+    assert "con-veh" in captured["url"]
+
+
+def test_non_conveh_exchange_does_not_send_it() -> None:
+    """The field is scoped to the con-veh host, not to the brand: point the same
+    NA client at a non-con-veh token endpoint and the field must NOT appear, so
+    a future EU-hosted exchange sharing this branch is never given a stray
+    Play-Integrity field its server did not ask for."""
+    session, captured = _capturing_session()
+    auth = IDKAuth(session, BRAND_VW_NA, token_url_override=_NON_CONVEH_URL)
+    asyncio.run(auth._exchange_code("thecode", "theverifier"))
+
+    assert "play_integrity_token" not in captured["data"]
+    assert "con-veh" not in captured["url"]
+
+
+def test_na_exchange_persists_the_verifier_for_refresh() -> None:
+    """The con-veh refresh grant needs the original PKCE verifier, so the token
+    set the exchange returns has to carry it."""
+    session, _ = _capturing_session()
+    auth = IDKAuth(session, BRAND_VW_NA, token_url_override=_US_TOKEN_URL)
+    tokens = asyncio.run(auth._exchange_code("thecode", "kept_verifier"))
+    assert tokens.code_verifier == "kept_verifier"
+
+
+def test_na_refresh_sends_token_and_verifier() -> None:
+    """Refresh must replay both the play_integrity_token and the stored
+    verifier, or the con-veh server 401s / 400s the refresh."""
+    session, captured = _capturing_session()
+    auth = IDKAuth(session, BRAND_VW_NA, token_url_override=_US_TOKEN_URL)
+    asyncio.run(auth.refresh("the_refresh_token", code_verifier="stored_verifier"))
+
+    data = captured["data"]
+    assert data["grant_type"] == "refresh_token"
+    assert data["play_integrity_token"] == "unavailable"
+    assert data["code_verifier"] == "stored_verifier"
+
+
+def test_non_conveh_refresh_stays_plain() -> None:
+    session, captured = _capturing_session()
+    auth = IDKAuth(session, BRAND_VW_NA, token_url_override=_NON_CONVEH_URL)
+    asyncio.run(auth.refresh("the_refresh_token", code_verifier="stored_verifier"))
+
+    assert "play_integrity_token" not in captured["data"]
+    assert "code_verifier" not in captured["data"]


### PR DESCRIPTION
Since 30 July 2026 VW's North American token endpoint (proxying to CarnetSPAuthorizationServer) refuses the code-to-token exchange unless a `play_integrity_token` form field is present, returning a 401 INVALID_REQUEST that looks like a wrong password but is not one. Sign-in completes and returns an authorization code; only the exchange right after it fails.

Three US/CA owners reported the identical 401, all pointing at the same 04:00 UTC cut-over on 30 July. Our own note that v2.25 authenticated fine matches: nothing in our request became wrong, VW added a required field.

**Fix:** the field is sent now, on both the initial exchange and the refresh. VW checks presence, not that it is a valid attestation (which cannot be minted off-device), so a placeholder satisfies it, the same value the maintained third-party NA clients send. It is scoped to the con-veh token host by its URL, so the CARIAD-BFF and OLA brands sharing this code path are untouched.

The refresh grant needs the same field, and the con-veh server additionally binds the refresh to the original PKCE `code_verifier`. That verifier is now persisted with the token set and replayed on refresh; a token set from before this change simply falls through to a full re-login rather than looping.

Five tests pin both grants and the con-veh scoping. Full suite green, ruff + mypy strict clean.

Fixes #1012. Thanks to briancmoses, chrisspatrickk1 and savabg for the reports and the pin to the exact date.