### PR TITLE
fix(audi_na): use the regional BFF for US vehicle reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [2.30.3] - 2026-08-08
+
+### Fixed
+- **Audi US accounts can now discover their vehicles after QR login (#13).** The login itself already worked, but the integration sent the resulting US access token to the EMEA vehicle service, which rejected it with `401 expected user token`. The current myAudi market configuration routes US vehicle requests through `na.bff.cariad.digital`; using that host returned the account's vehicle and populated its Home Assistant entities in a live test with a 2026 Q5. Canada remains on its configured EMEA host.
+
 ## [2.30.2] - 2026-08-07
 
 ### Fixed
@@ -2601,4 +2606,3 @@ First release candidate for v2.8.0. Bundles the five action items from the 2026-
 - Erste Version: VW EU, Audi, Škoda, SEAT, CUPRA
 - Sensoren: Akkustand, Reichweite, Kilometerstand, GPS, Türen, Fenster, Klimatisierung,
 - Services: lock, unlock, start/stop Klimatisierung, flash, wake, refresh
-

--- a/custom_components/vag_connect/cariad/api/audi_na.py
+++ b/custom_components/vag_connect/cariad/api/audi_na.py
@@ -1,57 +1,30 @@
 # Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Audi North America (myAudi US / CA) — CARIAD-BFF NA login foundation.
+"""Audi North America (myAudi US / CA) — regional CARIAD-BFF client.
 
-LIVE-VERIFIED architecture (US myAudi market-config + NA OIDC discovery, sweep
-2026-07-18): US Audi is the **EU-Audi CARIAD-BFF stack in the NA region** — NOT
-the VW-NA ``con-veh`` backend. So this mirrors the EU ``AudiClient`` (itself a
-CARIAD-BFF client on ``VWEUClient``) with the NA host / IDP / client_id, exactly
-as ``AudiClient`` mirrors ``VWEUClient``:
+LIVE-VERIFIED architecture (US account, 2026-08-08): US Audi uses the
+EU-Audi CARIAD-BFF stack in the NA region, not the VW-NA ``con-veh`` backend.
+This client therefore mirrors EU ``AudiClient`` on ``VWEUClient`` with the NA
+IDP, public client ID, and US data host:
 
   · client_id  ``7c6b4634-…@apps_vw-dilab_com``   (``BRAND_AUDI_NA``)
   · authorize  ``identity.na.vwgroup.io/oidc/v1/authorize``
   · token      ``na.bff.cariad.digital/auth/v1/idk/oidc/token``
   · reads      ``na.bff.cariad.digital/vehicle/v1/vehicles/{vin}/selectivestatus``
 
-════════════════════════════════════════════════════════════════════════════
-  DATA PLANE IS ATTESTATION-WALLED — this is a LOGIN FOUNDATION, not a working
-  read path. ``na.bff.cariad.digital`` is the same CARIAD-BFF product as EU Audi,
-  so vehicle reads will very likely 403 on the Play-Integrity / ``x-qmauth`` wall
-  (#503/#464/#526) off-device — the same open problem as EU Audi, minus the EU
-  Data Act portal fallback (the US has none). Auth is wired + real; a live US-Audi
-  login is what confirms (1) the client_id is accepted and (2) whether the
-  attestation wall blocks the token exchange / reads.
-════════════════════════════════════════════════════════════════════════════
+The RFC-8628 device grant returns an identity.na access token with
+``jtt=access_token``. That token is accepted directly by the US data BFF. Sending
+the same token to the EMEA garage produces 401 ``expected user token``; exchanging
+it for an Audi retail/AZS token produces 403 ``invalid token type``. The 401 was
+therefore a region mismatch, not evidence of a missing token exchange.
 
-AUTH MODE — DAG is now WIRED (Prash's preferred clean auth): ``audi_na`` is in
-``DAG_ENABLED_BRANDS`` and the browser-login flow drives RFC-8628 against the NA
-IDP via ``dag_idp_urls`` + the per-instance URL overrides on
-``DeviceAuthorizationGrant``. This client also carries the IDK-PKCE (password)
-path as a fallback.
-
-READ-PATH — corrected understanding: a community HA Audi-NA reference reads NA
-vehicle data via the PASSWORD / authorization-code IDK bearer against
-``na.bff.cariad.digital`` with NO attestation on the reads — the Play-Integrity
-wall sits on the device-grant / registration flow, not the authcode read. So NA
-reads may well work. The open, LIVE-GATED questions (a real US-Audi tester settles
-all three): does the NA IDP expose ``/oidc/v1/device_authorization``, is client
-7c6b4634 device-code-capable, and does a device-grant token (vs the password one)
-read ``na.bff``.
-
-Country: only the US market-config is live-verified. CA is accepted for interface
-parity but currently reuses the US brand — a CA-specific market-config sweep
-(``.../market/CA/en``) is a follow-up before CA can be trusted.
-
-v2.29.1 — one CA question is now answered externally. A CA-account debug capture
-(audi_connect_ha #814, 2026-08-05) showed the Canadian market config carries
-``marketSupportsAppAttestation: True`` and its discovery document routes CA to
-``token_endpoint = emea.bff.cariad.digital`` with ``device_code`` present in
-``grant_types_supported``. So CA has attestation enforced, which is why a
-password login there fails at the token step with the EU "invalid assertion
-headers" body, and device-code is the way through — exactly the path this client
-already drives (``audi_na`` is in ``DAG_ENABLED_BRANDS``). CA should therefore
-use the browser/device-code login, not the password fallback; a live CA-Audi
-tester is still what confirms it end to end (#13).
+The market configuration is authoritative because these endpoints are supplied
+at runtime and need not appear in the APK DEX. Its
+``connectedVehicleVehicleServiceBaseURLProduction`` currently maps US to
+``na.bff.cariad.digital`` and CA to ``emea.bff.cariad.digital``. Route reads by
+the configured country so fixing US does not change the Canadian path. CA still
+uses browser/device-code login because its token endpoint is attestation-gated;
+a live Canadian read remains to be confirmed (#13).
 """
 
 from __future__ import annotations
@@ -62,11 +35,6 @@ from ..models import BRAND_AUDI_NA, VehicleData
 from ..auth.idk import IDKAuth
 from .vw_eu import VWEUClient
 
-# v2.20.0 (APK audit) — the current myAudi 5.6.0 app has NO ``na.bff.cariad.digital``
-# string anywhere; its ONLY data BFF is the global ``emea.bff.cariad.digital`` (same
-# host EU Audi uses). The NA split is ONLY at the IDP layer (authorize at
-# identity.na.vwgroup.io). READS go to emea.bff (global).
-#
 # v2.24.0 (#13) — TOKEN EXCHANGE: the endpoint was wrong, and that is the whole
 # reason NA login never worked. Both of these were probed live (unauthenticated,
 # a deliberately invalid code, same client id and body in each):
@@ -84,9 +52,8 @@ from .vw_eu import VWEUClient
 # not a missing credential. The CARIAD BFF proxy accepts the public client.
 # ``na.bff.cariad.digital`` has zero hits in the DEX because, like the NA client
 # id itself, it is supplied at runtime by the US market config.
-# STILL LIVE-GATED: the 400 proves the client is accepted, not that a real code
-# completes. Needs a confirming capture on a real US/CA Audi (#13).
-_NA_BFF_BASE = "https://emea.bff.cariad.digital"
+_NA_BFF_BASE = "https://na.bff.cariad.digital"
+_EMEA_BFF_BASE = "https://emea.bff.cariad.digital"
 _NA_IDP_BASE = "https://identity.na.vwgroup.io"
 _NA_AUTHORIZE_URL = f"{_NA_IDP_BASE}/oidc/v1/authorize"
 _NA_TOKEN_URL = "https://na.bff.cariad.digital/auth/v1/idk/oidc/token"
@@ -119,10 +86,17 @@ class AudiNAClient(VWEUClient):
             idk_base_override=_NA_IDP_BASE,
         )
 
