### PR TITLE
fix(#465): resolve EU Data Act SoC by capture time when aliases disagree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.30.2] - 2026-08-07
+
+### Fixed
+- **Battery level no longer flips between two values on the EU Data Act portal (#465).** Some cars report the state of charge under two different fields that do not always agree, a fresh reading and a stale one, and the integration picked between them by a fixed priority order rather than by which one was newer. So the battery level could bounce between, for example, 57% and 81% while the real value sat steady near 80%. It now picks the freshest reading when they disagree (ties keep the previous order, so nothing changes for the normal case), and logs the candidates at debug level so a mismatch is traceable. Thanks @Arno-MA-73 for reading the mapper and pinning the exact cause.
+
 ## [2.30.1] - 2026-08-07
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1241,7 +1241,55 @@ def map_dataset_to_vehicle_data(
                 return val
         return None
 
-    soc = _to_int(first("battery_state_report.soc", "soc", "stateOfChargeInPercent",
+    def first_freshest(*names: str) -> str | None:
+        """Like ``first()``, but when the SAME datum is reported under multiple
+        DIFFERENT-source aliases that disagree, pick the FRESHEST by capture
+        time instead of the first in list order (#465, Arno-MA-73: portal SoC
+        oscillating 57<->81 because a stale alias out-ranked a newer one).
+
+        The common case is unchanged: bare/dotted spellings of ONE node share a
+        timestamp, so the tie-break falls back to the canonical list order and
+        the selected value is identical to ``first()``. Only when two genuinely
+        different-timestamped sources conflict does freshness decide. A candidate
+        WITH a timestamp always beats one without. Same sentinel-skip + used /
+        synonym bookkeeping as ``first()`` (every present alias is consumed).
+        """
+        # (ts, -idx, name, value): newest ts wins; ties keep the FIRST-listed name.
+        cands: list[tuple[float, int, str, str]] = []
+        for idx, n in enumerate(names):
+            if n not in fields:
+                continue
+            val = fields[n]
+            if _is_sentinel(n, val):
+                used.add(n)
+                for other in syn.get(n, frozenset()):
+                    if other in fields:
+                        used.add(other)
+                continue
+            used.add(n)
+            for other in syn.get(n, frozenset()):
+                if other in fields:
+                    used.add(other)
+            ts = (field_ts or {}).get(n)
+            cands.append((ts if ts is not None else float("-inf"), -idx, n, val))
+        if not cands:
+            return None
+        cands.sort(reverse=True)
+        best = cands[0]
+        # #465 diagnostic trace: when candidates DISAGREE, log each name/value/ts
+        # and the selected one so a reporter can confirm the resolution. Field
+        # names + SoC integers + capture times carry no PII.
+        if len({c[3] for c in cands}) > 1:
+            _LOGGER.debug(
+                "EU Data Act freshness-resolved field: candidates=%s selected=%s=%s",
+                [(c[2], c[3], None if c[0] == float("-inf") else c[0]) for c in cands],
+                best[2], best[3],
+            )
+        return best[3]
+
+    # #465 — SoC is the one field observed to ship under disagreeing aliases
+    # (a stale 57 vs the fresh 81); resolve it by capture time, not list order.
+    soc = _to_int(first_freshest("battery_state_report.soc", "soc", "stateOfChargeInPercent",
                         "state_of_charge",
                         # b13 (#504) — legacy Car-Net charger dialect: the HV
                         # battery level IS the traction SoC. Kept LAST so the

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -19,5 +19,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "2.30.1"
+  "version": "2.30.2"
 }

--- a/tests/test_465_soc_freshness.py
+++ b/tests/test_465_soc_freshness.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#465 (Arno-MA-73) — the EU Data Act portal shipped SoC under two DISAGREEING
+aliases (a stale 57 and a fresh 81). ``first()`` picked by fixed alias order, not
+by capture time, so the reported Battery Level oscillated 57<->81 while the real
+SoC (available/capacity = 80.2%) was steady. ``first_freshest()`` now resolves
+the SoC aliases by capture time; ties keep the canonical list order, so the
+common case (bare/dotted spellings of one node, same timestamp) is unchanged.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _soc(fields: dict[str, str], field_ts: dict[str, float] | None = None) -> int | None:
+    return map_dataset_to_vehicle_data(
+        fields, VehicleData(vin="X"), field_ts=field_ts
+    ).battery_soc
+
+
+class TestSocFreshness:
+    def test_fresher_alias_wins_over_canonical_order(self) -> None:
+        # canonical-first alias is STALE (57); a later alias is FRESH (81)
+        fields = {"battery_state_report.soc": "57", "soc": "81"}
+        ts = {"battery_state_report.soc": 100.0, "soc": 200.0}
+        assert _soc(fields, ts) == 81
+
+    def test_fresher_wins_even_when_later_in_the_list(self) -> None:
+        fields = {"soc": "57", "stateOfChargeInPercent": "81"}
+        ts = {"soc": 100.0, "stateOfChargeInPercent": 200.0}
+        assert _soc(fields, ts) == 81
+
+    def test_stale_later_alias_does_not_beat_fresh_canonical(self) -> None:
+        fields = {"battery_state_report.soc": "81", "soc": "57"}
+        ts = {"battery_state_report.soc": 200.0, "soc": 100.0}
+        assert _soc(fields, ts) == 81
+
+    def test_equal_timestamps_keep_canonical_order(self) -> None:
+        # the common case: same capture time -> first-listed (canonical) wins,
+        # identical to the old behaviour.
+        fields = {"battery_state_report.soc": "81", "soc": "57"}
+        ts = {"battery_state_report.soc": 100.0, "soc": 100.0}
+        assert _soc(fields, ts) == 81
+
+    def test_no_timestamps_falls_back_to_list_order(self) -> None:
+        # field_ts unavailable -> old first() behaviour (first present wins).
+        fields = {"battery_state_report.soc": "57", "soc": "81"}
+        assert _soc(fields, None) == 57
+
+    def test_candidate_with_a_timestamp_beats_one_without(self) -> None:
+        fields = {"battery_state_report.soc": "57", "soc": "81"}
+        ts = {"soc": 200.0}  # only the non-canonical alias carries a ts
+        assert _soc(fields, ts) == 81
+
+    def test_single_alias_unaffected(self) -> None:
+        assert _soc({"soc": "80"}, {"soc": 100.0}) == 80


### PR DESCRIPTION
2.30.2. Read-side bugfix, no breaking changes.

**#465 (Arno-MA-73): EU Data Act battery level oscillated between two values.**

The portal ships the state of charge under several alias field names, and `first()` returned the first present alias in a fixed priority order without comparing capture times. When two aliases disagreed (a stale 57 and a fresh 81), the value flipped as which alias was present varied per poll, while the real SoC (available / capacity = 80.2%) sat steady near 80.

New `first_freshest()` resolves the SoC aliases by capture time; ties keep the canonical list order, so the common case (bare/dotted spellings of one node, same timestamp) is byte-identical to before. When candidates disagree it logs each candidate's name, value and capture time plus the selected one at debug, so a mismatch is traceable.

7 cross-alias tests; existing mapper tests unchanged. Full notes in CHANGELOG.md.
