### PR TITLE
feat(vw-eu): opt-in test cohort — crowd-confirm the vw.de GPS lever (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **New opt-in "test cohort" option — help unlock features for your car.** A new tick-box in the integration's options (off by default). When you turn it on, the integration may run experimental reads on your car — the first one being an attempt to recover **GPS location for Volkswagen EU cars** over the volkswagen.de channel — and, occasionally, show a dismissible notification asking you to share a diagnostics file so a new capability can be confirmed for your exact model. Everything shared is redacted automatically before it leaves your system (no VIN, GPS, tokens or e-mail), and turning the option back off stops the experiments and the notifications. It's how features like location get proven across the many different VW EU platforms without one person's single car having to represent them all. (#923)
+
 ### Fixed
 - **A Volkswagen EU car read over the volkswagen.de channel no longer falsely shows OFFLINE.** That channel (and the EU Data Act one) can't tell the integration whether the car is online, and an *unknown* online state was being treated as *offline* — so a car that was answering its reads perfectly well still reported OFFLINE. It now says OFFLINE only when the backend actually reports the car as offline, and otherwise leaves the state unknown rather than inventing one. Thanks @fight3, whose T-Roc showed this alongside the separate, still-open missing-GPS question in #923.
 
 ### Internal
-- **VW EU position reads now explain themselves in the debug log.** When a GPS coordinate can't be produced — the CARIAD parking-position endpoint being closed for EU passenger cars, and the volkswagen.de channel having no position endpoint at all — the log now says so instead of leaving a silent gap, so a "device_tracker stays unknown" report (#923) is diagnosable rather than looking like a dropped read.
+- **VW EU position reads now explain themselves in the debug log.** The CARIAD parking-position endpoint being closed for EU passenger cars (403) is logged at debug instead of being swallowed silently, so a "device_tracker stays unknown" report (#923) is diagnosable rather than looking like a dropped read.
 
 ## [3.0.2] - 2026-08-10 — the reporter batch (cross-brand reliability)
 

--- a/custom_components/vag_connect/cariad/_authproxy.py
+++ b/custom_components/vag_connect/cariad/_authproxy.py
@@ -98,6 +98,58 @@ def build_warninglights_url(vin: str, gdc: str | None = None) -> str:
     )
 
 
+def build_parkingposition_url(vin: str, gdc: str | None = None) -> str:
+    """Last-parked GPS position (``parkingposition``) — EXPERIMENTAL / UNCONFIRMED.
+
+    Mirrors the warning-lights recipe exactly (WeConnect realm + live VCF host +
+    per-platform ``gdc``), on the theory that the reverse-proxy which already
+    passes charging + warning-lights may also pass position. This is NOT confirmed:
+    the myVolkswagen website has no "where's my car" map, so the proxy allowlist
+    very likely excludes the position service — expect 403/404/412. Wired
+    best-effort behind a live probe (#923); if a portal-enrolled car returns
+    ``{"data": {"lat", "lon"}}`` here, it becomes real live GPS for every VW EU
+    authproxy user. The underlying source of truth is the CARIAD BFF
+    ``/vehicle/v1/vehicles/{vin}/parkingposition`` (attestation-walled, 403 for VW
+    EU post-lockdown), so this proxy path is the only remaining attestation-free
+    lever.
+    """
+    return build_authproxy_url(
+        f"vehicles/{vin}/parkingposition",
+        realm=_REALM_WECONNECT,
+        resource_host=_HOST_VCF_LIVE,
+        gdc=gdc or _GDC_WCAR,
+    )
+
+
+def parse_parking_position(
+    body: object,
+) -> tuple[float, float, str | None] | None:
+    """Extract ``(lat, lon, carCapturedTimestamp)`` from a parkingposition body.
+
+    Same shape contract as the CARIAD-BFF read (vw_eu.py): coordinates live under
+    ``data`` (``{"data": {"lat", "lon", "carCapturedTimestamp"}}``), with a
+    top-level fallback for legacy/alternate firmwares. Returns ``None`` unless the
+    body carries BOTH a numeric lat and lon — a degraded 200 with an empty data
+    node must not overwrite a good last-known position with None (#923). The
+    timestamp is returned as the raw ISO string (or None), matching how the BFF
+    path stores ``position_captured_at``.
+    """
+    if not isinstance(body, dict):
+        return None
+    node = body.get("data")
+    if not isinstance(node, dict):
+        node = body  # top-level fallback
+    lat = node.get("lat")
+    lon = node.get("lon")
+    if not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
+        return None
+    if isinstance(lat, bool) or isinstance(lon, bool):  # bool is an int subclass
+        return None
+    ts = node.get("carCapturedTimestamp")
+    ts_str = ts if isinstance(ts, str) and ts else None
+    return float(lat), float(lon), ts_str
+
+
 def build_transactionhistory_url(vin: str, gdc: str | None = None) -> str:
     """Remote-command history (lock/unlock lives here). Realm ``vw-de``.
 

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -1193,6 +1193,40 @@ class WebsiteAuthProxyConnector:
         )
         return count
 
+    async def get_parking_position(
+        self, vin: str,
+    ) -> tuple[float, float, str | None] | None:
+        """Last-parked ``(lat, lon, carCapturedTimestamp)`` for *vin* — EXPERIMENTAL.
+
+        Attempts the parkingposition read through the same WeConnect reverse-proxy
+        realm that already carries charging + warning-lights. This is the one
+        remaining attestation-free lever for VW EU GPS (#923): the CARIAD app
+        backend's position endpoint is attestation-walled and 403 for EU passenger
+        cars, and the EU Data Act live feed has no coordinate field. UNCONFIRMED —
+        the proxy allowlist very likely excludes the position service, so this is
+        fail-soft + optional exactly like ``get_warning_lights``: any 4xx / empty /
+        parse-miss returns None and never forces a re-login. Returns coordinates
+        only when the body actually carries a numeric lat+lon.
+        """
+        from .._authproxy import (  # noqa: PLC0415
+            build_parkingposition_url,
+            parse_parking_position,
+        )
+
+        await self._ensure_backend(vin)
+        body = await self._get_json(
+            build_parkingposition_url(vin, self._gdc(vin)),
+            accept="*/*", soft=True, optional=True,
+        )
+        if body is None:
+            return None
+        parsed = parse_parking_position(body)
+        _LOGGER.debug(
+            "Website authproxy parkingposition %s → %s", vin[-6:],
+            "coords" if parsed else "no coordinates in body",
+        )
+        return parsed
+
     async def get_last_lock_action(self, vin: str) -> tuple[str, str | None] | None:
         """Last confirmed remote lock/unlock command for *vin*.
 
@@ -1384,14 +1418,29 @@ class WebsiteAuthProxyConnector:
                 exc_info=True,
             )
 
-        # #923: the vw.de web channel exposes NO vehicle-position endpoint (unlike
-        # the CARIAD app backend), so a VW EU device_tracker on this channel stays
-        # "unknown". Say so at debug, so a reporter's log explains the absence
-        # rather than it looking like a silently dropped position read.
-        _LOGGER.debug(
-            "vw.de channel carries no position endpoint; device_tracker stays "
-            "unknown for %s (see #923)", vin[-6:],
-        )
+        # #923 — EXPERIMENTAL: attempt parkingposition through the same WeConnect
+        # proxy realm that already carries charging + warning-lights. This is the
+        # only remaining attestation-free lever for VW EU GPS (the CARIAD app
+        # backend's position endpoint is attestation-walled + 403 for EU passenger
+        # cars, and the EU Data Act live feed has no coordinate field). The proxy
+        # allowlist very likely excludes it, so it is fail-soft and never forces a
+        # re-login; if it DOES return coordinates, the device_tracker gets a real
+        # live position on this channel.
+        try:
+            pos = await self.get_parking_position(vin)
+            if pos is not None:
+                d.latitude, d.longitude, _pos_ts = pos
+                if _pos_ts:
+                    d.position_captured_at = _pos_ts
+                got_data = True
+        except AuthenticationError:
+            raise
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Website authproxy parkingposition read skipped for %s", vin[-6:],
+                exc_info=True,
+            )
+
         if got_data:
             d.connection_state = "online"
         return d

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -352,6 +352,33 @@ class WebsiteAuthProxyConnector:
         # issues (#923 / #966). Keyed by endpoint (VIN stripped from the key);
         # the bodies are redacted at export time. Bounded — one per endpoint.
         self.last_raw_responses: dict[str, Any] = {}
