### PR TITLE
VW NA: open up the unseen app surface in the capture harness, drop the dead probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [2.29.4] - 2026-08-05
 
+### Changed
+- **The Volkswagen US and Canada capture script now reaches the parts of the app we have never seen (#659).** The official app calls a good deal more than we read: a vehicle-health service, public charging sessions, a message centre, an activity feed, trips, send-to-car and more. We have never seen a single response from any of them, so nothing can be built on guesses. The capture script an owner can run now probes all of them in one go, and two of its existing checks were sending truncated addresses that could only fail. Every request is a read, and the output masks your VIN, identifiers, locations, names and any message text before you paste it anywhere. Waking the car for the health check is a separate opt-in switch, off by default.
+- **Three vehicle-health probes for US and Canada were removed.** They pointed at an address that does not exist on the North American backend, sat on a client that could never run them, and were registered under a name that never matched, so nothing ever ran while the code looked as though it did.
+
 ### Fixed
 - **Volkswagen US and Canada commands report the car's real answer, not just "sent" (#659).** A remote command is accepted first and carried out a moment later, so a command the car quietly refused still looked successful here. While looking into remote start we noticed the app confirms the outcome afterwards, which we were not doing. Lock, unlock, flash and charge now wait for the car's actual result and surface a refusal as an error instead of a false success. The wait is short and best effort, so a slow or unavailable check never turns a command that worked into a reported failure.
 

--- a/custom_components/vag_connect/cariad/api/_v3_probes.py
+++ b/custom_components/vag_connect/cariad/api/_v3_probes.py
@@ -245,29 +245,28 @@ _CARIAD_BFF_PROBES: tuple[V3Probe, ...] = (
 )
 
 
-# ── VW NA (con-veh.net) ─────────────────────────────────────────────────────
-# matpoulin/CarConnectivity-connector-volkswagen-na Apache-2.0. Backend host
-# is `b-h-s.spr.us00.p.con-veh.net` (v2.20.0 N7: US + CA share it — the current
-# app has no ca00 host). We have limited
-# production parser coverage for VW NA; even a 1-endpoint probe yields
-# significant scout signal for the small but vocal US/CA user pool (#270).
-_VW_NA_PROBES: tuple[V3Probe, ...] = (
-    V3Probe(
-        name="vw_na_vehicle_health",
-        path="/v3/vehicles/{vin}/vehicleHealth",
-        notes="Combined health + warning lights for myVW US/CA",
-    ),
-    V3Probe(
-        name="vw_na_trip_data",
-        path="/v3/vehicles/{vin}/tripData/longTerm",
-        notes="Lifetime trip statistics — feature-parity with EU tripstatistics",
-    ),
-    V3Probe(
-        name="vw_na_subscription",
-        path="/v3/vehicles/{vin}/subscriptions",
-        notes="Car-Net subscription state — US-equivalent of EU pay/subscriptions",
-    ),
-)
+# ── VW NA (con-veh.net) — REMOVED in v2.29.x ────────────────────────────────
+# There were three VW-NA probes here (vehicle_health / trip_data / subscription)
+# on a ``/v3/vehicles/{vin}/…`` namespace. They were dead code in three
+# independent ways, and worse, their presence made the repo look as though NA
+# health/trip coverage was being probed when nothing ever ran:
+#
+#   1. The namespace is the CARIAD-BFF shape. An androguard sweep of the current
+#      myVW app (com.vw.carnet.release 2026.7.28-9380) shows con-veh exposes no
+#      ``/v3/vehicles/`` path at all — NA is addressed by vehicle UUID under
+#      per-service roots (``/rvs/v1/vehicle/{id}``, ``/ev/v1/vehicle/{id}/…``).
+#   2. ``VWNAClient`` does not inherit ``CariadBaseClient``, so the probe runner
+#      (base.py ``_run_v3_probe_pass``) is not even a method on it.
+#   3. They were registered under brand key ``volkswagen_na`` while the client
+#      builds its brand as ``volkswagen_us`` / ``volkswagen_ca``, so
+#      ``probes_for_brand`` would have returned nothing regardless — and
+#      ``BASE_URL_BY_BRAND`` has no NA entry, with the fallback reading
+#      ``self._BASE`` where vw_na.py defines ``self._base``.
+#
+# NA field discovery runs through ``scripts/vwna_capture.py`` instead: NA reads
+# are S-PIN/carnet-authorised, which the generic probe runner cannot do, so a
+# cooperating owner running the capture script is the honest path. Do not
+# re-add speculative NA probes here without a captured response to ground them.
 
 
 # ── Porsche (api.ppa.porsche.com) ───────────────────────────────────────────
@@ -304,7 +303,9 @@ PROBES_BY_BRAND: dict[str, tuple[V3Probe, ...]] = {
     "skoda":         _MYSMOB_PROBES,
     "volkswagen":    _CARIAD_BFF_PROBES,
     "audi":          _CARIAD_BFF_PROBES,
-    "volkswagen_na": _VW_NA_PROBES,
+    # No VW-NA entry: NA discovery runs through scripts/vwna_capture.py (the
+    # reads are S-PIN/carnet-authorised, which this runner cannot do). See the
+    # VW NA block above for why the old probes could never fire.
     "porsche":       _PORSCHE_PROBES,
 }
 
@@ -340,8 +341,8 @@ def base_url_for_brand(brand_name: str) -> str | None:
 #   OLA (SEAT+CUPRA): 10
 #   mysmob (Skoda):    8
 #   CARIAD-BFF (VW+Audi): 10
-#   VW NA:             3
+#   VW NA:             0 (removed in v2.29.x — see the VW NA block above)
 #   Porsche:           3
-# = 34 distinct endpoints. Per-VIN per-pass at 1×/h = 34 calls/h max across
+# = 31 distinct endpoints. Per-VIN per-pass at 1×/h = 31 calls/h max across
 # a multi-brand HA install. Per-user typical scope: 8-10 calls/h. Well under
 # any documented rate-limit for the targeted backends.

--- a/scripts/vwna_capture.py
+++ b/scripts/vwna_capture.py
@@ -14,9 +14,17 @@ What it settles:
        user-summary route embeds climateStatusInd?
   N6 — does /rrs/v1/privileges... still return coverage, and what shape does
        /account/v1/coverages expose for subscription.active / expiresAt?
+  v2.29.x hidden surface — vehicle health, the dedicated location read, the
+       remote-operation activity feed, message center, public charging
+       sessions, trips, send-to-car, ToS status, in-car wifi, phone-key
+       summary and the capability check. These are endpoints the official app
+       calls and we have never seen a response from; each is a candidate for
+       data we cannot offer today.
 
-Read-only. No commands are sent. Password read via a hidden getpass prompt —
-never echoed, never stored.
+Read-only. Every request is a GET and nothing changes state: no commands, no
+purchases, no pairing changes, no accepting terms, no starting a charging
+session (see the safety block next to the probes). Password read via a hidden
+getpass prompt — never echoed, never stored.
 
 Usage (PowerShell):
     py scripts/vwna_capture.py --vin 3VW... --email you@example.com --country us
@@ -136,15 +144,115 @@ async def _run(email: str, password: str, mfa: str | None, vin: str,
         await _probe(client, "rvs status",
                      f"{B}/rvs/v1/vehicle/{uuid}", carnet, True)
         # N6 candidates (subscription/coverage — plain account auth)
+        # v2.29.x — the coverages/VWCare URLs were TRUNCATED (bare
+        # /account/v1/coverages and /account/v1/VWCare), so they could only ever
+        # 404 and the N6 question this script exists to answer stayed
+        # unanswerable. The path templates below are verbatim from the current
+        # myVW app (androguard sweep of com.vw.carnet.release 2026.7.28-9380).
         await _probe(client, "N6 rrs privileges",
                      f"{B}/rrs/v1/privileges/user/{uid}/vehicle/{uuid}", None, False)
         await _probe(client, "N6 account/coverages",
-                     f"{B}/account/v1/coverages", None, False)
+                     f"{B}/account/v1/coverages/vehicle/{uuid}", None, False)
         await _probe(client, "N6 account/VWCare",
-                     f"{B}/account/v1/VWCare", None, False)
+                     f"{B}/account/v1/VWCare/user/{uid}/vehicle/{uuid}/summary",
+                     None, False)
+
+        # ── v2.29.x — hidden-surface probes ──────────────────────────────────
+        # Path templates verbatim from the current myVW app (androguard sweep of
+        # com.vw.carnet.release 2026.7.28-9380). These are endpoints the official
+        # app calls that we have NEVER seen a response from; each one is a
+        # candidate for data we cannot offer today (vehicle health, charging
+        # sessions, notifications, trips).
+        #
+        # SAFETY — every probe below is a plain GET and nothing here changes
+        # state. Deliberately NOT probed, and they must never be added:
+        #   * /account/v2/enrollment/toses (POST)  — POSTing would accept a legal
+        #     agreement on the owner's behalf. The GET status read below is fine.
+        #   * /estore/*                            — carts, payment, wallets.
+        #   * /pair/*, /mdk/*/pairing/password|reset — revokes the owner's phone
+        #     key / vehicle pairing.
+        #   * /cds/wifi/*/reset                    — rotates the hotspot creds.
+        #   * /device/v1/*/analytic, /devicestatistics/* — sends telemetry TO VW.
+        #   * /poi/*/session/start|stop            — starts/stops a PAID public
+        #     charging session on the owner's account.
+        # A 405 here is a useful answer too: it tells us the verb, exactly how
+        # the flash 405 told us honkflash wants PUT.
+        print("\n[5/5] hidden-surface probes (masked, read-only):")
+
+        # Vehicle health. NOTE: the app inventory only exposes a /refresh
+        # TRIGGER for this service and no health READ path, so we probe the
+        # trigger (expect 405/404 if it is POST-only) and diff the normal status
+        # read around it rather than assuming a read exists.
+        await _probe(client, "health listener (trigger; verb probe)",
+                     f"{B}/vehiclehealthlistener/v2/vehicle/{uuid}/refresh",
+                     carnet, True)
+        await _probe(client, "rvs status (post-health diff)",
+                     f"{B}/rvs/v1/vehicle/{uuid}", carnet, True)
+
+        # Dedicated location read (we only parse GPS out of the rvs aggregate).
+        await _probe(client, "location (dedicated)",
+                     f"{B}/rvs/v1/location/vehicle/{uuid}", carnet, True)
+
+        # Remote-operation activity feed (sibling of the correlationId history
+        # we already use for command confirmation).
+        await _probe(client, "activity feed",
+                     f"{B}/history/activity/v1/vehicle/{uuid}", carnet, True)
+
+        # Message center. Bodies may contain personal text — _shape() masks all
+        # free-text values, only field names/types/enums are printed.
+        await _probe(client, "messagecenter unread count",
+                     f"{B}/messagecenter/v2/user/{uid}/vehicle/{uuid}/unRead/count",
+                     carnet, True)
+        await _probe(client, "messagecenter inbox",
+                     f"{B}/messagecenter/v2/user/{uid}/vehicle/{uuid}", carnet, True)
+        await _probe(client, "messagecenter categories",
+                     f"{B}/messagecenter/v2/user/{uid}/vehicle/{uuid}/categories",
+                     carnet, True)
+
+        # Public charging sessions (history + any session in flight).
+        await _probe(client, "charging sessions (history)",
+                     f"{B}/poi/v1/history/vehicle/{uuid}/user/{uid}/sessions",
+                     carnet, True)
+        await _probe(client, "charging session (active)",
+                     f"{B}/poi/v1/vehicle/{uuid}/user/{uid}/session/active",
+                     carnet, True)
+
+        # Trips. Likely planned NAV routes rather than driven trips — the probe
+        # settles which, so we don't promise a trip sensor we cannot build.
+        await _probe(client, "trip v1", f"{B}/poi/v1/vehicle/{uuid}/trip",
+                     carnet, True)
+        await _probe(client, "trip v2", f"{B}/poi/v2/vehicle/{uuid}/trip",
+                     carnet, True)
+
+        # Send-to-car destination resource (GET only; we never POST a
+        # destination from a capture run).
+        await _probe(client, "destination (send-to-car resource)",
+                     f"{B}/poi/v1/vehicle/{uuid}/destination", carnet, True)
+
+        # Terms-of-service enrolment STATUS. GET ONLY — see the safety note.
+        await _probe(client, "enrollment toses (STATUS GET only)",
+                     f"{B}/account/v2/enrollment/toses/user/{uid}/vehicle/{uuid}",
+                     None, False)
+
+        # In-car wifi hotspot state (status only, never /reset).
+        await _probe(client, "wifi connection status",
+                     f"{B}/cds/wifi/v1/wifiConnection/vehicle/{uuid}/status",
+                     carnet, True)
+
+        # Mobile-device-key summary (read only, never pairing/password|reset).
+        # Also tells us whether this account has a paired phone key at all.
+        await _probe(client, "mdk summary",
+                     f"{B}/mdk/v1/vehicle/{uuid}/summary", carnet, True)
+
+        # Capability check. Its siblings (resolveAmbiguity / searchDatastore /
+        # provideFeedback) suggest a VOICE-assistant service rather than an
+        # entitlement source; this probe settles it before we would ever gate a
+        # button on it.
+        await _probe(client, "vas checkCapability",
+                     f"{B}/vas/v1/checkCapability/vehicle/{uuid}", carnet, True)
 
     print("\n" + "-" * 68)
