### PR TITLE
fix(ci): stop the dict watcher opening no-op PRs on a cosmetic page redeploy

### DIFF
--- a/.github/workflows/eu-data-dict-watch.yml
+++ b/.github/workflows/eu-data-dict-watch.yml
@@ -60,6 +60,19 @@ jobs:
           if [ -z "$(git status --porcelain docs/)" ]; then
             echo "page changed but generated doc is identical — nothing to PR"; exit 0
           fi
+          # Belt-and-suspenders: the regenerator stamps today's date into the
+          # ``Extracted:`` line, so a cosmetic re-run is never byte-clean. If the
+          # ONLY dictionary-doc change is that date line, there is no real content
+          # change — discard and skip the PR (this is what defeated the guard above
+          # and produced no-op PR #1124).
+          MEANINGFUL=$(git diff -U0 -- docs/EU_DATA_ACT_DATA_DICTIONARY.md \
+            | grep -E '^[+-]' | grep -vE '^(\+\+\+|---) ' \
+            | grep -vE '^[+-]- \*\*Extracted:\*\*' || true)
+          if [ -z "$MEANINGFUL" ]; then
+            echo "only the extraction date changed — no dictionary content change, not opening a PR"
+            git checkout -- docs/ 2>/dev/null || true
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           BRANCH="chore/eu-data-dict-v${VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - **The "update interval too short" message no longer asks you to raise an interval you already exceed.** A Škoda owner who had already gone up to 31 minutes kept being told to raise it to 30 minutes or more, which reads as nonsense. The suggestion now always steps up from the value you actually have configured. Thanks @starwarsfan.
 - **The charging-type sensor no longer shows "invalid".** When the backend has no charge type to report it sends an `invalid` placeholder, and that was being shown as if it were a real charging type — so the history painted "invalid" bands, often for ten minutes at a time while the car sat parked and not charging. It's now dropped on **every brand**: Volkswagen, Audi, Škoda, SEAT, CUPRA, Bentley, whether the data comes from the brand backend or the EU data portal. The sensor simply stays clear until a real type comes back. Thanks @Lagaff86, whose Recorder audit of 90 occurrences pinned the pattern down — and who caught that the first attempt only covered one of the four data paths and left his own car unfixed.
 
+### Internal
+- **The data-dictionary watcher no longer opens an empty pull request when Volkswagen only re-publishes the source page.** The automation that watches the EU-Data-Act dictionary was treating any change to the source page as a new dictionary, even a cosmetic re-deploy — which produced a pull request whose only real difference was the date. It now regenerates only when the dictionary's *version* or download links actually change (the PDFs are versioned in their own filename), and treats a same-version page change as noise. No user-facing effect.
+
 ## [3.0.1] - 2026-08-09 — Škoda login + diagnostics-redaction hotfix
 
 Two quick fixes on the heels of 3.0.0: Škoda's passwordless login (which Volkswagen switched off on their side), and a VIN that could slip through the diagnostics redaction.

--- a/scripts/check_eu_data_dict.py
+++ b/scripts/check_eu_data_dict.py
@@ -6,20 +6,23 @@
 The official SVK DataDictionary PDFs live behind the portal operator's page:
   https://eu-data-act.drivesomethinggreater.com/content/euda/de/de/service/data-dictionary
 
-The actual PDF downloads are JS-triggered and login-gated, so they have no stable
-public URL a CI runner can fetch — automated *download* is not possible. What we
-CAN do: fetch the public page, look for any version/filename/change signal, and
-compare it to a committed baseline (``docs/eu_data_act_source.lock``). When
-anything changes, the workflow opens an issue so a human pulls the fresh PDFs and
-re-runs ``scripts/build_eu_data_dict_doc.py``.
+The page embeds the DAM asset name (date-prefix + version), and that DAM asset IS
+publicly downloadable (verified: HTTP 200, application/pdf, no login). So we fetch
+the page, extract the versioned filename + download URLs, and compare against a
+committed baseline (``docs/eu_data_act_source.lock``). On a genuinely new
+dictionary the workflow auto-downloads the fresh PDFs and regenerates
+``docs/EU_DATA_ACT_DATA_DICTIONARY.md`` into a PR.
 
