### PR TITLE
fix(#465/#1027): surface the terms-and-conditions repair when the portal blocks at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.30.1] - 2026-08-07
+
+### Fixed
+- **Škoda (and any car using the data portal as an extra channel) now tells you when it needs new terms accepted, instead of just going quiet (#465, #1027).** When the data portal sign-in lands on Volkswagen Group's updated terms-of-use page, that is a required service agreement, separate from marketing consent. If the portal was your main sign-in this already showed up as a repair, but if it was a secondary channel on top of a working one, the terms page was hit later, during normal polling, and only ended up in the log with no repair, so there was no hint anything needed doing. It now raises the same "accept terms and conditions" repair with the one-click accept link in that case too, and clears itself the moment the next sign-in gets through, so accepting the terms is enough and you do not have to reload anything. Thanks @foobarth for the logs that pinned it down.
+
 ## [2.30.0] - 2026-08-07
 
 ### Added

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -2972,6 +2972,11 @@ class EUDataActConnector:
         #                  VW-side portal outage at the metadata layer)
         #   "empty"      → request exists but the portal delivered no dataset
         self.last_no_data_reason: str = ""
+        # #465/#1027 — last actionable sign-in interstitial the portal login hit
+        # (e.g. "terms_and_conditions"). A SUPPLEMENTARY portal fails PAST setup,
+        # at runtime, so the setup-path Repair never fires; the coordinator reads
+        # this each poll and surfaces the matching Repair. "" once login succeeds.
+        self.last_login_interaction: str = ""
         # v2.13.0 — device-code/QR Bearer mode. When set, every proxy_api call
         # authenticates via ``Authorization: Bearer <token>`` (the device-grant
         # access_token, aud=portal client) instead of the cookie-scrape session,
@@ -2987,6 +2992,7 @@ class EUDataActConnector:
         mid-poll)."""
         self._bearer = token
         self.logged_in = True
+        self.last_login_interaction = ""
 
     @staticmethod
     def _is_consent_landing(landing_url: str, landing_html: str) -> bool:
@@ -3220,6 +3226,13 @@ class EUDataActConnector:
             typed_exc, log_ctx = classify_portal_login_failure(
                 landing, landing_html
             )
+            # #465/#1027 — record an actionable interstitial (T&C / consent /
+            # 2FA / portal step) so a SUPPLEMENTARY portal, which hits this at
+            # runtime past setup, can still surface the matching Repair. A plain
+            # credential failure (typed_exc is None) is NOT an interaction.
+            self.last_login_interaction = (
+                log_ctx.get("classified", "") if typed_exc is not None else ""
+            )
             # Secret-free diagnostics: host+path (query STRIPPED), HTTP
             # status, and templateModel error/errorCode/page-type keys.
             # NEVER email/password/tokens/relayState/code/query strings.
@@ -3252,6 +3265,7 @@ class EUDataActConnector:
                 "login did not complete (unexpected landing page)"
             )
         self.logged_in = True
+        self.last_login_interaction = ""  # #465/#1027 — recovered → clear Repair
         _LOGGER.info(
             "EU Data Act portal: login succeeded (read-only, ~15min cadence)"
         )

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -651,6 +651,9 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         self._started = False
         self._was_available: bool = True  # tracks availability for log_when_unavailable
         self._cariad_client: Any = None
+        # #465/#1027 — the portal sign-in interstitial Repair we last surfaced
+        # (e.g. "terms_and_conditions"), so a good login clears exactly it, once.
+        self._portal_interaction_reason: str = ""
 
         # v2.0.0 (Big-Bang) — Push manager lifecycle slots.
         # Wired by ``async_start_push_manager`` after the first
@@ -1789,6 +1792,39 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             getattr(self._cariad_client, "_eu_portal", None)
             or getattr(self._cariad_client, "_supplementary_eu_portal", None)
         )
+        entry_id = self.entry.entry_id
+        # #465/#1027 — a portal login can land on an actionable sign-in
+        # interstitial (VW Group's updated Terms & Conditions, a marketing
+        # consent, a 2FA / portal step). On a SUPPLEMENTARY portal this happens
+        # at RUNTIME, past setup, so the setup-path Repair never fired and the
+        # user saw only a log line. Surface the SAME actionable Repair here each
+        # poll. It self-heals: the per-poll re-login clears the portal's flag the
+        # moment the user accepts (out-of-band, in the app / browser), and the
+        # Repair clears with it — no reload needed.
+        _INTERACTION_REASONS = (
+            "terms_and_conditions", "marketing_consent",
+            "two_factor_required", "email_two_factor_required",
+            "portal_interaction_required",
+        )
+        interaction = (
+            getattr(portal, "last_login_interaction", "") if portal else ""
+        )
+        if isinstance(interaction, str) and interaction in _INTERACTION_REASONS:
+            from .repairs import raise_issue_auth_required  # noqa: PLC0415
+            raise_issue_auth_required(
+                self.hass, entry_id, interaction,
+                brand=self.entry.data.get(CONF_BRAND),
+            )
+            self._portal_interaction_reason = interaction
+            # the interstitial is the real blocker — don't also nag "no data"
+            ir.async_delete_issue(self.hass, DOMAIN, f"data_act_no_data_{entry_id}")
+            return
+        # recovered (or never blocked) → clear only the Repair we actually
+        # raised, once, so a good login self-heals without per-poll churn.
+        prev = getattr(self, "_portal_interaction_reason", "")
+        if isinstance(prev, str) and prev in _INTERACTION_REASONS:
+            ir.async_delete_issue(self.hass, DOMAIN, f"{entry_id}_{prev}")
+            self._portal_interaction_reason = ""
         issue_id = f"data_act_no_data_{self.entry.entry_id}"
         reason = getattr(portal, "last_no_data_reason", "") if portal else ""
         if portal is None or not reason:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.30.0"
+  "version": "2.30.1"
 }

--- a/tests/test_465_runtime_tc_repair.py
+++ b/tests/test_465_runtime_tc_repair.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#465/#1027 — a SUPPLEMENTARY EU Data Act portal hits VW Group's sign-in
+interstitials (updated Terms & Conditions, marketing consent, a portal step) at
+RUNTIME, past setup, so the setup-path Repair never fired and the user (foobarth,
+Skoda) saw only a log line. The portal now records the actionable reason in
+``last_login_interaction`` and the coordinator surfaces the matching Repair each
+poll, self-clearing on the next good login.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    EUDataActConnector,
+    classify_portal_login_failure,
+)
+from custom_components.vag_connect.const import CONF_BRAND, DOMAIN
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+
+class TestClassifierTag:
+    def test_terms_page_is_tagged_terms_and_conditions(self) -> None:
+        # The reason string the portal records comes straight from the
+        # classifier's log_ctx, so pin it.
+        exc, ctx = classify_portal_login_failure(
+            "https://identity.vwgroup.io/signin-service/v1/CID/terms-and-conditions",
+            '<script>window._IDK = {templateModel: {"template":"termsAndConditions"}};</script>',
+        )
+        assert ctx.get("classified") == "terms_and_conditions"
+
+    def test_fresh_connector_has_no_interaction(self) -> None:
+        c = EUDataActConnector(MagicMock())
+        assert c.last_login_interaction == ""
+
+    def test_set_bearer_clears_interaction(self) -> None:
+        c = EUDataActConnector(MagicMock())
+        c.last_login_interaction = "terms_and_conditions"
+        c.set_bearer("tok")
+        assert c.last_login_interaction == ""
+
+
+def _fake_self(interaction: str, *, prev: str = "", supplementary: bool = True):
+    portal = SimpleNamespace(
+        last_login_interaction=interaction,
+        last_no_data_reason="",
+    )
+    client = SimpleNamespace(
+        _eu_portal=None if supplementary else portal,
+        _supplementary_eu_portal=portal if supplementary else None,
+    )
+    entry = SimpleNamespace(
+        entry_id="e1",
+        data={CONF_BRAND: "skoda"},
+    )
+    return SimpleNamespace(
+        _cariad_client=client,
+        entry=entry,
+        hass=MagicMock(),
+        _portal_interaction_reason=prev,
+    )
+
+
+class TestCoordinatorSurfacing:
+    def test_terms_interaction_raises_the_repair_and_suppresses_no_data(self) -> None:
+        me = _fake_self("terms_and_conditions")
+        with patch(
+            "custom_components.vag_connect.repairs.raise_issue_auth_required"
+        ) as raise_repair, patch(
+            "homeassistant.helpers.issue_registry.async_delete_issue"
+        ) as delete_issue, patch(
+            "homeassistant.helpers.issue_registry.async_create_issue"
+        ) as create_issue:
+            VagConnectCoordinator._update_data_act_no_data_repair(me)
+        raise_repair.assert_called_once()
+        args, kwargs = raise_repair.call_args
+        assert args[2] == "terms_and_conditions"
+        assert kwargs.get("brand") == "skoda"
+        # the "no data" repair must be cleared, not raised, while blocked
+        assert not create_issue.called
+        assert any(
+            "data_act_no_data_e1" in str(c.args) for c in delete_issue.call_args_list
+        )
+
+    def test_no_interaction_clears_the_interaction_repairs(self) -> None:
+        # simulate a prior poll that raised the T&C Repair; now login recovered
+        me = _fake_self("", prev="terms_and_conditions")
+        with patch(
+            "custom_components.vag_connect.repairs.raise_issue_auth_required"
+        ) as raise_repair, patch(
+            "homeassistant.helpers.issue_registry.async_delete_issue"
+        ) as delete_issue, patch(
+            "homeassistant.helpers.issue_registry.async_create_issue"
+        ):
+            VagConnectCoordinator._update_data_act_no_data_repair(me)
+        raise_repair.assert_not_called()
+        cleared = {str(c.args) for c in delete_issue.call_args_list}
+        assert any("e1_terms_and_conditions" in s for s in cleared)
+
+    def test_primary_portal_interaction_is_also_surfaced(self) -> None:
+        me = _fake_self("marketing_consent", supplementary=False)
+        with patch(
+            "custom_components.vag_connect.repairs.raise_issue_auth_required"
+        ) as raise_repair, patch(
+            "homeassistant.helpers.issue_registry.async_delete_issue"
+        ), patch(
+            "homeassistant.helpers.issue_registry.async_create_issue"
+        ):
+            VagConnectCoordinator._update_data_act_no_data_repair(me)
+        raise_repair.assert_called_once()
+        assert raise_repair.call_args.args[2] == "marketing_consent"


### PR DESCRIPTION
2.30.1. Read-side bugfix, no breaking changes.

**#465 / #1027, a runtime terms-and-conditions wall now surfaces a repair.**

When the data portal is a SECONDARY channel on top of a working native one (e.g. Skoda), Volkswagen Group's updated terms-of-use page is hit during polling, past setup, which is past where the setup-path repair fires. So the user (foobarth) only saw a log line, no repair, and no hint that a terms acceptance was needed.

The portal now records the actionable interstitial reason (terms, consent, 2FA, portal step) in `last_login_interaction`, and the coordinator surfaces the same fixable "accept terms and conditions" repair (with the one-click accept link) each poll, then clears exactly it once the next sign-in gets through. Because the per-poll re-login already retries, accepting the terms out-of-band recovers on its own, no reload needed. A primary portal is handled the same way.

It only surfaces the existing accept-terms guidance; it never auto-accepts anything. The terms marker is separate from the marketing-consent markers, so this is the required service agreement, not a marketing opt-in.

6 new tests; full suite green. Full notes in CHANGELOG.md.