+        # #923 — EXPERIMENTAL parkingposition probe, gated on the opt-in test
+        # cohort (set by the coordinator from entry.data at arm time). Self-
+        # limiting: it stops after a few no-coordinate polls so we never hammer
+        # VW's proxy with a doomed request forever. If coordinates DO come back,
+        # ``_position_available`` latches True and the read continues every poll
+        # (it's a real feature at that point).
+        self.probe_position: bool = False
+        self._position_probe_tries: int = 0
+        self._position_available: bool = False
+
+    _POSITION_PROBE_MAX_TRIES = 4
+
+    def _should_probe_position(self) -> bool:
+        """Whether to attempt the experimental parkingposition read this poll.
+
+        True once coordinates have been seen at least once (it latches on as a
+        real feature), or while the user is opted into the test cohort and still
+        within the self-limiting probe budget. False otherwise — so an opted-out
+        user never issues the request, and an opted-in car whose proxy keeps
+        refusing stops after ``_POSITION_PROBE_MAX_TRIES`` polls.
+        """
+        if self._position_available:
+            return True
+        return (
+            self.probe_position
+            and self._position_probe_tries < self._POSITION_PROBE_MAX_TRIES
+        )
 
     def _capture_raw(self, url: str, body: Any) -> None:
         """Stash a raw vw.de response for diagnostics, keyed by endpoint with the
@@ -1418,28 +1445,33 @@ class WebsiteAuthProxyConnector:
                 exc_info=True,
             )
 
-        # #923 — EXPERIMENTAL: attempt parkingposition through the same WeConnect
-        # proxy realm that already carries charging + warning-lights. This is the
-        # only remaining attestation-free lever for VW EU GPS (the CARIAD app
-        # backend's position endpoint is attestation-walled + 403 for EU passenger
-        # cars, and the EU Data Act live feed has no coordinate field). The proxy
-        # allowlist very likely excludes it, so it is fail-soft and never forces a
-        # re-login; if it DOES return coordinates, the device_tracker gets a real
-        # live position on this channel.
-        try:
-            pos = await self.get_parking_position(vin)
-            if pos is not None:
-                d.latitude, d.longitude, _pos_ts = pos
-                if _pos_ts:
-                    d.position_captured_at = _pos_ts
-                got_data = True
-        except AuthenticationError:
-            raise
-        except Exception:  # noqa: BLE001
-            _LOGGER.debug(
-                "Website authproxy parkingposition read skipped for %s", vin[-6:],
-                exc_info=True,
-            )
+        # #923 — EXPERIMENTAL parkingposition read, gated on the opt-in test
+        # cohort (``probe_position``, set by the coordinator from entry.data).
+        # Attempts the same WeConnect proxy realm that already carries charging +
+        # warning-lights — the only remaining attestation-free lever for VW EU GPS
+        # (the CARIAD app position endpoint is attestation-walled + 403 for EU
+        # passenger cars, and the EU Data Act live feed has no coordinate field).
+        # Fail-soft, never forces a re-login. Self-limiting: it stops after a few
+        # no-coordinate polls so a doomed request isn't sent forever; the moment
+        # coordinates come back it latches on and keeps reading as a real feature.
+        if self._should_probe_position():
+            if not self._position_available:
+                self._position_probe_tries += 1
+            try:
+                pos = await self.get_parking_position(vin)
+                if pos is not None:
+                    d.latitude, d.longitude, _pos_ts = pos
+                    if _pos_ts:
+                        d.position_captured_at = _pos_ts
+                    got_data = True
+                    self._position_available = True
+            except AuthenticationError:
+                raise
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Website authproxy parkingposition read skipped for %s",
+                    vin[-6:], exc_info=True,
+                )
 
         if got_data:
             d.connection_state = "online"

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -57,6 +57,7 @@ from .const import (
     CONF_HIDE_EMPTY_ENTITIES,
     CONF_SUPPLEMENTARY_AUTHPROXY,
     CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES,
+    CONF_TEST_COHORT,
     CONF_SUPPLEMENTARY_EU_PORTAL,
     CONF_SUPPLEMENTARY_EU_PORTAL_PASSWORD,
     CONF_SUPPLEMENTARY_EU_PORTAL_USERNAME,
@@ -1950,6 +1951,19 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                     default=current_options.get(
                         CONF_READ_ONLY,
                         current_data.get(CONF_READ_ONLY, False),
+                    ),
+                ): _BOOL_SELECTOR,
+                # #923 — opt-in test cohort. When ticked, the integration may run
+                # experimental reads/probes (e.g. the vw.de parkingposition GPS
+                # lever) and surface a dismissible Repair asking the user to share
+                # aggressively-redacted diagnostics so a capability can be
+                # confirmed for their model. Persistent bool, default OFF; read
+                # via entry.data (options are folded into data by the listener).
+                vol.Optional(
+                    CONF_TEST_COHORT,
+                    default=current_options.get(
+                        CONF_TEST_COHORT,
+                        current_data.get(CONF_TEST_COHORT, False),
                     ),
                 ): _BOOL_SELECTOR,
                 # P1-5 — opt-in diagnostic archive of raw EU Data Act dataset

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -198,6 +198,13 @@ CONF_WEBSITE_COOKIES          = "website_cookies"
 # read-only source that the coordinator unions onto the primary snapshot via
 # merge_channels. Absent / False = single-channel behaviour, unchanged.
 CONF_SUPPLEMENTARY_AUTHPROXY         = "supplementary_authproxy"
+# Opt-in test cohort. When a user ticks this, the integration may run EXPERIMENTAL
+# reads/probes on their car (e.g. the vw.de parkingposition GPS lever, #923) and
+# surface a dismissible Repair asking them to share aggressively-redacted
+# diagnostics so a new capability can be confirmed for their model. Default off;
+# read ONLY via entry.data (the options listener folds options → data, and
+# entry.options is always {} at read time — see [[vag-connect-entry-options-trap]]).
+CONF_TEST_COHORT                     = "test_cohort"
 # v2.15.0b8 (C1) — supplementary EU Data Act PORTAL read channel (email/pw,
 # no OTP) merged onto a command-capable primary like MBB to fill the reads MBB
 # can't. Creds stored separately from the primary's (an MBB-QR entry has none).

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1279,6 +1279,15 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             if not vins:
                 return False
 
+            # #923 — propagate the opt-in test-cohort flag to the vw.de
+            # connector(s) (gates the experimental parkingposition probe) and
+            # raise/clear the dismissible share-request Repair to match. Runs after
+            # both arm paths; idempotent, fail-soft.
+            try:
+                await self._apply_test_cohort()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("test-cohort apply skipped", exc_info=True)
+
             # Fetch status for all vehicles
             results = await asyncio.gather(
                 *[self._cariad_client.get_status(vin) for vin in vins],
@@ -2098,6 +2107,34 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if getattr(self._cariad_client, "_eu_portal", None) is not None:
             return "eu_data_act"
         return str(data.get(CONF_BRAND, "")) or "primary"
+
+    async def _apply_test_cohort(self) -> None:
+        """#923 — wire the opt-in test-cohort flag to the vw.de connector(s) and
+        the dismissible share Repair. The flag is read from ``entry.data`` (the
+        options listener folds options → data; ``entry.options`` is always {} at
+        read time). The experimental parkingposition probe runs ONLY when this is
+        on. The Repair is raised only when the user is BOTH opted in AND actually
+        has a vw.de channel to test — otherwise it's cleared, so a non-vw.de or
+        opted-out user never sees it."""
+        from .const import CONF_TEST_COHORT  # noqa: PLC0415
+        from .repairs import (  # noqa: PLC0415
+            clear_issue_test_cohort_share,
+            raise_issue_test_cohort_share,
+        )
+
+        cohort = bool(self.entry.data.get(CONF_TEST_COHORT))
+        client = self._cariad_client
+        has_web = False
+        for attr in ("_website_proxy", "_supplementary_authproxy"):
+            conn = getattr(client, attr, None)
+            if conn is not None and hasattr(conn, "probe_position"):
+                conn.probe_position = cohort
+                has_web = True
+
+        if cohort and has_web:
+            raise_issue_test_cohort_share(self.hass, self.entry.entry_id)
+        else:
+            clear_issue_test_cohort_share(self.hass, self.entry.entry_id)
 
     async def _arm_supplementary_channels(self) -> None:
         """v2.15.0b1 (C1) — arm configured supplementary read channels on the

--- a/custom_components/vag_connect/repairs.py
+++ b/custom_components/vag_connect/repairs.py
@@ -187,6 +187,30 @@ def clear_supplementary_reauth_issue(hass: HomeAssistant, entry_id: str) -> None
     ir.async_delete_issue(hass, DOMAIN, f"{entry_id}_supplementary_reauth")
 
 
