### PR TITLE
fix(vw-na): route Canada through its own ca00 host + CA client (#990/#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.29.5] - 2026-08-06
+
+### Fixed
+- **Volkswagen Canada login that failed with a server error now works (#990, #659).** Canadian accounts were being routed to the US login server with the US app client, and Volkswagen answered that mismatch with a server error at the password step even though the official app worked fine. Canada now logs in on its own server with its own app client, exactly the way the US already does. Volkswagen US is untouched. Two Canadian testers hit this, so if you are on a Canadian account please update and try again.
+
 ## [2.29.4] - 2026-08-05
 
 ### Changed

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -113,17 +113,17 @@ _COUNTRY_BASES: dict[str, str] = {
     "ca": "https://b-h-s.spr.ca00.p.con-veh.net",
 }
 
-# v2.26.1 (#990/#915) — OIDC authorize/token PROXY host for every NA country.
-# vrouleau confirmed the myVW app signs in on identity.na.vwgroup.io, and that
-# v2.25 (which sent every NA country through us00) authenticated fine; only the
-# vehicle-DATA host is per-country. The Canadian data host ca00 does NOT front a
-# working /oidc/v1/authorize (it returns HTTP 400 before any credentials are
-# submitted), so the auth flow must stay on the us00 con-veh proxy that 302s to
-# the NA IDP for ALL NA countries, while api_base (the vehicle reads/commands)
-# stays per-country from _COUNTRY_BASES above. This is the v2.26.0 regression:
-# routing CA auth to ca00 moved the failure from a late 500 (v2.25, us00 data
-# host wrong for a CA car) to an early 400 (ca00 has no authorize proxy).
-_NA_OIDC_PROXY_BASE = _COUNTRY_BASES["us"]
+# v2.29.x (#915/#990/#659) — the OIDC authorize/token proxy is PER-COUNTRY, on
+# each country's OWN con-veh host, mirroring US. A live probe settled the old
+# open question: ca00 /oidc/v1/authorize returns 302 to the CA sign-in (client
+# b43c9f82, ui_locales=en-CA) with the CA client 69eb3c39 — and 400 with the US
+# client; us00 is the exact mirror for US (302 to sign-in b680e751, en-US). The
+# earlier "ca00 authorize 400" (which pinned all NA auth to us00 in v2.26.1) was
+# probed while CA still used the US client (N7 had removed the CA one), so that
+# 400 was the wrong-client rejection, NOT a missing proxy. Routing CA through
+# us00 landed CA accounts on the US sign-in b680e751, whose password POST 500s
+# for CA. So each country proxies OIDC through its own con-veh host with its own
+# client (see the IDKAuth construction below): CA -> ca00, US -> us00 (unchanged).
 
 BRAND_VW_NA = BrandConfig(
     name="volkswagen_na",
@@ -142,12 +142,19 @@ BRAND_VW_NA = BrandConfig(
     scope="openid",
 )
 
-# v2.20.0 (N7) — the old per-CA client_id was REMOVED. Re-grepping the myVW DEX:
-# the old CA client = 0 hits; the only *_MYVW_ANDROID literals are 59992128
-# (phone) + the Wear-OS id. So CA shares the 59992128 CLIENT with US. Only the
-# HOST differs: v2.26.0 (#915) points CA at its own ca00 host (see the bases
-# above); the "ca00 = 0 DEX hits" that once argued for us00 was a static-scan
-# artefact of the runtime-templated host, not evidence ca00 does not exist.
+# v2.29.x (#915/#990/#659) — CA authorize client_id RESTORED. b13 grounded this
+# id as APK-CONFIRMED real ("the live MyVW DEX carries this exact id alongside
+# the US 59992128 and 5 others, a genuine app client"). N7 (v2.20.0) dropped it
+# on a "re-grep found 0 hits" reading, but that is the SAME static-scan artefact
+# that also wrongly dropped the ca00 host (a runtime-templated string never
+# appears as a literal). v2.26.0 restored the ca00 host but left CA on the US
+# authorize client, and CA sign-in has kept returning HTTP 500 for two testers
+# (vrouleau #990, shaunadam #659) at the password POST. A CA account authorizing
+# with the US client is the leading suspect. Restore the per-country authorize
+# client; the ca00 data host + us00 OIDC proxy stay. NEEDS a CA live-test to
+# confirm the 500 clears. The INNER signin-client override stays OFF (forcing it
+# broke the code exchange in a real b13 test).
+_CA_CLIENT_ID = "69eb3c39-d2be-4006-8197-37cc4971e8fe_MYVW_ANDROID"
 
 # v2.3.0 (#269) — VW NA-specific IDP host: identity.na.vwgroup.io
 # (NOT identity.vwgroup.io). The authorize-redirect lands on this NA IDP and
@@ -242,9 +249,13 @@ class VWNAClient:
         self._base     = _COUNTRY_BASES.get(self._country, _COUNTRY_BASES["us"])
         self._tokens: TokenSet | None = None
         # VW NA uses IDK auth but against a country-specific endpoint.
-        # v2.20.0 (N7) — US and CA share the one client the current app ships
-        # (59992128); the old per-CA client_id was unvalidated dead config.
-        client_id = BRAND_VW_NA.client_id
+        # US and CA each ship their OWN MyVW authorize client_id (both real DEX
+        # literals). N7 collapsed CA onto the US client; restored here because a
+        # CA account on the US client is the leading suspect for the CA sign-in
+        # 500 (#915/#990/#659). See the _CA_CLIENT_ID note above.
+        client_id = (
+            _CA_CLIENT_ID if self._country == "ca" else BRAND_VW_NA.client_id
+        )
         brand = BrandConfig(
             name=f"volkswagen_{self._country}",
             client_id=client_id,
@@ -256,7 +267,7 @@ class VWNAClient:
         # v2.3.0 (#269 roberttco, 2026-05-21) — VW NA auth requires four
         # IDP overrides vs the default identity.vwgroup.io (EU) flow:
         #
-        #   1. authorize_url_override → ``{_NA_OIDC_PROXY_BASE}/oidc/v1/authorize``
+        #   1. authorize_url_override → ``{self._base}/oidc/v1/authorize``
         #      (the us00 con-veh proxy, NOT identity.vwgroup.io). The
         #      MYVW_ANDROID client_id is only registered against this host —
         #      sending it to the EU IDP returns HTTP 400 (user's log on #269).
@@ -264,7 +275,7 @@ class VWNAClient:
         #      the per-country data host. The ca00 host has no working authorize
         #      endpoint (it 400s), and vrouleau confirmed CA signs in here fine.
         #
-        #   2. token_url_override → ``{_NA_OIDC_PROXY_BASE}/oidc/v1/token`` — same
+        #   2. token_url_override → ``{self._base}/oidc/v1/token`` — same
         #      us00 host for both code-exchange and refresh-token calls. The
         #      default fallback (emea.bff.cariad.digital/login/v1/idk/
         #      token) does not know NA client_ids.
@@ -304,11 +315,14 @@ class VWNAClient:
         #    unresolvable-client 500 rather than a clear error. Prefer parsing the
         #    client id out of the signin URL we actually landed on over
         #    hardcoding either value.
+        # Per-country OIDC proxy (see the _COUNTRY_BASES note above): CA authorizes
+        # on ca00 and lands on its real en-CA sign-in; US stays on us00. Both use
+        # their OWN client. self._base is ca00 for CA, us00 for US.
         self._auth = IDKAuth(
             session,
             brand,
-            authorize_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/authorize",
-            token_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/token",
+            authorize_url_override=f"{self._base}/oidc/v1/authorize",
+            token_url_override=f"{self._base}/oidc/v1/token",
             idk_base_override=_NA_IDP_BASE,
         )
         # UUID cache: VIN → UUID (returned by garage)

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.29.4"
+  "version": "2.29.5"
 }

--- a/tests/test_v2151_vwna_country.py
+++ b/tests/test_v2151_vwna_country.py
@@ -55,22 +55,23 @@ def _load(path: Path) -> dict:
 # ──────────────────────────────────────────────────────────────────────
 
 
-class TestCaUsesOwnHostSharedClient:
-    """v2.26.0 (#915) — Canada uses its OWN regional host (ca00), confirmed by a
-    live capture of the official app, but still SHARES the 59992128 client with
-    US (only the old per-CA client_id stays removed). The earlier N7 "CA = us00"
-    was a static-scan artefact: the host is runtime-templated by country code, so
-    ``ca00`` never appeared as a literal to find."""
+class TestCaUsesOwnHostAndClient:
+    """v2.29.x (#915/#990/#659) — Canada uses BOTH its own regional data host
+    (ca00) AND its own APK-confirmed authorize client_id (69eb3c39). N7 collapsed
+    the client onto the US 59992128 on the SAME static-scan artefact that also
+    wrongly dropped ca00 (a runtime-templated value never appears as a literal);
+    v2.26.0 restored the host but not the client, and CA sign-in kept 500ing for
+    two testers. Both the host and the client are per-country again. These tests
+    lock that so the collapse cannot silently return."""
 
-    def test_no_ca_client_id_constant(self) -> None:
+    def test_ca_client_id_constant_present(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        assert "_CA_CLIENT_ID" not in src
+        assert "_CA_CLIENT_ID" in src
 
-    def test_old_ca_client_id_stays_removed(self) -> None:
-        # Only the HOST changed to ca00; the old unvalidated per-CA client_id
-        # must stay gone (CA shares the 59992128 client with US).
+    def test_ca_client_id_is_apk_confirmed(self) -> None:
+        # The per-CA authorize client is the real DEX literal, restored (b13).
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        assert "69eb3c39" not in src
+        assert "69eb3c39" in src
 
     def test_ca_base_points_to_ca00(self) -> None:
         # The _COUNTRY_BASES["ca"] entry must resolve to Canada's own ca00 host.
@@ -87,26 +88,23 @@ class TestCaUsesOwnHostSharedClient:
         assert m is not None
         assert m.group(1) == "https://b-h-s.spr.us00.p.con-veh.net"
 
-    def test_client_id_is_unconditional_shared(self) -> None:
-        # No country ternary selecting a different client_id: CA shares 59992128.
+    def test_client_id_is_per_country(self) -> None:
+        # A country ternary selects the per-CA client; US keeps the shared one.
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        assert 'client_id = BRAND_VW_NA.client_id' in src
-        assert 'if self._country == "ca"' not in src
+        assert '_CA_CLIENT_ID if self._country == "ca" else BRAND_VW_NA.client_id' in src
 
-    def test_auth_uses_us00_proxy_but_api_stays_per_country(self) -> None:
-        # v2.26.1 (#990) — vrouleau proved the myVW app signs in on identity.na
-        # and that CA auth works through the us00 proxy (v2.25 authenticated;
-        # only the later data call 500'd). The Canadian ca00 host has no working
-        # /oidc/v1/authorize (400s). So the OIDC authorize+token must go to the
-        # fixed us00 proxy for every NA country, while api_base stays per-country.
+    def test_auth_proxy_and_api_base_are_per_country(self) -> None:
+        # v2.29.x (#915/#990/#659) — the OIDC authorize+token proxy is per-country
+        # (CA -> ca00, US -> us00), each with its own client. Live probe: ca00
+        # /oidc/v1/authorize 302s to the en-CA sign-in with the CA client and 400s
+        # with the US client; the old us00-for-all choice landed CA accounts on
+        # the US sign-in whose password POST 500s for CA.
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        assert '_NA_OIDC_PROXY_BASE = _COUNTRY_BASES["us"]' in src
-        assert 'authorize_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/authorize"' in src
-        assert 'token_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/token"' in src
-        # the auth override must no longer be gated on the per-country data host
-        assert 'authorize_url_override=f"{self._base}' not in src
-        # but the vehicle API base must still be per-country (ca00 for CA)
+        assert 'authorize_url_override=f"{self._base}/oidc/v1/authorize"' in src
+        assert 'token_url_override=f"{self._base}/oidc/v1/token"' in src
         assert 'api_base=self._base' in src
+        # the fixed us00 proxy constant is gone
+        assert '_NA_OIDC_PROXY_BASE' not in src
 
 
 class TestCountryConstAndSelector:

--- a/tests/test_v230_sprint_b.py
+++ b/tests/test_v230_sprint_b.py
@@ -132,16 +132,15 @@ class TestVWNAUsesNAOverrides:
 
     def test_idkauth_constructed_with_authorize_override(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        # v2.26.1 (#990) — the authorize URL points at the fixed us00 OIDC proxy
-        # (_NA_OIDC_PROXY_BASE), NOT the per-country data host. ca00 has no
-        # working /oidc/v1/authorize (it 400s); the us00 proxy 302s to
-        # identity.na for every NA country, and vrouleau confirmed CA signs in
-        # there (v2.25 authenticated this way). Only api_base is per-country.
-        assert 'authorize_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/authorize"' in src
+        # v2.29.x (#915/#990/#659) — the authorize URL is the PER-COUNTRY con-veh
+        # host (self._base: ca00 for CA, us00 for US). Live probe: ca00 authorize
+        # 302s to the en-CA sign-in with the CA client; the old fixed-us00 proxy
+        # landed CA accounts on the US sign-in whose password POST 500s for CA.
+        assert 'authorize_url_override=f"{self._base}/oidc/v1/authorize"' in src
 
     def test_idkauth_constructed_with_token_override(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")
-        assert 'token_url_override=f"{_NA_OIDC_PROXY_BASE}/oidc/v1/token"' in src
+        assert 'token_url_override=f"{self._base}/oidc/v1/token"' in src
 
     def test_idkauth_constructed_with_idk_base_override(self) -> None:
         src = _VW_NA_PY.read_text(encoding="utf-8")

--- a/tests/test_vw_ca_client_id.py
+++ b/tests/test_vw_ca_client_id.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""VW Canada authorize client_id regression (#915/#990/#659).
+
+N7 (v2.20.0) collapsed Canada onto the US authorize client_id on a "re-grep
+found 0 hits" reading — the same static-scan artefact that also wrongly dropped
+the ca00 data host (restored v2.26.0). The Canadian client is APK-confirmed real
+(b13). Two testers (vrouleau #990, shaunadam #659) get HTTP 500 at the CA
+password POST while the MyVW app works; a CA account authorizing with the US
+client is the leading suspect. These tests lock the per-country authorize client
+so the collapse cannot silently return.
+
+NOTE: fixing the client is grounded but LIVE-UNVERIFIED — it needs a real CA
+account to confirm the 500 clears. It cannot regress CA (already 500).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.cariad.api.vw_na import (
+    BRAND_VW_NA,
+    _CA_CLIENT_ID,
+    VWNAClient,
+)
+
+
+def _client(country: str):
+    return VWNAClient(MagicMock(), "u@t.com", "pw", country=country)._auth
+
+
+def _ca_client_id(country: str) -> str:
+    return _client(country)._brand.client_id
+
+
+def test_ca_uses_its_own_authorize_client() -> None:
+    assert _ca_client_id("ca") == _CA_CLIENT_ID
+
+
+def test_us_uses_the_shared_client() -> None:
+    assert _ca_client_id("us") == BRAND_VW_NA.client_id
+
+
+def test_ca_and_us_authorize_clients_differ() -> None:
+    # the whole point of the fix: they are NOT the same id.
+    assert _CA_CLIENT_ID != BRAND_VW_NA.client_id
+    assert _ca_client_id("ca") != _ca_client_id("us")
+
+
+def test_ca_client_is_the_apk_confirmed_id() -> None:
+    # pin the exact APK-confirmed literal so a future refactor cannot swap it.
+    assert _CA_CLIENT_ID == "69eb3c39-d2be-4006-8197-37cc4971e8fe_MYVW_ANDROID"
+
+
+# ── per-country OIDC proxy (live-probe grounded) ──────────────────────────────
+# ca00 /oidc/v1/authorize 302s to the en-CA sign-in with the CA client (and 400s
+# with the US client); us00 is the mirror for US. Routing CA through us00 landed
+# CA accounts on the US sign-in whose password POST 500s (#990, #659).
+
+def test_ca_authorizes_on_its_own_ca00_host() -> None:
+    url = _client("ca")._authorize_url
+    assert "ca00" in url and "us00" not in url
+
+
+def test_us_authorizes_on_us00_unchanged() -> None:
+    assert "us00" in _client("us")._authorize_url


### PR DESCRIPTION
## VW Canada sign-in HTTP 500 at the password POST (#915 / #990 / #970... vrouleau, #659 shaunadam)

Two Canadian testers get HTTP 500 at the sign-in password POST while the myVW app works. Root cause was settled by a live probe of the con-veh authorize endpoints:

| authorize call | result |
|---|---|
| **ca00 + CA client `69eb3c39`** | **302** to the en-CA sign-in (client `b43c9f82`), callback on ca00 |
| ca00 + US client `59992128` | 400 (wrong client) |
| **us00 + US client `59992128`** | **302** to the en-US sign-in (`b680e751`) |
| us00 + CA client `69eb3c39` | 400 |

So each NA country must authorize on its **own** con-veh host with its **own** client. N7 (v2.20.0) had collapsed Canada onto the US client on a "0 DEX hits" static-scan artefact (the same one that briefly dropped the ca00 data host). v2.26.0 restored the host but not the client, and v2.26.1 pinned CA auth to the us00 proxy *because the ca00-authorize-400 was probed with the US client*. With the correct CA client, ca00 authorizes fine, so CA stops landing on the US sign-in `b680e751` whose password POST 500s CA accounts.

### Changes
- Restore the per-country authorize client (`69eb3c39` for CA).
- Make the OIDC authorize+token proxy per-country (`self._base`: ca00 for CA, us00 for US) instead of fixed us00.
- **US is byte-for-byte unchanged.**
- Updates the tests in three files that had locked the collapsed-client / fixed-us00-proxy behaviour.

### Status
Grounded on the live authorize probe; **needs a Canadian live-test** to confirm the 500 clears end to end. Cannot regress Canada (already 500).