### PR TITLE
v3.0.1 — Škoda login hotfix + diagnostics VIN-redaction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
-## [3.0.1] - 2026-08-09 — Škoda login hotfix
+## [3.0.1] - 2026-08-09 — Škoda login + diagnostics-redaction hotfix
 
-Right after the 3.0.0 launch, Škoda owners found the passwordless (QR) login didn't work — it just reloaded with no code. This hotfix fixes that.
+Two quick fixes on the heels of 3.0.0: Škoda's passwordless login (which Volkswagen switched off on their side), and a VIN that could slip through the diagnostics redaction.
+
+### Security
+- **The "Download diagnostics" export no longer leaks your VIN when the car's data uses the VIN as a section key.** The auto-redaction masked VINs that appear as field *values*, but not when a VIN was used as a dictionary *key* (for example under `data_act_identifiers`) — so it could still show up in plain text in a file people attach to public issues. Dictionary keys are now masked too (VIN and tokens; harmless UUID keys are kept for troubleshooting). If you downloaded and attached a diagnostics file from 3.0.0, it's worth a look. Thanks @fight3 and @PeterPrelo, who both spotted this and hand-redacted their VIN before posting.
 
 ### Fixed
 - **Škoda's passwordless (QR) login no longer dead-ends — it points you to email + password instead.** Volkswagen switched off the device-code (QR) login for Škoda on their side, so the QR screen kept reloading with nothing to scan. Škoda is no longer offered that path: it now signs in with your MyŠkoda email and password — a separate login that VW's change doesn't affect — and if you somehow still land on the old QR option you get a clear message telling you exactly where to go instead of a silent reload. Existing Škoda setups that were created via QR move over to email + password automatically the next time they ask you to sign in, so nothing gets stuck. Audi, SEAT and CUPRA keep their QR login. Thanks to the Škoda owners who flagged this within hours of the 3.0.0 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [3.0.1] - 2026-08-09 — Škoda login hotfix
