### PR TITLE
feat(#584): surface no-legacy-MBB-enrolment verdict in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Internal
+- **Diagnostics now flag a "no legacy MBB enrolment" car (#584).** When a car set up on the durable-MBB channel gets the definitive `gw.error.authentication` reject on its service list — the fingerprint of a car/account with no legacy Car-Net enrolment (reads still work over the EU Data Act / volkswagen.de channel, but MBB commands never will) — the config-entry diagnostics now list that VIN under `mbb_no_legacy`. So a report of "MBB set up but no commands appear" is answerable straight from the diagnostics instead of asking for a debug log, and the verdict clears the moment the car's service list succeeds again (e.g. after becoming the primary user in the brand app). Grounded in the B8 Passat GTE reports (@Mattheisen87, @BengtKR79) and @JustAnotherDud's Polo probing.
+
 ## [3.0.3] - 2026-08-11 — vw.de session resilience + reporter fixes
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -1727,6 +1727,14 @@ class VWEUClient(CariadBaseClient):
         # single poll, spamming the log and burning a request per poll forever.
         if not hasattr(self, "_mbb_oplist_denied"):
             self._mbb_oplist_denied: dict[str, datetime] = {}
+        if not hasattr(self, "mbb_no_legacy_vins"):
+            # #584 — VINs whose MBB operationList returned the definitive
+            # ``gw.error.authentication`` verdict: no legacy Car-Net enrolment
+            # for this car↔account (reads still work via EU-DA / vw.de; MBB
+            # commands do not). Public so diagnostics can surface it and a
+            # #584-class report is triageable at a glance instead of asking
+            # for a debug log.
+            self.mbb_no_legacy_vins: set[str] = set()
         now = datetime.now(tz=timezone.utc)
         cached = self._mbb_oplist_cache.get(vin)
         if not force_refresh and cached and cached[1] > now:
@@ -1773,6 +1781,10 @@ class VWEUClient(CariadBaseClient):
                 # poll is pure log noise. Subsequent hits stay at DEBUG.
                 first_denial = vin not in self._mbb_oplist_denied
                 self._mbb_oplist_denied[vin] = now + _MBB_OPLIST_DENY_TTL
+                # #584 — record the durable no-legacy-enrolment verdict so
+                # diagnostics can show it (this is the definitive verdict, not
+                # the transient bare-401/403 backoff handled below).
+                self.mbb_no_legacy_vins.add(vin)
                 _LOGGER.log(
                     logging.WARNING if first_denial else logging.DEBUG,
                     "MBB operationList ***%s → 401 gw.error.authentication: the "
@@ -1819,6 +1831,7 @@ class VWEUClient(CariadBaseClient):
             # #909 — a successful list means the denial is over (e.g. the user
             # became primary user in the app), so drop the negative cache.
             self._mbb_oplist_denied.pop(vin, None)
+            self.mbb_no_legacy_vins.discard(vin)  # #584 — enrolment recovered
             self._mbb_oplist_cache[vin] = (oplist, now + timedelta(hours=12))
             enabled = [s for s in oplist.services.values() if s.enabled]
             _LOGGER.info(

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -410,6 +410,19 @@ async def async_get_config_entry_diagnostics(
             except Exception as err:  # noqa: BLE001 — never let one channel break the export
                 raw_responses[str(channel)] = {"error": f"{type(err).__name__}"}
 
+    # #584 — surface the durable "no legacy MBB enrolment" verdict. These VINs
+    # got the definitive ``gw.error.authentication`` reject on the MBB
+    # operationList, i.e. the car/account is read-only (EU-DA / vw.de) and MBB
+    # commands are unavailable — so a #584-class report is triageable straight
+    # from the diagnostics instead of asking the reporter for a debug log.
+    mbb_no_legacy: list[str] = []
+    _nl = getattr(client, "mbb_no_legacy_vins", None) if client is not None else None
+    if _nl:
+        try:
+            mbb_no_legacy = sorted(mask_vin(v) for v in _nl)
+        except Exception:  # noqa: BLE001
+            mbb_no_legacy = []
+
     return {
         "config": config_diag,
         "options": options_diag,
@@ -424,4 +437,5 @@ async def async_get_config_entry_diagnostics(
         "error_buffer": error_records,
         "parser_stats": parser_stats_diag,
         "capabilities": capabilities,
+        "mbb_no_legacy": mbb_no_legacy,
     }

--- a/tests/test_584_no_legacy_verdict.py
+++ b/tests/test_584_no_legacy_verdict.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#584 — durable "no legacy MBB enrolment" verdict.
+
+When the MBB operationList returns the definitive ``gw.error.authentication``
+401 (the Mattheisen87 / B8-GTE-line verdict — the car/account has no legacy
+Car-Net enrolment, so reads work only via EU-DA/vw.de and MBB commands never
+will), the client records the VIN in a public ``mbb_no_legacy_vins`` set so the
+diagnostics can surface it and a #584-class report is triageable at a glance.
+It clears the moment a fresh operationList succeeds (enrolment recovered), and
+it is NOT set by the transient bare-401/403 (systemId ACL) backoff path.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+from custom_components.vag_connect.cariad.exceptions import APIError
+
+VIN = "WVWZZZAUZFW805377"
+_URL = "https://mal-1a.prd.ece.vwg-connect.com/api/rolesrights/operationlist/v3"
+_AUTH_401 = APIError(
+    401, _URL,
+    '{"error":{"errorCode":"gw.error.authentication","description":"Unauthorized"}}',
+)
+_ACL_403 = APIError(
+    403, _URL,
+    '{"error":{"errorCode":"mbbc.rolesandrights.unauthorized",'
+    '"description":"Did not find permission for systemId \'XID_APP_VW\'"}}',
+)
+_GOOD = {"operationList": {"vin": VIN, "role": "PRIMARY_USER", "status": "ENABLED",
+                           "serviceInfo": [{"serviceId": "rclima_v1",
+                                            "serviceStatus": {"status": "Enabled"}}]}}
+
+
+def _client(side_effect) -> VWEUClient:
+    c = VWEUClient.__new__(VWEUClient)
+    c._mbb_get = AsyncMock(side_effect=side_effect)
+    c._refresh_tokens = AsyncMock(return_value=None)
+    return c
+
+
+def test_gw_error_authentication_records_no_legacy_verdict() -> None:
+    c = _client([_AUTH_401])
+    assert asyncio.run(c._get_mbb_operationlist(VIN, for_command=True)) is None
+    assert VIN in c.mbb_no_legacy_vins
+
+
+def test_successful_operationlist_clears_the_verdict() -> None:
+    """Enrolment recovered (e.g. the user became primary user in the app) → a
+    fresh list succeeds and the durable verdict drops."""
+    c = _client([_AUTH_401, _GOOD])
+    asyncio.run(c._get_mbb_operationlist(VIN, for_command=True))
+    assert VIN in c.mbb_no_legacy_vins
+    ol = asyncio.run(
+        c._get_mbb_operationlist(VIN, for_command=True, force_refresh=True)
+    )
+    assert ol is not None
+    assert VIN not in c.mbb_no_legacy_vins
+
+
+def test_systemid_acl_403_is_not_a_no_legacy_verdict() -> None:
+    """Only the definitive gw.error.authentication verdict counts. The bare
+    401/403 (systemId ACL) is the transient soft-backoff path and must NOT mark
+    the car as no-legacy — that would falsely flag a car having a bad minute."""
+    c = _client([_ACL_403])
+    assert asyncio.run(c._get_mbb_operationlist(VIN, for_command=True)) is None
+    assert VIN not in c.mbb_no_legacy_vins
+
+
+def test_verdict_set_exists_even_before_any_call() -> None:
+    """A fresh client that has never fetched an operationList still answers the
+    diagnostics probe cleanly (empty set, not AttributeError)."""
+    c = _client([_GOOD])
+    asyncio.run(c._get_mbb_operationlist(VIN))
+    assert c.mbb_no_legacy_vins == set()


### PR DESCRIPTION
## What (Refs #584)
When a car on the durable-MBB channel gets the definitive `gw.error.authentication` reject on its operationList — the fingerprint of **no legacy Car-Net enrolment** (reads work via EU-DA / volkswagen.de, MBB commands never will) — the client records the VIN in a public `mbb_no_legacy_vins` set, now surfaced in config-entry **diagnostics under `mbb_no_legacy`**.

So a #584-class report ("set up MBB, no command entities") is triageable **straight from the diagnostics** instead of asking the reporter for a debug log. Clears the moment a fresh operationList succeeds (enrolment recovered, e.g. became primary user in the app).

## Scope / safety
**Additive only.** The working read/command logic is untouched — commands already gate on `mbb_operation_granted` (denied → None → no actuation), and the existing #909/#584 negative-cache + no-refresh behaviour is unchanged. Only the definitive `gw.error.authentication` verdict is recorded; the transient bare-401/403 soft-backoff path is deliberately NOT flagged.

Grounded in the B8 Passat GTE reports (@Mattheisen87, @BengtKR79) + @JustAnotherDud's Polo probing.

## Tests
`test_584_no_legacy_verdict` (4): verdict recorded on gw.error.authentication, cleared on recovery, NOT set by systemId-ACL 403, safe empty default. Full suite 4849 passed, ruff + mypy strict clean.

Does not close #584 — it stays the MBB testing hub.