-    print("Paste the whole [4/4] block. It's masked (VIN/text hidden, only field")
+    print("Paste the whole [4/4] AND [5/5] blocks. They're masked (VIN/text hidden, only field")
     print("names + types + enum values shown). We ground N5/N6 from it.")
     return 0
 

--- a/scripts/vwna_capture.py
+++ b/scripts/vwna_capture.py
@@ -51,18 +51,83 @@ from custom_components.vag_connect.cariad.api.vw_na import VWNAClient  # noqa: E
 
 _ENUM = re.compile(r"^[A-Z][A-Z0-9_.:+-]{1,34}$")
 _VINISH = re.compile(r"^[A-HJ-NPR-Z0-9]{11,17}$")
+_JWTISH = re.compile(r"^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+$")
+_ISO = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}")
+_ERRCODE = re.compile(r"\b[A-Z][A-Z0-9_]{2,39}\b")
+
+# v2.29.x — key-name-driven masking. The value-shape rules below (_ENUM, the
+# <=3-char passthrough) decide on what a value LOOKS like, and a short all-caps
+# personal value looks exactly like an enum: a plate, a city, a first name and a
+# dealer code would all print verbatim. That was harmless while this script only
+# read ev/rvs telemetry; it is NOT harmless for the message-center, charging
+# session, trip and address payloads the hidden-surface pass added. So these key
+# families are masked regardless of what their value looks like.
+_KEY_ID = (
+    "userid", "user_id", "vehicleid", "vehicle_id", "uuid", "customerid",
+    "accountid", "deviceid", "pairingid", "sessionid", "tripid",
+    "notificationid", "cpoid", "locationid", "walletid", "cartid", "ptpref",
+    "correlationid", "requestid", "vin",
+)
+# Long, unambiguous GPS key fragments (substring match is safe).
+_KEY_GPS = (
+    "latitude", "longitude", "heading", "altitude", "accuracy", "position",
+    "coordinates",
+)
+# Short GPS keys are matched EXACTLY: "lat" as a substring also hits
+# "licensePlate" and "translate", which are not coordinates.
+_KEY_GPS_EXACT = ("lat", "lon", "lng", "geo", "coord")
+_KEY_SECRET = (
+    "token", "auth", "bearer", "secret", "pin", "hash", "signature",
+    "password", "credential", "challenge", "roken", "payload",
+)
+_KEY_PERSONAL = (
+    "address", "street", "city", "postalcode", "zip", "name", "firstname",
+    "lastname", "nickname", "email", "phone", "licenseplate", "plate",
+    "dealername", "operatorname", "subject", "body", "message", "title",
+    "description", "text",
+)
+# Two-letter country codes are a genuinely useful enum and carry no PII.
+_KEY_ALLOW = ("country", "countrycode", "locale", "unit", "units")
 
 
-def _shape(o, depth: int = 0):
-    """Structure + types + enum values only — free text / VIN / PII masked."""
+def _mask_for_key(key: str) -> str | None:
+    """Return a fixed placeholder when a KEY name alone makes its value unsafe."""
+    k = key.lower().replace("-", "").replace("_", "")
+    if any(a in k for a in _KEY_ALLOW):
+        return None
+    if any(s in k for s in _KEY_SECRET):
+        return "<redacted>"
+    if any(i == k or k.endswith(i) for i in _KEY_ID):
+        return "<id>"
+    # Personal before GPS: a plate/address key must not be mislabelled by a
+    # short coordinate fragment (both are masked either way, but the label
+    # should be honest).
+    if any(p in k for p in _KEY_PERSONAL):
+        return "<personal>"
+    if any(g in k for g in _KEY_GPS) or k in _KEY_GPS_EXACT:
+        return "<gps>"
+    return None
+
+
+def _shape(o, depth: int = 0, strict: bool = False):
+    """Structure + types + enum values only — free text / VIN / PII masked.
+
+    ``strict=True`` additionally drops the enum and short-string passthroughs, so
+    every leaf becomes a type placeholder. Used for payloads that can carry
+    arbitrary personal prose (message center, POI/charging locations).
+    """
     if depth > 8:
         return "…"
     if isinstance(o, dict):