+
+Right after the 3.0.0 launch, Škoda owners found the passwordless (QR) login didn't work — it just reloaded with no code. This hotfix fixes that.
+
+### Fixed
+- **Škoda's passwordless (QR) login no longer dead-ends — it points you to email + password instead.** Volkswagen switched off the device-code (QR) login for Škoda on their side, so the QR screen kept reloading with nothing to scan. Škoda is no longer offered that path: it now signs in with your MyŠkoda email and password — a separate login that VW's change doesn't affect — and if you somehow still land on the old QR option you get a clear message telling you exactly where to go instead of a silent reload. Existing Škoda setups that were created via QR move over to email + password automatically the next time they ask you to sign in, so nothing gets stuck. Audi, SEAT and CUPRA keep their QR login. Thanks to the Škoda owners who flagged this within hours of the 3.0.0 release.
+
+> If VW Group Connect is worth something to you, please consider **[sponsoring continued maintenance](https://github.com/sponsors/its-me-prash)**. 🙏
+
+---
+
 ## [3.0.0] - 2026-08-08 — "Bazinga" (Škoda Wave)
 
 A big Škoda-focused release: your car's own in-car assistant now lives inside Home Assistant, alongside a wave of new Škoda commands and read-only sensors — every field read straight out of the current MyŠkoda app so the names match what your car actually sends. It also carries the EU Data Act feed fixes previously staged as 2.30.3 (see below).

--- a/custom_components/vag_connect/cariad/_capabilities.py
+++ b/custom_components/vag_connect/cariad/_capabilities.py
@@ -278,7 +278,10 @@ DECLARED_CAPABILITIES: dict[str, dict[str, bool]] = {
         "brake_service": True,
         "ola_push": False,
         "fcm_push": False,
-        "dag_login": True,
+        # v3.0.1 — VW revoked Škoda's device_code grant (403 unauthorized_client),
+        # so the QR/browser login no longer works for Škoda. It signs in via
+        # email + password (IDK authorization-code) instead.
+        "dag_login": False,
         "mqtt_push": True,
     },
     "seat": {

--- a/custom_components/vag_connect/cariad/auth/_device_grant.py
+++ b/custom_components/vag_connect/cariad/auth/_device_grant.py
@@ -41,7 +41,12 @@ This module implements the standard headless-device OAuth flow:
 ## Brand coverage
 
 - ✅ Audi (client_id ``09b6cbec-…`` + ``f4d0934f-…`` both whitelisted)
-- ✅ Skoda (client_id ``7f045eee-…``)
+- ❌ Skoda (client_id ``7f045eee-…``) — REVOKED 2026-08. VW pulled the
+  device_code grant for the Skoda client: ``/device_authorization`` now
+  returns ``403 unauthorized_client`` ("client is not allowed to use the
+  device_code grant"), and the alternate ``4fffed6b-…`` returns ``400``.
+  Live-confirmed against identity.vwgroup.io (Audi still 200). Skoda now
+  signs in via email + password (IDK authorization-code) instead.
 - ✅ SEAT (client_id ``99a5b77d-…``)
 - ✅ CUPRA (client_id ``3c756d46-…``)
 - ❌ Volkswagen EU (client_id ``a24fba63-…`` returns ``unauthorized_client``
@@ -461,7 +466,14 @@ class DeviceAuthorizationGrant:
 # client is still not whitelisted either way.)
 #
 # Update when VW expands the whitelist.
-DAG_ENABLED_BRANDS = frozenset({"audi", "skoda", "seat", "cupra", "audi_na"})
+#
+# v3.0.1 — "skoda" REMOVED. VW revoked the Skoda client's device_code grant
+# (2026-08): /device_authorization returns 403 unauthorized_client for
+# 7f045eee, 400 "legal entity" for the alternate 4fffed6b, while Audi still
+# returns 200 (live-probed). Offering the QR path for Skoda produced a silent
+# form reload for users. Skoda signs in via email + password (IDK
+# authorization-code) — a separate, unaffected path (base.py strategy chain).
+DAG_ENABLED_BRANDS = frozenset({"audi", "seat", "cupra", "audi_na"})
 
 # v2.19.0 — Audi US/CA (audi_na) drives the SAME RFC-8628 flow against the NA IDP
 # instead of the EU one (endpoints mirror EU on identity.na.vwgroup.io, from the

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -407,8 +407,10 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         menu render correctly regardless of cache state.
         """
         # b12 — TWO login paths only. QR/browser-login (passwordless, two-way
-        # native) for Audi/Škoda/SEAT/CUPRA; Portal (email/pw) for Volkswagen
-        # EU / Porsche, which can opt into a durable-MBB command channel right
+        # native) for Audi/SEAT/CUPRA; Portal (email/pw) for Volkswagen EU /
+        # Škoda / Porsche (v3.0.1: VW revoked Škoda's device_code grant, so
+        # Škoda moved from QR to email+password), which can opt into a
+        # durable-MBB command channel right
         # in that step (the old standalone "mbb_login" + "website_authproxy"
         # menu entries are gone — MBB is now the Portal's command toggle, and
         # vw.de is an options-only supplementary read channel).
@@ -416,11 +418,11 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             step_id="user",
             menu_options={
                 "browser_login": (
-                    "Browser-Login (QR) — Audi / Škoda / SEAT / CUPRA "
+                    "Browser-Login (QR) — Audi / SEAT / CUPRA "
                     "(empfohlen, kein Passwort in HA)"
                 ),
                 "email_password": (
-                    "Portal (E-Mail + Passwort) — Volkswagen EU / Porsche "
+                    "Portal (E-Mail + Passwort) — Volkswagen EU / Škoda / Porsche "
                     "(+ Toggle: MBB-Fahrzeug → Fernbefehle)"
                 ),
                 # v3.0.0-alpha — experimental fourth source. Drives the official
@@ -954,7 +956,14 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
 
         if user_input is not None:
             brand = user_input[CONF_BRAND]
-            if brand not in DAG_ENABLED_BRANDS:
+            if brand == "skoda":
+                # v3.0.1 — VW revoked Škoda's device_code grant (403
+                # unauthorized_client on identity.vwgroup.io). QR is dead for
+                # Škoda only; the form no longer offers it, but a stale/crafted
+                # payload lands here — send the user to email + password with a
+                # clear reason instead of a silent form reload.
+                errors["base"] = "skoda_qr_retired"
+            elif brand not in DAG_ENABLED_BRANDS:
                 # Defence in depth — the form should have filtered these
                 # out already, but the user could send a crafted payload.
                 errors["base"] = "brand_not_dag_eligible"

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -189,6 +189,23 @@ _HASH_KEYS = frozenset({
 })
 
 
+def _mask_key(k: Any) -> Any:
+    """Mask PII that appears as a dict KEY, not just as a value.
+
+    v3.0.1 (#923, #1088) — some payloads key a container by the VIN itself
+    (e.g. ``data_act_identifiers: {"<VIN>": {...}}``). The recursive scrubbers
+    only ran the VIN/JWT regexes over string VALUES, so a VIN used as a key
+    survived in plain text — two reporters had to hand-redact their download
+    before posting. VIN + JWT are masked here; UUID keys are deliberately kept
+    (they are structural grounding data, not PII).
+    """
+    if not isinstance(k, str):
+        return k
+    masked = _VIN_RE.sub(lambda m: mask_vin(m.group(0)), k)
+    masked = _JWT_RE.sub("[token]", masked)
+    return masked
+
+
 def _scrub(value: Any, *, gps_round: bool = False) -> Any:
     """Recursively redact sensitive fields from diagnostics output.
 
@@ -203,25 +220,27 @@ def _scrub(value: Any, *, gps_round: bool = False) -> Any:
         for k, v in value.items():
             if k in ("_client", "_vehicle"):
                 continue
+            # v3.0.1 — mask PII in the KEY too (a VIN can be a container key).
+            sk = _mask_key(k)
             if k in _HASH_KEYS and isinstance(v, str):
                 # v1.15.0 — stable hash so repeat reporters cross-link
                 # without leaking the real ID. Pattern from myskoda.
-                scrubbed[k] = f"sha256:{_stable_hash(v)}" if v else "**REDACTED**"
+                scrubbed[sk] = f"sha256:{_stable_hash(v)}" if v else "**REDACTED**"
             elif k in _REDACT_KEYS:
-                scrubbed[k] = "**REDACTED**"
+                scrubbed[sk] = "**REDACTED**"
             elif k == "email" and isinstance(v, str):
                 # Partial mask preserves debug context.
-                scrubbed[k] = _mask_email(v)
+                scrubbed[sk] = _mask_email(v)
             elif k in ("latitude", "longitude"):
                 # Privacy-by-default: full removal. Opt-in 1-decimal
                 # rounding when user already opted into reverse-geocoding
                 # (signals comfort with GPS processing).
                 if gps_round and isinstance(v, (int, float)):
-                    scrubbed[k] = round(float(v), 1)
+                    scrubbed[sk] = round(float(v), 1)
                 else:
-                    scrubbed[k] = "**REDACTED**"
+                    scrubbed[sk] = "**REDACTED**"
             else:
-                scrubbed[k] = _scrub(v, gps_round=gps_round)
+                scrubbed[sk] = _scrub(v, gps_round=gps_round)
         return scrubbed
     if isinstance(value, list):
         return [_scrub(v, gps_round=gps_round) for v in value]
@@ -272,12 +291,14 @@ def _scrub_raw(value: Any) -> Any:
         out: dict[str, Any] = {}
         for k, v in value.items():
             kl = k.lower() if isinstance(k, str) else ""
+            # v3.0.1 — mask PII in the KEY too (a VIN can be a container key).
+            sk = _mask_key(k)
             if k in _REDACT_KEYS or kl in _RAW_REDACT_KEYS:
-                out[k] = "**REDACTED**"
+                out[sk] = "**REDACTED**"
             elif k in _HASH_KEYS and isinstance(v, str):
-                out[k] = f"sha256:{_stable_hash(v)}" if v else "**REDACTED**"
+                out[sk] = f"sha256:{_stable_hash(v)}" if v else "**REDACTED**"
             else:
-                out[k] = _scrub_raw(v)
+                out[sk] = _scrub_raw(v)
         return out
     if isinstance(value, list):
         return [_scrub_raw(v) for v in value]

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -22,5 +22,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "Set up VW Group Connect",
-        "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU and Porsche.",
+        "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU, Škoda and Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
           "email_password": "Email + Password (legacy)",
@@ -165,6 +165,7 @@
       "invalid_credentials": "Email address or password incorrect.",
       "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, not a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "skoda_qr_retired": "Škoda's passwordless (QR) login was switched off by Volkswagen and no longer works. Go back and choose “Email + Password (legacy)”, then pick Škoda there and sign in with your MyŠkoda email and password.",
       "portal_interaction_required": "The EU Data Act portal needs a one-time action in your browser or brand app (e.g. accept terms, confirm consent, finish onboarding/region selection) before headless access works. This is NOT a wrong-password problem — open the portal once in a browser, complete the prompt, then try again.",
       "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Nastavit VW Group Connect",
-        "description": "Připojte své vozidlo k Home Assistant.\n\nVyberte značku a zadejte přihlašovací údaje z aplikace výrobce.",
+        "description": "Jak se chcete přihlásit?\n\n**Přihlášení přes prohlížeč (doporučeno)** — otevřete URL v telefonu nebo notebooku, přihlaste se ke svému účtu Brand ID a schvalte zařízení. V Home Assistant se nikdy neukládá žádné heslo. Dostupné pro Audi, SEAT a CUPRA.\n\n**E-mail + heslo (starší způsob)** — zadejte přihlašovací údaje Brand ID přímo. Vyžadováno pro Volkswagen EU, Škoda a Porsche.",
         "menu_options": {
           "browser_login": "Přihlášení přes prohlížeč (doporučeno)",
           "email_password": "E-mail + heslo (starší způsob)",
@@ -166,6 +166,7 @@
       "portal_interaction_required": "Portál EU Data Act vyžaduje jednorázovou akci ve vašem prohlížeči nebo aplikaci značky (např. přijmout podmínky, potvrdit souhlas, dokončit onboarding/výběr regionu), než začne fungovat bezhlavý přístup. Toto NENÍ problém se špatným heslem — otevřete portál jednou v prohlížeči, dokončete výzvu a zkuste to znovu.",
       "upstream_unavailable": "Backend VW dočasně nedostupný. Toto je problém na straně serveru VW, NIKOLI chyba přihlášení. Počkejte 5–15 minut a zkuste to znovu. Integraci znovu NEKONFIGURUJTE.",
       "brand_not_dag_eligible": "Vybraná značka nepodporuje přihlášení přes prohlížeč. Použijte místo toho přihlášení e-mailem + heslem.",
+      "skoda_qr_retired": "Bezheslové přihlášení Škoda (QR) společnost Volkswagen vypnula a už nefunguje. Vraťte se zpět a zvolte „E-mail + heslo (starší způsob)“, tam vyberte Škoda a přihlaste se svým e-mailem a heslem MyŠkoda.",
       "still_waiting_browser": "Stále se čeká na potvrzení v prohlížeči. Otevřete URL výše, přihlaste se, potvrďte kód a poté znovu klikněte na Odeslat.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
       "companion_needs_addon": "Vypadá to na telefon s Androidem 11+ používající bezdrátové ladění, které zdejší přímé připojení neumí (vyžaduje TLS a párování). Nainstalujte doplněk 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) a nasměrujte na něj companion. Starší telefony (Android 10 a starší) se připojí přímo zde.",

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "Opsæt VW Group Connect",
-        "description": "Hvordan vil du logge ind?\n\n**Browser-login (anbefalet)** — åbn en URL på din telefon eller bærbare, log ind på din Brand ID-konto, og godkend enheden. Ingen adgangskode gemmes nogensinde i Home Assistant. Tilgængelig for Audi, Škoda, SEAT og CUPRA.\n\n**E-mail + adgangskode (ældre metode)** — indtast dine Brand ID-loginoplysninger direkte. Kræves for Volkswagen EU og Porsche.",
+        "description": "Hvordan vil du logge ind?\n\n**Browser-login (anbefalet)** — åbn en URL på din telefon eller bærbare, log ind på din Brand ID-konto, og godkend enheden. Ingen adgangskode gemmes nogensinde i Home Assistant. Tilgængelig for Audi, SEAT og CUPRA.\n\n**E-mail + adgangskode (ældre metode)** — indtast dine Brand ID-loginoplysninger direkte. Kræves for Volkswagen EU, Škoda og Porsche.",
         "menu_options": {
           "browser_login": "Browser-login (anbefalet)",
           "email_password": "E-mail + adgangskode (ældre metode)",
@@ -165,6 +165,7 @@
       "invalid_credentials": "E-mailadresse eller adgangskode er forkert.",
       "upstream_unavailable": "VW-backendet er midlertidigt utilgængeligt. Dette er et serverproblem hos VW, IKKE et problem med loginoplysninger. Vent venligst 5-15 minutter, og prøv igen. Konfigurer IKKE integrationen igen.",
       "brand_not_dag_eligible": "Det valgte mærke understøtter ikke browser-login. Brug flowet med e-mail + adgangskode i stedet.",
+      "skoda_qr_retired": "Škodas adgangskodefri login (QR) blev slået fra af Volkswagen og virker ikke længere. Gå tilbage, og vælg “E-mail + adgangskode (ældre metode)”, vælg derefter Škoda der, og log ind med din MyŠkoda-e-mail og adgangskode.",
       "portal_interaction_required": "EU Data Act-portalen kræver en engangshandling i din browser eller mærke-app (f.eks. accepter vilkår, bekræft samtykke, fuldfør onboarding/regionsvalg), før headless-adgang virker. Dette er IKKE et problem med forkert adgangskode — åbn portalen én gang i en browser, fuldfør anmodningen, og prøv igen.",
       "still_waiting_browser": "Venter stadig på browser-godkendelse. Åbn URL'en ovenfor, log ind, bekræft koden, og klik på Send igen.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "VW Group Connect einrichten",
-        "description": "Wie möchtest du dich anmelden?\n\n**Browser-Login (empfohlen)** — öffne eine URL auf Handy oder Laptop, melde dich mit deinem Brand-ID-Konto an, bestätige das Gerät. Kein Passwort wird in Home Assistant gespeichert. Verfügbar für Audi, Škoda, SEAT und CUPRA.\n\n**E-Mail + Passwort (Legacy)** — gib deine Brand-ID-Zugangsdaten direkt ein. Erforderlich für Volkswagen EU und Porsche.",
+        "description": "Wie möchtest du dich anmelden?\n\n**Browser-Login (empfohlen)** — öffne eine URL auf Handy oder Laptop, melde dich mit deinem Brand-ID-Konto an, bestätige das Gerät. Kein Passwort wird in Home Assistant gespeichert. Verfügbar für Audi, SEAT und CUPRA.\n\n**E-Mail + Passwort (Legacy)** — gib deine Brand-ID-Zugangsdaten direkt ein. Erforderlich für Volkswagen EU, Škoda und Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (empfohlen)",
           "email_password": "E-Mail + Passwort (Legacy)",
@@ -166,6 +166,7 @@
       "portal_interaction_required": "Das EU-Data-Act-Portal benötigt eine einmalige Aktion in deinem Browser oder der Marken-App (z. B. AGB akzeptieren, Einwilligung bestätigen, Onboarding/Region-Auswahl abschließen), bevor der headless-Zugriff funktioniert. Das ist KEIN Passwort-Problem — öffne das Portal einmal im Browser, schließe die Abfrage ab und versuche es erneut.",
       "upstream_unavailable": "VW-Backend vorübergehend nicht erreichbar. Das ist ein Server-Problem bei VW, KEIN Anmeldefehler. Bitte 5–15 Minuten warten und nochmal versuchen. Die Integration NICHT neu konfigurieren.",
       "brand_not_dag_eligible": "Diese Marke unterstützt kein Browser-Login. Nutze stattdessen E-Mail + Passwort.",
+      "skoda_qr_retired": "Škodas passwortloser (QR-)Login wurde von Volkswagen abgeschaltet und funktioniert nicht mehr. Geh zurück und wähle „E-Mail + Passwort (Legacy)“, dort dann Škoda auswählen und mit deiner MyŠkoda-E-Mail und deinem Passwort anmelden.",
       "still_waiting_browser": "Warte noch auf die Browser-Bestätigung. Öffne die URL oben, melde dich an, bestätige den Code und klick dann nochmal auf Senden.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
       "companion_needs_addon": "Das sieht nach einem Android-11+-Telefon mit kabellosem Debugging aus, das die direkte Verbindung hier nicht nutzen kann (sie läuft über TLS + Pairing). Installiere das Add-on 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) und verweise den Companion darauf. Ältere Telefone (Android 10 oder älter) verbinden sich hier direkt.",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "Set up VW Group Connect",
-        "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, Škoda, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU and Porsche.",
+        "description": "How would you like to sign in?\n\n**Browser-Login (recommended)** — open a URL on your phone or laptop, sign in to your Brand ID account, approve the device. No password is ever stored in Home Assistant. Available for Audi, SEAT and CUPRA.\n\n**Email + Password (legacy)** — enter your Brand ID credentials directly. Required for Volkswagen EU, Škoda and Porsche.",
         "menu_options": {
           "browser_login": "Browser-Login (recommended)",
           "email_password": "Email + Password (legacy)",
@@ -165,6 +165,7 @@
       "invalid_credentials": "Email address or password incorrect.",
       "upstream_unavailable": "VW backend temporarily unavailable. This is a server-side issue at VW, NOT a credentials problem. Please wait 5–15 minutes and try again. Do NOT reconfigure the integration.",
       "brand_not_dag_eligible": "Selected brand does not support browser login. Use the email + password flow instead.",
+      "skoda_qr_retired": "Škoda's passwordless (QR) login was switched off by Volkswagen and no longer works. Go back and choose “Email + Password (legacy)”, then pick Škoda there and sign in with your MyŠkoda email and password.",
       "portal_interaction_required": "The EU Data Act portal needs a one-time action in your browser or brand app (e.g. accept terms, confirm consent, finish onboarding/region selection) before headless access works. This is NOT a wrong-password problem — open the portal once in a browser, complete the prompt, then try again.",
       "still_waiting_browser": "Still waiting for browser approval. Open the URL above, sign in, confirm the code, then click Submit again.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configurar VW Group Connect",
-        "description": "Conecta tu vehículo a Home Assistant.\n\nElige tu marca e introduce las credenciales de la app del fabricante.",
+        "description": "¿Cómo quieres iniciar sesión?\n\n**Inicio de sesión por navegador (recomendado)** — abre una URL en tu teléfono o portátil, inicia sesión en tu cuenta Brand ID y aprueba el dispositivo. Nunca se almacena ninguna contraseña en Home Assistant. Disponible para Audi, SEAT y CUPRA.\n\n**Correo electrónico + contraseña (heredado)** — introduce directamente tus credenciales de Brand ID. Necesario para Volkswagen EU, Škoda y Porsche.",
         "menu_options": {
           "browser_login": "Inicio de sesión por navegador (recomendado)",
           "email_password": "Correo electrónico + contraseña (heredado)",
@@ -166,6 +166,7 @@
       "portal_interaction_required": "El portal de la EU Data Act necesita una acción única en tu navegador o en la app de la marca (p. ej. aceptar los términos, confirmar el consentimiento, completar el onboarding/selección de región) antes de que funcione el acceso sin interfaz. Esto NO es un problema de contraseña: abre el portal una vez en un navegador, completa el aviso y vuelve a intentarlo.",
       "upstream_unavailable": "Backend de VW temporalmente no disponible. Es un problema del servidor de VW, NO un problema de credenciales. Espera 5–15 minutos e inténtalo de nuevo. NO reconfigures la integración.",
       "brand_not_dag_eligible": "La marca seleccionada no admite el inicio de sesión por navegador. Usa el flujo de correo electrónico + contraseña en su lugar.",
+      "skoda_qr_retired": "El inicio de sesión sin contraseña (QR) de Škoda fue desactivado por Volkswagen y ya no funciona. Vuelve atrás y elige «Correo electrónico + contraseña (heredado)», después selecciona Škoda ahí e inicia sesión con tu correo y contraseña de MyŠkoda.",
       "still_waiting_browser": "Aún esperando la aprobación en el navegador. Abre la URL de arriba, inicia sesión, confirma el código y vuelve a hacer clic en Enviar.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
       "companion_needs_addon": "Parece un teléfono con Android 11 o superior con depuración inalámbrica, que la conexión directa de aquí no admite (usa TLS y emparejamiento). Instala el complemento 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) e indica aquí su dirección. Los teléfonos más antiguos (Android 10 o anterior) se conectan aquí directamente.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "Määritä VW Group Connect",
-        "description": "Miten haluat kirjautua?\n\n**Selainkirjautuminen (suositeltu)** — avaa URL-osoite puhelimellasi tai kannettavallasi, kirjaudu Brand ID -tiliisi ja hyväksy laite. Salasanaa ei koskaan tallenneta Home Assistantiin. Saatavilla merkeille Audi, Škoda, SEAT ja CUPRA.\n\n**Sähköposti + salasana (vanha tapa)** — syötä Brand ID -kirjautumistietosi suoraan. Vaaditaan Volkswagen EU:lle ja Porschelle.",
+        "description": "Miten haluat kirjautua?\n\n**Selainkirjautuminen (suositeltu)** — avaa URL-osoite puhelimellasi tai kannettavallasi, kirjaudu Brand ID -tiliisi ja hyväksy laite. Salasanaa ei koskaan tallenneta Home Assistantiin. Saatavilla merkeille Audi, SEAT ja CUPRA.\n\n**Sähköposti + salasana (vanha tapa)** — syötä Brand ID -kirjautumistietosi suoraan. Vaaditaan Volkswagen EU:lle, Škodalle ja Porschelle.",
         "menu_options": {
           "browser_login": "Selainkirjautuminen (suositeltu)",
           "email_password": "Sähköposti + salasana (vanha tapa)",
@@ -165,6 +165,7 @@
       "invalid_credentials": "Sähköpostiosoite tai salasana väärin.",
       "upstream_unavailable": "VW-taustajärjestelmä tilapäisesti tavoittamattomissa. Tämä on palvelinpuolen ongelma VW:llä, EI kirjautumistieto-ongelma. Odota 5–15 minuuttia ja yritä uudelleen. ÄLÄ määritä integraatiota uudelleen.",
       "brand_not_dag_eligible": "Valittu merkki ei tue selainkirjautumista. Käytä sen sijaan sähköposti + salasana -kirjautumista.",
+      "skoda_qr_retired": "Volkswagen sammutti Škodan salasanattoman (QR) kirjautumisen, eikä se toimi enää. Palaa takaisin ja valitse ”Sähköposti + salasana (vanha tapa)”, valitse siellä Škoda ja kirjaudu MyŠkoda-sähköpostillasi ja -salasanallasi.",
       "portal_interaction_required": "EU Data Act -portaali vaatii kertaluonteisen toimenpiteen selaimessasi tai merkin sovelluksessa (esim. käyttöehtojen hyväksyminen, suostumuksen vahvistaminen, käyttöönoton/alueen valinnan viimeistely) ennen kuin selaimeton pääsy toimii. Tämä EI ole väärän salasanan ongelma — avaa portaali kerran selaimessa, suorita kehote loppuun ja yritä sitten uudelleen.",
       "still_waiting_browser": "Odotetaan yhä selaimen hyväksyntää. Avaa yllä oleva URL-osoite, kirjaudu sisään, vahvista koodi ja napsauta sitten Lähetä uudelleen.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configurer VW Group Connect",
-        "description": "Connectez votre véhicule à Home Assistant.\n\nChoisissez votre marque et entrez les identifiants de l'application fabricant.",
+        "description": "Comment souhaitez-vous vous connecter ?\n\n**Connexion via navigateur (recommandé)** — ouvrez une URL sur votre téléphone ou votre ordinateur, connectez-vous à votre compte Brand ID et approuvez l'appareil. Aucun mot de passe n'est jamais stocké dans Home Assistant. Disponible pour Audi, SEAT et CUPRA.\n\n**E-mail + mot de passe (ancienne méthode)** — saisissez directement vos identifiants Brand ID. Requis pour Volkswagen EU, Škoda et Porsche.",
         "menu_options": {
           "browser_login": "Connexion via navigateur (recommandé)",
           "email_password": "E-mail + mot de passe (ancienne méthode)",
@@ -166,6 +166,7 @@
       "portal_interaction_required": "Le portail EU Data Act nécessite une action ponctuelle dans votre navigateur ou l'application de la marque (par ex. accepter les conditions, confirmer le consentement, terminer l'intégration / la sélection de région) avant que l'accès sans interface ne fonctionne. Ce n'est PAS un problème de mot de passe — ouvrez le portail une fois dans un navigateur, complétez l'invite, puis réessayez.",
       "upstream_unavailable": "Backend VW temporairement indisponible. C'est un problème côté serveur chez VW, PAS un problème d'identifiants. Veuillez patienter 5 à 15 minutes puis réessayer. NE reconfigurez PAS l'intégration.",
       "brand_not_dag_eligible": "La marque sélectionnée ne prend pas en charge la connexion via navigateur. Utilisez plutôt le flux e-mail + mot de passe.",
+      "skoda_qr_retired": "La connexion sans mot de passe (QR) de Škoda a été désactivée par Volkswagen et ne fonctionne plus. Revenez en arrière et choisissez « E-mail + mot de passe (ancienne méthode) », puis sélectionnez-y Škoda et connectez-vous avec votre e-mail et votre mot de passe MyŠkoda.",
       "still_waiting_browser": "En attente de l'approbation dans le navigateur. Ouvrez l'URL ci-dessus, connectez-vous, confirmez le code, puis cliquez à nouveau sur Valider.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
       "companion_needs_addon": "Ce téléphone semble être un Android 11 ou plus récent en débogage sans fil, que la connexion directe d'ici ne peut pas utiliser (TLS + appairage). Installez le module complémentaire « VW Group App ADB Bridge » (github.com/its-me-prash/vwgroup-app-adb-bridge) et indiquez son adresse ici. Les téléphones plus anciens (Android 10 ou antérieur) se connectent directement ici.",

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "Configura VW Group Connect",
-        "description": "Come vuoi accedere?\n\n**Login via browser (consigliato)** — apri un URL sul telefono o sul laptop, accedi al tuo account Brand ID e approva il dispositivo. Nessuna password viene mai salvata in Home Assistant. Disponibile per Audi, Škoda, SEAT e CUPRA.\n\n**Email + password (legacy)** — inserisci direttamente le credenziali Brand ID. Necessario per Volkswagen EU e Porsche.",
+        "description": "Come vuoi accedere?\n\n**Login via browser (consigliato)** — apri un URL sul telefono o sul laptop, accedi al tuo account Brand ID e approva il dispositivo. Nessuna password viene mai salvata in Home Assistant. Disponibile per Audi, SEAT e CUPRA.\n\n**Email + password (legacy)** — inserisci direttamente le credenziali Brand ID. Necessario per Volkswagen EU, Škoda e Porsche.",
         "menu_options": {
           "browser_login": "Login via browser (consigliato)",
           "email_password": "Email + password (legacy)",
@@ -165,6 +165,7 @@
       "invalid_credentials": "Indirizzo email o password errati.",
       "upstream_unavailable": "Backend VW temporaneamente non disponibile. Si tratta di un problema lato server di VW, NON di un problema di credenziali. Attendi 5–15 minuti e riprova. NON riconfigurare l'integrazione.",
       "brand_not_dag_eligible": "La marca selezionata non supporta il login via browser. Usa invece la procedura con email + password.",
+      "skoda_qr_retired": "Il login senza password (QR) di Škoda è stato disattivato da Volkswagen e non funziona più. Torna indietro e scegli “Email + password (legacy)”, poi seleziona lì Škoda e accedi con l'email e la password del tuo MyŠkoda.",
       "portal_interaction_required": "Il portale EU Data Act richiede un'azione una tantum nel tuo browser o nell'app della marca (ad es. accettare i termini, confermare il consenso, completare l'onboarding/la selezione della regione) prima che l'accesso headless funzioni. Questo NON è un problema di password errata — apri il portale una volta in un browser, completa la richiesta, poi riprova.",
       "still_waiting_browser": "In attesa dell'approvazione dal browser. Apri l'URL qui sopra, accedi, conferma il codice, poi clicca di nuovo su Invia.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -53,7 +53,7 @@
       },
       "user": {
         "title": "Sett opp VW Group Connect",
-        "description": "Hvordan vil du logge inn?\n\n**Nettleserpålogging (anbefalt)** — åpne en URL på telefonen eller den bærbare PC-en din, logg inn på Brand ID-kontoen din, godkjenn enheten. Ingen passord lagres noen gang i Home Assistant. Tilgjengelig for Audi, Škoda, SEAT og CUPRA.\n\n**E-post + passord (eldre metode)** — skriv inn Brand ID-påloggingen din direkte. Kreves for Volkswagen EU og Porsche.",
+        "description": "Hvordan vil du logge inn?\n\n**Nettleserpålogging (anbefalt)** — åpne en URL på telefonen eller den bærbare PC-en din, logg inn på Brand ID-kontoen din, godkjenn enheten. Ingen passord lagres noen gang i Home Assistant. Tilgjengelig for Audi, SEAT og CUPRA.\n\n**E-post + passord (eldre metode)** — skriv inn Brand ID-påloggingen din direkte. Kreves for Volkswagen EU, Škoda og Porsche.",
         "menu_options": {
           "browser_login": "Nettleserpålogging (anbefalt)",
           "email_password": "E-post + passord (eldre metode)",
@@ -165,6 +165,7 @@
       "invalid_credentials": "E-postadresse eller passord er feil.",
       "upstream_unavailable": "VW-baksystemet er midlertidig utilgjengelig. Dette er et problem på VWs side, IKKE et problem med påloggingsinformasjonen. Vent 5–15 minutter og prøv igjen. IKKE konfigurer integrasjonen på nytt.",
       "brand_not_dag_eligible": "Det valgte merket støtter ikke nettleserpålogging. Bruk e-post + passord-flyten i stedet.",
+      "skoda_qr_retired": "Volkswagen har slått av Škodas passordløse innlogging (QR), og den fungerer ikke lenger. Gå tilbake og velg «E-post + passord (eldre metode)», velg deretter Škoda der og logg inn med e-postadressen og passordet til MyŠkoda-kontoen din.",
       "portal_interaction_required": "EU Data Act-portalen trenger en engangshandling i nettleseren din eller merkeappen (f.eks. godta vilkår, bekrefte samtykke, fullføre onboarding/regionvalg) før tilgang uten nettleser fungerer. Dette er IKKE et problem med feil passord — åpne portalen én gang i en nettleser, fullfør oppgaven, og prøv igjen.",
       "still_waiting_browser": "Venter fortsatt på godkjenning i nettleseren. Åpne URL-en ovenfor, logg inn, bekreft koden, og klikk Send inn igjen.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "VW Group Connect instellen",
-        "description": "Verbind je voertuig met Home Assistant.\n\nKies je merk en voer de inloggegevens van de fabrieksapp in.",
+        "description": "Hoe wil je je aanmelden?\n\n**Browser-login (aanbevolen)** — open een URL op je telefoon of laptop, meld je aan bij je Brand ID-account en keur het apparaat goed. Er wordt nooit een wachtwoord opgeslagen in Home Assistant. Beschikbaar voor Audi, SEAT en CUPRA.\n\n**E-mail + wachtwoord (verouderd)** — voer je Brand ID-inloggegevens rechtstreeks in. Vereist voor Volkswagen EU, Škoda en Porsche.",
         "menu_options": {
           "browser_login": "Browser-login (aanbevolen)",
           "email_password": "E-mail + wachtwoord (verouderd)",
@@ -166,6 +166,7 @@
       "portal_interaction_required": "Het EU Data Act-portaal vereist een eenmalige actie in je browser of merk-app (bijv. voorwaarden accepteren, toestemming bevestigen, onboarding/regiokeuze voltooien) voordat headless-toegang werkt. Dit is GEEN wachtwoordprobleem — open het portaal één keer in een browser, voltooi de melding en probeer het opnieuw.",
       "upstream_unavailable": "VW backend tijdelijk onbereikbaar. Dit is een serverprobleem bij VW, GEEN inlogfout. Wacht 5–15 minuten en probeer opnieuw. Configureer de integratie NIET opnieuw.",
       "brand_not_dag_eligible": "Het geselecteerde merk ondersteunt geen browser-login. Gebruik in plaats daarvan de e-mail + wachtwoord-methode.",
+      "skoda_qr_retired": "De wachtwoordloze (QR-)login van Škoda is door Volkswagen uitgeschakeld en werkt niet meer. Ga terug en kies “E-mail + wachtwoord (verouderd)”, selecteer daar Škoda en meld je aan met je MyŠkoda-e-mailadres en -wachtwoord.",
       "still_waiting_browser": "Nog steeds wachten op goedkeuring in de browser. Open de bovenstaande URL, meld je aan, bevestig de code en klik daarna opnieuw op Verzenden.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
       "companion_needs_addon": "Dit lijkt een telefoon met Android 11 of nieuwer die draadloos debuggen gebruikt; de directe verbinding hier kan daar niet mee overweg (dat is TLS + koppelen). Installeer de add-on 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) en laat de companion daarnaar wijzen. Oudere telefoons (Android 10 of ouder) verbinden hier rechtstreeks.",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Skonfiguruj VW Group Connect",
-        "description": "Połącz swój pojazd z Home Assistant.\n\nWybierz markę i wprowadź dane logowania z aplikacji producenta.",
+        "description": "Jak chcesz się zalogować?\n\n**Logowanie przez przeglądarkę (zalecane)** — otwórz adres URL na telefonie lub laptopie, zaloguj się na konto Brand ID i zatwierdź urządzenie. Żadne hasło nie jest przechowywane w Home Assistant. Dostępne dla Audi, SEAT i CUPRA.\n\n**E-mail + hasło (starsza metoda)** — wprowadź bezpośrednio dane logowania Brand ID. Wymagane dla Volkswagen EU, Škoda i Porsche.",
         "menu_options": {
           "browser_login": "Logowanie przez przeglądarkę (zalecane)",
           "email_password": "E-mail + hasło (starsza metoda)",
@@ -166,6 +166,7 @@
       "portal_interaction_required": "Portal EU Data Act wymaga jednorazowej czynności w przeglądarce lub aplikacji marki (np. zaakceptowania warunków, potwierdzenia zgody, dokończenia onboardingu/wyboru regionu), zanim zadziała dostęp bez interfejsu. To NIE jest problem z hasłem — otwórz portal raz w przeglądarce, wykonaj polecenie i spróbuj ponownie.",
       "upstream_unavailable": "Backend VW chwilowo niedostępny. To problem po stronie serwera VW, a NIE błąd uwierzytelniania. Poczekaj 5–15 minut i spróbuj ponownie. NIE konfiguruj integracji ponownie.",
       "brand_not_dag_eligible": "Wybrana marka nie obsługuje logowania przez przeglądarkę. Użyj zamiast tego metody e-mail + hasło.",
+      "skoda_qr_retired": "Logowanie bez hasła (QR) marki Škoda zostało wyłączone przez Volkswagena i już nie działa. Wróć i wybierz „E-mail + hasło (starsza metoda)”, a następnie wybierz tam markę Škoda i zaloguj się przy użyciu adresu e-mail i hasła do MyŠkoda.",
       "still_waiting_browser": "Nadal trwa oczekiwanie na zatwierdzenie w przeglądarce. Otwórz powyższy adres URL, zaloguj się, potwierdź kod, a następnie ponownie kliknij Zatwierdź.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
       "companion_needs_addon": "To wygląda na telefon z Androidem 11 lub nowszym z debugowaniem bezprzewodowym, którego bezpośrednie połączenie stąd nie obsługuje (wymaga TLS i parowania). Zainstaluj dodatek „VW Group App ADB Bridge” (github.com/its-me-prash/vwgroup-app-adb-bridge) i wskaż go tutaj. Starsze telefony (Android 10 lub wcześniejszy) łączą się bezpośrednio.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfigurera VW Group Connect",
-        "description": "Anslut ditt fordon till Home Assistant.\n\nVälj ditt märke och ange inloggningsuppgifterna från tillverkarens app.",
+        "description": "Hur vill du logga in?\n\n**Webbläsarinloggning (rekommenderas)** — öppna en URL på din telefon eller dator, logga in på ditt Brand ID-konto och godkänn enheten. Inget lösenord lagras någonsin i Home Assistant. Tillgängligt för Audi, SEAT och CUPRA.\n\n**E-post + lösenord (äldre metod)** — ange dina Brand ID-uppgifter direkt. Krävs för Volkswagen EU, Škoda och Porsche.",
         "menu_options": {
           "browser_login": "Webbläsarinloggning (rekommenderas)",
           "email_password": "E-post + lösenord (äldre metod)",
@@ -166,6 +166,7 @@
       "portal_interaction_required": "EU Data Act-portalen kräver en engångsåtgärd i din webbläsare eller varumärkesapp (t.ex. godkänna villkor, bekräfta samtycke, slutföra onboarding/regionval) innan huvudlös åtkomst fungerar. Detta är INTE ett lösenordsproblem — öppna portalen en gång i en webbläsare, slutför uppmaningen och försök igen.",
       "upstream_unavailable": "VW backend tillfälligt otillgänglig. Detta är ett serverproblem hos VW, INTE ett autentiseringsfel. Vänta 5–15 minuter och försök igen. Konfigurera INTE om integrationen.",
       "brand_not_dag_eligible": "Det valda märket stöder inte webbläsarinloggning. Använd flödet för e-post + lösenord i stället.",
+      "skoda_qr_retired": "Škodas lösenordsfria inloggning (QR) inaktiverades av Volkswagen och fungerar inte längre. Gå tillbaka och välj ”E-post + lösenord (äldre metod)”, välj sedan Škoda där och logga in med din MyŠkoda-e-post och ditt lösenord.",
       "still_waiting_browser": "Väntar fortfarande på godkännande i webbläsaren. Öppna URL:en ovan, logga in, bekräfta koden och klicka sedan på Skicka igen.",
       "companion_cannot_connect": "Could not reach the phone over ADB. Check it is on the network, that ADB over Wi-Fi is on, and that you accepted the debugging prompt.",
       "companion_needs_addon": "Det här ser ut som en telefon med Android 11 eller nyare som använder trådlös felsökning, vilket den direkta anslutningen här inte klarar (den bygger på TLS och parkoppling). Installera tillägget 'VW Group App ADB Bridge' (github.com/its-me-prash/vwgroup-app-adb-bridge) och peka companion-anslutningen mot tillägget. Äldre telefoner (Android 10 eller tidigare) ansluter direkt här.",

--- a/tests/test_diagnostics_raw_capture.py
+++ b/tests/test_diagnostics_raw_capture.py
@@ -12,7 +12,13 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock
 
-from custom_components.vag_connect.diagnostics import _scrub_raw
+from custom_components.vag_connect.diagnostics import _scrub, _scrub_raw
+
+# A synthetic JWT used to check token-as-key masking (not a real token).
+_SYNTH_JWT = (
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+    "dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"
+)
 
 # A deliberately nasty raw payload: every kind of PII a brand backend can ship,
 # under the unpredictable camelCase keys a raw response actually uses.
@@ -78,6 +84,37 @@ def test_scrub_raw_is_none_safe() -> None:
     assert _scrub_raw(None) is None
     assert _scrub_raw({}) == {}
     assert _scrub_raw([]) == []
+
+
+def test_vin_as_a_dict_key_is_masked_raw() -> None:
+    """#923 / #1088 — a VIN used as a container KEY (e.g. ``data_act_identifiers``)
+    must not survive in plain text. The value-only scrub missed it and two
+    reporters had to hand-redact their download before posting."""
+    raw = {"data_act_identifiers": {"WVWZZZSYNTHET0001": {"lastSeen": "2026-08-09"}}}
+    out = _scrub_raw(raw)
+    assert "WVWZZZSYNTHET0001" not in json.dumps(out)
+    # the container structure survives (masked key still there, one entry)
+    assert "data_act_identifiers" in out
+    assert len(out["data_act_identifiers"]) == 1
+
+
+def test_vin_as_a_dict_key_is_masked_scrub() -> None:
+    """Same leak, the non-raw ``_scrub`` path (config-entry data)."""
+    data = {"data_act_identifiers": {"WVWZZZSYNTHET0001": {"seen": 1}}}
+    assert "WVWZZZSYNTHET0001" not in json.dumps(_scrub(data))
+
+
+def test_token_as_a_dict_key_is_masked() -> None:
+    """A JWT used as a key is masked too."""
+    assert "eyJhbGci" not in json.dumps(_scrub_raw({_SYNTH_JWT: {"x": 1}}))
+
+
+def test_uuid_key_is_kept_structural() -> None:
+    """UUID keys are structural grounding data (not PII) and must survive so a
+    UUID-keyed portal point stays discoverable."""
+    out = _scrub_raw({"0a18a053-1234-4abc-8def-0123456789ab": {"currentSoc": 61}})
+    assert "0a18a053-1234-4abc-8def-0123456789ab" in out
+    assert out["0a18a053-1234-4abc-8def-0123456789ab"]["currentSoc"] == 61
 
 
 def test_vwna_client_has_raw_responses_bucket() -> None:

--- a/tests/test_v2130_portal_device_grant.py
+++ b/tests/test_v2130_portal_device_grant.py
@@ -84,9 +84,13 @@ def test_dag_enabled_brands_unchanged():
     # v2.19.0 — audi_na (Audi US/CA, NA IDP) is a deliberate addition; the guard
     # that matters is that volkswagen never joins (routes to the dead EU BFF).
     assert dg.DAG_ENABLED_BRANDS == frozenset(
-        {"audi", "skoda", "seat", "cupra", "audi_na"}
+        {"audi", "seat", "cupra", "audi_na"}
     )
     assert "volkswagen" not in dg.DAG_ENABLED_BRANDS
+    # v3.0.1 — VW revoked Škoda's device_code grant (403 unauthorized_client on
+    # identity.vwgroup.io), so Škoda is deliberately removed from the QR path and
+    # now signs in via email + password (IDK authorization-code).
+    assert "skoda" not in dg.DAG_ENABLED_BRANDS
 
 
 def test_strategy_param_wired():

--- a/tests/test_v2190_audi_na_dag.py
+++ b/tests/test_v2190_audi_na_dag.py
@@ -28,8 +28,10 @@ from custom_components.vag_connect.cariad.models import BRANDS, BRAND_AUDI_NA
 
 def test_audi_na_is_dag_eligible() -> None:
     assert "audi_na" in DAG_ENABLED_BRANDS
-    # the EU brands are untouched
-    assert {"audi", "skoda", "seat", "cupra"} <= DAG_ENABLED_BRANDS
+    # the EU brands are untouched (v3.0.1: Škoda dropped — VW revoked its
+    # device_code grant; it now signs in via email + password)
+    assert {"audi", "seat", "cupra"} <= DAG_ENABLED_BRANDS
+    assert "skoda" not in DAG_ENABLED_BRANDS
 
 
 def test_dag_idp_urls_switches_na_vs_eu() -> None:
@@ -37,7 +39,7 @@ def test_dag_idp_urls_switches_na_vs_eu() -> None:
     assert dev == "https://identity.na.vwgroup.io/oidc/v1/device_authorization"
     assert tok == "https://identity.na.vwgroup.io/oidc/v1/token"
     # every other brand keeps the EU IDP
-    for eu in ("audi", "skoda", "seat", "cupra"):
+    for eu in ("audi", "seat", "cupra"):
         assert dag_idp_urls(eu) == (_IDP_DEVICE_AUTH_URL, _IDP_TOKEN_URL)
 
 

--- a/tests/test_v301_skoda_qr_retired.py
+++ b/tests/test_v301_skoda_qr_retired.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v3.0.1 — Škoda passwordless (QR / device_code) login retired.
+
+Volkswagen revoked the Škoda client's device_code grant in 2026-08:
+``identity.vwgroup.io/oidc/v1/device_authorization`` returns
+``403 unauthorized_client`` ("client is not allowed to use the device_code
+grant") for the canonical Škoda client (7f045eee) and ``400`` for the
+alternate (4fffed6b), while Audi still returns ``200`` (live-probed). Offering
+the QR path for Škoda produced a silent config-flow reload for users.
+
+The hotfix removes Škoda from the QR/device-grant surface; it now signs in via
+email + password (IDK authorization-code), an independent path VW's revocation
+does not touch. These tests pin the invariants of that fix.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from custom_components.vag_connect.cariad.auth._device_grant import (
+    DAG_ENABLED_BRANDS,
+)
+from custom_components.vag_connect.cariad._capabilities import (
+    DECLARED_CAPABILITIES,
+)
+
+_COMPONENT = Path(__file__).resolve().parents[1] / "custom_components" / "vag_connect"
+
+
+def test_skoda_not_dag_eligible() -> None:
+    """Škoda must no longer be offered the QR/device_code path."""
+    assert "skoda" not in DAG_ENABLED_BRANDS
+    # the other DAG brands are untouched
+    assert {"audi", "seat", "cupra", "audi_na"} <= DAG_ENABLED_BRANDS
+
+
+def test_skoda_capability_dag_login_false() -> None:
+    """The declared-capabilities table reflects the revoked grant."""
+    assert DECLARED_CAPABILITIES["skoda"]["dag_login"] is False
+
+
+def _error_block(fname: str) -> dict:
+    data = json.loads((_COMPONENT / fname).read_text(encoding="utf-8"))
+    return data["config"]["error"]
+
+
+def test_skoda_qr_retired_string_present() -> None:
+    """The guidance string exists in the source and the must-do locales."""
+    for fname in ("strings.json", "translations/en.json", "translations/de.json"):
+        errors = _error_block(fname)
+        assert "skoda_qr_retired" in errors, fname
+        # points the user at the email + password flow
+        assert errors["skoda_qr_retired"].strip()


### PR DESCRIPTION
Two quick fixes on the heels of 3.0.0. Bumps to **3.0.1**.

### Škoda passwordless (QR) login → email + password
Volkswagen switched off the `device_code` grant for Škoda's client on their identity provider — `/device_authorization` now returns `403 unauthorized_client` for the canonical Škoda client and `400` for the alternate, while Audi still returns `200` (live-probed). The integration still offered the QR/browser login for Škoda, so `request_device_code()` threw and the config-flow form silently reloaded — Škoda owners couldn't sign in after the 3.0.0 launch.

Škoda is removed from the device-grant whitelist and routed to the email+password (IDK authorization-code) flow, which VW's revocation doesn't touch and which was already fully wired. A clear `skoda_qr_retired` message covers a stale/crafted QR payload; the sign-in-method brand lists are updated across all 12 translations; Škoda's declared `dag_login` capability is flipped to false. Existing QR-created Škoda entries migrate to email+password automatically on the next reauth. Audi/SEAT/CUPRA keep their QR login.

### Security: VIN could survive the diagnostics redaction as a dict key
The "Download diagnostics" export masked VINs that appear as field *values*, but the recursive scrubbers copied dict *keys* through verbatim — so a VIN used as a container key (e.g. under `data_act_identifiers`) survived in plain text in a file users attach to public issues. Two reporters had to hand-redact it. Dict keys are now masked too (VIN + tokens; structural UUID keys are kept). Regression tests cover VIN/JWT-as-key on both scrub paths.

Full suite green (`4731 passed`). Thanks @fight3 and @PeterPrelo for the redaction catch.
