### PR TITLE
Portal: don't adopt an expired data request (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.29.3] - 2026-08-05
+
+### Fixed
+- **An expired portal data feed is renewed instead of quietly staying dead (#465).** The data portal keeps old requests in its list even after they lapse, and we adopted the first one we found without checking whether it was still live. So once a request created with the older one-month duration ran out, about four weeks after setup, we kept pointing at the dead one and never asked for a fresh feed: the sensors just stopped moving while everything looked healthy. We now skip a request whose window has ended and start a new feed in its place. A no-expiry request keeps its far-future end date and is never mistaken for a dead one.
+
 ## [2.29.2] - 2026-08-05
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
@@ -835,11 +835,66 @@ class DataActScraper:
                 if payload.get("Identifier"):
                     candidates = [payload]
         for c in candidates:
-            if str(c.get("Frequency", "")).lower() == "15mins":
-                identifier = c.get("Identifier")
-                if isinstance(identifier, str) and len(identifier) >= 16:
-                    return identifier
+            if str(c.get("Frequency", "")).lower() != "15mins":
+                continue
+            identifier = c.get("Identifier")
+            if not (isinstance(identifier, str) and len(identifier) >= 16):
+                continue
+            # v2.29.x (#465) — skip an EXPIRED descriptor. The portal keeps
+            # expired requests in metadata/partial, so adopting the first 15-min
+            # one meant that once an old "One Month" request lapsed (~4 weeks
+            # after setup) we never kicked off a fresh feed and the data silently
+            # stopped while the stale request still showed up here. A "No Expiry"
+            # request keeps its EndDate ~10 years out (_NO_EXPIRY_WINDOW_DAYS) so
+            # it is never seen as expired; only a genuinely lapsed window is.
+            if self._descriptor_expired(c):
+                _LOGGER.debug(
+                    "metadata/partial: 15-min request %s… for VIN %s is expired "
+                    "— ignoring it so a fresh feed is kicked off",
+                    identifier[:8], _mask_vin(vin),
+                )
+                continue
+            return identifier
         return None
+
+    @staticmethod
+    def _descriptor_expired(desc: dict[str, Any]) -> bool:
+        """True only when a metadata/partial descriptor clearly reports it is
+        past its window / no longer active. Unknown or unparseable -> False, so
+        we never drop a possibly-valid request on a shape we don't recognise.
+
+        The portal's window-end field is ``EndDate`` (a "No Expiry" request keeps
+        an EndDate ~10 years out, a "One Month" one ~31 days out), so a past
+        EndDate is the reliable "this feed has lapsed" signal. A few alternate key
+        names plus an explicit status field are checked defensively.
+        """
+        from datetime import datetime, timezone  # noqa: PLC0415
+
+        status = str(
+            desc.get("Status") or desc.get("State") or desc.get("RequestState") or ""
+        ).upper()
+        if status in (
+            "EXPIRED", "INACTIVE", "COMPLETED", "CANCELLED", "CANCELED",
+            "CLOSED", "FINISHED", "TERMINATED",
+        ):
+            return True
+        now = datetime.now(tz=timezone.utc)
+        for key in (
+            "EndDate", "ExpiryDate", "ExpiresAt", "ValidUntil",
+            "ExpirationDate", "ValidTo",
+        ):
+            raw = desc.get(key)
+            if not isinstance(raw, str) or len(raw) < 10:
+                continue
+            try:
+                dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                continue
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            if dt < now:
+                return True
+        return False
 
     async def kickoff_custom_data_request(
         self,

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.29.2"
+  "version": "2.29.3"
 }

--- a/tests/test_v2293_portal_expired_request.py
+++ b/tests/test_v2293_portal_expired_request.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.29.x (#465, second half) — the portal must not adopt an EXPIRED request.
+
+The portal keeps expired requests in metadata/partial. Our
+``get_active_custom_request_identifier`` picked the first Frequency=="15mins"
+descriptor with no expiry check, so once an old "One Month" request lapsed
+(~4 weeks after setup) it kept adopting the stale request forever and never
+kicked off a fresh feed — the data silently stopped while the request still
+listed. A "No Expiry" request keeps its EndDate ~10 years out and must NOT be
+treated as expired.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._data_act_scraper import (
+    DataActScraper,
+)
+
+_VIN = "WVWZZZAUZFW805377"
+
+
+def _iso(delta_days: int) -> str:
+    return (datetime.now(tz=timezone.utc) + timedelta(days=delta_days)).isoformat()
+
+
+# ── _descriptor_expired (pure) ──────────────────────────────────────────────
+
+
+class TestDescriptorExpired:
+    def test_past_enddate_is_expired(self):
+        assert DataActScraper._descriptor_expired({"EndDate": _iso(-1)}) is True
+
+    def test_future_enddate_not_expired(self):
+        assert DataActScraper._descriptor_expired({"EndDate": _iso(20)}) is False
+
+    def test_no_expiry_far_future_not_expired(self):
+        # "No Expiry" keeps EndDate ~10 years out
+        assert DataActScraper._descriptor_expired({"EndDate": _iso(3650)}) is False
+
+    def test_explicit_status_expired(self):
+        assert DataActScraper._descriptor_expired({"Status": "EXPIRED"}) is True
+        assert DataActScraper._descriptor_expired({"State": "cancelled"}) is True
+
+    def test_date_only_enddate(self):
+        past = (datetime.now(tz=timezone.utc) - timedelta(days=2)).date().isoformat()
+        assert DataActScraper._descriptor_expired({"EndDate": past}) is True
+
+    def test_unknown_shape_not_expired(self):
+        # no recognisable expiry -> treat as active (never drop a valid request)
+        assert DataActScraper._descriptor_expired({"foo": "bar"}) is False
+        assert DataActScraper._descriptor_expired({"EndDate": "garbage"}) is False
+
+
+# ── get_active_custom_request_identifier (via a mock session) ───────────────
+
+
+class _Resp:
+    def __init__(self, status: int, payload: Any) -> None:
+        self.status = status
+        self._payload = payload
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def json(self, content_type: Any = None) -> Any:
+        return self._payload
+
+
+class _Session:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def get(self, url: str, **kw: Any) -> _Resp:  # noqa: ARG002
+        return _Resp(200, self._payload)
+
+
+def _scraper(payload: Any) -> DataActScraper:
+    return DataActScraper(_Session(payload), brand_name="volkswagen")
+
+
+class TestActiveIdentifierSelection:
+    @pytest.mark.asyncio
+    async def test_active_request_returned(self):
+        s = _scraper([
+            {"Frequency": "15mins", "Identifier": "ACTIVE-1234567890AB",
+             "EndDate": _iso(15)},
+        ])
+        assert await s.get_active_custom_request_identifier(_VIN) == "ACTIVE-1234567890AB"
+
+    @pytest.mark.asyncio
+    async def test_expired_request_ignored_returns_none(self):
+        # a lapsed One-Month request still listed -> None so a fresh feed kicks off
+        s = _scraper([
+            {"Frequency": "15mins", "Identifier": "EXPIRED-1234567890AB",
+             "EndDate": _iso(-3)},
+        ])
+        assert await s.get_active_custom_request_identifier(_VIN) is None
+
+    @pytest.mark.asyncio
+    async def test_no_expiry_request_kept(self):
+        s = _scraper([
+            {"Frequency": "15mins", "Identifier": "NOEXPIRY-1234567890AB",
+             "EndDate": _iso(3650)},
+        ])
+        assert (
+            await s.get_active_custom_request_identifier(_VIN)
+            == "NOEXPIRY-1234567890AB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mixed_skips_expired_takes_active(self):
+        s = _scraper([
+            {"Frequency": "15mins", "Identifier": "EXPIRED-1234567890AB",
+             "EndDate": _iso(-3)},
+            {"Frequency": "15mins", "Identifier": "ACTIVE-1234567890AB",
+             "EndDate": _iso(15)},
+        ])
+        assert (
+            await s.get_active_custom_request_identifier(_VIN)
+            == "ACTIVE-1234567890AB"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_enddate_still_adopted(self):
+        # a descriptor with no expiry info at all stays adopted (old behaviour):
+        # better than dropping a possibly-valid request on an unknown shape
+        s = _scraper([
+            {"Frequency": "15mins", "Identifier": "LEGACY-1234567890AB"},
+        ])
+        assert (
+            await s.get_active_custom_request_identifier(_VIN)
+            == "LEGACY-1234567890AB"
+        )


### PR DESCRIPTION
Fixes a silent data-stop on the EU Data Act portal (#465, second half). The portal keeps lapsed requests in metadata/partial, and get_active_custom_request_identifier adopted the first 15-min descriptor with no expiry check. So an old "One Month" request that ran out ~4 weeks after setup was adopted forever and no fresh feed was kicked off, the sensors just froze while everything looked healthy. Now a descriptor whose EndDate (or explicit expired status) is past is skipped; a "No Expiry" request keeps its far-future EndDate and is never mistaken for lapsed, and an unknown shape stays adopted so we never drop a possibly-valid request. Bumps 2.29.3 (not released yet). 16 new tests, full suite green.
