### PR TITLE
chore(release): v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [3.0.3] - 2026-08-11 — vw.de session resilience + reporter fixes
+
 ### Added
 - **New opt-in "test cohort" option — help unlock features for your car.** A new tick-box in the integration's options (off by default). When you turn it on, the integration may run experimental reads on your car — the first one being an attempt to recover **GPS location for Volkswagen EU cars** over the volkswagen.de channel — and, occasionally, show a dismissible notification asking you to share a diagnostics file so a new capability can be confirmed for your exact model. Everything shared is redacted automatically before it leaves your system (no VIN, GPS, tokens or e-mail), and turning the option back off stops the experiments and the notifications. It's how features like location get proven across the many different VW EU platforms without one person's single car having to represent them all. (#923)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @BASTAHT
 - @Beeky2022
 - @begga77
+- @BengtKR79
 - @BennoJinx
 - @BentChr
 - @beolink
@@ -113,6 +114,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @fg877khkv8-maker
 - @fight3
 - @fightboy89
+- @Fishermanjb
 - @Flieger37
 - @Flux1959
 - @foobarth
@@ -177,6 +179,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @Juhapt
 - @julianteufel96-pixel
 - @juluga
+- @JustAnotherDud
 - @jwaeles
 - @jwmaas
 - @kaledii
@@ -418,6 +421,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @zaphod25
 - @zarengagmbh
 - @zax-29
+- @zdravac
 - @zemanchester-tech
 - @zopyx
 - @Zwergnase94

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -22,5 +22,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "3.0.2"
+  "version": "3.0.3"
 }


### PR DESCRIPTION
Release-prep for **v3.0.3 — vw.de session resilience + reporter fixes**.

- Rename CHANGELOG `[Unreleased]` → `[3.0.3] - 2026-08-11`; fresh empty `[Unreleased]` on top.
- Bump `manifest.json` 3.0.2 → 3.0.3.
- Credit new reporters in CONTRIBUTORS: @BengtKR79, @Fishermanjb, @JustAnotherDud, @zdravac.

Content already merged into main via #1138 #1139 #1141 #1144 #1147. Tag `v3.0.3` follows on merge.