-        return {k: _shape(v, depth + 1) for k, v in list(o.items())[:60]}
+        out = {}
+        for k, v in list(o.items())[:60]:
+            forced = _mask_for_key(str(k))
+            out[k] = forced if forced is not None else _shape(v, depth + 1, strict)
+        return out
     if isinstance(o, list):
         if not o:
             return []
-        head = _shape(o[0], depth + 1)
+        head = _shape(o[0], depth + 1, strict)
         return [head, f"…(+{len(o) - 1})"] if len(o) > 1 else [head]
     if isinstance(o, bool):
         return o
@@ -71,8 +136,14 @@ def _shape(o, depth: int = 0):
     if o is None:
         return None
     if isinstance(o, str):
+        if _JWTISH.match(o):
+            return "<redacted>"
         if _VINISH.match(o):
             return "<VIN>"
+        if _ISO.match(o):
+            return "<iso8601>"             # "it is a timestamp", not when
+        if strict:
+            return f"<str:{len(o)}>"
         if _ENUM.match(o):
             return o                       # enum value — safe + the useful bit
         if len(o) <= 3:
@@ -81,25 +152,52 @@ def _shape(o, depth: int = 0):
     return f"<{type(o).__name__}>"
 
 
+def _safe_error_line(exc: Exception) -> str:
+    """Status plus error CODES only — never free-form body text.
+
+    v2.29.x: this used to print ``str(exc.body)[:120]`` raw, and a con-veh error
+    body can carry the VIN, the vehicle UUID or the userId. The status code is
+    the diagnostic value; the body prose is pure risk. We shape a JSON body
+    through the same masker and, for a non-JSON body, emit only its length plus
+    any SCREAMING_CASE error codes (USER_NOT_AUTHORIZED, METHOD_NOT_ALLOWED …).
+    """
+    status = getattr(exc, "status", None)
+    raw = str(getattr(exc, "body", "") or "")
+    if not raw:
+        return f"status={status}"
+    try:
+        shaped = _shape(json.loads(raw))
+        return f"status={status} body={json.dumps(shaped, ensure_ascii=False)[:300]}"
+    except Exception:  # noqa: BLE001
+        # A VIN is all-caps alphanumeric and matches an error-code pattern, so
+        # require an underscore (USER_NOT_AUTHORIZED, METHOD_NOT_ALLOWED …) and
+        # reject anything VIN-shaped outright.
+        codes = sorted({
+            c for c in _ERRCODE.findall(raw)
+            if "_" in c and not _VINISH.match(c)
+        })[:6]
+        return f"status={status} len={len(raw)} codes={codes}"
+
+
 async def _probe(client: VWNAClient, label: str, url: str,
-                 carnet_token: str | None, use_read: bool) -> None:
+                 carnet_token: str | None, use_read: bool,
+                 strict: bool = False) -> None:
     try:
         if use_read:
             data = await client._read(url, carnet_token)
         else:
             data = await client._get(url)
         print(f"\n  === {label} → OK ===")