-Signals checked (best-effort, in order of confidence):
-  1. any ``SVK_DataDictionary_V<x>`` filename exposed in the HTML,
-  2. any ``Version: <x>`` / date string,
-  3. a sha256 of the normalised page HTML (catches structural/content changes).
+What TRIGGERS a PR vs. what is merely informational (see ``_classify``):
+  * a new ``SVK_DataDictionary_V<x>`` version, or a changed download URL, IS a new
+    dictionary — the PDFs are versioned in their own filename, so real content can
+    only arrive with a version/URL bump. These TRIGGER a regenerate + PR.
+  * a bare page-HTML hash change with the SAME version and URLs is a cosmetic AEM
+    redeploy (nonce/markup/CDN churn). It is recorded as INFORMATIONAL and does
+    NOT open a PR — that false-positive produced the no-op PR #1124.
 
 Exit code is always 0; the ``changed`` verdict is written to ``$GITHUB_OUTPUT``
-(and printed) so the workflow can decide whether to open an issue.
+(and printed) so the workflow can decide whether to regenerate + open a PR.
 
 Usage:
   py scripts/check_eu_data_dict.py                # check, report changed=true/false
@@ -80,6 +83,44 @@ def _signals(html: str) -> dict[str, object]:
     }
 
 
+def _classify(
+    now: dict[str, object], base: dict[str, object]
+) -> tuple[bool, list[str], list[str]]:
+    """Split the signals into what warrants a PR vs. what is merely informational.
+
+    A genuinely new dictionary always bumps the SVK version inside the DAM filename
+    (``…_V4.0_…`` → ``…_V4.1_…``) and therefore the download URLs, because the PDFs
+    are versioned in their own name — VW cannot ship different content at the exact
+    same versioned URL. So the version/URL signals **trigger** a regenerate + PR.
+
+    A bare ``page_sha256`` change with the SAME version and URLs is a cosmetic AEM
+    redeploy of the landing page (markup churn the normaliser did not strip). It is
+    reported as **informational** only and must NOT open a PR — that is exactly the
+    false-positive that produced the no-op PR #1124.
+
+    Returns ``(should_pr, trigger_diffs, info_diffs)``.
+    """
+    trigger: list[str] = []
+    info: list[str] = []
+    if now.get("svk_versions") != base.get("svk_versions"):
+        trigger.append(
+            f"SVK version: {base.get('svk_versions')} -> {now.get('svk_versions')}"
+            "  (NEW DICTIONARY VERSION)"
+        )
+    if now.get("download_urls") != base.get("download_urls"):
+        trigger.append(
+            f"download URLs changed -> {json.dumps(now.get('download_urls') or {})}"
+        )
+    if now.get("page_sha256") != base.get("page_sha256"):
+        info.append(
+            f"page content hash changed "
+            f"({str(base.get('page_sha256', '?'))[:12]} -> "
+            f"{str(now.get('page_sha256', '?'))[:12]}) — cosmetic redeploy, "
+            "version + URLs unchanged"
+        )
+    return bool(trigger), trigger, info
+
+
 def _emit(changed: bool, summary: str) -> None:
     print(("CHANGED — " if changed else "unchanged — ") + summary)
     out = os.environ.get("GITHUB_OUTPUT")
@@ -119,22 +160,24 @@ def main() -> int:
             fh.write(f"continuous_url={urls.get('continuous','')}\n")
             fh.write(f"historical_url={urls.get('historical','')}\n")
 
-    diffs = []
-    if now["svk_versions"] != base.get("svk_versions"):
-        diffs.append(f"SVK version: {base.get('svk_versions')} -> {now['svk_versions']}  (NEW DICTIONARY VERSION)")
-    if now["download_urls"] != base.get("download_urls"):
-        diffs.append(f"download URLs changed -> {json.dumps(urls)}")
-    if now["page_sha256"] != base.get("page_sha256"):
-        diffs.append(f"page content hash changed ({base.get('page_sha256','?')[:12]} -> {now['page_sha256'][:12]})")
+    should_pr, trigger, info = _classify(now, base)
 
