### PR TITLE
VW NA: flash is a PUT, not a POST (#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ## [2.29.3] - 2026-08-05
 
 ### Fixed
+- **Headlight flash on Volkswagen US and Canada uses the right request type (#659).** With v2.29.2 a North American owner confirmed lock and unlock now work, but flash still bounced because it was sent as the wrong request type, the same problem lock had. It now matches the shape the app uses. (The exact flash-versus-honk body is still a best guess; if a car reports a different error now, that is the next thing to pin.)
 - **An expired portal data feed is renewed instead of quietly staying dead (#465).** The data portal keeps old requests in its list even after they lapse, and we adopted the first one we found without checking whether it was still live. So once a request created with the older one-month duration ran out, about four weeks after setup, we kept pointing at the dead one and never asked for a fresh feed: the sensors just stopped moving while everything looked healthy. We now skip a request whose window has ended and start a new feed in its place. A no-expiry request keeps its far-future end date and is never mistaken for a dead one.
 
 ## [2.29.2] - 2026-08-05

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -1408,10 +1408,15 @@ class VWNAClient:
         # the old /ev/.../horn-and-lights path doesn't exist → 404. NOTE: the exact
         # action/mode body value is not yet confirmed (FLASH_ONLY is the EU value);
         # live-capture on a real myVW before relying on flash-only vs honk+flash.
-        # v2.29.x (#659) — carnet-gated: Rizencip's Tiguan 403'd USER_NOT_AUTHORIZED
-        # on flash with the plain access_token, the same wall wake hit.
+        # v2.29.x (#659) — carnet-gated AND a PUT, not a POST. A VW-US owner on
+        # v2.29.2 (chrisspatrickk1-sys) confirmed lock/unlock now actuate, but
+        # flash still 405'd METHOD_NOT_ALLOWED from HonkAndFlashService — the same
+        # wrong-method signature lock had before we switched it to PUT. The
+        # honkflash service on con-veh follows the lockunlock convention, so it is
+        # PUT. The body value (FLASH_ONLY) is still the EU guess and unconfirmed;
+        # if the PUT now 400s instead of 405, the body is the next thing to fix.
         await self._carnet_command(
-            "POST", f"{self._base}/honkflash/v1/vehicle/{uuid}", vin,
+            "PUT", f"{self._base}/honkflash/v1/vehicle/{uuid}", vin,
             json={"action": "FLASH_ONLY"},
         )
 

--- a/tests/test_v220_apk_audit_fixes.py
+++ b/tests/test_v220_apk_audit_fixes.py
@@ -122,13 +122,14 @@ def test_vwna_target_soc_percentage_field() -> None:
 
 
 def test_vwna_flash_uses_honkflash_service() -> None:
-    # v2.29.x (#659) — flash is now carnet-gated too (same 403 wall wake hit),
-    # routed via _carnet_command -> _request with the carnet Bearer.
+    # v2.29.x (#659) — flash is carnet-gated AND a PUT: a VW-US owner on v2.29.2
+    # got 405 METHOD_NOT_ALLOWED on the POST from HonkAndFlashService, the same
+    # wrong-method signature lock had before its PUT switch.
     c = _vwna()
     c._get_read_session_token = AsyncMock(return_value="carnet")  # type: ignore[method-assign]
     c._request = AsyncMock(return_value={})  # type: ignore[method-assign]
     asyncio.run(c.command_flash("VIN1"))
     a = c._request.call_args
-    assert a.args[0] == "POST"
+    assert a.args[0] == "PUT"
     assert a.args[1].endswith("/honkflash/v1/vehicle/uuid-1")  # not /ev/.../horn-and-lights
     assert a.kwargs["headers"]["Authorization"] == "Bearer carnet"


### PR DESCRIPTION
Follow-up to the #659 live test: a VW-US owner on v2.29.2 confirmed lock and unlock now actuate, but flash still returned 405 METHOD_NOT_ALLOWED from HonkAndFlashService, the same wrong-method signature lock had before its PUT switch. honkflash follows the lockunlock convention on con-veh, so switch it from POST to PUT. The FLASH_ONLY body stays the EU best-guess; if flash now returns a 400 instead of a 405, the body is the next thing to pin. Folds into the unreleased 2.29.3 (alongside the portal expired-request fix). Tests green.