-        print("  " + json.dumps(_shape(data), indent=2, ensure_ascii=False)[:2400].replace("\n", "\n  "))
+        shaped = json.dumps(_shape(data, strict=strict), indent=2, ensure_ascii=False)
+        print("  " + shaped[:2400].replace("\n", "\n  "))
     except Exception as exc:  # noqa: BLE001
         # An APIError carries .status; show it so a 404 (dead) vs 403/200 is clear.
-        status = getattr(exc, "status", None)
-        body = str(getattr(exc, "body", "") or "")[:120]
         print(f"\n  === {label} → {type(exc).__name__} "
-              f"status={status} {body} ===")
+              f"{_safe_error_line(exc)} ===")
 
 
 async def _run(email: str, password: str, mfa: str | None, vin: str,
-               country: str) -> int:
+               country: str, probe_health: bool = False) -> int:
     vin = vin.strip().upper()
     print("\n" + "=" * 68)
     print(f"  VW-NA read-shape capture — VIN ...{vin[-6:]}  country={country}")
@@ -183,20 +281,27 @@ async def _run(email: str, password: str, mfa: str | None, vin: str,
         # TRIGGER for this service and no health READ path, so we probe the
         # trigger (expect 405/404 if it is POST-only) and diff the normal status
         # read around it rather than assuming a read exists.
-        await _probe(client, "health listener (trigger; verb probe)",
-                     f"{B}/vehiclehealthlistener/v2/vehicle/{uuid}/refresh",
-                     carnet, True)
-        await _probe(client, "rvs status (post-health diff)",
-                     f"{B}/rvs/v1/vehicle/{uuid}", carnet, True)
+        # OPT-IN: a refresh trigger wakes the car and spends modem budget. It is
+        # not destructive (changes no setting, sends VW nothing about us), but it
+        # is a mutation, so it stays behind --probe-health and runs at most once.
+        if probe_health:
+            await _probe(client, "health listener (trigger; verb probe)",
+                         f"{B}/vehiclehealthlistener/v2/vehicle/{uuid}/refresh",
+                         carnet, True)
+            await _probe(client, "rvs status (post-health diff)",
+                         f"{B}/rvs/v1/vehicle/{uuid}", carnet, True)
+        else:
+            print("\n  === health listener → SKIPPED (pass --probe-health to "
+                  "wake the car once and diff the status read) ===")
 
         # Dedicated location read (we only parse GPS out of the rvs aggregate).
         await _probe(client, "location (dedicated)",
-                     f"{B}/rvs/v1/location/vehicle/{uuid}", carnet, True)
+                     f"{B}/rvs/v1/location/vehicle/{uuid}", carnet, True, strict=True)
 
         # Remote-operation activity feed (sibling of the correlationId history
         # we already use for command confirmation).
         await _probe(client, "activity feed",
-                     f"{B}/history/activity/v1/vehicle/{uuid}", carnet, True)
+                     f"{B}/history/activity/v1/vehicle/{uuid}", carnet, True, strict=True)
 
         # Message center. Bodies may contain personal text — _shape() masks all
         # free-text values, only field names/types/enums are printed.