-    if diffs:
+    if should_pr:
         summary = ("The EU Data Act data-dictionary page changed — a new SVK DataDictionary "
                    "is likely published. The workflow will auto-download the fresh PDFs from the "
                    "public DAM URLs and regenerate `docs/EU_DATA_ACT_DATA_DICTIONARY.md` into a PR. "
-                   "Source: " + URL + "\n\nDetected:\n- " + "\n- ".join(diffs))
+                   "Source: " + URL + "\n\nDetected:\n- " + "\n- ".join(trigger + info))
         _emit(True, summary)
+    elif info:
+        # Page redeployed but the SVK version and PDF URLs are unchanged: the actual
+        # dictionary cannot have changed (the PDFs are versioned in their filename),
+        # so this is a cosmetic AEM redeploy. Report it, but do NOT open a PR — this
+        # is the #1124 no-op guard.
+        _emit(False,
+              "page redeployed but SVK version + PDF URLs unchanged — not opening a PR ("
+              + "; ".join(info) + ")")
     else:
-        _emit(False, f"no change (sha {now['page_sha256'][:12]})")
+        _emit(False, f"no change (sha {str(now.get('page_sha256', '?'))[:12]})")
     return 0
 
 

--- a/tests/test_eu_data_dict_watch_trigger.py
+++ b/tests/test_eu_data_dict_watch_trigger.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The EU-Data-Act dictionary watcher must not open a PR for a cosmetic page
+redeploy.
+
+On 2026-08-10 the watch workflow opened PR #1124 ("regenerate EU Data Act data
+dictionary (SVK V4.0)") whose only real diff was the extraction date and the
+tracked ``page_sha256``. The regenerated dictionary was byte-identical — same SVK
+V4.0, same 1141 + 5139 keys. The portal had merely re-published the AEM landing
+page (its HTML hash moved); the versioned PDFs were untouched.
+
+Root cause: ``check_eu_data_dict.py`` treated a bare ``page_sha256`` change as a
+new-dictionary signal. But the PDFs are versioned in their own filename
+(``…_V4.0_…``), so real content can only arrive with a version/URL bump — the page
+hash is the wrong trigger. ``_classify`` now splits *trigger* signals (version /
+download URLs) from *informational* ones (page hash), and a hash-only change no
+longer opens a PR.
+
+The states below are lifted verbatim from ``docs/eu_data_act_source.lock`` before
+and after PR #1124, so this test reproduces the exact false-positive.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_eu_data_dict.py"
+_spec = importlib.util.spec_from_file_location("check_eu_data_dict", _SCRIPT)
+assert _spec and _spec.loader
+check_eu_data_dict = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_eu_data_dict)
+_classify = check_eu_data_dict._classify
+
+
+# ── the real #1124 states ────────────────────────────────────────────────────
+
+_V40_URLS = {
+    "continuous": (
+        "https://eu-data-act.drivesomethinggreater.com/content/dam/datahub/pdf/"
+        "data-dictionary/251022_01_SVK_DataDictionary_V4.0_Continous_Data.pdf"
+    ),
+    "historical": (
+        "https://eu-data-act.drivesomethinggreater.com/content/dam/datahub/pdf/"
+        "data-dictionary/251022_01_SVK_DataDictionary_V4.0_Historical%20Data.pdf"
+    ),
+    "version": "4.0",
+    "prefix": "251022_01",
+}
+_BASE_1124 = {
+    "svk_versions": ["4.0"],
+    "download_urls": _V40_URLS,
+    "page_sha256": "26bfa2517beb4ab453a1ab3ddf6165869f33758b7c2ed20be783dd8b4a456d5f",
+}
+_NOW_1124 = {
+    "svk_versions": ["4.0"],
+    "download_urls": _V40_URLS,
+    # only this moved — the AEM page was cosmetically re-published
+    "page_sha256": "1753253b6702b06a142abd5fb10a7a3636453a85f8a449fa581ff212493c9b5b",
+}
+
+
+def test_1124_cosmetic_page_redeploy_does_not_open_a_pr() -> None:
+    """The exact #1124 state: page hash moved, version + URLs identical."""
+    should_pr, trigger, info = _classify(_NOW_1124, _BASE_1124)
+    assert should_pr is False       # was True before the fix → no-op PR #1124
+    assert trigger == []            # nothing warranting a regenerate
+    assert len(info) == 1           # the hash change is recorded, not suppressed
+    assert "cosmetic" in info[0].lower()
+
+
+def test_a_new_svk_version_triggers_a_pr() -> None:
+    """A real new dictionary bumps the version in the DAM filename."""
+    now = {
+        "svk_versions": ["4.1"],
+        "download_urls": {**_V40_URLS, "version": "4.1"},
+        "page_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    }
+    should_pr, trigger, info = _classify(now, _BASE_1124)
+    assert should_pr is True
+    assert any("NEW DICTIONARY VERSION" in t for t in trigger)
+
+
+def test_a_changed_download_url_triggers_a_pr() -> None:
+    """Same version string but a new date-prefix (new asset) must still PR."""
+    now = {
+        "svk_versions": ["4.0"],
+        "download_urls": {**_V40_URLS, "prefix": "260101_02"},
+        "page_sha256": _BASE_1124["page_sha256"],
+    }
+    should_pr, trigger, info = _classify(now, _BASE_1124)
+    assert should_pr is True
+    assert any("download URLs changed" in t for t in trigger)
+
+
+def test_identical_signals_are_no_change() -> None:
+    should_pr, trigger, info = _classify(_BASE_1124, _BASE_1124)
+    assert should_pr is False
+    assert trigger == []
+    assert info == []
+
+
+def test_a_real_version_bump_still_reports_the_hash_as_info() -> None:
+    """When both change, the PR fires (version) and the hash rides along as info —
+    never suppressed, matching the no-suppression spirit of the watcher."""
+    now = {
+        "svk_versions": ["5.0"],
+        "download_urls": {**_V40_URLS, "version": "5.0"},
+        "page_sha256": _NOW_1124["page_sha256"],
+    }
+    should_pr, trigger, info = _classify(now, _BASE_1124)
+    assert should_pr is True
+    assert trigger and info


### PR DESCRIPTION
## What

The EU-Data-Act dictionary watcher opened **PR #1124** whose only real diff was the extraction date and the tracked page hash — the regenerated dictionary was **byte-identical** (same SVK V4.0, same 1141 + 5139 keys). Volkswagen had merely re-published the AEM landing page (its HTML hash moved); the versioned PDFs were untouched.

## Root cause

`check_eu_data_dict.py` treated **any** `page_sha256` change as a new-dictionary signal. But the PDFs are versioned in their own filename (`…_V4.0_…`), so real content can only arrive with a **version/URL** bump — the page hash is the wrong trigger. On top of that, the workflow's "generated doc is identical → skip PR" guard was defeated by the regenerator stamping today's date into the `Extracted:` line, so `docs/` was never byte-clean.

## Fix

- New pure `_classify()` splits **trigger** signals (SVK version / download URLs) from **informational** ones (page hash). A hash-only change with the same version + URLs no longer opens a PR — it's reported and dropped.
- Belt-and-suspenders: the workflow's PR guard now ignores a **date-only** doc diff.
- Corrected the stale docstring that claimed the PDFs can't be auto-downloaded (the workflow already fetches them from the public DAM).

## Tests

New `tests/test_eu_data_dict_watch_trigger.py` — the cosmetic-redeploy case uses the **verbatim #1124 lock states** (real before/after `page_sha256`, same V4.0 URLs) and asserts no PR is opened; a real version bump and a URL change still trigger. Full suite: **4789 passed**.

No user-facing effect (CI/tooling only). No release tag.
