### PR TITLE
VW NA: confirm command outcome via correlationId poll (#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.29.4] - 2026-08-05
+
+### Fixed
+- **Volkswagen US and Canada commands report the car's real answer, not just "sent" (#659).** A remote command is accepted first and carried out a moment later, so a command the car quietly refused still looked successful here. While looking into remote start we noticed the app confirms the outcome afterwards, which we were not doing. Lock, unlock, flash and charge now wait for the car's actual result and surface a refusal as an error instead of a false success. The wait is short and best effort, so a slow or unavailable check never turns a command that worked into a reported failure.
+
 ## [2.29.3] - 2026-08-05
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -27,6 +27,7 @@ from ..exceptions import (
     CommandFailureReason,
     TokenExpiredError,
     UpstreamUnavailableError,
+    VehicleCommandError,
     classify_command_failure,
 )
 from ..auth.idk import IDKAuth
@@ -157,6 +158,65 @@ _NA_IDP_BASE = "https://identity.na.vwgroup.io"
 # uses the MYVW_ANDROID client throughout, so this would dead-end at
 # ``signin-service/v1/b680e751… → "no code"``. Kept documented, not used.
 _NA_SIGNIN_CLIENT_GUID_DORMANT = "b680e751-7e1f-4008-8ec1-3a528183d215@apps_vw-dilab_com"
+
+
+# ── v2.29.x (#659) — NA command completion poll ────────────────────────────
+# A con-veh command 2xx-accepts, then runs asynchronously against the vehicle;
+# without confirming, we report success on accept, so a command the car later
+# REJECTS looks successful (the NA twin of the EU #666 optimistic snap-back).
+# Found while digging the current myVW APK for remote-start: the app polls
+# ``/history/v1/vehicle/{id}/correlationId/{cid}/ro/`` by the command's
+# correlationId to a terminal outcome. Outcome enum (sstur/vwapp live-verified):
+# 0 REJECTED / 1 QUEUED / 2 SUCCESS / 3 FAILED. Bounded, and best-effort: raises
+# ONLY on an explicit rejected/failed — no correlationId, a poll error, an
+# unknown shape or a timeout all return silently, never worse than the old
+# fire-and-forget accept.
+_NA_CONFIRM_ATTEMPTS = 5
+_NA_CONFIRM_SLEEP_S = 2.0
+_NA_OUTCOME_REJECTED = 0
+_NA_OUTCOME_SUCCESS = 2
+_NA_OUTCOME_FAILED = 3
+
+
+def _na_correlation_id(resp: Any) -> str | None:
+    """Extract the async correlationId from a con-veh command response."""
+    if not isinstance(resp, dict):
+        return None
+    data = resp.get("data")
+    for obj in ([data] if isinstance(data, dict) else []) + [resp]:
+        for key in ("correlationId", "correlationID", "requestId", "requestID", "id"):
+            val = obj.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    return None
+
+
+def _na_command_outcome(hist: Any) -> int | None:
+    """Terminal outcome int from the ro-history response, or ``None`` when it is
+    not yet terminal / the shape is unrecognised.
+
+    sstur/vwapp: ``responseBody.eventStatus.responseOutcome``. We try that plus a
+    couple of envelope variants defensively; a bool is rejected (never an outcome)
+    and a numeric string is coerced."""
+    if not isinstance(hist, dict):
+        return None
+
+    def _dig(node: Any, *path: str) -> Any:
+        for key in path:
+            if not isinstance(node, dict):
+                return None
+            node = node.get(key)
+        return node
+
+    for prefix in ((), ("data",), ("responseBody",), ("data", "responseBody")):
+        oc = _dig(hist, *prefix, "eventStatus", "responseOutcome")
+        if isinstance(oc, bool):
+            continue
+        if isinstance(oc, int):
+            return oc
+        if isinstance(oc, str) and oc.strip().lstrip("-").isdigit():
+            return int(oc.strip())
+    return None
 
 
 class VWNAClient:
@@ -1305,7 +1365,7 @@ class VWNAClient:
             headers = dict(self._READ_HEADERS)
             headers["Authorization"] = f"Bearer {carnet}"
             try:
-                return await self._request(
+                resp = await self._request(
                     method, url, headers=headers, _carnet_auth=True, json=json
                 )
             except APIError as err:
@@ -1318,7 +1378,48 @@ class VWNAClient:
                         self._vin_to_uuid.get(vin, vin), None
                     )
                 raise
-        return await self._request(method, url, json=json)
+        else:
+            resp = await self._request(method, url, json=json)
+        # v2.29.x (#659) — confirm the async outcome (raises only on an explicit
+        # rejected/failed; best-effort otherwise). No-op when the command returned
+        # no correlationId (e.g. a sync settings PUT or the refresh trigger).
+        await self._confirm_na_command(vin, resp)
+        return resp
+
+    async def _confirm_na_command(self, vin: str, resp: Any) -> None:
+        """v2.29.x (#659) — poll the ro-history by the command's correlationId to
+        a terminal outcome and raise ``VehicleCommandError`` ONLY on an explicit
+        rejected/failed, so a command the car quietly refused stops reporting
+        success. Best-effort: no correlationId, no carnet (can't poll), a poll
+        error, an unknown shape or a timeout all return silently — never worse
+        than the old fire-and-forget accept."""
+        cid = _na_correlation_id(resp)
+        if not cid:
+            return
+        carnet = await self._get_read_session_token(vin)  # cached, no S-PIN spend
+        if not carnet:
+            return  # the ro-history is carnet-gated; stay optimistic without it
+        uuid = self._vin_to_uuid.get(vin, vin)
+        url = f"{self._base}/history/v1/vehicle/{uuid}/correlationId/{cid}/ro/"
+        for _ in range(_NA_CONFIRM_ATTEMPTS):
+            await asyncio.sleep(_NA_CONFIRM_SLEEP_S)
+            try:
+                hist = await self._read(url, carnet)
+            except APIError:
+                return  # poll unavailable → keep the accept behaviour
+            outcome = _na_command_outcome(hist)
+            if outcome is None:
+                continue  # not terminal yet / unknown → keep polling
+            if outcome in (_NA_OUTCOME_REJECTED, _NA_OUTCOME_FAILED):
+                raise VehicleCommandError(
+                    "command",
+                    "the vehicle did not carry out the command "
+                    f"(outcome {outcome})",
+                )
+            if outcome == _NA_OUTCOME_SUCCESS:
+                return
+            # queued (1) or any other non-terminal value → keep polling in-bound
+        return  # bound reached without a terminal outcome → optimistic accept
 
     async def command_lock(self, vin: str) -> None:
         """NA lock — v2.29.x (sstur/vwapp): PUT ``{lock: true}`` with the

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.29.3"
+  "version": "2.29.4"
 }

--- a/tests/test_v2294_na_command_confirmation.py
+++ b/tests/test_v2294_na_command_confirmation.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.29.x (#659) — VW NA command completion poll.
+
+Found while digging the current myVW APK for remote-start: a con-veh command
+2xx-accepts, then runs asynchronously, and the app confirms the real outcome by
+polling ``/history/v1/vehicle/{id}/correlationId/{cid}/ro/``. Without that, a
+command the car quietly REJECTS still looks successful. We now poll to a terminal
+outcome and raise ONLY on an explicit rejected/failed; everything else (no
+correlationId, no carnet, a poll error, an unknown shape, a timeout) stays
+optimistic, so it is never worse than the old fire-and-forget accept.
+
+Outcome enum (sstur/vwapp live-verified): 0 REJECTED / 1 QUEUED / 2 SUCCESS /
+3 FAILED.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api import vw_na
+from custom_components.vag_connect.cariad.api.vw_na import (
+    VWNAClient,
+    _na_command_outcome,
+    _na_correlation_id,
+)
+from custom_components.vag_connect.cariad.exceptions import (
+    APIError,
+    VehicleCommandError,
+)
+
+pytestmark = pytest.mark.ha_required
+
+_VIN = "WVWZZZ1KZAW000659"
+_UUID = "uuid-659"
+
+
+# ── pure helpers ────────────────────────────────────────────────────────────
+
+
+class TestCorrelationId:
+    def test_top_level(self):
+        assert _na_correlation_id({"correlationId": "abc123"}) == "abc123"
+
+    def test_data_envelope(self):
+        assert _na_correlation_id({"data": {"correlationId": "xy"}}) == "xy"
+
+    def test_alt_keys(self):
+        assert _na_correlation_id({"requestId": "r1"}) == "r1"
+
+    def test_absent(self):
+        assert _na_correlation_id({"foo": "bar"}) is None
+        assert _na_correlation_id("nope") is None
+
+
+class TestOutcome:
+    def test_responsebody_eventstatus(self):
+        h = {"responseBody": {"eventStatus": {"responseOutcome": 2}}}
+        assert _na_command_outcome(h) == 2
+
+    def test_data_envelope(self):
+        h = {"data": {"eventStatus": {"responseOutcome": 0}}}
+        assert _na_command_outcome(h) == 0
+
+    def test_string_int_coerced(self):
+        h = {"eventStatus": {"responseOutcome": "3"}}
+        assert _na_command_outcome(h) == 3
+
+    def test_bool_is_not_outcome(self):
+        h = {"eventStatus": {"responseOutcome": True}}
+        assert _na_command_outcome(h) is None
+
+    def test_absent_or_nonterminal(self):
+        assert _na_command_outcome({"eventStatus": {}}) is None
+        assert _na_command_outcome({}) is None
+        assert _na_command_outcome("x") is None
+
+
+# ── _confirm_na_command behaviour ───────────────────────────────────────────
+
+
+def _client() -> VWNAClient:
+    c = VWNAClient.__new__(VWNAClient)
+    c._base = "https://example.test"
+    c._vin_to_uuid = {_VIN: _UUID}
+    c._read_session_tokens = {}
+    c._get_read_session_token = AsyncMock(return_value="carnet-tok")  # type: ignore[method-assign]
+    return c
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(vw_na, "_NA_CONFIRM_SLEEP_S", 0)
+
+
+class TestConfirm:
+    @pytest.mark.asyncio
+    async def test_no_correlation_id_no_poll(self):
+        c = _client()
+        c._read = AsyncMock()  # type: ignore[method-assign]
+        await c._confirm_na_command(_VIN, {"status": "accepted"})
+        c._read.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejected_raises(self):
+        c = _client()
+        c._read = AsyncMock(  # type: ignore[method-assign]
+            return_value={"responseBody": {"eventStatus": {"responseOutcome": 0}}}
+        )
+        with pytest.raises(VehicleCommandError):
+            await c._confirm_na_command(_VIN, {"correlationId": "cid1"})
+
+    @pytest.mark.asyncio
+    async def test_failed_raises(self):
+        c = _client()
+        c._read = AsyncMock(  # type: ignore[method-assign]
+            return_value={"eventStatus": {"responseOutcome": 3}}
+        )
+        with pytest.raises(VehicleCommandError):
+            await c._confirm_na_command(_VIN, {"correlationId": "cid1"})
+
+    @pytest.mark.asyncio
+    async def test_success_returns(self):
+        c = _client()
+        c._read = AsyncMock(  # type: ignore[method-assign]
+            return_value={"eventStatus": {"responseOutcome": 2}}
+        )
+        await c._confirm_na_command(_VIN, {"correlationId": "cid1"})  # no raise
+
+    @pytest.mark.asyncio
+    async def test_queued_then_success(self):
+        c = _client()
+        c._read = AsyncMock(side_effect=[  # type: ignore[method-assign]
+            {"eventStatus": {"responseOutcome": 1}},   # queued
+            {"eventStatus": {"responseOutcome": 2}},   # success
+        ])
+        await c._confirm_na_command(_VIN, {"correlationId": "cid1"})
+        assert c._read.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_poll_error_stays_optimistic(self):
+        c = _client()
+        c._read = AsyncMock(  # type: ignore[method-assign]
+            side_effect=APIError(500, "/x", "boom")
+        )
+        await c._confirm_na_command(_VIN, {"correlationId": "cid1"})  # no raise
+
+    @pytest.mark.asyncio
+    async def test_no_carnet_no_poll(self):
+        c = _client()
+        c._get_read_session_token = AsyncMock(return_value=None)  # type: ignore[method-assign]
+        c._read = AsyncMock()  # type: ignore[method-assign]
+        await c._confirm_na_command(_VIN, {"correlationId": "cid1"})
+        c._read.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_timeout_queued_stays_optimistic(self):
+        c = _client()
+        c._read = AsyncMock(  # type: ignore[method-assign]
+            return_value={"eventStatus": {"responseOutcome": 1}}  # always queued
+        )
+        await c._confirm_na_command(_VIN, {"correlationId": "cid1"})  # no raise
+        assert c._read.await_count == vw_na._NA_CONFIRM_ATTEMPTS
+
+
+class TestCarnetCommandIntegration:
+    @pytest.mark.asyncio
+    async def test_rejected_command_raises_through_carnet_command(self):
+        c = _client()
+        c._request = AsyncMock(  # type: ignore[method-assign]
+            return_value={"correlationId": "cid1"}
+        )
+        c._read = AsyncMock(  # type: ignore[method-assign]
+            return_value={"responseBody": {"eventStatus": {"responseOutcome": 0}}}
+        )
+        with pytest.raises(VehicleCommandError):
+            await c._carnet_command("PUT", "https://example.test/x", _VIN,
+                                    json={"lock": True})


### PR DESCRIPTION
Found while digging the current myVW APK for remote-start (which turned out to be MDK secure-pairing-gated and not replicable off-device): the app confirms a command's real outcome by polling /history/v1/vehicle/{id}/correlationId/{cid}/ro/ after the 2xx accept. We were fire-and-forget, so a command the car quietly rejected still reported success. _carnet_command now polls to a terminal outcome (enum from the sstur/vwapp reference: 0 rejected / 1 queued / 2 success / 3 failed) and raises VehicleCommandError only on an explicit rejected/failed. Best-effort: no correlationId, no carnet, a poll error, an unknown shape or a timeout all stay optimistic, so it is never worse than the old accept. Mirrors vw_eu._await_bff_command. Bumps 2.29.4 (not released yet). 18 new tests, full suite green (4496).
