### PR TITLE
fix(eu-data): drop the CHARGE_TYPE_INVALID end-of-charge sentinel (#1104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ### Fixed
 - **A battery level that shows up several times in one data export now settles on the value the export repeats, not a lone stale copy.** Some Volkswagen EU exports list the state of charge more than twice under one capture time with no per-point clock to separate them — for example 71 once and 60 twice. The integration now treats a value the export repeats as the real reading and keeps it, instead of possibly latching onto the single odd-one-out when your last known level happened to sit near it. A genuine two-way tie (each value once) is unchanged and still reconciles against your last known value. Thanks @PeterPrelo for the export that showed the three-way case.
+- **The charging-type sensor no longer flashes "invalid" at the end of a session.** Around the moment a charge finishes, the backend briefly sends an `invalid` placeholder for the charge type; it was being shown as if it were a real charging type, so the history/timeline painted "invalid" bands after every session. It's now dropped like the other backend placeholders, so the sensor stays clear until a real type comes back. Thanks @Lagaff86 for the detailed timeline that pinned it down.
 
 ## [3.0.1] - 2026-08-09 — Škoda login + diagnostics-redaction hotfix
 

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -2071,9 +2071,21 @@ def map_dataset_to_vehicle_data(
             d.available_charge_modes.append(_label)
 
     # charge_type → charging_type (_shorten_enum, CHARGE_TYPE_ prefix added).
+    # #1104 (Lagaff86) — junk-filter AFTER shortening: an end-of-charge
+    # CHARGE_TYPE_INVALID shortens to "invalid", which Recorder would store as a
+    # real charging type and paint "invalid" history bands. Skip the sentinel so
+    # the field stays None (matching charging_mode/#764 and the connector states)
+    # until the backend sends a real type again — the check is on the SHORTENED
+    # value because the junk arrives prefixed (CHARGE_TYPE_INVALID), unlike the
+    # bare sentinels _charge_str() screens.
     _ctype = first("charging_state_report.charge_type", "charge_type", "chargeType")
     if _ctype is not None:
-        d.charging_type = _shorten_enum(_ctype)
+        _ctype_short = _shorten_enum(_ctype)
+        if (
+            _ctype_short is not None
+            and _ctype_short.strip().lower() not in _CHARGE_STATE_JUNK
+        ):
+            d.charging_type = _ctype_short
 
     # charging_mode → charging_preferred_mode (guard is None so a BFF value
     # is never clobbered). #764 — drop the portal 'invalid'/etc. junk sentinels

--- a/tests/test_1104_charge_type_invalid_sentinel.py
+++ b/tests/test_1104_charge_type_invalid_sentinel.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Prash Balan (@its-me-prash) - Apache License 2.0
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1104 (Lagaff86, Audi e-tron GT) — the charge_type field leaked the backend
+end-of-charge sentinel: CHARGE_TYPE_INVALID shortened to the literal "invalid"
+and Recorder stored it as a real charging type, painting "invalid" history
+bands around every session end. charge_type was missing the junk-sentinel
+filter its sibling fields (charging_mode/#764, the connector states) already
+have — and the junk arrives PREFIXED, so the check must run on the shortened
+value. It now drops to None until the backend sends a real type again.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(fields: dict[str, str]) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_charge_type_prefixed_invalid_sentinel_dropped() -> None:
+    # the real end-of-charge value Lagaff86 saw
+    assert _map({"charge_type": "CHARGE_TYPE_INVALID"}).charging_type is None
+
+
+def test_charge_type_bare_invalid_sentinel_dropped() -> None:
+    # bare-spelling dialects are screened too
+    assert _map({"charge_type": "invalid"}).charging_type is None
+    assert _map({"charge_type": "unavailable"}).charging_type is None
+
+
+def test_charge_type_real_value_kept() -> None:
+    d = _map({"charge_type": "CHARGE_TYPE_AC"})
+    assert d.charging_type is not None
+    assert d.charging_type.strip().lower() not in (
+        "invalid", "error", "unavailable", "unknown", "notavailable",
+    )
+    assert d.charging_type.lower() == "ac"  # prefix stripped, real value kept


### PR DESCRIPTION
Fixes #1104 (thanks @Lagaff86 for the forensic timeline).

Around the end of a charging session the backend briefly sends `CHARGE_TYPE_INVALID` for the charge type. `_shorten_enum` turned that into the literal `invalid`, which was written straight to `charging_type` — so Recorder stored `invalid` as a real state and the history painted "invalid" bands after every session (50 occurrences observed on an Audi e-tron GT, all at end-of-charge).

`charge_type` was missing the junk-sentinel filter its siblings already have (`charging_mode`/#764, the connector states). Because the junk arrives **prefixed**, the check runs on the *shortened* value: an `invalid`/`unavailable`/`error`/`unknown` result is dropped to `None` until the backend sends a real type again.

Goes into `[Unreleased]` — not tagged yet. Suite green (`4736 passed`), incl. the exact `CHARGE_TYPE_INVALID` case + a real-value-kept test.
