### PR TITLE
fix(eu-data): resolve a repeated SoC by mode instead of leaving it contested (#1088)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 > — mit jeder geänderten Datei, jeder Zeile, jeder Issue-Referenz und der
 > Methodik dahinter.
 
+## [Unreleased]
+
+### Fixed
+- **A battery level that shows up several times in one data export now settles on the value the export repeats, not a lone stale copy.** Some Volkswagen EU exports list the state of charge more than twice under one capture time with no per-point clock to separate them — for example 71 once and 60 twice. The integration now treats a value the export repeats as the real reading and keeps it, instead of possibly latching onto the single odd-one-out when your last known level happened to sit near it. A genuine two-way tie (each value once) is unchanged and still reconciles against your last known value. Thanks @PeterPrelo for the export that showed the three-way case.
+
 ## [3.0.1] - 2026-08-09 — Škoda login + diagnostics-redaction hotfix
 
 Two quick fixes on the heels of 3.0.0: Škoda's passwordless login (which Volkswagen switched off on their side), and a VIN that could slip through the diagnostics redaction.

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -793,6 +793,10 @@ def _walk_fields(
     # its OWN sibling timestamp — that ts is order-dependent (VW reorders the log
     # between exports), so it must not be trusted to decide a value conflict (#465).
     best: dict[str, tuple[str, float, bool, bool]] = {}
+    # #1088 — per-name value occurrence counts, so a contest with a clear
+    # majority (the same reading repeated) can be resolved by mode instead of
+    # left ambiguous. Only consulted for names that end up contested.
+    counts: dict[str, dict[str, int]] = {}
     dataset_ts = _dataset_captured_ts(payload)  # a11: dataset-level freshness floor
 
     def add(
@@ -806,6 +810,8 @@ def _walk_fields(
             return
         if not isinstance(value, (str, int, float, bool)):
             return
+        vc = counts.setdefault(name, {})
+        vc[str(value)] = vc.get(str(value), 0) + 1
         # NO-SUPPRESSION (hard rule): sentinels ("no reading" / uint-max) must
         # NOT be dropped from the flattened surface here — that removed the
         # field from raw_unmapped (Scout) entirely, even for fields we never
@@ -992,6 +998,28 @@ def _walk_fields(
                 )
 
     walk(payload, node_ts=dataset_ts)  # a11: bare fields inherit dataset freshness
+    # #1088 — mode-aware contest resolution. When one field turns up several
+    # times under a single capture time (a name-collision across UUIDs), a value
+    # the export REPEATS is the real reading and a singleton twin is the stale
+    # one (@PeterPrelo's ID export: 71 once vs 60 twice → 60). If one contested
+    # value has a strictly higher occurrence count, resolve to it here and drop
+    # it from the contested set: it is no longer genuinely ambiguous, so
+    # reconcile's closest-to-last must not second-guess it and possibly latch the
+    # stale twin. A true tie (each value once, e.g. #465's 57 vs 81) has no mode
+    # and stays contested for reconcile to settle against the last known value.
+    if _contested_out is not None:
+        for name in list(_contested_out.keys()):
+            vc = counts.get(name) or {}
+            ranked = sorted(
+                ((vc.get(v, 0), v) for v in _contested_out[name]),
+                reverse=True,
+            )
+            if len(ranked) >= 2 and ranked[0][0] > ranked[1][0]:
+                winner = ranked[0][1]
+                prev = best.get(name)
+                if prev is not None:
+                    best[name] = (winner, prev[1], prev[2], prev[3])
+                del _contested_out[name]
     if _ts_out is not None:
         # Expose only GENUINE (real) per-point capture timestamps; floor/unknown
         # (-inf) carry no snapshot identity and must not constrain last_seen.

--- a/tests/test_1088_dup_soc_no_timestamp.py
+++ b/tests/test_1088_dup_soc_no_timestamp.py
@@ -41,3 +41,30 @@ def test_legacy_caller_without_contested_dict_is_safe() -> None:
     # a caller that passes no contested dict must not crash, and last still wins
     fields = _walk_fields(_dup("50", "76"))
     assert fields["battery_state_report.soc"] == "76"
+
+
+def _triple(v1: str, v2: str, v3: str) -> dict:
+    return {"data": [
+        {"dataFieldName": "battery_state_report.soc", "value": v1},
+        {"dataFieldName": "battery_state_report.soc", "value": v2},
+        {"dataFieldName": "battery_state_report.soc", "value": v3},
+    ]}
+
+
+def test_repeated_value_wins_by_mode_and_is_not_contested() -> None:
+    # @PeterPrelo's real ID export: soc appears three times as 71, 60, 60 with no
+    # timestamps. The repeated 60 is the real reading; the singleton 71 is the
+    # stale twin. The parser resolves to the mode and does NOT leave it contested,
+    # so reconcile can't latch the 71 when the last known value happens to be high.
+    contested: dict = {}
+    fields = _walk_fields(_triple("71", "60", "60"), {}, {}, contested)
+    assert fields["battery_state_report.soc"] == "60"
+    assert "battery_state_report.soc" not in contested
+
+
+def test_three_way_tie_without_a_mode_stays_contested() -> None:
+    # No majority (each distinct value once) → still ambiguous, stays contested
+    # for reconcile to settle against the last known value.
+    contested: dict = {}
+    _walk_fields(_triple("50", "60", "70"), {}, {}, contested)
+    assert contested.get("battery_state_report.soc") == {"50", "60", "70"}


### PR DESCRIPTION
Follow-up to #1088, grounded in @PeterPrelo's real ID export.

Some EU Data Act exports list the same `battery_state_report.soc` several times under one capture time with **no** per-point timestamp — e.g. `71` once and `60` twice. The parser recorded the disagreement as contested and let `vehicle_cache.reconcile` pick the candidate closest to the last known value, which could latch the singleton stale twin (`71`) when the last known level happened to sit near it.

Now: when one contested value occurs **strictly more often** than the others, the parser resolves to that mode and drops it from the contested set — it isn't genuinely ambiguous, so reconcile won't second-guess it. A true tie (each value once, e.g. #465's 57 vs 81) has no mode and stays contested as before.

Suite green (`4733 passed`), incl. a regression test on the exact `71/60/60` case and a three-way tie.
