### PR TITLE
Release 2.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [Unreleased]
+## [2.29.1] - 2026-08-05
 
 ### Fixed
 - **Volkswagen US and Canada could not be added since 30 July (#1012).** Sign-in itself was working: it ran through to an authorization code and only the step that trades that code for a token was refused, with a 401 that read like a wrong password but was not one. On 30 July VW's North American token service began requiring a field that was not there before, and every request without it now bounces. That field is sent now, on both the initial token exchange and the refresh, so an affected account adds and stays signed in. Confirmed by three owners, whose reports all point at the same 04:00 UTC cut-over. Thanks to briancmoses, chrisspatrickk1 and savabg.

--- a/custom_components/vag_connect/cariad/api/audi_na.py
+++ b/custom_components/vag_connect/cariad/api/audi_na.py
@@ -41,6 +41,17 @@ read ``na.bff``.
 Country: only the US market-config is live-verified. CA is accepted for interface
 parity but currently reuses the US brand — a CA-specific market-config sweep
 (``.../market/CA/en``) is a follow-up before CA can be trusted.
+
+v2.29.1 — one CA question is now answered externally. A CA-account debug capture
+(audi_connect_ha #814, 2026-08-05) showed the Canadian market config carries
+``marketSupportsAppAttestation: True`` and its discovery document routes CA to
+``token_endpoint = emea.bff.cariad.digital`` with ``device_code`` present in
+``grant_types_supported``. So CA has attestation enforced, which is why a
+password login there fails at the token step with the EU "invalid assertion
+headers" body, and device-code is the way through — exactly the path this client
+already drives (``audi_na`` is in ``DAG_ENABLED_BRANDS``). CA should therefore
+use the browser/device-code login, not the password fallback; a live CA-Audi
+tester is still what confirms it end to end (#13).
 """
 
 from __future__ import annotations

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.29.0"
+  "version": "2.29.1"
 }


### PR DESCRIPTION
Bugfix release bundling the merged fixes since 2.29.0: VW North America play_integrity_token (#1012), Porsche Auth0 resume hop (experimental), the twelve companion strings across all languages, the zero-reading fix, the companion spelled-out-units fix, and idp_idt withheld from discovery. Plus a note recording that Audi Canada enforces attestation and offers device-code (audi_connect_ha #814). PATCH per semver: all bugfixes, no new feature, no breaking change.