@@ -204,7 +309,7 @@ async def _run(email: str, password: str, mfa: str | None, vin: str,
                      f"{B}/messagecenter/v2/user/{uid}/vehicle/{uuid}/unRead/count",
                      carnet, True)
         await _probe(client, "messagecenter inbox",
-                     f"{B}/messagecenter/v2/user/{uid}/vehicle/{uuid}", carnet, True)
+                     f"{B}/messagecenter/v2/user/{uid}/vehicle/{uuid}", carnet, True, strict=True)
         await _probe(client, "messagecenter categories",
                      f"{B}/messagecenter/v2/user/{uid}/vehicle/{uuid}/categories",
                      carnet, True)
@@ -212,22 +317,22 @@ async def _run(email: str, password: str, mfa: str | None, vin: str,
         # Public charging sessions (history + any session in flight).
         await _probe(client, "charging sessions (history)",
                      f"{B}/poi/v1/history/vehicle/{uuid}/user/{uid}/sessions",
-                     carnet, True)
+                     carnet, True, strict=True)
         await _probe(client, "charging session (active)",
                      f"{B}/poi/v1/vehicle/{uuid}/user/{uid}/session/active",
-                     carnet, True)
+                     carnet, True, strict=True)
 
         # Trips. Likely planned NAV routes rather than driven trips — the probe
         # settles which, so we don't promise a trip sensor we cannot build.
         await _probe(client, "trip v1", f"{B}/poi/v1/vehicle/{uuid}/trip",
-                     carnet, True)
+                     carnet, True, strict=True)
         await _probe(client, "trip v2", f"{B}/poi/v2/vehicle/{uuid}/trip",
-                     carnet, True)
+                     carnet, True, strict=True)
 
         # Send-to-car destination resource (GET only; we never POST a
         # destination from a capture run).
         await _probe(client, "destination (send-to-car resource)",
-                     f"{B}/poi/v1/vehicle/{uuid}/destination", carnet, True)
+                     f"{B}/poi/v1/vehicle/{uuid}/destination", carnet, True, strict=True)
 
         # Terms-of-service enrolment STATUS. GET ONLY — see the safety note.
         await _probe(client, "enrollment toses (STATUS GET only)",
@@ -242,7 +347,7 @@ async def _run(email: str, password: str, mfa: str | None, vin: str,
         # Mobile-device-key summary (read only, never pairing/password|reset).
         # Also tells us whether this account has a paired phone key at all.
         await _probe(client, "mdk summary",
-                     f"{B}/mdk/v1/vehicle/{uuid}/summary", carnet, True)
+                     f"{B}/mdk/v1/vehicle/{uuid}/summary", carnet, True, strict=True)
 
         # Capability check. Its siblings (resolveAmbiguity / searchDatastore /
         # provideFeedback) suggest a VOICE-assistant service rather than an
@@ -263,6 +368,13 @@ def main() -> int:
     p.add_argument("--email", help="myVW account email (prompted if omitted).")
     p.add_argument("--country", default="us", choices=["us", "ca"], help="us or ca.")
     p.add_argument("--mfa", help="2FA code, if your account has it.")
+    p.add_argument(
+        "--probe-health", action="store_true",
+        help="Also trigger the vehicle-health refresh once and diff the status "
+             "read around it. This WAKES the car and spends a little modem "
+             "budget; it changes no setting and sends VW nothing about you. "
+             "Off by default.",
+    )
     args = p.parse_args()
     email = args.email or input("myVW email: ").strip()
     vin = args.vin or input("VIN: ").strip()
@@ -274,7 +386,8 @@ def main() -> int:
     if not password:
         print("ERROR: password required", file=sys.stderr)
         return 1
-    return asyncio.run(_run(email, password, args.mfa, vin, args.country))
+    return asyncio.run(_run(email, password, args.mfa, vin, args.country,
+                            args.probe_health))
 
 
 if __name__ == "__main__":

--- a/tests/test_v2294_capture_masking.py
+++ b/tests/test_v2294_capture_masking.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v2.29.x — scripts/vwna_capture.py masking guarantees.
+
+The capture script asks a real owner to paste its output into a public issue, so
+the masking is a privacy promise, not a nicety. The original value-shape rules
+decided on what a value LOOKED like, which was fine while the script only read
+ev/rvs telemetry but not once the hidden-surface pass added message-center,
+charging-session, trip and address payloads: a plate (ZH123456), a city
+(ZURICH) or a first name (PRASH) looks exactly like an enum and printed
+verbatim. Error bodies were printed raw and a con-veh error body can carry the
+VIN, the vehicle UUID or the userId.
+
+These tests pin the hardened behaviour so a future probe cannot quietly
+reintroduce a leak.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "vwna_capture.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("vwna_capture", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cap = _load()
+
+
+class TestKeyDrivenMasking:
+    """A key name alone can make its value unsafe, whatever the value looks like."""
+
+    def test_ids_masked(self):
+        out = cap._shape({"userId": "PRASH123", "vehicleId": "abc", "sessionId": "S1"})
+        assert out == {"userId": "<id>", "vehicleId": "<id>", "sessionId": "<id>"}
+
+    def test_gps_masked_even_as_string(self):
+        out = cap._shape({"latitude": "47.37", "longitude": 8.54, "heading": "N"})
+        assert out == {"latitude": "<gps>", "longitude": "<gps>", "heading": "<gps>"}
+
+    def test_secrets_redacted(self):
+        out = cap._shape({"idToken": "x", "spinHash": "y", "encryptedSignature": "z"})
+        assert out == {
+            "idToken": "<redacted>",
+            "spinHash": "<redacted>",
+            "encryptedSignature": "<redacted>",
+        }
+
+    def test_personal_masked(self):
+        out = cap._shape({
+            "city": "ZURICH", "licensePlate": "ZH123456", "firstName": "PRASH",
+            "subject": "Your alarm triggered", "operatorName": "IONITY",
+        })
+        assert set(out.values()) == {"<personal>"}
+
+    def test_country_and_unit_kept(self):
+        # a 2-char country code is a useful enum and carries no PII
+        out = cap._shape({"country": "US", "unit": "KM", "locale": "en-US"})
+        assert out["country"] == "US"
+        assert out["unit"] == "KM"
+
+
+class TestValueMasking:
+    def test_vin_masked(self):
+        assert cap._shape("WVWZZZ1KZAW000503") == "<VIN>"
+
+    def test_jwt_redacted(self):
+        jwt = "eyJhbGciOiJub25l.eyJleHAiOjE3MDAwMDAwMDB9.sig"
+        assert cap._shape(jwt) == "<redacted>"
+
+    def test_timestamp_classified_not_revealed(self):
+        assert cap._shape("2026-08-05T14:30:00Z") == "<iso8601>"
+
+    def test_numbers_masked(self):
+        assert cap._shape({"odometer": 123456}) == {"odometer": "<num>"}
+
+    def test_enum_kept_in_normal_mode(self):
+        assert cap._shape("USER_NOT_AUTHORIZED") == "USER_NOT_AUTHORIZED"
+
+
+class TestStrictMode:
+    """Payloads that can carry arbitrary personal prose get no passthroughs."""
+
+    def test_strict_drops_enum_passthrough(self):
+        assert cap._shape("ZURICH", strict=True) == "<str:6>"
+        assert cap._shape("PRASH", strict=True) == "<str:5>"
+
+    def test_strict_drops_short_string_passthrough(self):
+        assert cap._shape("ZH", strict=True) == "<str:2>"
+
+    def test_strict_keeps_structure_and_types(self):
+        out = cap._shape({"a": {"b": ["TEXT", "TEXT2"]}, "n": 1, "ok": True},
+                         strict=True)
+        assert out == {"a": {"b": ["<str:4>", "…(+1)"]}, "n": "<num>", "ok": True}
+
+
+class TestErrorBodyNeverRaw:
+    """The single worst leak: error bodies were printed verbatim."""
+
+    class _Err(Exception):
+        def __init__(self, status, body):
+            super().__init__("x")
+            self.status = status
+            self.body = body
+
+    def test_json_body_is_shaped_not_raw(self):
+        body = json.dumps({"error": {"errorCode": "USER_NOT_AUTHORIZED",
+                                     "vin": "WVWZZZ1KZAW000503",
+                                     "userId": "1234-5678"}})
+        line = cap._safe_error_line(self._Err(403, body))
+        assert "WVWZZZ1KZAW000503" not in line
+        assert "1234-5678" not in line
+        assert "USER_NOT_AUTHORIZED" in line   # the diagnostic value survives
+        assert "status=403" in line
+
+    def test_non_json_body_yields_codes_and_length_only(self):
+        body = "Forbidden for VIN WVWZZZ1KZAW000503 user prash@example.com"
+        line = cap._safe_error_line(self._Err(403, body))
+        assert "WVWZZZ1KZAW000503" not in line
+        assert "prash@example.com" not in line
+        assert "len=" in line
+
+    def test_empty_body(self):
+        assert cap._safe_error_line(self._Err(404, "")) == "status=404"
+
+
+class TestProbeSafety:
+    """The script must stay read-only, and the mutating trigger opt-in."""
+
+    def test_no_denied_endpoint_is_probed(self):
+        src = _SCRIPT.read_text(encoding="utf-8")
+        # everything after the safety block: never probe these
+        denied = (
+            "/estore/", "/pair/v1/", "pairing/password", "pairing/reset",
+            "wifiConnection/vehicle/{uuid}/reset", "/device/v1/event/analytic",
+            "/devicestatistics/", "session/start", "/stop",
+            "garage/adjust", "valetMode", "/notification/{", "provideFeedback",
+            "documents/ingest",
+        )
+        # only look at actual probe call sites, not the safety comment block
+        probe_lines = [ln for ln in src.splitlines()
+                       if "_probe(client," in ln or ('f"{B}/' in ln and "await" not in ln)]
+        joined = "\n".join(probe_lines)
+        for bad in denied:
+            assert bad not in joined, f"probe hits denied endpoint {bad!r}"
+
+    def test_health_trigger_is_opt_in(self):
+        src = _SCRIPT.read_text(encoding="utf-8")
+        assert "--probe-health" in src
+        assert "if probe_health:" in src
+        # and it defaults to off
+        assert "probe_health: bool = False" in src
+
+    def test_tos_is_get_status_only_never_post(self):
+        src = _SCRIPT.read_text(encoding="utf-8")
+        assert "enrollment/toses" in src
+        # the script has no POST helper at all
+        assert "_post(" not in src
+
+
+@pytest.mark.parametrize("probe_label", [
+    "messagecenter inbox", "charging sessions (history)",
+    "charging session (active)", "trip v1", "trip v2",
+    "destination (send-to-car resource)", "mdk summary",
+    "location (dedicated)", "activity feed",
+])
+def test_pii_bearing_probes_use_strict(probe_label: str):
+    """Probes whose payload can carry prose/addresses must run strict."""
+    src = _SCRIPT.read_text(encoding="utf-8")
+    idx = src.index(f'"{probe_label}"')
+    # the strict flag must appear within the same call (next ~200 chars)
+    assert "strict=True" in src[idx:idx + 220], (
+        f"{probe_label} must be captured with strict=True"
+    )

--- a/tests/test_v252_v3_probes.py
+++ b/tests/test_v252_v3_probes.py
@@ -18,17 +18,37 @@ import pytest
 class TestProbeInventory:
     """Per-brand probe lists must be populated, well-formed and unique."""
 
-    def test_all_seven_brands_have_probes(self) -> None:
+    def test_all_probe_brands_have_probes(self) -> None:
         from custom_components.vag_connect.cariad.api._v3_probes import (
             PROBES_BY_BRAND,
         )
         expected = {
-            "seat", "cupra", "skoda", "volkswagen", "audi",
-            "volkswagen_na", "porsche",
+            "seat", "cupra", "skoda", "volkswagen", "audi", "porsche",
         }
         assert expected.issubset(PROBES_BY_BRAND.keys())
         for brand, probes in PROBES_BY_BRAND.items():
             assert probes, f"Brand {brand!r} has empty probe list"
+
+    def test_vw_na_has_no_probes(self) -> None:
+        """v2.29.x — VW NA is deliberately absent from the probe registry.
+
+        The old ``volkswagen_na`` entry was dead three ways over: its
+        ``/v3/vehicles/{vin}/…`` namespace does not exist on con-veh (androguard
+        sweep of myVW 2026.7.28-9380), ``VWNAClient`` does not inherit
+        ``CariadBaseClient`` so the probe runner is not even a method on it, and
+        the client's brand is ``volkswagen_us`` / ``volkswagen_ca`` so the
+        registry key could never match. It made the repo look as though NA health
+        and trip data were being probed while nothing ever ran. NA discovery goes
+        through ``scripts/vwna_capture.py`` (the reads are S-PIN/carnet
+        authorised, which the generic runner cannot do). Do not re-add
+        speculative NA probes here without a captured response to ground them.
+        """
+        from custom_components.vag_connect.cariad.api._v3_probes import (
+            PROBES_BY_BRAND, probes_for_brand,
+        )
+        assert "volkswagen_na" not in PROBES_BY_BRAND
+        for brand in ("volkswagen_na", "volkswagen_us", "volkswagen_ca"):
+            assert probes_for_brand(brand) == ()
 
     def test_probe_names_unique_within_brand(self) -> None:
         from custom_components.vag_connect.cariad.api._v3_probes import (
@@ -65,9 +85,9 @@ class TestProbeInventory:
         from custom_components.vag_connect.cariad.api._v3_probes import (
             BASE_URL_BY_BRAND, PROBES_BY_BRAND,
         )
-        # VW NA intentionally omitted from BASE_URL_BY_BRAND (regional).
-        non_regional = {b for b in PROBES_BY_BRAND if b != "volkswagen_na"}
-        for brand in non_regional:
+        # v2.29.x — every brand that still has probes must have a base URL.
+        # (VW NA used to be the exception; its probes are gone entirely now.)
+        for brand in PROBES_BY_BRAND:
             assert brand in BASE_URL_BY_BRAND, (
                 f"Brand {brand!r} has probes but no base URL"
             )


### PR DESCRIPTION
Opens up the parts of the VW North America surface we have never seen, and removes code that pretended to cover them.

The official myVW app calls a good deal more than we read. An androguard sweep of com.vw.carnet.release 2026.7.28-9380 shows a vehicle-health service, public charging sessions with history, a message centre, a remote-operation activity feed, trips, send-to-car, a dedicated location read, in-car wifi state, a phone-key summary and a capability check. We have never seen a single response from any of them, so nothing can be built on top without guessing. scripts/vwna_capture.py now probes all of them in one run, and two of its existing probes were sending truncated URLs (bare /account/v1/coverages and /account/v1/VWCare) that could only 404, which is why the question that script exists to answer stayed unanswered.

Safety and privacy, since a real owner runs this and pastes the output publicly:
- Every probe is a GET. An explicit block lists what must never be probed and why: accepting terms of service on the owner's behalf, the estore, pairing writes that revoke a phone key, the wifi credential reset, telemetry sent to VW, and starting or stopping a paid charging session.
- The masking had to be hardened first. It decided on what a value looked like, so a plate, a city or a first name looked exactly like an enum and printed verbatim. That was harmless for ev/rvs telemetry and not at all harmless for message-centre prose and charging addresses. Masking is now driven by key name (ids, coordinates, secrets, personal fields) regardless of the value, with a strict mode for payloads that can carry arbitrary text.
- The worst leak is fixed: error bodies were printed raw, and a con-veh error body can carry the VIN, the vehicle UUID or the userId. JSON bodies go through the same masker; a non-JSON body yields only its length and real error codes. A VIN matches the error-code pattern, so codes must contain an underscore and VIN-shaped tokens are rejected.
- The one mutating probe (the vehicle-health refresh, which wakes the car) sits behind an explicit opt-in flag, off by default.

Two bugs the new tests caught in the first cut of the hardening: "lat" as a substring also matches licensePlate, and the error-code extractor leaked the VIN.

Also removes the three VW-NA entries from the v3 probe registry. They were dead three ways over: a /v3/vehicles/ namespace con-veh does not expose, a client that does not inherit the class the probe runner lives on, and a registry key the client's brand never matches. They made the repo look as though NA health and trip data were covered while nothing ever ran. The reasoning stays in place so they do not come back ungrounded.

28 new masking tests. Full suite green (4525).