+def raise_issue_test_cohort_share(hass: HomeAssistant, entry_id: str) -> None:
+    """#923 — the user opted INTO the test cohort; ask them once (dismissibly) to
+    share aggressively-redacted diagnostics so an experimental capability (right
+    now the vw.de GPS lever) can be confirmed across models/platforms. Not
+    auto-fixable (the user shares the file); WARNING is the lowest HA severity;
+    idempotent (HA de-dupes by issue id). Only ever raised when the cohort flag is
+    on — cleared the moment it's turned off."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"{entry_id}_test_cohort_share",
+        is_fixable=False,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="test_cohort_share_request",
+        learn_more_url="https://github.com/its-me-prash/vwgroup-connect-ha/issues/923",
+    )
+
+
+def clear_issue_test_cohort_share(hass: HomeAssistant, entry_id: str) -> None:
+    """Clear the test-cohort share request (cohort opted out)."""
+    ir.async_delete_issue(hass, DOMAIN, f"{entry_id}_test_cohort_share")
+
+
 def raise_issue_requirements_conflict(hass: HomeAssistant) -> None:
     """Raise a repair issue for configuration problems."""
     ir.async_create_issue(

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Enable ABRP telemetry push",
           "abrp_api_key": "ABRP api_key (developer key)",
           "abrp_user_token": "ABRP token (per vehicle)",
-          "keep_raw_datasets": "Keep raw EU Data Act datasets (diagnostics)"
+          "keep_raw_datasets": "Keep raw EU Data Act datasets (diagnostics)",
+          "test_cohort": "Help improve VW Group Connect (opt-in test cohort)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Send live telemetry to A Better Routeplanner. Needs both an api_key and a per-vehicle token below. Off = no outbound calls.",
           "abrp_api_key": "A developer/partner key you register with iternio (we don't ship one). Identifies the integration. Never logged.",
           "abrp_user_token": "The 'Generic' token from the ABRP app: Settings -> your car -> Live Data. Never logged.",
-          "keep_raw_datasets": "Only useful on the EU Data Act portal channel. When on, the last few raw dataset ZIPs the portal delivers are kept on disk (under .storage, per vehicle and size-capped) so a wrong or missing value can be reproduced from the exact bytes your car sent. These files contain your GPS, VIN and telemetry, so it is off by default; turn it on only while troubleshooting."
+          "keep_raw_datasets": "Only useful on the EU Data Act portal channel. When on, the last few raw dataset ZIPs the portal delivers are kept on disk (under .storage, per vehicle and size-capped) so a wrong or missing value can be reproduced from the exact bytes your car sent. These files contain your GPS, VIN and telemetry, so it is off by default; turn it on only while troubleshooting.",
+          "test_cohort": "Off by default. Turn this on to let the integration try experimental reads on your car — such as the ongoing attempt to recover GPS location for Volkswagen EU cars — and occasionally show a dismissible notification asking you to share a diagnostics file so a new capability can be confirmed for your model. Everything shared is redacted automatically before it leaves your system: no VIN, GPS, tokens or email is ever included. It is how new features get unlocked for your car and everyone driving the same model, and you can switch it off again at any time."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: mandatory consent not accepted",
       "description": "Your {brand} account hasn't accepted a mandatory service consent, so some data or features may be unavailable. Open the MyŠkoda app and accept the required consent — this notice clears itself once you do."
+    },
+    "test_cohort_share_request": {
+      "title": "Help confirm a new capability — share your test result?",
+      "description": "Thanks for joining the opt-in test cohort. Your car was included in an experiment — right now, the attempt to recover GPS location for Volkswagen EU cars over the volkswagen.de channel. To confirm the result across different models and platforms, it would genuinely help if you shared a diagnostics file: go to Settings → Devices & Services → VW Group Connect → the three-dot menu → Download diagnostics, then attach the file to GitHub issue #923.\n\nThe export is redacted automatically before you download it — no VIN, GPS, tokens or email are included — so it is safe to post publicly. You are only seeing this because you opted in; you can dismiss it, and turning the test cohort back off in the integration's options stops these notifications entirely. Thank you for helping unlock features for everyone driving your model."
     }
   },
   "selector": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Povolit odesílání telemetrie ABRP",
           "abrp_api_key": "api_key ABRP (vývojářský klíč)",
           "abrp_user_token": "Token ABRP (pro vozidlo)",
-          "keep_raw_datasets": "Uchovávat surová data EU Data Act (diagnostika)"
+          "keep_raw_datasets": "Uchovávat surová data EU Data Act (diagnostika)",
+          "test_cohort": "Pomozte vylepšit VW Group Connect (dobrovolná testovací skupina)"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Odesílat živou telemetrii do A Better Routeplanner. Vyžaduje api_key a token pro každé vozidlo. Vypnuto = žádná odchozí volání.",
           "abrp_api_key": "Vývojářský/partnerský klíč, který si zaregistrujete u iternio (žádný nedodáváme). Identifikuje integraci. Nikdy se neloguje.",
           "abrp_user_token": "Token 'Generic' z aplikace ABRP: Nastavení -> vaše auto -> Live Data. Nikdy se neloguje.",
-          "keep_raw_datasets": "Užitečné pouze na kanálu portálu EU Data Act. Po zapnutí se posledních několik surových ZIP souborů s daty, které portál dodá, uchová na disku (v .storage, na vozidlo a s limitem velikosti), aby bylo možné chybnou nebo chybějící hodnotu reprodukovat z přesně těch bajtů, které vůz odeslal. Tyto soubory obsahují vaši GPS polohu, VIN a telemetrii, proto je funkce ve výchozím nastavení vypnutá – zapněte ji jen při řešení potíží."
+          "keep_raw_datasets": "Užitečné pouze na kanálu portálu EU Data Act. Po zapnutí se posledních několik surových ZIP souborů s daty, které portál dodá, uchová na disku (v .storage, na vozidlo a s limitem velikosti), aby bylo možné chybnou nebo chybějící hodnotu reprodukovat z přesně těch bajtů, které vůz odeslal. Tyto soubory obsahují vaši GPS polohu, VIN a telemetrii, proto je funkce ve výchozím nastavení vypnutá – zapněte ji jen při řešení potíží.",
+          "test_cohort": "Ve výchozím nastavení vypnuto. Když tuto možnost zapnete, integrace bude moci na vašem voze zkoušet experimentální čtení dat — třeba právě probíhající pokus o získání polohy GPS u vozů Volkswagen v EU — a občas vám zobrazí upozornění (které lze zavřít) s prosbou o sdílení diagnostického souboru, aby se pro váš model mohla potvrdit nová funkce. Vše, co sdílíte, se automaticky anonymizuje ještě předtím, než to opustí váš systém: nikdy to neobsahuje VIN, GPS, tokeny ani e-mail. Právě takto se odemykají nové funkce pro váš vůz i pro všechny, kdo jezdí stejným modelem — a kdykoli to zase můžete vypnout."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: povinný souhlas nebyl přijat",
       "description": "Váš účet {brand} nepřijal povinný servisní souhlas, takže některá data nebo funkce nemusí být dostupné. Otevřete aplikaci MyŠkoda a přijměte požadovaný souhlas — toto upozornění poté samo zmizí."
+    },
+    "test_cohort_share_request": {
+      "title": "Pomozte potvrdit novou funkci — podělíte se o výsledek testu?",
+      "description": "Děkujeme, že jste se přidali do dobrovolné testovací skupiny. Váš vůz byl zařazen do experimentu — právě teď jde o pokus získat polohu GPS u vozů Volkswagen v EU přes kanál volkswagen.de. Abychom výsledek mohli potvrdit napříč různými modely a platformami, moc by nám pomohlo, kdybyste sdíleli diagnostický soubor: přejděte do Nastavení → Zařízení a služby → VW Group Connect → nabídka se třemi tečkami → Stáhnout diagnostiku a soubor pak připojte ke GitHub issue #923.\n\nExport se automaticky anonymizuje ještě předtím, než si ho stáhnete — neobsahuje VIN, GPS, tokeny ani e-mail —, takže ho můžete klidně zveřejnit. Tuto zprávu vidíte jen proto, že jste se sami přihlásili; můžete ji zavřít a vypnutím testovací skupiny v nastavení integrace tato upozornění úplně zastavíte. Děkujeme, že pomáháte odemykat funkce pro všechny, kdo jezdí stejným modelem jako vy."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Aktivér ABRP-telemetri-push",
           "abrp_api_key": "ABRP api_key (udviklernøgle)",
           "abrp_user_token": "ABRP-token (pr. køretøj)",
-          "keep_raw_datasets": "Behold rå EU Data Act-datasæt (diagnostik)"
+          "keep_raw_datasets": "Behold rå EU Data Act-datasæt (diagnostik)",
+          "test_cohort": "Vær med til at forbedre VW Group Connect (frivillig testgruppe)"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Send live-telemetri til A Better Routeplanner. Kræver både en api_key og et token pr. køretøj nedenfor. Fra = ingen udgående kald.",
           "abrp_api_key": "En udvikler-/partnernøgle, du registrerer hos iternio (vi leverer ikke en). Identificerer integrationen. Logges aldrig.",
           "abrp_user_token": "'Generic'-tokenet fra ABRP-appen: Indstillinger -> din bil -> Live Data. Logges aldrig.",
-          "keep_raw_datasets": "Kun nyttigt på EU Data Act-portalkanalen. Når det er slået til, gemmes de sidste få rå datasæt-ZIP-filer, som portalen leverer, på disken (under .storage, pr. køretøj og med en størrelsesgrænse), så en forkert eller manglende værdi kan gengives ud fra præcis de bytes, din bil sendte. Disse filer indeholder din GPS-position, VIN og telemetri, så det er slået fra som standard – slå det kun til under fejlfinding."
+          "keep_raw_datasets": "Kun nyttigt på EU Data Act-portalkanalen. Når det er slået til, gemmes de sidste få rå datasæt-ZIP-filer, som portalen leverer, på disken (under .storage, pr. køretøj og med en størrelsesgrænse), så en forkert eller manglende værdi kan gengives ud fra præcis de bytes, din bil sendte. Disse filer indeholder din GPS-position, VIN og telemetri, så det er slået fra som standard – slå det kun til under fejlfinding.",
+          "test_cohort": "Slået fra som standard. Slå den til, hvis du vil lade integrationen forsøge sig med eksperimentelle aflæsninger fra din bil — for eksempel det igangværende forsøg på at hente GPS-position for Volkswagen-biler i EU — og en gang imellem vise en notifikation, du kan afvise, hvor du bliver bedt om at dele en diagnostikfil, så en ny funktion kan bekræftes for din model. Alt, hvad du deler, bliver automatisk renset, før det forlader dit system: der er aldrig VIN, GPS, tokens eller e-mail med. Det er sådan, nye funktioner bliver låst op for din bil og for alle andre, der kører samme model, og du kan når som helst slå den fra igen."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: obligatorisk samtykke ikke accepteret",
       "description": "Din {brand}-konto har ikke accepteret et obligatorisk servicesamtykke, så nogle data eller funktioner kan være utilgængelige. Åbn MyŠkoda-appen og accepter det påkrævede samtykke — denne besked forsvinder af sig selv."
+    },
+    "test_cohort_share_request": {
+      "title": "Hjælp med at bekræfte en ny funktion — vil du dele dit testresultat?",
+      "description": "Tak, fordi du er med i den frivillige testgruppe. Din bil var med i et eksperiment — lige nu forsøget på at hente GPS-position for Volkswagen-biler i EU via volkswagen.de-kanalen. For at bekræfte resultatet på tværs af forskellige modeller og platforme ville det være en stor hjælp, hvis du delte en diagnostikfil: gå til Indstillinger → Enheder og tjenester → VW Group Connect → trepunktsmenuen → Download diagnostik, og vedhæft så filen til GitHub-issue #923.\n\nEksporten bliver automatisk renset, før du downloader den — der er ingen VIN, GPS, tokens eller e-mail med — så den er sikker at dele offentligt. Du ser kun dette, fordi du har tilmeldt dig; du kan afvise det, og hvis du slår testgruppen fra igen i integrationens indstillinger, stopper disse notifikationer helt. Tak, fordi du hjælper med at låse funktioner op for alle, der kører din model."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -212,7 +212,8 @@
           "abrp_enable": "ABRP-Telemetrie senden",
           "abrp_api_key": "ABRP-api_key (Entwicklerschlüssel)",
           "abrp_user_token": "ABRP-Token (pro Fahrzeug)",
-          "keep_raw_datasets": "Rohe EU-Data-Act-Datensätze behalten (Diagnose)"
+          "keep_raw_datasets": "Rohe EU-Data-Act-Datensätze behalten (Diagnose)",
+          "test_cohort": "Hilf mit, VW Group Connect zu verbessern (freiwillige Testgruppe)"
         },
         "data_description": {
           "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",
@@ -230,7 +231,8 @@
           "abrp_enable": "Live-Telemetrie an A Better Routeplanner senden. Benötigt api_key und einen Token pro Fahrzeug. Aus = keine ausgehenden Aufrufe.",
           "abrp_api_key": "Ein Entwickler-/Partnerschlüssel, den du bei iternio registrierst (wir liefern keinen). Identifiziert die Integration. Wird nie protokolliert.",
           "abrp_user_token": "Der 'Generic'-Token aus der ABRP-App: Einstellungen -> dein Auto -> Live Data. Wird nie protokolliert.",
-          "keep_raw_datasets": "Nur auf dem EU-Data-Act-Portal-Kanal sinnvoll. Wenn aktiv, werden die letzten paar rohen Datensatz-ZIPs des Portals auf der Festplatte behalten (unter .storage, pro Fahrzeug und größenbegrenzt), damit sich ein falscher oder fehlender Wert aus genau den Bytes reproduzieren lässt, die dein Auto gesendet hat. Diese Dateien enthalten GPS, VIN und Telemetrie, deshalb ist die Option standardmäßig aus – schalte sie nur zur Fehlersuche ein."
+          "keep_raw_datasets": "Nur auf dem EU-Data-Act-Portal-Kanal sinnvoll. Wenn aktiv, werden die letzten paar rohen Datensatz-ZIPs des Portals auf der Festplatte behalten (unter .storage, pro Fahrzeug und größenbegrenzt), damit sich ein falscher oder fehlender Wert aus genau den Bytes reproduzieren lässt, die dein Auto gesendet hat. Diese Dateien enthalten GPS, VIN und Telemetrie, deshalb ist die Option standardmäßig aus – schalte sie nur zur Fehlersuche ein.",
+          "test_cohort": "Standardmäßig aus. Wenn du das einschaltest, darf die Integration experimentelle Abfragen an deinem Auto ausprobieren — etwa den laufenden Versuch, den GPS-Standort für Volkswagen-EU-Fahrzeuge auszulesen — und dir hin und wieder eine wegklickbare Benachrichtigung zeigen, die dich bittet, eine Diagnosedatei zu teilen, damit eine neue Funktion für dein Modell bestätigt werden kann. Alles, was du teilst, wird automatisch anonymisiert, bevor es dein System verlässt: Weder VIN noch GPS, Tokens oder E-Mail sind je enthalten. So werden neue Funktionen für dein Auto und für alle freigeschaltet, die dasselbe Modell fahren — und du kannst es jederzeit wieder ausschalten."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: Pflichtzustimmung nicht akzeptiert",
       "description": "Dein {brand}-Konto hat eine erforderliche Service-Zustimmung nicht akzeptiert, daher könnten einige Daten oder Funktionen fehlen. Öffne die MyŠkoda-App und akzeptiere die erforderliche Zustimmung — dieser Hinweis verschwindet danach von selbst."
+    },
+    "test_cohort_share_request": {
+      "title": "Hilf mit, eine neue Funktion zu bestätigen — teilst du dein Testergebnis?",
+      "description": "Danke, dass du bei der freiwilligen Testgruppe mitmachst. Dein Auto war Teil eines Experiments — im Moment der Versuch, den GPS-Standort für Volkswagen-EU-Fahrzeuge über den volkswagen.de-Kanal auszulesen. Damit sich das Ergebnis über verschiedene Modelle und Plattformen hinweg bestätigen lässt, würde es wirklich helfen, wenn du eine Diagnosedatei teilst: Geh zu Einstellungen → Geräte & Dienste → VW Group Connect → das Drei-Punkte-Menü → Diagnose herunterladen und häng die Datei an das GitHub-Issue #923 an.\n\nDer Export wird automatisch anonymisiert, bevor du ihn herunterlädst — weder VIN noch GPS, Tokens oder E-Mail sind enthalten —, sodass du ihn bedenkenlos öffentlich posten kannst. Du siehst das nur, weil du dich dafür entschieden hast; du kannst es einfach wegklicken, und wenn du die Testgruppe in den Optionen der Integration wieder ausschaltest, hören diese Benachrichtigungen ganz auf. Danke, dass du hilfst, Funktionen für alle freizuschalten, die dein Modell fahren."
     }
   },
   "selector": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Enable ABRP telemetry push",
           "abrp_api_key": "ABRP api_key (developer key)",
           "abrp_user_token": "ABRP token (per vehicle)",
-          "keep_raw_datasets": "Keep raw EU Data Act datasets (diagnostics)"
+          "keep_raw_datasets": "Keep raw EU Data Act datasets (diagnostics)",
+          "test_cohort": "Help improve VW Group Connect (opt-in test cohort)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Send live telemetry to A Better Routeplanner. Needs both an api_key and a per-vehicle token below. Off = no outbound calls.",
           "abrp_api_key": "A developer/partner key you register with iternio (we don't ship one). Identifies the integration. Never logged.",
           "abrp_user_token": "The 'Generic' token from the ABRP app: Settings -> your car -> Live Data. Never logged.",
-          "keep_raw_datasets": "Only useful on the EU Data Act portal channel. When on, the last few raw dataset ZIPs the portal delivers are kept on disk (under .storage, per vehicle and size-capped) so a wrong or missing value can be reproduced from the exact bytes your car sent. These files contain your GPS, VIN and telemetry, so it is off by default; turn it on only while troubleshooting."
+          "keep_raw_datasets": "Only useful on the EU Data Act portal channel. When on, the last few raw dataset ZIPs the portal delivers are kept on disk (under .storage, per vehicle and size-capped) so a wrong or missing value can be reproduced from the exact bytes your car sent. These files contain your GPS, VIN and telemetry, so it is off by default; turn it on only while troubleshooting.",
+          "test_cohort": "Off by default. Turn this on to let the integration try experimental reads on your car — such as the ongoing attempt to recover GPS location for Volkswagen EU cars — and occasionally show a dismissible notification asking you to share a diagnostics file so a new capability can be confirmed for your model. Everything shared is redacted automatically before it leaves your system: no VIN, GPS, tokens or email is ever included. It is how new features get unlocked for your car and everyone driving the same model, and you can switch it off again at any time."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: mandatory consent not accepted",
       "description": "Your {brand} account hasn't accepted a mandatory service consent, so some data or features may be unavailable. Open the MyŠkoda app and accept the required consent — this notice clears itself once you do."
+    },
+    "test_cohort_share_request": {
+      "title": "Help confirm a new capability — share your test result?",
+      "description": "Thanks for joining the opt-in test cohort. Your car was included in an experiment — right now, the attempt to recover GPS location for Volkswagen EU cars over the volkswagen.de channel. To confirm the result across different models and platforms, it would genuinely help if you shared a diagnostics file: go to Settings → Devices & Services → VW Group Connect → the three-dot menu → Download diagnostics, then attach the file to GitHub issue #923.\n\nThe export is redacted automatically before you download it — no VIN, GPS, tokens or email are included — so it is safe to post publicly. You are only seeing this because you opted in; you can dismiss it, and turning the test cohort back off in the integration's options stops these notifications entirely. Thank you for helping unlock features for everyone driving your model."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Activar envío de telemetría a ABRP",
           "abrp_api_key": "api_key de ABRP (clave de desarrollador)",
           "abrp_user_token": "Token de ABRP (por vehículo)",
-          "keep_raw_datasets": "Conservar los conjuntos de datos brutos de EU Data Act (diagnóstico)"
+          "keep_raw_datasets": "Conservar los conjuntos de datos brutos de EU Data Act (diagnóstico)",
+          "test_cohort": "Ayuda a mejorar VW Group Connect (grupo de pruebas voluntario)"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Enviar telemetría en vivo a A Better Routeplanner. Requiere una api_key y un token por vehículo. Desactivado = sin llamadas salientes.",
           "abrp_api_key": "Una clave de desarrollador/socio que registras en iternio (no incluimos ninguna). Identifica la integración. Nunca se registra.",
           "abrp_user_token": "El token 'Generic' de la app ABRP: Ajustes -> tu coche -> Live Data. Nunca se registra.",
-          "keep_raw_datasets": "Solo es útil en el canal del portal EU Data Act. Cuando está activado, los últimos archivos ZIP de datos brutos que entrega el portal se guardan en el disco (en .storage, por vehículo y con un límite de tamaño) para poder reproducir un valor incorrecto o ausente a partir de los bytes exactos que envió tu coche. Estos archivos contienen tu ubicación GPS, el VIN y la telemetría, por lo que está desactivado de forma predeterminada; actívalo solo mientras diagnosticas un problema."
+          "keep_raw_datasets": "Solo es útil en el canal del portal EU Data Act. Cuando está activado, los últimos archivos ZIP de datos brutos que entrega el portal se guardan en el disco (en .storage, por vehículo y con un límite de tamaño) para poder reproducir un valor incorrecto o ausente a partir de los bytes exactos que envió tu coche. Estos archivos contienen tu ubicación GPS, el VIN y la telemetría, por lo que está desactivado de forma predeterminada; actívalo solo mientras diagnosticas un problema.",
+          "test_cohort": "Desactivado de forma predeterminada. Actívalo para permitir que la integración pruebe lecturas experimentales en tu coche —como el intento en curso de recuperar la ubicación GPS de los Volkswagen de la UE— y para que, de vez en cuando, te muestre una notificación que puedes descartar pidiéndote que compartas un archivo de diagnóstico con el que confirmar una nueva función para tu modelo. Todo lo que compartes se anonimiza automáticamente antes de salir de tu sistema: nunca se incluye el VIN, el GPS, tokens ni tu correo electrónico. Así es como se desbloquean nuevas funciones para tu coche y para todos los que conducen el mismo modelo, y puedes volver a desactivarlo cuando quieras."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: consentimiento obligatorio no aceptado",
       "description": "Tu cuenta {brand} no ha aceptado un consentimiento de servicio obligatorio, por lo que algunos datos o funciones pueden no estar disponibles. Abre la app MyŠkoda y acepta el consentimiento requerido; este aviso desaparece cuando lo hagas."
+    },
+    "test_cohort_share_request": {
+      "title": "Ayuda a confirmar una nueva función — ¿compartes el resultado de tu prueba?",
+      "description": "Gracias por unirte al grupo de pruebas voluntario. Tu coche formó parte de un experimento: ahora mismo, el intento de recuperar la ubicación GPS de los Volkswagen de la UE a través del canal de volkswagen.de. Para confirmar el resultado en distintos modelos y plataformas, nos ayudaría de verdad que compartieras un archivo de diagnóstico: ve a Ajustes → Dispositivos y servicios → VW Group Connect → el menú de tres puntos → Descargar diagnóstico y adjunta el archivo al issue #923 de GitHub.\n\nEl archivo exportado se anonimiza automáticamente antes de que lo descargues —no incluye VIN, GPS, tokens ni correo electrónico—, así que puedes publicarlo sin problema. Solo ves esto porque te uniste al grupo de pruebas; puedes descartar este aviso, y si vuelves a desactivarlo en las opciones de la integración, estas notificaciones dejarán de aparecer por completo. Gracias por ayudar a desbloquear funciones para todos los que conducen tu mismo modelo."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Ota käyttöön ABRP-telemetrian lähetys",
           "abrp_api_key": "ABRP api_key (kehittäjäavain)",
           "abrp_user_token": "ABRP-tunniste (ajoneuvokohtainen)",
-          "keep_raw_datasets": "Säilytä EU Data Act -raakadatajoukot (diagnostiikka)"
+          "keep_raw_datasets": "Säilytä EU Data Act -raakadatajoukot (diagnostiikka)",
+          "test_cohort": "Auta parantamaan VW Group Connectia (vapaaehtoinen testiryhmä)"
         },
         "data_description": {
           "scan_interval": "Kuinka usein tietoja haetaan (minuutteja). Vähintään: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Lähetä live-telemetriaa A Better Routeplannerille. Tarvitsee sekä api_keyn että ajoneuvokohtaisen tunnisteen alla. Pois = ei lähteviä kutsuja.",
           "abrp_api_key": "Kehittäjä-/kumppaniavain, jonka rekisteröit iterniolla (emme toimita sellaista). Tunnistaa integraation. Ei koskaan lokiin.",
           "abrp_user_token": "'Generic'-tunniste ABRP-sovelluksesta: Asetukset -> autosi -> Live Data. Ei koskaan lokiin.",
-          "keep_raw_datasets": "Hyödyllinen vain EU Data Act -portaalikanavalla. Kun käytössä, portaalin toimittamat viimeisimmät raa'at datajoukko-ZIP-tiedostot säilytetään levyllä (.storage-kansiossa, ajoneuvokohtaisesti ja kokorajoitettuna), jotta väärä tai puuttuva arvo voidaan toistaa juuri niistä tavuista, jotka autosi lähetti. Nämä tiedostot sisältävät GPS-sijaintisi, VIN-numerosi ja telemetriasi, joten oletuksena se on pois päältä – ota se käyttöön vain vianmäärityksen ajaksi."
+          "keep_raw_datasets": "Hyödyllinen vain EU Data Act -portaalikanavalla. Kun käytössä, portaalin toimittamat viimeisimmät raa'at datajoukko-ZIP-tiedostot säilytetään levyllä (.storage-kansiossa, ajoneuvokohtaisesti ja kokorajoitettuna), jotta väärä tai puuttuva arvo voidaan toistaa juuri niistä tavuista, jotka autosi lähetti. Nämä tiedostot sisältävät GPS-sijaintisi, VIN-numerosi ja telemetriasi, joten oletuksena se on pois päältä – ota se käyttöön vain vianmäärityksen ajaksi.",
+          "test_cohort": "Oletuksena pois päältä. Kun otat tämän käyttöön, integraatio saa tehdä autoosi kokeellisia lukupyyntöjä — kuten parhaillaan käynnissä olevaa yritystä hakea GPS-sijainti Volkswagenin EU-autoille — ja näyttää silloin tällöin suljettavan ilmoituksen, jossa sinua pyydetään jakamaan diagnostiikkatiedosto, jotta uusi ominaisuus voidaan varmistaa juuri sinun automallillesi. Kaikki jaettavat tiedot puhdistetaan automaattisesti ennen kuin ne lähtevät järjestelmästäsi: mukana ei koskaan ole VIN-tunnusta, GPS-sijaintia, tokeneita eikä sähköpostia. Juuri näin uudet ominaisuudet avautuvat sekä sinun autoosi että kaikille muille samaa mallia ajaville, ja voit halutessasi kytkeä sen milloin tahansa takaisin pois päältä."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: pakollista suostumusta ei hyväksytty",
       "description": "{brand}-tilisi ei ole hyväksynyt pakollista palvelusuostumusta, joten osa tiedoista tai toiminnoista voi olla poissa käytöstä. Avaa MyŠkoda-sovellus ja hyväksy vaadittu suostumus — tämä ilmoitus poistuu itsestään."
+    },
+    "test_cohort_share_request": {
+      "title": "Auta varmistamaan uusi ominaisuus — jaatko testituloksesi?",
+      "description": "Kiitos, että liityit vapaaehtoiseen testiryhmään. Autosi oli mukana kokeilussa — tällä hetkellä kyseessä on yritys hakea GPS-sijainti Volkswagenin EU-autoille volkswagen.de-kanavan kautta. Jotta tulos saadaan varmistettua eri malleissa ja alustoilla, siitä olisi todella suuri apu, jos jakaisit diagnostiikkatiedoston: mene kohtaan Asetukset → Laitteet ja palvelut → VW Group Connect → kolmen pisteen valikko → Lataa vianmääritystiedot ja liitä tiedosto sitten GitHub-issueen #923.\n\nVientitiedosto puhdistetaan automaattisesti ennen kuin lataat sen — mukana ei ole VIN-tunnusta, GPS-sijaintia, tokeneita eikä sähköpostia — joten sen voi turvallisesti julkaista. Näet tämän vain siksi, että liityit testiryhmään; voit ohittaa tämän, ja kun kytket testiryhmän integraation asetuksista takaisin pois päältä, nämä ilmoitukset loppuvat kokonaan. Kiitos, että autat avaamaan ominaisuuksia kaikille samaa mallia ajaville."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Activer l'envoi de télémétrie ABRP",
           "abrp_api_key": "api_key ABRP (clé développeur)",
           "abrp_user_token": "Jeton ABRP (par véhicule)",
-          "keep_raw_datasets": "Conserver les jeux de données EU Data Act bruts (diagnostic)"
+          "keep_raw_datasets": "Conserver les jeux de données EU Data Act bruts (diagnostic)",
+          "test_cohort": "Aider à améliorer VW Group Connect (groupe de test volontaire)"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Envoyer la télémétrie en direct à A Better Routeplanner. Nécessite une api_key et un jeton par véhicule. Désactivé = aucun appel sortant.",
           "abrp_api_key": "Une clé développeur/partenaire que vous enregistrez auprès d'iternio (nous n'en fournissons pas). Identifie l'intégration. Jamais journalisée.",
           "abrp_user_token": "Le jeton « Generic » de l'application ABRP : Paramètres -> votre voiture -> Live Data. Jamais journalisé.",
-          "keep_raw_datasets": "Utile uniquement sur le canal du portail EU Data Act. Une fois activé, les derniers fichiers ZIP de données bruts fournis par le portail sont conservés sur le disque (sous .storage, par véhicule et avec une limite de taille) afin qu'une valeur erronée ou manquante puisse être reproduite à partir des octets exacts envoyés par votre voiture. Ces fichiers contiennent votre position GPS, votre VIN et votre télémétrie ; l'option est donc désactivée par défaut – ne l'activez que pour le dépannage."
+          "keep_raw_datasets": "Utile uniquement sur le canal du portail EU Data Act. Une fois activé, les derniers fichiers ZIP de données bruts fournis par le portail sont conservés sur le disque (sous .storage, par véhicule et avec une limite de taille) afin qu'une valeur erronée ou manquante puisse être reproduite à partir des octets exacts envoyés par votre voiture. Ces fichiers contiennent votre position GPS, votre VIN et votre télémétrie ; l'option est donc désactivée par défaut – ne l'activez que pour le dépannage.",
+          "test_cohort": "Désactivé par défaut. Activez cette option pour autoriser l'intégration à tenter des relevés expérimentaux sur votre voiture — comme la tentative en cours de récupérer la position GPS des Volkswagen de l'UE — et à afficher de temps en temps une notification, que vous pouvez fermer, vous proposant de partager un fichier de diagnostic afin de confirmer une nouvelle fonctionnalité pour votre modèle. Tout ce qui est partagé est automatiquement expurgé avant de quitter votre système : ni VIN, ni GPS, ni jetons, ni adresse e-mail n'y figurent jamais. C'est ainsi que de nouvelles fonctionnalités sont débloquées pour votre voiture et pour tous ceux qui conduisent le même modèle — et vous pouvez la désactiver à tout moment."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda : consentement obligatoire non accepté",
       "description": "Votre compte {brand} n'a pas accepté un consentement de service obligatoire ; certaines données ou fonctions peuvent être indisponibles. Ouvrez l'application MyŠkoda et acceptez le consentement requis — cet avis disparaît ensuite tout seul."
+    },
+    "test_cohort_share_request": {
+      "title": "Aidez-nous à confirmer une nouvelle fonctionnalité — partager votre résultat de test ?",
+      "description": "Merci d'avoir rejoint le groupe de test volontaire. Votre voiture a été incluse dans une expérimentation — en ce moment, la tentative de récupérer la position GPS des Volkswagen de l'UE via le canal volkswagen.de. Pour confirmer le résultat sur différents modèles et plateformes, cela nous aiderait vraiment que vous partagiez un fichier de diagnostic : allez dans Paramètres → Appareils et services → VW Group Connect → le menu à trois points → Télécharger les diagnostics, puis joignez le fichier au ticket GitHub #923.\n\nL'export est automatiquement expurgé avant même que vous ne le téléchargiez — ni VIN, ni GPS, ni jetons, ni adresse e-mail n'y figurent — vous pouvez donc le publier sans crainte. Vous voyez ce message uniquement parce que vous avez choisi de participer ; vous pouvez le fermer, et désactiver le groupe de test dans les options de l'intégration met complètement fin à ces notifications. Merci de nous aider à débloquer des fonctionnalités pour tous ceux qui conduisent votre modèle."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Abilita l'invio di telemetria ad ABRP",
           "abrp_api_key": "ABRP api_key (chiave sviluppatore)",
           "abrp_user_token": "Token ABRP (per veicolo)",
-          "keep_raw_datasets": "Conserva i set di dati grezzi EU Data Act (diagnostica)"
+          "keep_raw_datasets": "Conserva i set di dati grezzi EU Data Act (diagnostica)",
+          "test_cohort": "Aiutaci a migliorare VW Group Connect (gruppo di test ad adesione volontaria)"
         },
         "data_description": {
           "scan_interval": "Con quale frequenza vengono recuperati i dati (minuti). Minimo: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Invia telemetria in tempo reale ad A Better Routeplanner. Richiede sia una api_key sia un token per veicolo qui sotto. Disattivato = nessuna chiamata in uscita.",
           "abrp_api_key": "Una chiave sviluppatore/partner che registri presso iternio (non ne forniamo una). Identifica l'integrazione. Mai registrata nei log.",
           "abrp_user_token": "Il token 'Generic' dell'app ABRP: Impostazioni -> la tua auto -> Live Data. Mai registrato nei log.",
-          "keep_raw_datasets": "Utile solo sul canale del portale EU Data Act. Se attivo, gli ultimi file ZIP di dati grezzi forniti dal portale vengono conservati su disco (in .storage, per veicolo e con un limite di dimensione) così un valore errato o mancante può essere riprodotto dai byte esatti inviati dalla tua auto. Questi file contengono la posizione GPS, il VIN e la telemetria, quindi è disattivato per impostazione predefinita: attivalo solo durante la risoluzione dei problemi."
+          "keep_raw_datasets": "Utile solo sul canale del portale EU Data Act. Se attivo, gli ultimi file ZIP di dati grezzi forniti dal portale vengono conservati su disco (in .storage, per veicolo e con un limite di dimensione) così un valore errato o mancante può essere riprodotto dai byte esatti inviati dalla tua auto. Questi file contengono la posizione GPS, il VIN e la telemetria, quindi è disattivato per impostazione predefinita: attivalo solo durante la risoluzione dei problemi.",
+          "test_cohort": "Disattivato per impostazione predefinita. Attivalo per permettere all'integrazione di provare letture sperimentali sulla tua auto — come il tentativo, tuttora in corso, di recuperare la posizione GPS per le auto Volkswagen europee — e di mostrarti ogni tanto una notifica (che puoi chiudere) in cui ti chiede di condividere un file di diagnostica, così da confermare una nuova funzionalità per il tuo modello. Tutto ciò che condividi viene oscurato automaticamente prima di lasciare il tuo sistema: non vengono mai inclusi VIN, GPS, token o indirizzo email. È così che si sbloccano nuove funzioni per la tua auto e per tutti quelli che guidano lo stesso modello, e puoi disattivarlo di nuovo in qualsiasi momento."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: consenso obbligatorio non accettato",
       "description": "Il tuo account {brand} non ha accettato un consenso di servizio obbligatorio, quindi alcuni dati o funzioni potrebbero non essere disponibili. Apri l'app MyŠkoda e accetta il consenso richiesto — questo avviso scompare da solo."
+    },
+    "test_cohort_share_request": {
+      "title": "Aiutaci a confermare una nuova funzionalità — condividi il risultato del tuo test?",
+      "description": "Grazie per aver aderito al gruppo di test ad adesione volontaria. La tua auto è stata inclusa in un esperimento — in questo momento, il tentativo di recuperare la posizione GPS per le auto Volkswagen europee tramite il canale volkswagen.de. Per confermare il risultato su modelli e piattaforme diversi, ci saresti davvero d'aiuto condividendo un file di diagnostica: vai su Impostazioni → Dispositivi e servizi → VW Group Connect → il menu a tre puntini → Scarica diagnostica, poi allega il file alla segnalazione GitHub #923.\n\nL'esportazione viene oscurata automaticamente prima che tu la scarichi — non contiene VIN, GPS, token o email — quindi puoi pubblicarla senza problemi. Vedi questo messaggio solo perché hai scelto di aderire; puoi ignorarlo, e disattivando di nuovo il gruppo di test nelle opzioni dell'integrazione queste notifiche spariranno del tutto. Grazie per contribuire a sbloccare nuove funzioni per tutti quelli che guidano il tuo stesso modello."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Aktiver ABRP-telemetripush",
           "abrp_api_key": "ABRP api_key (utviklernøkkel)",
           "abrp_user_token": "ABRP-token (per kjøretøy)",
-          "keep_raw_datasets": "Behold rå EU Data Act-datasett (diagnostikk)"
+          "keep_raw_datasets": "Behold rå EU Data Act-datasett (diagnostikk)",
+          "test_cohort": "Hjelp oss å forbedre VW Group Connect (frivillig testgruppe)"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Send sanntidstelemetri til A Better Routeplanner. Trenger både en api_key og et token per kjøretøy nedenfor. Av = ingen utgående kall.",
           "abrp_api_key": "En utvikler-/partnernøkkel du registrerer hos iternio (vi leverer ingen). Identifiserer integrasjonen. Logges aldri.",
           "abrp_user_token": "«Generic»-tokenet fra ABRP-appen: Innstillinger -> bilen din -> Live Data. Logges aldri.",
-          "keep_raw_datasets": "Bare nyttig på EU Data Act-portalkanalen. Når det er på, lagres de siste rå datasett-ZIP-filene portalen leverer på disk (under .storage, per kjøretøy og med en størrelsesgrense), slik at en feil eller manglende verdi kan gjenskapes fra nøyaktig de bytene bilen din sendte. Disse filene inneholder GPS-posisjon, VIN og telemetri, så det er av som standard – slå det på bare under feilsøking."
+          "keep_raw_datasets": "Bare nyttig på EU Data Act-portalkanalen. Når det er på, lagres de siste rå datasett-ZIP-filene portalen leverer på disk (under .storage, per kjøretøy og med en størrelsesgrense), slik at en feil eller manglende verdi kan gjenskapes fra nøyaktig de bytene bilen din sendte. Disse filene inneholder GPS-posisjon, VIN og telemetri, så det er av som standard – slå det på bare under feilsøking.",
+          "test_cohort": "Avslått som standard. Slå den på for å la integrasjonen prøve eksperimentelle avlesninger fra bilen din — for eksempel det pågående forsøket på å hente GPS-posisjon for Volkswagen-biler i EU — og av og til vise et varsel du kan lukke, der du blir bedt om å dele en diagnostikkfil så en ny funksjon kan bekreftes for modellen din. Alt som deles blir automatisk sladdet før det forlater systemet ditt: verken VIN, GPS, tokens eller e-post er noen gang med. Det er slik nye funksjoner låses opp for bilen din og for alle andre som kjører samme modell, og du kan slå det av igjen når som helst."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: obligatorisk samtykke ikke akseptert",
       "description": "{brand}-kontoen din har ikke akseptert et obligatorisk tjenestesamtykke, så noen data eller funksjoner kan være utilgjengelige. Åpne MyŠkoda-appen og godta det nødvendige samtykket — dette varselet forsvinner av seg selv."
+    },
+    "test_cohort_share_request": {
+      "title": "Hjelp oss å bekrefte en ny funksjon — vil du dele testresultatet ditt?",
+      "description": "Takk for at du er med i den frivillige testgruppen. Bilen din ble en del av et eksperiment — akkurat nå forsøket på å hente GPS-posisjon for Volkswagen-biler i EU via volkswagen.de-kanalen. For å bekrefte resultatet på tvers av ulike modeller og plattformer ville det være til stor hjelp om du delte en diagnostikkfil: gå til Innstillinger → Enheter og tjenester → VW Group Connect → trepunktsmenyen → Last ned diagnostikk, og legg deretter filen ved GitHub-sak #923.\n\nEksporten blir automatisk sladdet før du laster den ned — verken VIN, GPS, tokens eller e-post er med — så det er trygt å legge den ut offentlig. Du ser dette bare fordi du har meldt deg på; du kan lukke det, og hvis du slår av testgruppen igjen i integrasjonens innstillinger, stopper disse varslene helt. Takk for at du bidrar til å låse opp funksjoner for alle som kjører samme modell som deg."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -212,7 +212,8 @@
           "abrp_enable": "ABRP-telemetrie verzenden inschakelen",
           "abrp_api_key": "ABRP-api_key (ontwikkelaarssleutel)",
           "abrp_user_token": "ABRP-token (per voertuig)",
-          "keep_raw_datasets": "Ruwe EU Data Act-datasets bewaren (diagnose)"
+          "keep_raw_datasets": "Ruwe EU Data Act-datasets bewaren (diagnose)",
+          "test_cohort": "Help VW Group Connect verbeteren (opt-in testgroep)"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Live telemetrie naar A Better Routeplanner sturen. Vereist een api_key en een token per voertuig. Uit = geen uitgaande oproepen.",
           "abrp_api_key": "Een ontwikkelaars-/partnersleutel die je bij iternio registreert (wij leveren er geen). Identificeert de integratie. Wordt nooit gelogd.",
           "abrp_user_token": "Het 'Generic'-token uit de ABRP-app: Instellingen -> je auto -> Live Data. Wordt nooit gelogd.",
-          "keep_raw_datasets": "Alleen nuttig op het EU Data Act-portaalkanaal. Indien ingeschakeld worden de laatste paar ruwe dataset-ZIP's die het portaal levert op schijf bewaard (onder .storage, per voertuig en met een groottelimiet), zodat een verkeerde of ontbrekende waarde kan worden gereproduceerd uit precies de bytes die je auto heeft verzonden. Deze bestanden bevatten je GPS-locatie, VIN en telemetrie, dus standaard staat dit uit – schakel het alleen in tijdens het oplossen van problemen."
+          "keep_raw_datasets": "Alleen nuttig op het EU Data Act-portaalkanaal. Indien ingeschakeld worden de laatste paar ruwe dataset-ZIP's die het portaal levert op schijf bewaard (onder .storage, per voertuig en met een groottelimiet), zodat een verkeerde of ontbrekende waarde kan worden gereproduceerd uit precies de bytes die je auto heeft verzonden. Deze bestanden bevatten je GPS-locatie, VIN en telemetrie, dus standaard staat dit uit – schakel het alleen in tijdens het oplossen van problemen.",
+          "test_cohort": "Standaard uitgeschakeld. Zet dit aan om de integratie experimenteel gegevens van je auto te laten uitlezen — zoals de lopende poging om de GPS-locatie van Volkswagen EU-auto's terug te halen — en af en toe een melding te tonen die je kunt wegklikken, met de vraag of je een diagnosebestand wilt delen zodat een nieuwe functie voor jouw model bevestigd kan worden. Alles wat je deelt wordt automatisch geanonimiseerd voordat het je systeem verlaat: er zit nooit een VIN, GPS, token of e-mailadres in. Zo worden nieuwe functies ontgrendeld voor jouw auto en voor iedereen die hetzelfde model rijdt — en je kunt het op elk moment weer uitzetten."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: verplichte toestemming niet geaccepteerd",
       "description": "Je {brand}-account heeft een verplichte servicetoestemming niet geaccepteerd, waardoor sommige gegevens of functies mogelijk niet beschikbaar zijn. Open de MyŠkoda-app en accepteer de vereiste toestemming — deze melding verdwijnt daarna vanzelf."
+    },
+    "test_cohort_share_request": {
+      "title": "Help een nieuwe functie bevestigen — deel je testresultaat?",
+      "description": "Bedankt dat je meedoet aan de opt-in testgroep. Jouw auto is meegenomen in een experiment — op dit moment de poging om de GPS-locatie van Volkswagen EU-auto's terug te halen via het volkswagen.de-kanaal. Om het resultaat over verschillende modellen en platforms te bevestigen, zou het echt helpen als je een diagnosebestand deelt: ga naar Instellingen → Apparaten en services → VW Group Connect → het menu met drie puntjes → Diagnostische gegevens downloaden, en voeg het bestand toe aan GitHub-issue #923.\n\nDe export wordt automatisch geanonimiseerd voordat je hem downloadt — er zit geen VIN, GPS, token of e-mailadres in — dus je kunt hem gerust openbaar delen. Je ziet dit alleen omdat je je hebt aangemeld; je kunt het wegklikken, en als je de testgroep weer uitzet in de opties van de integratie, stoppen deze meldingen helemaal. Bedankt dat je helpt om functies te ontgrendelen voor iedereen die jouw model rijdt."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Włącz wysyłanie telemetrii ABRP",
           "abrp_api_key": "api_key ABRP (klucz dewelopera)",
           "abrp_user_token": "Token ABRP (na pojazd)",
-          "keep_raw_datasets": "Zachowuj surowe zestawy danych EU Data Act (diagnostyka)"
+          "keep_raw_datasets": "Zachowuj surowe zestawy danych EU Data Act (diagnostyka)",
+          "test_cohort": "Pomóż ulepszać VW Group Connect (dobrowolna grupa testowa)"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Wysyłaj telemetrię na żywo do A Better Routeplanner. Wymaga api_key oraz tokenu na pojazd. Wyłączone = brak połączeń wychodzących.",
           "abrp_api_key": "Klucz dewelopera/partnera rejestrowany w iternio (nie dostarczamy go). Identyfikuje integrację. Nigdy nie jest logowany.",
           "abrp_user_token": "Token 'Generic' z aplikacji ABRP: Ustawienia -> Twój samochód -> Live Data. Nigdy nie jest logowany.",
-          "keep_raw_datasets": "Przydatne tylko na kanale portalu EU Data Act. Po włączeniu ostatnie surowe pliki ZIP z danymi dostarczane przez portal są przechowywane na dysku (w .storage, na pojazd i z limitem rozmiaru), aby błędną lub brakującą wartość można było odtworzyć z dokładnie tych bajtów, które wysłał samochód. Te pliki zawierają Twoją lokalizację GPS, VIN i telemetrię, dlatego domyślnie są wyłączone – włącz je tylko podczas rozwiązywania problemów."
+          "keep_raw_datasets": "Przydatne tylko na kanale portalu EU Data Act. Po włączeniu ostatnie surowe pliki ZIP z danymi dostarczane przez portal są przechowywane na dysku (w .storage, na pojazd i z limitem rozmiaru), aby błędną lub brakującą wartość można było odtworzyć z dokładnie tych bajtów, które wysłał samochód. Te pliki zawierają Twoją lokalizację GPS, VIN i telemetrię, dlatego domyślnie są wyłączone – włącz je tylko podczas rozwiązywania problemów.",
+          "test_cohort": "Domyślnie wyłączone. Włącz tę opcję, aby integracja mogła próbować eksperymentalnych odczytów danych z Twojego samochodu — na przykład trwającej próby odzyskania pozycji GPS w samochodach Volkswagena z UE — i od czasu do czasu wyświetlać powiadomienie (które możesz zamknąć) z prośbą o udostępnienie pliku diagnostycznego, dzięki czemu nowa funkcja może zostać potwierdzona dla Twojego modelu. Wszystko, co udostępniasz, jest automatycznie anonimizowane, zanim opuści Twój system: nigdy nie zawiera numeru VIN, danych GPS, tokenów ani adresu e-mail. Właśnie w ten sposób odblokowywane są nowe funkcje — dla Twojego samochodu i wszystkich, którzy jeżdżą tym samym modelem — a w każdej chwili możesz ją z powrotem wyłączyć."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: nie zaakceptowano wymaganej zgody",
       "description": "Twoje konto {brand} nie zaakceptowało wymaganej zgody serwisowej, więc część danych lub funkcji może być niedostępna. Otwórz aplikację MyŠkoda i zaakceptuj wymaganą zgodę — to powiadomienie zniknie samo."
+    },
+    "test_cohort_share_request": {
+      "title": "Pomóż potwierdzić nową funkcję — udostępnisz wynik testu?",
+      "description": "Dziękujemy za dołączenie do dobrowolnej grupy testowej. Twój samochód został objęty eksperymentem — w tej chwili chodzi o próbę odzyskania pozycji GPS w samochodach Volkswagena z UE za pośrednictwem kanału volkswagen.de. Aby potwierdzić wynik na różnych modelach i platformach, ogromną pomocą byłoby udostępnienie pliku diagnostycznego: przejdź do Ustawienia → Urządzenia i usługi → VW Group Connect → menu z trzema kropkami → Pobierz diagnostykę, a następnie dołącz plik do zgłoszenia #923 na GitHubie.\n\nEksport jest automatycznie anonimizowany, zanim go pobierzesz — nie zawiera numeru VIN, danych GPS, tokenów ani adresu e-mail — więc bez obaw możesz go opublikować. Widzisz to powiadomienie tylko dlatego, że dołączenie do grupy testowej było Twoją własną decyzją; możesz je zamknąć, a wyłączenie grupy testowej w opcjach integracji całkowicie zatrzyma tego typu powiadomienia. Dziękujemy, że pomagasz odblokowywać funkcje dla wszystkich, którzy jeżdżą Twoim modelem."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -212,7 +212,8 @@
           "abrp_enable": "Aktivera ABRP-telemetri",
           "abrp_api_key": "ABRP-api_key (utvecklarnyckel)",
           "abrp_user_token": "ABRP-token (per fordon)",
-          "keep_raw_datasets": "Behåll rå EU Data Act-datauppsättningar (diagnostik)"
+          "keep_raw_datasets": "Behåll rå EU Data Act-datauppsättningar (diagnostik)",
+          "test_cohort": "Hjälp till att förbättra VW Group Connect (frivillig testgrupp)"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",
@@ -230,7 +231,8 @@
           "abrp_enable": "Skicka livetelemetri till A Better Routeplanner. Kräver en api_key och en token per fordon. Av = inga utgående anrop.",
           "abrp_api_key": "En utvecklar-/partnernyckel som du registrerar hos iternio (vi levererar ingen). Identifierar integrationen. Loggas aldrig.",
           "abrp_user_token": "'Generic'-token från ABRP-appen: Inställningar -> din bil -> Live Data. Loggas aldrig.",
-          "keep_raw_datasets": "Endast användbart på EU Data Act-portalkanalen. När det är på sparas de senaste råa dataset-ZIP-filerna som portalen levererar på disken (under .storage, per fordon och med en storleksgräns), så att ett felaktigt eller saknat värde kan återskapas från exakt de byte som din bil skickade. Dessa filer innehåller din GPS-position, VIN och telemetri, så det är avstängt som standard – slå bara på det vid felsökning."
+          "keep_raw_datasets": "Endast användbart på EU Data Act-portalkanalen. När det är på sparas de senaste råa dataset-ZIP-filerna som portalen levererar på disken (under .storage, per fordon och med en storleksgräns), så att ett felaktigt eller saknat värde kan återskapas från exakt de byte som din bil skickade. Dessa filer innehåller din GPS-position, VIN och telemetri, så det är avstängt som standard – slå bara på det vid felsökning.",
+          "test_cohort": "Avstängt som standard. Slå på det här så får integrationen prova experimentella avläsningar från din bil — till exempel det pågående försöket att få fram GPS-position för Volkswagen-bilar i EU — och då och då visa en avisering, som du enkelt kan stänga, där du ombeds dela en diagnostikfil så att en ny funktion kan bekräftas för just din modell. Allt som delas rensas automatiskt innan det lämnar ditt system: inget VIN, ingen GPS, inga tokens och ingen e-post skickas någonsin med. Det är så nya funktioner låses upp — för din bil och för alla andra som kör samma modell — och du kan stänga av det igen när du vill."
         }
       },
       "add_vwde": {
@@ -1791,6 +1793,10 @@
     "mandatory_consent_missing": {
       "title": "Škoda: obligatoriskt samtycke ej accepterat",
       "description": "Ditt {brand}-konto har inte accepterat ett obligatoriskt tjänstesamtycke, så vissa data eller funktioner kan vara otillgängliga. Öppna MyŠkoda-appen och acceptera det begärda samtycket — den här notisen försvinner av sig själv."
+    },
+    "test_cohort_share_request": {
+      "title": "Hjälp till att bekräfta en ny funktion — vill du dela ditt testresultat?",
+      "description": "Tack för att du är med i den frivilliga testgruppen. Din bil ingick i ett experiment — just nu försöket att få fram GPS-position för Volkswagen-bilar i EU via kanalen volkswagen.de. För att kunna bekräfta resultatet på olika modeller och plattformar skulle det verkligen hjälpa om du delade en diagnostikfil: gå till Inställningar → Enheter och tjänster → VW Group Connect → trepunktsmenyn → Ladda ner diagnostik och bifoga sedan filen till GitHub-ärendet #923.\n\nExporten rensas automatiskt innan du laddar ner den — inget VIN, ingen GPS, inga tokens och ingen e-post ingår — så den är trygg att dela offentligt. Du ser det här bara för att du har valt att delta; du kan avfärda det, och om du stänger av testgruppen igen i integrationens inställningar upphör de här aviseringarna helt. Tack för att du hjälper till att låsa upp funktioner för alla som kör din modell."
     }
   },
   "services": {

--- a/tests/test_923_authproxy_parkingposition_prep.py
+++ b/tests/test_923_authproxy_parkingposition_prep.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#923 — PREP (unmerged until a live probe confirms it): the VW EU authproxy
+parkingposition lever.
+
+VW EU GPS is structurally unavailable on every channel we currently ship: the
+CARIAD app backend's position endpoint is attestation-walled (403 for EU
+passenger cars post-lockdown) and the EU Data Act live feed has no coordinate
+field. The one remaining attestation-free lever is whether the volkswagen.de
+reverse-proxy will pass a parkingposition read through the same WeConnect realm
+that already carries charging + warning-lights. This wiring is prepared and
+tested but only ships once a live probe on a portal-enrolled car returns a
+coordinate — these tests pin the URL recipe and the parse contract so the moment
+that happens it's one merge away.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad._authproxy import (
+    build_parkingposition_url,
+    parse_parking_position,
+)
+
+
+# ── URL recipe (mirrors warning-lights: WeConnect realm + live VCF host + gdc) ──
+
+def test_url_uses_the_weconnect_realm_and_live_host() -> None:
+    url = build_parkingposition_url("WVWZZZAUZ1234567")
+    assert "/vwag-weconnect/proxy/vehicles/WVWZZZAUZ1234567/parkingposition" in url
+    assert "resourceHost=myvw-vcf-prod" in url
+    assert "gdc=myvw-wcar-prod" in url  # WeConnect default when no platform given
+
+
+def test_url_honours_an_mbb_gdc_for_legacy_cars() -> None:
+    url = build_parkingposition_url("WVWZZZAUZ1234567", gdc="myvw-mbb-prod")
+    assert "gdc=myvw-mbb-prod" in url
+
+
+# ── parse contract (same shape as the CARIAD-BFF read) ─────────────────────────
+
+def test_data_wrapped_coordinates_parse() -> None:
+    body = {"data": {"lat": 48.21, "lon": 16.37,
+                     "carCapturedTimestamp": "2026-08-10T12:00:00Z"}}
+    assert parse_parking_position(body) == (48.21, 16.37, "2026-08-10T12:00:00Z")
+
+
+def test_top_level_coordinates_are_a_fallback() -> None:
+    """Legacy/alternate firmwares may ship lat/lon at the top level."""
+    assert parse_parking_position({"lat": 48.2, "lon": 16.3}) == (48.2, 16.3, None)
+
+
+def test_a_degraded_empty_body_yields_no_coordinates() -> None:
+    """#923: a 200 with an empty data node must NOT be read as (None, None) — it
+    returns None so the last-known position carries forward instead of being
+    overwritten."""
+    assert parse_parking_position({"data": {}}) is None
+    assert parse_parking_position({"data": {"lat": 48.2}}) is None  # lon missing
+
+
+def test_non_numeric_or_bool_coordinates_are_rejected() -> None:
+    assert parse_parking_position({"data": {"lat": "48.2", "lon": "16.3"}}) is None
+    assert parse_parking_position({"data": {"lat": True, "lon": False}}) is None
+
+
+def test_non_dict_bodies_pass_through_as_none() -> None:
+    assert parse_parking_position(None) is None
+    assert parse_parking_position("nope") is None
+    assert parse_parking_position([{"lat": 1, "lon": 2}]) is None
+
+
+def test_a_missing_timestamp_is_none_not_a_crash() -> None:
+    assert parse_parking_position({"data": {"lat": 1.0, "lon": 2.0}}) == (1.0, 2.0, None)
+    assert parse_parking_position(
+        {"data": {"lat": 1.0, "lon": 2.0, "carCapturedTimestamp": ""}}
+    ) == (1.0, 2.0, None)

--- a/tests/test_923_test_cohort_optin.py
+++ b/tests/test_923_test_cohort_optin.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#923 — opt-in test cohort: the experimental vw.de parkingposition probe and its
+share-request Repair run ONLY for users who ticked the cohort option, and the flag
+is read the trap-safe way (entry.data, never entry.options).
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+)
+from custom_components.vag_connect.const import CONF_TEST_COHORT
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+_REPAIRS = "custom_components.vag_connect.repairs"
+
+
+# ── connector: self-limiting probe gate ─────────────────────────────────────
+
+def _conn(*, cohort: bool, tries: int = 0, available: bool = False):
+    c = WebsiteAuthProxyConnector.__new__(WebsiteAuthProxyConnector)
+    c.probe_position = cohort
+    c._position_probe_tries = tries
+    c._position_available = available
+    return c
+
+
+def test_opted_out_never_probes() -> None:
+    assert _conn(cohort=False)._should_probe_position() is False
+
+
+def test_opted_in_probes_within_budget() -> None:
+    assert _conn(cohort=True, tries=0)._should_probe_position() is True
+    assert _conn(cohort=True, tries=3)._should_probe_position() is True
+
+
+def test_self_limits_after_the_budget() -> None:
+    """A car whose proxy keeps refusing stops probing — no doomed request forever."""
+    max_tries = WebsiteAuthProxyConnector._POSITION_PROBE_MAX_TRIES
+    assert _conn(cohort=True, tries=max_tries)._should_probe_position() is False
+
+
+def test_coordinates_seen_latches_the_read_on() -> None:
+    """Once a position came back, keep reading even if the budget is spent — it is
+    a real feature at that point, not a probe."""
+    assert _conn(cohort=False, tries=99, available=True)._should_probe_position() is True
+
+
+# ── coordinator: cohort flag → connector + Repair, read from entry.data ─────
+
+def _coord(*, data: dict, options: dict, web: bool = True):
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    coord.hass = MagicMock()
+    coord.entry = SimpleNamespace(entry_id="e1", data=data, options=options)
+    conn = SimpleNamespace(probe_position=False) if web else None
+    coord._cariad_client = SimpleNamespace(
+        _website_proxy=conn, _supplementary_authproxy=None,
+    )
+    return coord, conn
+
+
+def test_cohort_on_arms_probe_and_raises_repair() -> None:
+    coord, conn = _coord(data={CONF_TEST_COHORT: True}, options={})
+    with patch(f"{_REPAIRS}.raise_issue_test_cohort_share") as raise_m, \
+         patch(f"{_REPAIRS}.clear_issue_test_cohort_share") as clear_m:
+        asyncio.run(coord._apply_test_cohort())
+    assert conn.probe_position is True
+    raise_m.assert_called_once()
+    clear_m.assert_not_called()
+
+
+def test_cohort_off_clears_probe_and_repair() -> None:
+    coord, conn = _coord(data={CONF_TEST_COHORT: False}, options={})
+    with patch(f"{_REPAIRS}.raise_issue_test_cohort_share") as raise_m, \
+         patch(f"{_REPAIRS}.clear_issue_test_cohort_share") as clear_m:
+        asyncio.run(coord._apply_test_cohort())
+    assert conn.probe_position is False
+    clear_m.assert_called_once()
+    raise_m.assert_not_called()
+
+
+def test_reads_entry_data_not_options_the_trap() -> None:
+    """entry.options is folded into entry.data by the listener and is always {} at
+    read time — reading options would be dead code (the documented options trap).
+    data=False must win even though options=True."""
+    coord, conn = _coord(
+        data={CONF_TEST_COHORT: False}, options={CONF_TEST_COHORT: True},
+    )
+    with patch(f"{_REPAIRS}.raise_issue_test_cohort_share") as raise_m, \
+         patch(f"{_REPAIRS}.clear_issue_test_cohort_share") as clear_m:
+        asyncio.run(coord._apply_test_cohort())
+    assert conn.probe_position is False  # data wins, not options
+    clear_m.assert_called_once()
+    raise_m.assert_not_called()
+
+
+def test_cohort_on_but_no_web_channel_does_not_nag() -> None:
+    """An opted-in user with no vw.de channel has nothing to test → no Repair."""
+    coord, _ = _coord(data={CONF_TEST_COHORT: True}, options={}, web=False)
+    with patch(f"{_REPAIRS}.raise_issue_test_cohort_share") as raise_m, \
+         patch(f"{_REPAIRS}.clear_issue_test_cohort_share") as clear_m:
+        asyncio.run(coord._apply_test_cohort())
+    raise_m.assert_not_called()
+    clear_m.assert_called_once()


### PR DESCRIPTION
Ships the vw.de parkingposition GPS lever **gated behind an opt-in "test cohort"**, so it can be crowd-confirmed across VW EU platforms (MEB / MBB / regions) instead of resting on one person's single car — without sending a doomed request for every user.

## What
- **`CONF_TEST_COHORT`** — a new persistent opt-in option (default **off**) in the integration's Configure screen. Read **only via `entry.data`** (the options listener folds options → data; `entry.options` is always `{}` at read time — the documented options trap), with a regression test that data wins over options.
- **Gated + self-limiting probe** — the parkingposition read runs only for opted-in users, stops after 4 no-coordinate polls, and latches on the moment coordinates come back (`_should_probe_position`). An opted-out user never issues the request.
- **Dismissible share-request Repair** — raised only when the user is *both* opted in *and* has a vw.de channel to test, asking them to share aggressively-redacted diagnostics on #923. Cleared the moment they opt out. Nobody else is nagged.
- **All 12 languages** — the toggle label/description and the Repair copy, translated by native-speaker agents (natural phrasing, not literal), with the privacy guarantee (nothing identifying leaves the user's system) front and centre.

## Also in this PR (the prep commit)
`build_parkingposition_url` + `parse_parking_position` (mirror the warning-lights recipe + BFF parse contract) and the `get_parking_position` connector read.

## Why gated, not always-on
The only VW EU coordinate source is attestation-walled for third parties (all incumbents lost it at the 2026 lockdown); this proxy path is the one untested attestation-free lever. It very likely 403s on most platforms — so shipping it to *everyone* would send a doomed request per poll for thousands of users. Opt-in bounds it to volunteers and turns the result into real cross-platform signal.

## Tests
16 new (gate budget/latch, coordinator apply, options-trap regression, URL + parse). Full suite **4818 passed**. Translation parity green across all 12 languages.

No release tag.
