### PR TITLE
VW NA: carnet-Bearer remote commands + connector-lock + throttle marker (2.29.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.29.2] - 2026-08-05
+
+### Fixed
+- **The connector-lock status shows on Volkswagen US and Canada.** The charging read already carried whether the charge cable is latched, but that one field was never picked up, so the connector-lock sensor stayed blank on those cars. It is read now.
+- **A throttled Volkswagen North America sign-in is no longer mistaken for a wrong password.** When the North American login is rate-limited it answers with an ordinary-looking page instead of a clear "too many attempts", so the login read it as bad credentials and prompted a re-login — which only piled on more attempts. It is recognised as the rate-limit it is now, and the integration backs off instead.
+- **Minutes-until-ready fills in for Volkswagen North America climate.** The remaining pre-conditioning time was already a sensor for other brands; it now populates for VW US/CA too.
+
+### Changed
+- **Volkswagen US and Canada remote commands were rewritten to the shape the app actually sends (experimental — needs a North America tester).** Lock, unlock, wake, charge start/stop, the charge target and the climate temperature were being sent in a form the server quietly ignored, so a command came back "accepted" while the car never moved. They now go out the way the official app sends them — the right request type, the right body, and signed with the per-car token that North America has required for every command since late July. This is grounded in a live, community-maintained reference client but is not yet confirmed on our own side, because we have no North American car to test on. If you run Volkswagen US or Canada, a note on whether lock/unlock now actuates would settle it.
+
 ## [2.29.1] - 2026-08-05
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -396,11 +396,11 @@ class VWNAClient:
                     body {idToken, spinHash, tsp:"WCT"}
                     -> data.carnetVehicleToken (a JWT)
 
-        NOTE — this READ session endpoint
-        (``/ss/v1/user/{uid}/vehicle/{uuid}/session``) is DISTINCT from our
-        command-SPIN path (``/ss/v1/user/{uid}/spin`` with {challenge,response}
-        in ``_get_na_spin_session_token``). We implement the read flow exactly
-        as the peer does; we do NOT assume the two are identical.
+        v2.29.x (sstur/vwapp): this SAME ``carnetVehicleToken`` is now the auth
+        for the remote COMMANDS too (lock/unlock/wake/charge/climate use it as
+        the Bearer via ``_carnet_command``). The old separate command-SPIN path
+        (``/ss/v1/user/{uid}/spin`` with {challenge,response} → an X-Spin-Session
+        header) was wrong — VW never honoured it — and has been removed.
 
         SAFETY:
         - S-PIN-gated: returns ``None`` immediately if no S-PIN is configured
@@ -447,88 +447,111 @@ class VWNAClient:
         if not id_token:
             return None
 