+    def _market_bff_base(self) -> str:
+        """Return the data BFF advertised by the selected market."""
+        return _EMEA_BFF_BASE if self._country == "ca" else _NA_BFF_BASE
+
+    def _garage_base(self) -> str:
+        """Route vehicle discovery to the selected market's data BFF."""
+        return self._market_bff_base()
+
     def _base_for_vin(self, vin: str) -> str:  # noqa: ARG002
-        """All NA reads target na.bff.cariad.digital. Overrides VWEUClient's EU
-        per-VIN HomeRegion base (there is no EU HomeRegion split on the NA BFF)."""
-        return _NA_BFF_BASE
+        """Route vehicle reads without the EU per-VIN HomeRegion split."""
+        return self._market_bff_base()
 
     async def get_status(self, vin: str) -> VehicleData:  # type: ignore[override]
         """Inherit the CARIAD-BFF selectivestatus read (NA host via _base_for_vin);

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -289,6 +289,10 @@ class VWEUClient(CariadBaseClient):
         bases: dict[str, str] = getattr(self, "_vehicle_bases", {})
         return bases.get(vin, _BASE)
 
+    def _garage_base(self) -> str:
+        """Return the account garage base; regional subclasses may override."""
+        return _BASE
+
     async def get_vehicles(self) -> list[str]:
         """Return list of VINs from the CARIAD garage."""
         # v2.14.0 — OPT-IN website-authproxy mode (read-only beta). When the
@@ -356,7 +360,7 @@ class VWEUClient(CariadBaseClient):
         if self._tokens and self._tokens.strategy == "mbb":
             return await self._get_vehicles_via_mbb()
 
-        data = await self._get(f"{_BASE}/vehicle/v1/vehicles")
+        data = await self._get(f"{self._garage_base()}/vehicle/v1/vehicles")
         vehicles: list[dict[str, Any]] = data.get("data", [])
 
         # Cache nickname/model per VIN — used in _parse_status to set device name

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -106,11 +106,10 @@ BRAND_AUDI = BrandConfig(
 # con-veh backend. One global app (de.myaudi.mobile.assistant), region-switched at
 # runtime. Auth: authorize at identity.na.vwgroup.io, token at na.bff.cariad.digital.
 #
-# DATA-PLANE CAVEAT: na.bff.cariad.digital is the same CARIAD-BFF product as EU
-# Audi → the same Play-Integrity / x-qmauth attestation wall (#503/#464/#526).
-# Off-device vehicle reads will very likely 403, same as EU Audi — and the US has
-# NO EU-Data-Act portal fallback. So this is a LOGIN FOUNDATION; live data needs a
-# data path (device-grant-data or a US portal) that does not exist yet.
+# v2.30.3 (#13) — current market config and a live US account both confirm the
+# US data plane is na.bff.cariad.digital. The same device-grant access token gets
+# 401 "expected user token" on emea.bff but 200 on na.bff. CA remains on emea.bff
+# and is selected dynamically by AudiNAClient.
 BRAND_AUDI_NA = BrandConfig(
     name="audi_na",
     # LIVE (Android) client from the US market config — apps_vw-dilab_com family,
@@ -119,9 +118,8 @@ BRAND_AUDI_NA = BrandConfig(
     client_id="7c6b4634-f0c5-488b-a78f-b1a65414fb90@apps_vw-dilab_com",
     redirect_uri="myaudi:///",
     user_agent="Android/5.6.0 (Build 800344256.root project 'myaudi_android'.ext.buildTime) Android/13",
-    # v2.20.0 (APK audit) — reads go to the global emea.bff (the NA app has no
-    # na.bff host); only authorize is region-split at identity.na.vwgroup.io.
-    api_base="https://emea.bff.cariad.digital",
+    # US is the default market; AudiNAClient overrides reads to emea.bff for CA.
+    api_base="https://na.bff.cariad.digital",
     scope=(
         "address profile badge birthdate birthplace nationalIdentifier nationality "
         "profession email vin phone nickname name picture mbb gallery openid"

--- a/tests/test_audi_na_token_endpoint.py
+++ b/tests/test_audi_na_token_endpoint.py
@@ -72,14 +72,13 @@ class TestAudiNaTokenEndpoint:
         assert _NA_IDP_TOKEN_URL == "https://identity.na.vwgroup.io/oidc/v1/token"
         assert _NA_TOKEN_URL != _NA_IDP_TOKEN_URL
 
-    def test_reads_still_target_emea_bff(self) -> None:
-        # The fix must NOT move reads. The myAudi APK's only data BFF is the
-        # global emea.bff; na.bff is the auth proxy, supplied by the US market
-        # config at runtime (hence zero DEX hits for either it or the NA client id).
+    def test_us_reads_target_the_na_bff(self) -> None:
+        # The US market config supplies na.bff at runtime. A live device-grant
+        # bearer gets 200 there and 401 "expected user token" from emea.bff.
         from custom_components.vag_connect.cariad.api.audi_na import (
             BRAND_AUDI_NA,
             _NA_BFF_BASE,
         )
 
-        assert _NA_BFF_BASE == "https://emea.bff.cariad.digital"
-        assert BRAND_AUDI_NA.api_base == "https://emea.bff.cariad.digital"
+        assert _NA_BFF_BASE == "https://na.bff.cariad.digital"
+        assert BRAND_AUDI_NA.api_base == "https://na.bff.cariad.digital"

--- a/tests/test_v2182_audi_na_scaffold.py
+++ b/tests/test_v2182_audi_na_scaffold.py
@@ -7,13 +7,16 @@ region — NOT the VW-NA con-veh backend. So ``AudiNAClient`` rides ``VWEUClient
 (exactly as the EU ``AudiClient`` does), with the NA host / IDP / client_id, and
 is deliberately NOT a ``VWNAClient``.
 
-These tests cover the WIRING + the real endpoints. They do NOT cover a live login
-or read: the CARIAD-BFF NA data plane is attestation-walled like EU Audi, so reads
-403 off-device until a data path exists (see audi_na.py / BRAND_AUDI_NA).
+The US data path was live-verified on 2026-08-08: the device-grant access token
+gets 401 from the EMEA garage but 200 from the NA garage. The current market
+configuration keeps Canada on EMEA, so discovery and per-VIN reads route by
+country.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from custom_components.vag_connect.cariad.api.audi_na import AudiNAClient
 from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
@@ -41,9 +44,7 @@ def test_brand_audi_na_has_live_na_endpoints() -> None:
         BRAND_AUDI_NA.client_id
         == "7c6b4634-f0c5-488b-a78f-b1a65414fb90@apps_vw-dilab_com"
     )
-    # v2.20.0 (APK audit) — myAudi 5.6.0 has no na.bff host; reads/token use the
-    # global emea.bff (only authorize is region-split at identity.na.vwgroup.io).
-    assert BRAND_AUDI_NA.api_base == "https://emea.bff.cariad.digital"
+    assert BRAND_AUDI_NA.api_base == "https://na.bff.cariad.digital"
 
 
 def test_factory_routes_audi_na() -> None:
@@ -53,9 +54,35 @@ def test_factory_routes_audi_na() -> None:
 
 
 def test_audi_na_reads_target_na_bff() -> None:
-    # v2.20.0 (APK audit) — reads hit the global emea.bff (the NA app has no
-    # na.bff host); the EU per-VIN HomeRegion split is still overridden off.
-    assert _client()._base_for_vin("WAUZZZ00000000000") == "https://emea.bff.cariad.digital"
+    assert _client("us")._base_for_vin("WAUZZZ00000000000") == (
+        "https://na.bff.cariad.digital"
+    )
+
+
+def test_audi_ca_reads_remain_on_emea_bff() -> None:
+    assert _client("ca")._base_for_vin("WAUZZZ00000000000") == (
+        "https://emea.bff.cariad.digital"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("country", "base"),
+    (
+        ("us", "https://na.bff.cariad.digital"),
+        ("ca", "https://emea.bff.cariad.digital"),
+    ),
+)
+async def test_audi_na_vehicle_discovery_routes_by_market(
+    country: str, base: str
+) -> None:
+    client = _client(country)
+    client._get = AsyncMock(return_value={"data": []})
+    client._resolve_home_regions = AsyncMock()
+    client.fetch_images = AsyncMock()
+
+    assert await client.get_vehicles() == []
+    client._get.assert_awaited_once_with(f"{base}/vehicle/v1/vehicles")
 
 
 def test_audi_na_registered_in_brands() -> None:


### PR DESCRIPTION
I had an issue registering my 2026 Audi Q5 through `vwgroup-connect-ha`, so I tried to debug what was going on and see if I could fix what was happening. 

## Problem

Audi NA login succeeds through the QR device-grant flow, but vehicle discovery then fails:

```text
GET https://emea.bff.cariad.digital/vehicle/v1/vehicles
HTTP 401
{"error":{"message":"Unauthorized","info":"expected user token"}}
```

The access token is valid. It is being sent to the wrong regional vehicle service.

Refs [issue #13](https://github.com/its-me-prash/vwgroup-connect-ha/issues/13).

## Root cause

The current myAudi market configuration gives the US and Canada different vehicle service URLs:

- [US market configuration](https://content.app.my.audi.com/service/mobileapp/configurations/market/US/en?v=5.6.0): `https://na.bff.cariad.digital`
- [Canadian market configuration](https://content.app.my.audi.com/service/mobileapp/configurations/market/CA/en?v=5.6.0): `https://emea.bff.cariad.digital`

The integration used the EMEA host for both markets.

I replayed vehicle discovery with the same stored device-grant access token:

```text
GET https://emea.bff.cariad.digital/vehicle/v1/vehicles
-> HTTP 401, expected user token

GET https://na.bff.cariad.digital/vehicle/v1/vehicles
-> HTTP 200, one vehicle
```

The token has issuer `https://identity.na.vwgroup.io` and `jtt=access_token`. The NA vehicle service accepts it directly.

I also tried the Audi AZS exchange used by the EU client. The exchange returned a token, but the vehicle API rejected it with `403 invalid token type`. There is no missing user-token exchange on this path. The 401 came from sending a US token to the EMEA service.

## Fix

`VWEUClient` now has a garage-base hook whose default remains the existing EMEA host. `AudiNAClient` overrides that hook and its per-vehicle base according to the selected market:

- US uses `na.bff.cariad.digital`
- Canada continues to use `emea.bff.cariad.digital`

No other brand behavior changes.

## Live test

Tested with a US myAudi account, a 2026 Audi Q5, and Home Assistant Container 2026.7.2.

After deployment:

- setup completed with one vehicle (my own)
- the vehicle and integration settings devices were registered
- 58 entities loaded
- 45 states had values
- 7 states were `unknown`
- 0 states were unavailable

All output used for the test was redacted. No token, VIN, or account email is included in this PR.

## Automated checks

- Ruff passed
- Audi NA tests: 18 passed
- Full suite: 4,597 passed and 15 skipped
- One unrelated existing datetime-boundary test failed because its expected values omit the existing `standby` state