### PR TITLE
fix(vw-eu): stop unknown online-state reading as OFFLINE + log missing position (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **A Volkswagen EU car read over the volkswagen.de channel no longer falsely shows OFFLINE.** That channel (and the EU Data Act one) can't tell the integration whether the car is online, and an *unknown* online state was being treated as *offline* — so a car that was answering its reads perfectly well still reported OFFLINE. It now says OFFLINE only when the backend actually reports the car as offline, and otherwise leaves the state unknown rather than inventing one. Thanks @fight3, whose T-Roc showed this alongside the separate, still-open missing-GPS question in #923.
+
+### Internal
+- **VW EU position reads now explain themselves in the debug log.** When a GPS coordinate can't be produced — the CARIAD parking-position endpoint being closed for EU passenger cars, and the volkswagen.de channel having no position endpoint at all — the log now says so instead of leaving a silent gap, so a "device_tracker stays unknown" report (#923) is diagnosable rather than looking like a dropped read.
+
 ## [3.0.2] - 2026-08-10 — the reporter batch (cross-brand reliability)
 
 A round of fixes driven entirely by reporter diagnostics in the hours after 3.0.0: two cross-brand sentinel screens (charging type and odometer), Volkswagen US climate + door-lock mapping, volkswagen.de sessions that finally survive a restart, a diagnosable EU data-request creation, and the Škoda push channel that can now actually start. Thank you to everyone who sent logs and diagnostics.

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -654,8 +654,12 @@ class VWEUClient(CariadBaseClient):
                 parking = await self._get(
                     f"{base}/vehicle/v1/vehicles/{vin}/parkingposition"
                 )
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as exc:  # noqa: BLE001
+            # Best-effort: parkingposition is a separate endpoint that is
+            # attestation/ACL-closed (403 XID_APP_VW) for VW EU passenger cars
+            # post-lockdown. Log at debug so a #923-class diagnostic shows the
+            # attempt+failure instead of a silent gap.
+            _LOGGER.debug("parkingposition fetch failed for %s: %s", vin[-6:], exc)
 
         # v2.7.0b11 — Trip statistics (separate endpoint, two query
         # types). Lifetime and last-trip stats live here, NOT in

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -1384,6 +1384,14 @@ class WebsiteAuthProxyConnector:
                 exc_info=True,
             )
 
+        # #923: the vw.de web channel exposes NO vehicle-position endpoint (unlike
+        # the CARIAD app backend), so a VW EU device_tracker on this channel stays
+        # "unknown". Say so at debug, so a reporter's log explains the absence
+        # rather than it looking like a silently dropped position read.
+        _LOGGER.debug(
+            "vw.de channel carries no position endpoint; device_tracker stays "
+            "unknown for %s (see #923)", vin[-6:],
+        )
         if got_data:
             d.connection_state = "online"
         return d

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -4662,16 +4662,25 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 "is_charging reset to False — plug not connected (defensive fix #32)"
             )
 
-        # Derive vehicle_state if not set by client
+        # Derive vehicle_state if not set by client. is_online is TRI-STATE:
+        # True (online), False (explicitly offline), or None (unknown — the vw.de
+        # authproxy and EU-Data-Act channels never report it; to_dict/asdict keeps
+        # the key present as None). #923: the old `not is_online` test read None as
+        # falsy and stamped OFFLINE on every VW EU authproxy car even while it was
+        # answering reads. Only an explicit False is OFFLINE now; when is_online is
+        # unknown and there is no driving/charging signal, leave vehicle_state
+        # unset rather than fabricate a state (Hard Rule #8).
         if not data.get("vehicle_state"):
-            if not data.get("is_online", True):
+            online = data.get("is_online")
+            if online is False:
                 data["vehicle_state"] = "OFFLINE"
             elif data.get("is_driving"):
                 data["vehicle_state"] = "DRIVING"
             elif data.get("is_charging"):
                 data["vehicle_state"] = "CHARGING"
-            else:
+            elif online is True:
                 data["vehicle_state"] = "PARKED"
+            # else: is_online unknown + no driving/charging → leave unset (unknown)
 
         # Derive is_driving from vehicle_state if client didn't set it
         if not data.get("is_driving") and data.get("vehicle_state") == "DRIVING":

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -178,6 +178,31 @@ class TestEnrich:
         result = asyncio.run(coord._enrich(data))
         assert result["vehicle_state"] == "CHARGING"
 
+    def test_vehicle_state_unknown_online_is_not_offline(self):
+        """#923: is_online=None means UNKNOWN, not offline. The vw.de authproxy
+        and EU-Data-Act channels never set is_online, and to_dict()/asdict keeps
+        the key present as None — the old `not is_online` test read that as falsy
+        and stamped OFFLINE on cars that were answering reads. Unknown online +
+        no driving/charging signal must NOT become OFFLINE; it is left unset."""
+        import asyncio
+        coord = self._make_coord()
+        data = {"is_online": None, "is_driving": False, "is_charging": False,
+                "latitude": None, "longitude": None}
+        result = asyncio.run(coord._enrich(data))
+        assert result.get("vehicle_state") != "OFFLINE"
+        assert result.get("vehicle_state") is None  # unknown, not fabricated
+
+    def test_vehicle_state_unknown_online_still_derives_charging(self):
+        """An active charging signal wins even when is_online is unknown, so an
+        EV on the authproxy channel still reads CHARGING rather than unknown."""
+        import asyncio
+        coord = self._make_coord()
+        data = {"is_online": None, "is_driving": False, "is_charging": True,
+                "plug_connected": True,
+                "latitude": None, "longitude": None}
+        result = asyncio.run(coord._enrich(data))
+        assert result["vehicle_state"] == "CHARGING"
+
     def test_existing_vehicle_state_preserved(self):
         """Client-set vehicle_state must not be overwritten."""
         import asyncio


### PR DESCRIPTION
## What

Two things surfaced by the #923 GPS investigation, both verified against source.

**1. Bug — unknown online-state read as OFFLINE.** `is_online` is tri-state (True / False / **None**). The vw.de authproxy and EU Data Act channels never set it, and `to_dict()`/`asdict` keeps the key present as `None`, so the derivation's `not data.get("is_online", True)` read `None` as falsy and stamped `vehicle_state=OFFLINE` on **every** VW EU authproxy car — even while it was answering its reads. Now only an explicit `False` is OFFLINE; unknown-online with no driving/charging signal leaves `vehicle_state` unset rather than fabricating one (Hard Rule #8).

**2. Diagnosability.** The CARIAD `parkingposition` fetch no longer swallows its 403 silently (debug log), and the volkswagen.de channel logs that it has no position endpoint at all — so a "device_tracker stays unknown" report shows the cause instead of a silent gap.

## Not in scope
Position itself stays **structurally unavailable** for VW EU: the only real coordinate source is the CARIAD `parkingposition` endpoint, which every incumbent lost at the 2026 lockdown (attestation-walled, 403 for EU passenger cars); the EU Data Act live feed has no coordinate field. This PR is the honesty + groundwork, not a position fix. One untested attestation-free lever (an authproxy reverse-proxy probe) remains — separate follow-up.

## Tests
`is_online=None` must not derive OFFLINE (stays unset) and still derives CHARGING on an active charge signal. Full suite **4802 passed**.

No release tag.