-        # ── 1) challenge ──────────────────────────────────────────────────────
-        try:
-            ch_resp = await self._get(
-                f"{self._base}/ss/v1/user/{self._user_id}/challenge"
-            )
-        except APIError as err:
-            _LOGGER.debug(
-                "VW NA read-session: challenge failed (%s) for vin ***%s — "
-                "falling back to access_token reads",
-                err.status, vin[-6:],
-            )
-            return None
-        if not isinstance(ch_resp, dict):
-            return None
-        _ch_nested = ch_resp.get("data")
-        data: dict[str, Any] = _ch_nested if isinstance(_ch_nested, dict) else ch_resp
-        challenge = data.get("challenge")
-        remaining = data.get("remainingTries")
-        if not isinstance(challenge, str) or not challenge:
-            return None
-        # LOCKOUT GUARD: refuse to spend an attempt when few tries remain.
-        if isinstance(remaining, int) and remaining <= self._SPIN_MIN_REMAINING_TRIES:
-            self._spin_read_session_disabled = True
-            if not self._spin_read_warned:
-                self._spin_read_warned = True
-                _LOGGER.warning(
-                    "VW NA read-session: only %d S-PIN attempt(s) remain — "
-                    "NOT spending one on the data-read session exchange to "
-                    "avoid locking your S-PIN. Falling back to the standard "
-                    "read path. Verify your S-PIN is correct, then reload the "
-                    "integration to re-enable the SPIN read path.",
-                    remaining,
+        challenge_url = f"{self._base}/ss/v1/user/{self._user_id}/challenge"
+        session_url = (
+            f"{self._base}/ss/v1/user/{self._user_id}/vehicle/{uuid}/session"
+        )
+
+        # spinHash casing — v2.29.x (sstur/vwapp, iOS live-capture 2026-08): VW's
+        # OWN app sends LOWERCASE SHA-512 hex. Our prior uppercase (from
+        # zackcornelius) was never end-to-end validated on our stack, and SHA-512
+        # hex is canonically lowercase — an uppercase-only server is implausible,
+        # so if uppercase ever "worked" it was because VW compares case-
+        # insensitively. Try lowercase first; only if the session POST rejects it
+        # (401/403) fetch a FRESH single-use challenge and retry with the legacy
+        # uppercase before disabling. The remaining-tries guard runs on each
+        # challenge, so the fallback can never push the S-PIN budget to lockout.
+        for use_upper in (False, True):
+            # ── 1) challenge (fresh each attempt: single-use) ──────────────────
+            try:
+                ch_resp = await self._get(challenge_url)
+            except APIError as err:
+                _LOGGER.debug(
+                    "VW NA read-session: challenge failed (%s) for vin ***%s — "
+                    "falling back to access_token reads",
+                    err.status, vin[-6:],
                 )
-            return None
-
-        # ── 2) spinHash ───────────────────────────────────────────────────────
-        spin_hash = hashlib.sha512(
-            f"{challenge}.{spin}".encode("utf-8")
-        ).hexdigest().upper()
-
-        # ── 3) session ────────────────────────────────────────────────────────
-        try:
-            sess = await self._post(
-                f"{self._base}/ss/v1/user/{self._user_id}/vehicle/{uuid}/session",
-                json={"idToken": id_token, "spinHash": spin_hash, "tsp": "WCT"},
+                return None
+            if not isinstance(ch_resp, dict):
+                return None
+            _ch_nested = ch_resp.get("data")
+            data: dict[str, Any] = (
+                _ch_nested if isinstance(_ch_nested, dict) else ch_resp
             )
-        except APIError as err:
-            status = err.status or 0
-            if status in (401, 403):
-                # Wrong S-PIN (or PIN-protected lockout). DISABLE for the
-                # session so we never loop and burn the remaining tries.
+            challenge = data.get("challenge")
+            remaining = data.get("remainingTries")
+            if not isinstance(challenge, str) or not challenge:
+                return None
+            # LOCKOUT GUARD: refuse to spend an attempt when few tries remain.
+            if isinstance(remaining, int) and remaining <= self._SPIN_MIN_REMAINING_TRIES:
                 self._spin_read_session_disabled = True
                 if not self._spin_read_warned:
                     self._spin_read_warned = True
                     _LOGGER.warning(
-                        "VW NA read-session: the S-PIN session exchange was "
-                        "rejected (%s) — your S-PIN may be wrong. Disabling the "
-                        "SPIN read path for this session (falling back to the "
-                        "standard reads) so we don't lock your S-PIN. Fix the "
-                        "S-PIN and reload the integration to retry.",
-                        status,
+                        "VW NA read-session: only %d S-PIN attempt(s) remain — "
+                        "NOT spending one on the data-read session exchange to "
+                        "avoid locking your S-PIN. Falling back to the standard "
+                        "read path. Verify your S-PIN is correct, then reload the "
+                        "integration to re-enable the SPIN read path.",
+                        remaining,
                     )
-            else:
+                return None
+
+            # ── 2) spinHash (lowercase primary, uppercase legacy fallback) ─────
+            digest = hashlib.sha512(
+                f"{challenge}.{spin}".encode("utf-8")
+            ).hexdigest()
+            spin_hash = digest.upper() if use_upper else digest
+
+            # ── 3) session ─────────────────────────────────────────────────────
+            try:
+                sess = await self._post(
+                    session_url,
+                    json={"idToken": id_token, "spinHash": spin_hash, "tsp": "WCT"},
+                )
+            except APIError as err:
+                status = err.status or 0
+                if status in (401, 403):
+                    if not use_upper:
+                        # Lowercase rejected — retry once with the legacy
+                        # uppercase casing on a fresh challenge before disabling.
+                        continue
+                    # Both casings rejected: wrong S-PIN (or PIN lockout).
+                    # DISABLE for the session so we never loop and burn tries.
+                    self._spin_read_session_disabled = True
+                    if not self._spin_read_warned:
+                        self._spin_read_warned = True
+                        _LOGGER.warning(
+                            "VW NA read-session: the S-PIN session exchange was "
+                            "rejected (%s) — your S-PIN may be wrong. Disabling "
+                            "the SPIN read path for this session (falling back to "
+                            "the standard reads) so we don't lock your S-PIN. Fix "
+                            "the S-PIN and reload the integration to retry.",
+                            status,
+                        )
+                    return None
                 _LOGGER.debug(
                     "VW NA read-session: session POST failed (%s) for vin "
                     "***%s — falling back to access_token reads",
                     status, vin[-6:],
                 )
-            return None
-        if not isinstance(sess, dict):
-            return None
-        _s_nested = sess.get("data")
-        sdata: dict[str, Any] = _s_nested if isinstance(_s_nested, dict) else sess
-        new_token = sdata.get("carnetVehicleToken")
-        if not isinstance(new_token, str) or not new_token:
-            return None
-        self._read_session_tokens[uuid] = (new_token, self._jwt_exp(new_token))
-        _LOGGER.debug(
-            "VW NA read-session: obtained carnetVehicleToken for vin ***%s "
-            "(cached)", vin[-6:],
-        )
-        return new_token
+                return None
+            if not isinstance(sess, dict):
+                return None
+            _s_nested = sess.get("data")
+            sdata: dict[str, Any] = (
+                _s_nested if isinstance(_s_nested, dict) else sess
+            )
+            new_token = sdata.get("carnetVehicleToken")
+            if not isinstance(new_token, str) or not new_token:
+                return None
+            self._read_session_tokens[uuid] = (new_token, self._jwt_exp(new_token))
+            _LOGGER.debug(
+                "VW NA read-session: obtained carnetVehicleToken for vin ***%s "
+                "(cached)", vin[-6:],
+            )
+            return new_token
+        return None
 
     async def get_vehicles(self) -> list[str]:
         """Return VINs from VW NA garage.
@@ -1101,6 +1124,13 @@ class VWNAClient:
             if isinstance(plug, str):
                 d.plug_connected = plug.upper() == "CONNECTED"
                 d.plug_state = plug
+            # v2.29.x (sstur/vwapp) — plug LOCK state → connector_locked, the most
+            # safety-relevant plug signal (whether the cable is latched). vw_na
+            # read plugConnectionState but never the lock state; four other brands
+            # already map it. NA field is plugStatus.plugLockState ("LOCKED"/...).
+            plug_lock = v(charge, "plugStatus", "plugLockState")
+            if isinstance(plug_lock, str):
+                d.connector_locked = plug_lock.upper() == "LOCKED"
             d.target_soc = first_not_none(
                 v(charge, "chargeSettings", "targetSOCPercentage"),
                 v(charge, "chargingSettings", "targetSOC_pct"),
@@ -1155,6 +1185,14 @@ class VWNAClient:
                 or v(climate, "climatisationStatus", "climatisationState")
             )
             d.climatisation_active = d.climatisation_state not in (None, "OFF", "off")
+            # v2.29.x (sstur/vwapp) — minutes left until the cabin reaches target.
+            # NA field is climateStatusReport.remainingClimatizationTimeMin; feeds
+            # the existing cross-brand climate_remaining_time_min sensor.
+            rem = safe_int(
+                v(climate, "climateStatusReport", "remainingClimatizationTimeMin")
+            )
+            if rem is not None and rem >= 0:
+                d.climate_remaining_time_min = rem
             # Settings block: target temperature. NA backend reports
             # this in either Celsius (modern firmware on ID.4) or
             # Fahrenheit + Kelvin depending on the user's app preference.
@@ -1238,114 +1276,6 @@ class VWNAClient:
         """
         return {}
 
-    async def _get_na_spin_session_token(
-        self, vin: str, spin: str  # noqa: ARG002
-    ) -> str | None:
-        """v2.10.0 (Group C). VW NA two-step SPIN verification.
-
-        NA uses a DIFFERENT SPIN protocol from EU. The EU flow puts the
-        raw SPIN into the action payload; NA requires a challenge /
-        response handshake against a per-user endpoint:
-
-            1. ``POST /ss/v1/user/{user_id}/challenge`` returns a
-               single-use ``nonce``/``challenge`` string.
-            2. Compute ``SHA1(spin + nonce).upper()`` as the response.
-            3. ``POST /ss/v1/user/{user_id}/spin`` with the response.
-               On success the backend returns a short-lived
-               ``sessionToken`` that subsequent lock/unlock POSTs must
-               present as the ``X-Spin-Session`` header.
-
-        Pattern verified against the matpoulin reference + a smali
-        excerpt from the MyVW APK. Both ``challenge`` and ``response``
-        key names have shipped, defensive walk tries the known variants.
-
-        Returns ``None`` on any error. Caller falls back to attempting
-        the action without a session token (some firmware will still
-        accept a privileged token unprompted).
-        """
-        if not self._user_id or not spin:
-            _LOGGER.debug(
-                "VW NA SPIN flow skipped (user_id=%s, spin_set=%s)",
-                bool(self._user_id), bool(spin),
-            )
-            return None
-        try:
-            challenge_resp = await self._post(
-                f"{self._base}/ss/v1/user/{self._user_id}/challenge", json={}
-            )
-        except APIError as err:
-            _LOGGER.debug(
-                "VW NA SPIN challenge failed (%s) for vin ***%s",
-                err.status, vin[-6:],
-            )
-            return None
-        if not isinstance(challenge_resp, dict):
-            return None
-        # Defensive walk: backend has shipped at least 3 key names for
-        # the same field over the past 18 months.
-        nonce = (
-            challenge_resp.get("challenge")
-            or challenge_resp.get("nonce")
-            or challenge_resp.get("challengeData")
-        )
-        if not isinstance(nonce, str) or not nonce:
-            return None
-        # v2.11.0 (zackcornelius source-verified) - the SPIN hash is
-        # SHA-512 of ``"{challenge}.{spin}"`` (challenge first, then
-        # the dot separator, then the spin), NOT SHA-1 of (spin+nonce).
-        # Try the modern shape first; fall back to legacy SHA-1 if
-        # the modern path returns 4xx (kept so users whose accounts
-        # still respond to the old algorithm don't regress).
-        response = hashlib.sha512(
-            f"{nonce}.{spin}".encode("utf-8")
-        ).hexdigest().upper()
-        response_legacy = hashlib.sha1(  # noqa: S324
-            (spin + nonce).encode("utf-8")
-        ).hexdigest().upper()
-        # v2.11.0 - try modern (SHA-512) first; on 4xx fall back to
-        # legacy (SHA-1) which the older endpoint still expects on
-        # some firmwares.
-        spin_resp = None
-        try:
-            spin_resp = await self._post(
-                f"{self._base}/ss/v1/user/{self._user_id}/spin",
-                json={"challenge": nonce, "response": response},
-            )
-        except APIError as err:
-            if 400 <= (err.status or 0) < 500:
-                try:
-                    spin_resp = await self._post(
-                        f"{self._base}/ss/v1/user/{self._user_id}/spin",
-                        json={"challenge": nonce, "response": response_legacy},
-                    )
-                except APIError as legacy_err:
-                    _LOGGER.debug(
-                        "VW NA SPIN both modern + legacy failed (%s/%s) for vin ***%s",
-                        err.status, legacy_err.status, vin[-6:],
-                    )
-                    return None
-            else:
-                _LOGGER.debug(
-                    "VW NA SPIN POST failed (%s) for vin ***%s",
-                    err.status, vin[-6:],
-                )
-                return None
-        if not isinstance(spin_resp, dict):
-            return None
-        # v2.11.0 (zackcornelius source-verified) - canonical token
-        # field is `carnetVehicleToken` (NOT sessionToken). Kept the
-        # other variants as defensive fallbacks for non-canonical
-        # firmware responses.
-        token = (
-            spin_resp.get("carnetVehicleToken")
-            or spin_resp.get("sessionToken")
-            or spin_resp.get("spinSessionToken")
-            or spin_resp.get("token")
-        )
-        if isinstance(token, str) and token:
-            return token
-        return None
-
     async def _post_with_ab_fallback(
         self,
         *,
@@ -1384,64 +1314,83 @@ class VWNAClient:
             fallback_kwargs["headers"] = fallback_headers
         await self._post(fallback_url, **fallback_kwargs)
 
-    async def command_lock(self, vin: str) -> None:
-        """v2.10.0 (Group C). NA lockunlock endpoint with EU fallback.
+    async def _carnet_command(
+        self,
+        method: str,
+        url: str,
+        vin: str,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        """v2.29.x (sstur/vwapp, APK + live-verified 2026-07-30) — issue an NA
+        remote command authorised with the per-vehicle carnetVehicleToken.
 
-        Modern Cox firmware exposes ``/lockunlock/v1/vehicle/{uuid}``
-        as the lock/unlock action endpoint. Older firmware (legacy
-        Cox) only knows ``/ev/v1/vehicle/{uuid}/lock``. Try the
-        modern path first, fall back to the legacy one on 404 so
-        existing installs keep working through the firmware
-        transition window.
+        VW moved NA remote commands behind the same S-PIN ``carnetVehicleToken``
+        the reads now require: with the plain access_token every command returns
+        ``403 USER_NOT_AUTHORIZED`` and lock/unlock is silently ignored (VW drops
+        the unknown ``action`` field). Reuse the CACHED read-session carnet token
+        (``_get_read_session_token`` — no extra S-PIN spend) as the
+        ``Authorization: Bearer``. When no carnet token is available (no S-PIN, or
+        the exchange is disabled) fall back to the plain access_token path so a
+        non-S-PIN account is no worse off than before.
+
+        NOT YET live-confirmed on our own stack (we have no NA car): the routes,
+        HTTP methods and bodies are taken verbatim from sstur/vwapp's live-
+        verified client, which fixed why NA commands never actuated. See the
+        #1012 / #915 lineage and the open "testers wanted" issue.
+        """
+        carnet = await self._get_read_session_token(vin)
+        if carnet:
+            headers = dict(self._READ_HEADERS)
+            headers["Authorization"] = f"Bearer {carnet}"
+            try:
+                return await self._request(
+                    method, url, headers=headers, _carnet_auth=True, json=json
+                )
+            except APIError as err:
+                # A 401/403 with the carnet token means it was rejected/expired —
+                # drop it so the NEXT command re-mints (subject to the lockout
+                # guard). Never re-mint in this call (avoids a 2nd S-PIN attempt
+                # back-to-back).
+                if (err.status or 0) in (401, 403):
+                    self._read_session_tokens.pop(
+                        self._vin_to_uuid.get(vin, vin), None
+                    )
+                raise
+        return await self._request(method, url, json=json)
+
+    async def command_lock(self, vin: str) -> None:
+        """NA lock — v2.29.x (sstur/vwapp): PUT ``{lock: true}`` with the
+        carnetVehicleToken as Bearer.
+
+        The old ``POST {"action":"lock"}`` on the access_token was silently
+        ignored by VW (unknown ``action`` field) — the command was accepted but
+        never actuated. VW's own app PUTs ``{lock: boolean}`` to
+        ``/lockunlock/v1/vehicle/{uuid}`` with the carnet token as the bearer.
         """
         uuid = self._vin_to_uuid.get(vin, vin)
-        await self._post_with_ab_fallback(
-            primary_url=f"{self._base}/lockunlock/v1/vehicle/{uuid}",
-            primary_json={"action": "lock"},
-            fallback_url=f"{self._base}/ev/v1/vehicle/{uuid}/lock",
-            fallback_json={"action": "lock"},
-            label="lock",
-            vin=vin,
+        await self._carnet_command(
+            "PUT",
+            f"{self._base}/lockunlock/v1/vehicle/{uuid}",
+            vin,
+            json={"lock": True},
         )
 
-    async def command_unlock(self, vin: str, spin: str = "") -> None:
-        """v2.10.0 (Group C). NA unlock with two-step SPIN handshake.
+    async def command_unlock(self, vin: str, spin: str = "") -> None:  # noqa: ARG002
+        """NA unlock — v2.29.x (sstur/vwapp): PUT ``{lock: false}`` with the
+        carnetVehicleToken as Bearer (see :meth:`command_lock`).
 
-        Pre-v2.10.0 we put the SPIN directly into the unlock body which
-        worked for some firmware but failed on Cox post-2024 builds. NA
-        actually requires the two-step ``/challenge`` + ``/spin``
-        handshake to obtain a session token, then the unlock POST
-        carries that token as an ``X-Spin-Session`` header. The body
-        no longer needs to contain the SPIN itself.
-
-        If the SPIN session token cannot be fetched (no user_id, no
-        SPIN configured, backend down), we fall back to the legacy
-        in-body SPIN behaviour so existing accounts that worked on
-        older firmware keep working.
+        The ``spin`` argument is kept for signature compatibility; the S-PIN is
+        consumed by the carnet-token exchange (``_get_read_session_token``), not
+        sent in the request. The old two-step ``/challenge`` + ``/spin`` handshake
+        with an ``X-Spin-Session`` header and ``{"action":"unlock"}`` body never
+        actuated (VW ignores the unknown ``action`` field).
         """
         uuid = self._vin_to_uuid.get(vin, vin)
-        spin_to_use = spin or self._spin
-        session_token = await self._get_na_spin_session_token(vin, spin_to_use)
-
-        primary_headers: dict[str, str] | None = None
-        if session_token:
-            primary_headers = {"X-Spin-Session": session_token}
-
-        primary_payload: dict[str, Any] = {"action": "unlock"}
-        legacy_payload: dict[str, Any] = {"action": "unlock"}
-        # Legacy path keeps the in-body SPIN for older Cox firmware
-        # that doesn't honour the X-Spin-Session header.
-        if spin_to_use:
-            legacy_payload["spin"] = spin_to_use
-
-        await self._post_with_ab_fallback(
-            primary_url=f"{self._base}/lockunlock/v1/vehicle/{uuid}",
-            primary_json=primary_payload,
-            fallback_url=f"{self._base}/ev/v1/vehicle/{uuid}/lock",
-            fallback_json=legacy_payload,
-            label="unlock",
-            vin=vin,
-            primary_headers=primary_headers,
+        await self._carnet_command(
+            "PUT",
+            f"{self._base}/lockunlock/v1/vehicle/{uuid}",
+            vin,
+            json={"lock": False},
         )
 
     async def command_start_climate(self, vin: str) -> None:
@@ -1477,11 +1426,19 @@ class VWNAClient:
 
     async def command_start_charging(self, vin: str) -> None:
         uuid = self._vin_to_uuid.get(vin, vin)
-        await self._post(f"{self._base}/ev/v1/vehicle/{uuid}/charging/start", json={})
+        # v2.29.x (sstur/vwapp) — body {actionMode:"immediate"} + carnet Bearer;
+        # the old empty-body POST on the access_token was ignored / 403'd.
+        await self._carnet_command(
+            "POST", f"{self._base}/ev/v1/vehicle/{uuid}/charging/start", vin,
+            json={"actionMode": "immediate"},
+        )
 
     async def command_stop_charging(self, vin: str) -> None:
         uuid = self._vin_to_uuid.get(vin, vin)
-        await self._post(f"{self._base}/ev/v1/vehicle/{uuid}/charging/stop", json={})
+        await self._carnet_command(
+            "POST", f"{self._base}/ev/v1/vehicle/{uuid}/charging/stop", vin,
+            json={"actionMode": "immediate"},
+        )
 
     async def command_flash(
         self,
@@ -1503,22 +1460,62 @@ class VWNAClient:
         uuid = self._vin_to_uuid.get(vin, vin)
         # v2.20.0 (APK audit) — no /wakeup route exists on con-veh.net; a fresh
         # status is forced via the vehicle-status-request refresh endpoint.
-        await self._post(f"{self._base}/rvs/v1/vehicle/{uuid}/refresh", json={})
+        # v2.29.x (sstur/vwapp) — carnet-gated: with the plain access_token this
+        # 403s USER_NOT_AUTHORIZED. This is our freshness lever, so it matters.
+        await self._carnet_command(
+            "POST", f"{self._base}/rvs/v1/vehicle/{uuid}/refresh", vin, json={}
+        )
 
     async def command_set_target_soc(self, vin: str, target: int) -> None:
         uuid = self._vin_to_uuid.get(vin, vin)
         # v2.20.0 (APK audit) — myVW models use targetSOCPercentage (matches the
         # read side); the invented targetSOC_pct was silently ignored.
-        await self._post(
-            f"{self._base}/ev/v1/vehicle/{uuid}/charging/settings",
-            json={"targetSOCPercentage": target},
+        # v2.29.x (sstur/vwapp) — set-charge-limit is a PUT that REPLACES the whole
+        # charging-settings object, so read the current settings and merge the new
+        # target rather than PUTting a bare {targetSOCPercentage} (which would wipe
+        # the other charge settings). carnet Bearer. The old POST never actuated.
+        merged: dict[str, Any] = {"targetSOCPercentage": target}
+        try:
+            carnet = await self._get_read_session_token(vin)
+            summary = await self._read(
+                f"{self._base}/ev/v1/vehicle/{uuid}/charge/summary", carnet
+            )
+            if isinstance(summary, dict):
+                cur = summary.get("chargeSettings") or summary.get("chargingSettings")
+                if isinstance(cur, dict) and cur:
+                    merged = {**cur, "targetSOCPercentage": target}
+        except APIError:
+            pass  # fall back to the bare target below
+        await self._carnet_command(
+            "PUT", f"{self._base}/ev/v1/vehicle/{uuid}/charging/settings", vin,
+            json=merged,
         )
 
     async def command_set_climate_temperature(self, vin: str, temp_c: float) -> None:
         uuid = self._vin_to_uuid.get(vin, vin)
-        await self._post(
-            f"{self._base}/ev/v1/vehicle/{uuid}/pretripclimate/settings",
-            json={"targetTemperature_K": temp_c + 273.15, "tempUnit": "C"},
+        # v2.29.x (sstur/vwapp) — PUT the full climate-settings object with a
+        # NESTED targetTemperature {temperature, unit}; VW replaces the whole
+        # object, so read + merge to preserve the other zones/toggles. carnet
+        # Bearer. The old POST of a scalar {targetTemperature_K} was dropped.
+        target = {"temperature": round(temp_c, 1), "unit": "celsius"}
+        body: dict[str, Any] = {"targetTemperature": target}
+        try:
+            carnet = await self._get_read_session_token(vin)
+            summary = await self._read(
+                f"{self._base}/ev/v1/vehicle/{uuid}/climate/summary", carnet
+            )
+            if isinstance(summary, dict):
+                cur = (
+                    summary.get("climateSettings")
+                    or summary.get("climatisationSettings")
+                )
+                if isinstance(cur, dict) and cur:
+                    body = {**cur, "targetTemperature": target}
+        except APIError:
+            pass
+        await self._carnet_command(
+            "PUT", f"{self._base}/ev/v1/vehicle/{uuid}/pretripclimate/settings",
+            vin, json=body,
         )
 
     async def command_start_window_heating(self, vin: str) -> None:

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -1194,6 +1194,14 @@ class IDKAuth:
                 raise EmailTwoFactorRequiredError()
             if "two-factor" in pw_body_lc or "2fa" in pw_body_lc:
                 raise TwoFactorRequiredError()
+            # v2.29.x (sstur/vwapp) — a con-veh NA login returns THROTTLING as a
+            # 200 signin-HTML page (marker "login.error.throttled"), not an HTTP
+            # 429. Without this it fell to the "wrong credentials?" catch-all below
+            # and was misreported as a bad password → a reauth prompt that then
+            # fired more (throttled) login attempts. Classify it as the rate-limit
+            # it is so the coordinator backs off instead.
+            if "login.error.throttled" in pw_body_lc or "throttl" in pw_body_lc:
+                raise RateLimitError()
             raise AuthenticationError(
                 "Unexpected 200 after password POST — wrong credentials?"
             )

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.29.1"
+  "version": "2.29.2"
 }

--- a/tests/test_v210_vw_na_endpoints.py
+++ b/tests/test_v210_vw_na_endpoints.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """v2.10.0 (Group C) - VW NA endpoint parity tests.
 
-Covers the 4 new Cox-backend behaviours added in Group C:
+Covers the Cox-backend behaviours:
 
 1. ``get_subscription_privileges`` parses the
    ``/rrs/v1/privileges/user/{uid}/vehicle/{uuid}`` response and feeds
@@ -10,14 +10,13 @@ Covers the 4 new Cox-backend behaviours added in Group C:
    ``subscription_days_remaining`` + ``capabilities_count`` onto
    VehicleData. Soft-fails on 401 / 403 / 404 / non-dict.
 
-2. SPIN flow: ``SHA1(spin + nonce).hexdigest().upper()`` digest is the
-   protocol-mandated handshake response.
+2. Remote commands (v2.29.x, sstur/vwapp APK-verified): lock/unlock is
+   ``PUT {lock: bool}`` with the per-vehicle carnetVehicleToken as the
+   Authorization Bearer (NOT ``POST {"action":...}`` on the access_token,
+   which VW silently ignored). ``_carnet_command`` falls back to the plain
+   access_token path when no carnet token is available.
 
-3. ``command_lock`` / ``command_unlock`` hit the new
-   ``/lockunlock/v1/vehicle/{uuid}`` endpoint first and fall back to the
-   legacy ``/ev/v1/vehicle/{uuid}/lock`` on 404.
-
-4. ``command_start_climate`` / stop hit ``/pretripclimate/{start,stop}``
+3. ``command_start_climate`` / stop hit ``/pretripclimate/{start,stop}``
    first and fall back to ``/climatisation/{start,stop}`` on 404.
 
 Pure-Python tests; constructs VWNAClient via __new__ to skip the HA /
@@ -26,7 +25,6 @@ aiohttp setup chain. Matches the pattern of test_v1242_porsche_vw_na_parity.
 
 from __future__ import annotations
 
-import hashlib
 from unittest.mock import AsyncMock
 
 import pytest
@@ -48,6 +46,7 @@ def _client(user_id: str | None = "user-abc"):
     client._vin_to_uuid = {"VWNA00000000000001": "uuid-xyz"}
     client._user_id = user_id
     client._spin = ""
+    client._read_session_tokens = {}
     return client
 
 
@@ -162,195 +161,127 @@ class TestSubscriptionPrivileges:
 
 
 # ---------------------------------------------------------------------------
-# 2) SPIN handshake
+# 2) Remote commands — carnet-token Bearer (v2.29.x, sstur/vwapp)
 # ---------------------------------------------------------------------------
 
 
-class TestSpinFlow:
-    """Two-step challenge / response with SHA1(SPIN + nonce) digest."""
+class TestCommandCarnet:
+    """lock/unlock/wake/charge use ``_carnet_command``: PUT/POST with the
+    carnetVehicleToken as the Authorization Bearer, or the plain access_token
+    path when no carnet token is available."""
 
     @pytest.mark.asyncio
-    async def test_sha1_response_correctness(self):
-        """v2.11.0: protocol response is SHA-512('{challenge}.{spin}')
-        as the primary attempt (zackcornelius source-verified).
-        Legacy SHA-1(spin+nonce) stays as fallback on 4xx."""
+    async def test_lock_puts_lock_true_with_carnet_bearer(self):
         client = _client()
-        nonce = "deadbeef12345678"
-        spin = "1234"
-        expected_digest = hashlib.sha512(
-            f"{nonce}.{spin}".encode("utf-8")
-        ).hexdigest().upper()
-
-        # Capture the response body the helper sends to /spin
-        sent_payloads: list = []
-
-        async def fake_post(url, **kwargs):
-            sent_payloads.append((url, kwargs.get("json")))
-            if url.endswith("/challenge"):
-                return {"challenge": nonce}
-            if url.endswith("/spin"):
-                return {"carnetVehicleToken": "session-token-xyz"}
-            raise AssertionError(f"unexpected url {url}")
-
-        client._post = fake_post  # type: ignore[method-assign]
-
-        token = await client._get_na_spin_session_token(
-            "VWNA00000000000001", spin
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value="carnet-tok"
         )
-        assert token == "session-token-xyz"
-        # Two POSTs total: challenge, spin
-        assert len(sent_payloads) == 2
-        assert sent_payloads[0][0].endswith(
-            "/ss/v1/user/user-abc/challenge"
-        )
-        assert sent_payloads[1][0].endswith(
-            "/ss/v1/user/user-abc/spin"
-        )
-        # The /spin body carries the protocol digest (SHA-512)
-        assert sent_payloads[1][1]["response"] == expected_digest
-        assert sent_payloads[1][1]["challenge"] == nonce
-
-    @pytest.mark.asyncio
-    async def test_alt_nonce_field_names(self):
-        """Backend has shipped 3 key-names for the same field."""
-        client = _client()
-
-        async def fake_post(url, **kwargs):
-            if url.endswith("/challenge"):
-                return {"nonce": "abc"}  # alt key name
-            return {"token": "tok"}  # alt session-token key
-
-        client._post = fake_post  # type: ignore[method-assign]
-        token = await client._get_na_spin_session_token(
-            "VWNA00000000000001", "1234"
-        )
-        assert token == "tok"
-
-    @pytest.mark.asyncio
-    async def test_no_user_id_short_circuits(self):
-        client = _client(user_id=None)
-        token = await client._get_na_spin_session_token(
-            "VWNA00000000000001", "1234"
-        )
-        assert token is None
-
-    @pytest.mark.asyncio
-    async def test_empty_spin_short_circuits(self):
-        client = _client()
-        token = await client._get_na_spin_session_token(
-            "VWNA00000000000001", ""
-        )
-        assert token is None
-
-    @pytest.mark.asyncio
-    async def test_challenge_failure_returns_none(self):
-        from custom_components.vag_connect.cariad.exceptions import APIError
-
-        client = _client()
-        client._post = AsyncMock(  # type: ignore[method-assign]
-            side_effect=APIError(500, "/x", "server error")
-        )
-        token = await client._get_na_spin_session_token(
-            "VWNA00000000000001", "1234"
-        )
-        assert token is None
-
-    @pytest.mark.asyncio
-    async def test_garbage_nonce_returns_none(self):
-        client = _client()
-
-        async def fake_post(url, **kwargs):  # noqa: ARG001
-            return {"unrelated_field": 42}  # no challenge key
-
-        client._post = fake_post  # type: ignore[method-assign]
-        token = await client._get_na_spin_session_token(
-            "VWNA00000000000001", "1234"
-        )
-        assert token is None
-
-
-# ---------------------------------------------------------------------------
-# 3) Lock primary endpoint, fallback to legacy on 404
-# ---------------------------------------------------------------------------
-
-
-class TestLockFallback:
-    """``command_lock`` tries /lockunlock/v1 first, falls back on 404."""
-
-    @pytest.mark.asyncio
-    async def test_primary_endpoint_called_first(self):
-        client = _client()
-        urls: list[str] = []
-
-        async def fake_post(url, **kwargs):  # noqa: ARG001
-            urls.append(url)
-            return {}
-
-        client._post = fake_post  # type: ignore[method-assign]
+        client._request = AsyncMock(return_value={})  # type: ignore[method-assign]
         await client.command_lock("VWNA00000000000001")
-        assert len(urls) == 1
-        assert urls[0] == (
-            "https://example.test/lockunlock/v1/vehicle/uuid-xyz"
+        a = client._request.await_args
+        assert a.args[0] == "PUT"
+        assert a.args[1].endswith("/lockunlock/v1/vehicle/uuid-xyz")
+        assert a.kwargs["json"] == {"lock": True}
+        assert a.kwargs["headers"]["Authorization"] == "Bearer carnet-tok"
+        assert a.kwargs["_carnet_auth"] is True
+
+    @pytest.mark.asyncio
+    async def test_unlock_puts_lock_false_with_carnet_bearer(self):
+        client = _client()
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value="carnet-tok"
         )
+        client._request = AsyncMock(return_value={})  # type: ignore[method-assign]
+        await client.command_unlock("VWNA00000000000001")
+        a = client._request.await_args
+        assert a.args[0] == "PUT"
+        assert a.args[1].endswith("/lockunlock/v1/vehicle/uuid-xyz")
+        assert a.kwargs["json"] == {"lock": False}
+        assert a.kwargs["headers"]["Authorization"] == "Bearer carnet-tok"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_legacy_on_404(self):
-        from custom_components.vag_connect.cariad.exceptions import APIError
-
+    async def test_no_carnet_falls_back_to_access_token_path(self):
+        """No S-PIN (or exchange disabled) -> plain access_token _request with
+        no carnet Authorization header injected by the helper."""
         client = _client()
-        urls: list[str] = []
-
-        async def fake_post(url, **kwargs):  # noqa: ARG001
-            urls.append(url)
-            if "/lockunlock/" in url:
-                raise APIError(404, url, "not found")
-            return {}
-
-        client._post = fake_post  # type: ignore[method-assign]
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value=None
+        )
+        client._request = AsyncMock(return_value={})  # type: ignore[method-assign]
         await client.command_lock("VWNA00000000000001")
-        # Primary attempted, then legacy
-        assert len(urls) == 2
-        assert urls[0].endswith("/lockunlock/v1/vehicle/uuid-xyz")
-        assert urls[1].endswith("/ev/v1/vehicle/uuid-xyz/lock")
+        a = client._request.await_args
+        assert a.args[0] == "PUT"
+        assert "headers" not in a.kwargs
+        assert a.kwargs.get("_carnet_auth") in (None, False)
 
     @pytest.mark.asyncio
-    async def test_non_404_propagates(self):
-        """500 must propagate so the caller surfaces the real error."""
+    async def test_carnet_command_403_drops_cached_token_and_raises(self):
         from custom_components.vag_connect.cariad.exceptions import APIError
 
         client = _client()
-        client._post = AsyncMock(  # type: ignore[method-assign]
-            side_effect=APIError(500, "/x", "server error")
+        client._read_session_tokens = {"uuid-xyz": ("carnet-tok", None)}
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value="carnet-tok"
+        )
+        client._request = AsyncMock(  # type: ignore[method-assign]
+            side_effect=APIError(403, "/x", "USER_NOT_AUTHORIZED")
         )
         with pytest.raises(APIError) as exc:
             await client.command_lock("VWNA00000000000001")
-        assert exc.value.status == 500
+        assert exc.value.status == 403
+        # cached carnet token popped so the next command re-mints
+        assert "uuid-xyz" not in client._read_session_tokens
 
     @pytest.mark.asyncio
-    async def test_unlock_sends_x_spin_session_when_token_present(self):
-        """When the SPIN handshake succeeds, the unlock POST must carry
-        the ``X-Spin-Session`` header."""
+    async def test_wake_posts_rvs_refresh_with_carnet(self):
         client = _client()
-        client._spin = "1234"
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value="carnet-tok"
+        )
+        client._request = AsyncMock(return_value={})  # type: ignore[method-assign]
+        await client.command_wake("VWNA00000000000001")
+        a = client._request.await_args
+        assert a.args[0] == "POST"
+        assert a.args[1].endswith("/rvs/v1/vehicle/uuid-xyz/refresh")
+        assert a.kwargs["headers"]["Authorization"] == "Bearer carnet-tok"
 
-        captured_headers: dict = {}
+    @pytest.mark.asyncio
+    async def test_charging_start_actionmode_immediate(self):
+        client = _client()
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value="carnet-tok"
+        )
+        client._request = AsyncMock(return_value={})  # type: ignore[method-assign]
+        await client.command_start_charging("VWNA00000000000001")
+        a = client._request.await_args
+        assert a.args[0] == "POST"
+        assert a.args[1].endswith("/ev/v1/vehicle/uuid-xyz/charging/start")
+        assert a.kwargs["json"] == {"actionMode": "immediate"}
 
-        async def fake_post(url, **kwargs):
-            if "/challenge" in url:
-                return {"challenge": "n0nc3"}
-            if url.endswith("/spin"):
-                return {"sessionToken": "session-xyz"}
-            # Action POST
-            captured_headers.update(kwargs.get("headers") or {})
-            return {}
-
-        client._post = fake_post  # type: ignore[method-assign]
-        await client.command_unlock("VWNA00000000000001")
-        assert captured_headers.get("X-Spin-Session") == "session-xyz"
+    @pytest.mark.asyncio
+    async def test_target_soc_puts_merged_settings(self):
+        """set-target-soc reads current charge settings and PUTs the merged
+        object (VW replaces the whole object) with the carnet Bearer."""
+        client = _client()
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value="carnet-tok"
+        )
+        client._read = AsyncMock(  # type: ignore[method-assign]
+            return_value={"chargeSettings": {"autoUnlockPlug": "PERMANENT",
+                                             "targetSOCPercentage": 80}}
+        )
+        client._request = AsyncMock(return_value={})  # type: ignore[method-assign]
+        await client.command_set_target_soc("VWNA00000000000001", 90)
+        a = client._request.await_args
+        assert a.args[0] == "PUT"
+        assert a.args[1].endswith("/ev/v1/vehicle/uuid-xyz/charging/settings")
+        # merged: other setting preserved, target overwritten to 90
+        assert a.kwargs["json"] == {"autoUnlockPlug": "PERMANENT",
+                                    "targetSOCPercentage": 90}
 
 
 # ---------------------------------------------------------------------------
-# 4) Climate naming fallback (NA pretripclimate -> EU climatisation on 404)
+# 3) Climate naming fallback (NA pretripclimate -> EU climatisation on 404)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_v2155_vw_na_spin_read_auth.py
+++ b/tests/test_v2155_vw_na_spin_read_auth.py
@@ -9,7 +9,8 @@ access_token but succeed when authorised with a per-vehicle
 
 Flow:
     1. GET  {base}/ss/v1/user/{uid}/challenge -> data.challenge + remainingTries
-    2. spinHash = SHA512(challenge + "." + spin).hexdigest().upper()
+    2. spinHash = SHA512(challenge + "." + spin).hexdigest()  [LOWERCASE first,
+       v2.29.x sstur/vwapp; uppercase is retried on a 401/403 as a legacy fallback]
     3. POST {base}/ss/v1/user/{uid}/vehicle/{uuid}/session
             body {idToken, spinHash, tsp:"WCT"} -> data.carnetVehicleToken
     4. Authorization: Bearer <carnetVehicleToken> on the rvs + ev reads.
@@ -106,9 +107,10 @@ class TestReadSessionHappyPath:
         future_exp = (datetime.now(tz=timezone.utc) + timedelta(hours=1)).timestamp()
         carnet_jwt = _make_jwt(future_exp)
         challenge = "deadbeefchallenge"
+        # v2.29.x — lowercase hex is the primary casing (VW's own app form).
         expected_hash = hashlib.sha512(
             f"{challenge}.1234".encode("utf-8")
-        ).hexdigest().upper()
+        ).hexdigest()
 
         get_calls: list[tuple[str, dict]] = []
         post_calls: list[tuple[str, dict]] = []
@@ -214,10 +216,13 @@ class TestSessionFailureNoRetryLoop:
         client._request = fake_request  # type: ignore[method-assign]
         client.get_subscription_privileges = AsyncMock(return_value={})  # type: ignore[method-assign]
 
-        # First poll: challenge + session(403) -> disable, reads via access_token
+        # First poll: lowercase session(403) -> fresh challenge + uppercase
+        # session(403) -> BOTH casings rejected -> disable, reads via access_token.
+        # v2.29.x: the lowercase→uppercase fallback means 2 challenges + 2 sessions
+        # on the failing poll (each on a fresh single-use challenge).
         await client.get_status(_VIN)
-        assert challenge_calls["n"] == 1
-        assert session_calls["n"] == 1
+        assert challenge_calls["n"] == 2
+        assert session_calls["n"] == 2
         assert client._spin_read_session_disabled is True
         assert all(f is False for f in read_carnet_flags)
         assert client._spin_read_warned is True
@@ -225,9 +230,44 @@ class TestSessionFailureNoRetryLoop:
         # Second poll: MUST NOT re-challenge or re-session (no try-burning loop)
         read_carnet_flags.clear()
         await client.get_status(_VIN)
-        assert challenge_calls["n"] == 1  # unchanged
-        assert session_calls["n"] == 1  # unchanged
+        assert challenge_calls["n"] == 2  # unchanged
+        assert session_calls["n"] == 2  # unchanged
         assert all(f is False for f in read_carnet_flags)
+
+    @pytest.mark.asyncio
+    async def test_lowercase_403_then_uppercase_succeeds(self):
+        """v2.29.x — lowercase is tried first; if VW rejects it (401/403) the
+        legacy uppercase casing is retried on a fresh challenge and, when it
+        succeeds, yields the carnet token (no disable)."""
+        client = _client(spin="1234")
+        future_exp = (datetime.now(tz=timezone.utc) + timedelta(hours=1)).timestamp()
+        carnet_jwt = _make_jwt(future_exp)
+        challenge = "chal-xyz"
+        lower = hashlib.sha512(f"{challenge}.1234".encode("utf-8")).hexdigest()
+        upper = lower.upper()
+        seen_hashes: list[str] = []
+
+        async def fake_request(method, url, retry=True, _carnet_auth=False, **kwargs):
+            if url.endswith("/challenge"):
+                return {"data": {"challenge": challenge, "remainingTries": 5}}
+            if url.endswith("/session"):
+                h = kwargs["json"]["spinHash"]
+                seen_hashes.append(h)
+                if h == lower:
+                    raise _api_error(403, "wrong casing")
+                return {"data": {"carnetVehicleToken": carnet_jwt}}
+            if "/rvs/" in url:
+                return {"powerStatus": {}}
+            return {}
+
+        client._request = fake_request  # type: ignore[method-assign]
+        client.get_subscription_privileges = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        await client.get_status(_VIN)
+        # lowercase tried first, then uppercase which succeeded
+        assert seen_hashes == [lower, upper]
+        assert client._spin_read_session_disabled is False
+        assert client._read_session_tokens[_UUID][0] == carnet_jwt
 
     @pytest.mark.asyncio
     async def test_low_remaining_tries_aborts_without_session(self):

--- a/tests/test_v220_apk_audit_fixes.py
+++ b/tests/test_v220_apk_audit_fixes.py
@@ -89,23 +89,36 @@ def _vwna() -> VWNAClient:
     c = VWNAClient.__new__(VWNAClient)
     c._base = "https://b-h-s.spr.us00.p.con-veh.net"
     c._vin_to_uuid = {"VIN1": "uuid-1"}
+    c._read_session_tokens = {}
     c._post = AsyncMock()  # type: ignore[method-assign]
     return c
 
 
 def test_vwna_wake_uses_rvs_refresh() -> None:
+    # v2.29.x — wake is now carnet-gated (sstur/vwapp): routed via _carnet_command
+    # -> _request with the carnetVehicleToken as Bearer, not a plain _post.
     c = _vwna()
+    c._get_read_session_token = AsyncMock(return_value="carnet")  # type: ignore[method-assign]
+    c._request = AsyncMock(return_value={})  # type: ignore[method-assign]
     asyncio.run(c.command_wake("VIN1"))
-    url, _ = _url_body(c)
-    assert url.endswith("/rvs/v1/vehicle/uuid-1/refresh")  # not /ev/.../wakeup
+    a = c._request.call_args
+    assert a.args[0] == "POST"
+    assert a.args[1].endswith("/rvs/v1/vehicle/uuid-1/refresh")  # not /ev/.../wakeup
+    assert a.kwargs["headers"]["Authorization"] == "Bearer carnet"
 
 
 def test_vwna_target_soc_percentage_field() -> None:
+    # v2.29.x — set-charge-limit is a PUT that replaces the whole settings object;
+    # with no readable current settings it PUTs the bare targetSOCPercentage.
     c = _vwna()
+    c._get_read_session_token = AsyncMock(return_value="carnet")  # type: ignore[method-assign]
+    c._read = AsyncMock(return_value={})  # type: ignore[method-assign]
+    c._request = AsyncMock(return_value={})  # type: ignore[method-assign]
     asyncio.run(c.command_set_target_soc("VIN1", 90))
-    url, body = _url_body(c)
-    assert url.endswith("/ev/v1/vehicle/uuid-1/charging/settings")
-    assert body == {"targetSOCPercentage": 90}  # not targetSOC_pct
+    a = c._request.call_args
+    assert a.args[0] == "PUT"
+    assert a.args[1].endswith("/ev/v1/vehicle/uuid-1/charging/settings")
+    assert a.kwargs["json"] == {"targetSOCPercentage": 90}  # not targetSOC_pct
 
 
 def test_vwna_flash_uses_honkflash_service() -> None:

--- a/tests/test_v2291_vwna_sstur_fixes.py
+++ b/tests/test_v2291_vwna_sstur_fixes.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.29.x — VW NA fixes derived from sstur/vwapp (iOS-decompiled, live-verified
+myVW NA reference).
+
+Read side (safe, non-live-gated):
+  - plugStatus.plugLockState -> connector_locked (was never set for NA).
+  - climateStatusReport.remainingClimatizationTimeMin -> climate_remaining_time_min.
+
+Command side (carnet-Bearer rewrite, live-gated shapes):
+  - set-climate-temperature is a nested-object PUT
+    {targetTemperature:{temperature,unit}} with the carnetVehicleToken as Bearer.
+
+Pure-Python: VWNAClient via __new__, mocking at the _request boundary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+pytestmark = pytest.mark.ha_required
+
+_VIN = "WVWZZZ1KZAW000503"
+_UUID = "11112222-3333-4444-5555-666677778888"
+
+
+class _FakeTokens:
+    access_token = "ACCESS-TOKEN"
+    id_token = "ID-TOKEN"
+    refresh_token = "REFRESH-TOKEN"
+
+
+def _client(spin: str = ""):
+    from custom_components.vag_connect.cariad.api.vw_na import VWNAClient
+
+    c = VWNAClient.__new__(VWNAClient)
+    c._base = "https://example.test"
+    c._vin_to_uuid = {_VIN: _UUID}
+    c._vin_to_model = {}
+    c._vin_to_nickname = {}
+    c._user_id = "user-abc"
+    c._spin = spin
+    c._tokens = _FakeTokens()
+    c.vw_na_data_forbidden = False
+    c.vw_na_data_forbidden_reason = ""
+    c._last_privileges_status = None
+    c._read_session_tokens = {}
+    c._spin_read_session_disabled = False
+    c._spin_read_warned = False
+    c._bare_403_streak = 0
+    return c
+
+
+# ── read-side mappings ──────────────────────────────────────────────────────
+
+
+class TestReadMappings:
+    @pytest.mark.asyncio
+    async def test_plug_lock_state_maps_connector_locked(self):
+        client = _client(spin="")  # no S-PIN -> plain reads
+
+        async def fake_request(method, url, retry=True, _carnet_auth=False, **kwargs):
+            if "/charge/summary" in url:
+                return {
+                    "plugStatus": {
+                        "plugConnectionState": "CONNECTED",
+                        "plugLockState": "LOCKED",
+                    }
+                }
+            if "/rvs/" in url:
+                return {"powerStatus": {}}
+            return {}
+
+        client._request = fake_request  # type: ignore[method-assign]
+        client.get_subscription_privileges = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        d = await client.get_status(_VIN)
+        assert d.connector_locked is True
+        assert d.plug_connected is True
+
+    @pytest.mark.asyncio
+    async def test_plug_lock_state_unlocked(self):
+        client = _client(spin="")
+
+        async def fake_request(method, url, retry=True, _carnet_auth=False, **kwargs):
+            if "/charge/summary" in url:
+                return {"plugStatus": {"plugLockState": "UNLOCKED"}}
+            if "/rvs/" in url:
+                return {"powerStatus": {}}
+            return {}
+
+        client._request = fake_request  # type: ignore[method-assign]
+        client.get_subscription_privileges = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        d = await client.get_status(_VIN)
+        assert d.connector_locked is False
+
+    @pytest.mark.asyncio
+    async def test_remaining_climatization_time_maps(self):
+        client = _client(spin="")
+
+        async def fake_request(method, url, retry=True, _carnet_auth=False, **kwargs):
+            if "/climate/summary" in url:
+                return {
+                    "climateStatusReport": {
+                        "climateStatusInd": "COOLING",
+                        "remainingClimatizationTimeMin": 12,
+                    }
+                }
+            if "/rvs/" in url:
+                return {"powerStatus": {}}
+            return {}
+
+        client._request = fake_request  # type: ignore[method-assign]
+        client.get_subscription_privileges = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        d = await client.get_status(_VIN)
+        assert d.climate_remaining_time_min == 12
+
+
+# ── command side ────────────────────────────────────────────────────────────
+
+
+class TestClimateTemperatureCommand:
+    @pytest.mark.asyncio
+    async def test_set_temp_nested_put_with_carnet(self):
+        client = _client(spin="1234")
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value="carnet-tok"
+        )
+        client._read = AsyncMock(return_value={})  # type: ignore[method-assign]  # no current settings
+        client._request = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        await client.command_set_climate_temperature(_VIN, 21.5)
+        a = client._request.await_args
+        assert a.args[0] == "PUT"
+        assert a.args[1].endswith(f"/ev/v1/vehicle/{_UUID}/pretripclimate/settings")
+        assert a.kwargs["json"] == {
+            "targetTemperature": {"temperature": 21.5, "unit": "celsius"}
+        }
+        assert a.kwargs["headers"]["Authorization"] == "Bearer carnet-tok"
+
+    @pytest.mark.asyncio
+    async def test_set_temp_merges_existing_settings(self):
+        client = _client(spin="1234")
+        client._get_read_session_token = AsyncMock(  # type: ignore[method-assign]
+            return_value="carnet-tok"
+        )
+        client._read = AsyncMock(  # type: ignore[method-assign]
+            return_value={"climateSettings": {"climatisationWithoutHVpower": True}}
+        )
+        client._request = AsyncMock(return_value={})  # type: ignore[method-assign]
+
+        await client.command_set_climate_temperature(_VIN, 20.0)
+        body = client._request.await_args.kwargs["json"]
+        # existing setting preserved, target temperature added as nested object
+        assert body["climatisationWithoutHVpower"] is True
+        assert body["targetTemperature"] == {"temperature": 20.0, "unit": "celsius"}
+
+
+# ── idk NA login throttle marker ────────────────────────────────────────────
+
+
+class TestNaLoginThrottleMarker:
+    """A con-veh NA login returns throttling as a 200 signin-HTML body
+    (marker ``login.error.throttled``), not a 429. It must classify as a
+    rate-limit, not a wrong-password (which fired a reauth/throttle loop)."""
+
+    def test_throttle_marker_substring(self) -> None:
+        throttled = "<html>login.error.throttled please wait</html>".lower()
+        normal = "<html>please enter your password</html>".lower()
+        assert (
+            "login.error.throttled" in throttled or "throttl" in throttled
+        ) is True
+        assert (
+            "login.error.throttled" in normal or "throttl" in normal
+        ) is False
+
+    def test_source_checks_throttle_before_wrong_credentials(self) -> None:
+        from pathlib import Path
+
+        src = Path(
+            "custom_components/vag_connect/cariad/auth/idk.py"
+        ).read_text(encoding="utf-8")
+        throttle_pos = src.find("login.error.throttled")
+        wrong_creds_pos = src.find("Unexpected 200 after password POST")
+        assert throttle_pos > 0, "throttle marker check missing in idk.py"
+        assert wrong_creds_pos > 0
+        assert throttle_pos < wrong_creds_pos, (
+            "the throttle→RateLimitError branch must run BEFORE the generic "
+            "wrong-credentials raise"
+        )


### PR DESCRIPTION
The North America command path never actuated: lock/unlock POSTed {"action":...} on the plain access_token, which VW silently ignores, and since late July every NA command must be signed with the per-vehicle carnetVehicleToken.

This rewrites lock, unlock, wake, charge start/stop, the charge target and the climate temperature to the shapes the official app uses (PUT {lock:bool}, {actionMode:"immediate"}, nested targetTemperature, carnet Bearer) via a shared _carnet_command helper that reuses the cached read-session token, and removes the dead command-SPIN path.

Also: map plugStatus.plugLockState to connector_locked and climateStatusReport.remainingClimatizationTimeMin (both were never read for NA); switch the S-PIN hash to lowercase-first with an uppercase legacy fallback; and classify a throttled NA login (a 200 login.error.throttled page) as a rate-limit instead of a wrong password.

Command shapes are grounded in a live community reference but not yet confirmed on our own stack (no NA car), so they ship experimental with a tester call. Full suite green (4465 passed). Bumps 2.29.2.
