### PR TITLE
chore(release): v3.0.5 — cohort probe observability + SoC / interval fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [3.0.5] - 2026-08-14 — cohort probe observability + SoC / interval fixes
+
+### Fixed
+- **Battery SoC no longer sticks on a stale value on some EU cars (#1088).** A few cars (ID. Buzz) ship `battery_state_report.soc` twice — and VW stamps the *stale* value with the *newer* capture time, so the freshness resolver picked the wrong one and the contested-reading guard never noticed (the timestamps genuinely differ, so it isn't a tie). When VW marks the HV battery level `VALID`, that single, unambiguous reading is now trusted over the contested SoC leaf. Grounded in @ggfbrkt6mc-max's raw export (36 VALID vs the stale 18). Inert for cars that don't ship the HV pair.
+- **The "raise your update interval" tip no longer suggests an interval you can't select (#1115).** The advice is now clamped to the 60-minute maximum the options picker allows; when you're already at the ceiling the tip is suppressed instead of asking you to set 61 or 75 minutes. Thanks @Reluca and @christianmhz.
+- **Audi aux-heating request-queue field no longer re-flagged by the Scout (#1154).** `climatisation.auxiliaryHeatingStatus.requests` (an internal empty-list counter) is now silenced — it had slipped past the existing wildcards. Thanks @neuweddemer.
+
+### Internal
+- **Experimental vw.de probes now record their outcome in diagnostics (#923/#1157).** The opt-in GPS (parkingposition) and battery State-of-Health probes run fail-soft, so a 403/404/412 refusal or an empty 200 previously left no trace — the test cohort was flying blind. A new `probe_outcomes` block in the config-entry diagnostics now shows each probe's status (`404`, `412`, `200 no-coords`, …), merged up from the supplementary connector. Bare status labels only, no PII.
+- **`battery_charging_status_soc` wired as a last-resort SoC source (#1164).** A charging-status HV SoC (`%`) recovers the reading for a car that ships nothing else, ranked below the canonical sources. Thanks @morpheusbdf.
+
 ## [3.0.4] - 2026-08-13 — odometer self-heal + attestation-free SoH probe
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,9 +12,9 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @AFPhome
 - @agirud
 - @alamaison62
+- @alex-zilmer
 - @Alexclubm
 - @alexthegalex13
-- @alex-zilmer
 - @amateurdeveloper
 - @ammelch
 - @AndiTails
@@ -126,6 +126,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @GeraldMalits
 - @Gerhard2808
 - @gerlofkeulen-svg
+- @ggfbrkt6mc-max
 - @GitHobi
 - @GiuseppeAlbano
 - @gleeballs
@@ -270,6 +271,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @moeller-cyper
 - @moltke69
 - @morkis82
+- @morpheusbdf
 - @mortenbroesby
 - @Motii08
 - @MrSnoot
@@ -285,6 +287,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @neuhausf
 - @neumanntv
 - @Neumaz
+- @neuweddemer
 - @NevelSavage
 - @normand198
 - @nox2805
@@ -329,6 +332,7 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @rborkenhagen
 - @redlake
 - @Reindbe1
+- @Reluca
 - @RichardL6
 - @Richardvp73
 - @Rizencip
@@ -368,8 +372,8 @@ Everyone below has reported an issue or a Vehicle Data Scout finding, requested 
 - @starwarsfan
 - @StefanBW1984
 - @StefanSch84
-- @StevenLies
 - @steven-r
+- @StevenLies
 - @stingyraccoon
 - @StoneH74
 - @Svenruotsi

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -946,6 +946,13 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             "climatisation.auxiliaryHeatingStatus.value.*",
             "climatisation.auxiliaryHeatingStatus.error",
             "climatisation.auxiliaryHeatingStatus.error.*",
+            # #1154 (neuweddemer, Audi) — an internal request-queue counter that
+            # arrives as an empty list; not telemetry, no user value. The nested
+            # ``.requests`` was NOT covered by the 2-seg leaf or the 4-seg
+            # ``.value.*``/``.error.*`` globs (``_path_matches`` is exact / equal-
+            # length, not prefix), so the Scout kept re-flagging it. Silence it.
+            "climatisation.auxiliaryHeatingStatus.requests",
+            "climatisation.auxiliaryHeatingStatus.requests.*",
             "climatisationTimers.auxiliaryHeatingTimersStatus",
             "climatisationTimers.auxiliaryHeatingTimersStatus.value",
             "climatisationTimers.auxiliaryHeatingTimersStatus.value.*",

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -243,6 +243,11 @@ class CariadBaseClient:
         # ``"vehicle-status"``); values are the unparsed dict from the
         # backend. Re-populated per poll — never accumulates across polls.
         self.last_raw_responses: dict[str, dict[str, Any]] = {}
+        # #923/#1157 — last outcome of each experimental vw.de probe
+        # (parkingposition / SoH), merged up from the supplementary connector so
+        # the test cohort's diagnostics show WHY a probe yielded nothing. Bare
+        # status labels only ("404"/"412"/"200 no-value") — no PII.
+        self.probe_outcomes: dict[str, str] = {}
         # v1.19.1 — Pycupra-style API quota visibility. Most VAG backends
         # send X-RateLimit-Remaining (and sometimes X-RateLimit-Limit /
         # X-RateLimit-Reset) on successful responses. We capture the
@@ -520,15 +525,25 @@ class CariadBaseClient:
         except Exception:  # noqa: BLE001
             pass
         try:
-            return await connector.get_vehicle_data(vin)  # type: ignore[no-any-return]
-        except AuthenticationError:
             try:
-                await connector.refresh()
                 return await connector.get_vehicle_data(vin)  # type: ignore[no-any-return]
+            except AuthenticationError:
+                try:
+                    await connector.refresh()
+                    return await connector.get_vehicle_data(vin)  # type: ignore[no-any-return]
+                except Exception:  # noqa: BLE001
+                    return None
             except Exception:  # noqa: BLE001
                 return None
-        except Exception:  # noqa: BLE001
-            return None
+        finally:
+            # #923/#1157 — surface the connector's probe outcomes even when the
+            # read itself fail-softed to None, so the cohort's diagnostics show
+            # WHY a probe yielded nothing (403/404/412 vs 200-no-value vs never).
+            _outc = getattr(connector, "probe_outcomes", None)
+            if _outc:
+                if not isinstance(getattr(self, "probe_outcomes", None), dict):
+                    self.probe_outcomes = {}
+                self.probe_outcomes.update(_outc)
 
     async def _read_eu_portal(
         self, connector: Any, vin: str

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -610,6 +610,8 @@ class VWEUClient(CariadBaseClient):
             # otherwise a vw.de reporter's diagnostics carries no raw data to
             # ground the location / auth issues (#923 / #966).
             self.last_raw_responses = dict(getattr(web, "last_raw_responses", {}))
+            # #923/#1157 — surface the sole-mode probe outcomes too.
+            self.probe_outcomes = dict(getattr(web, "probe_outcomes", {}))
             return web_data
 
         # v2.12.0 — EU Data Act portal mode (read-only fallback). When the

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1377,9 +1377,28 @@ def map_dataset_to_vehicle_data(
             )
         return best[3]
 
+    # #1088 (ggfbrkt6mc-max, ID.Buzz) — some cars ship battery_state_report.soc
+    # TWICE, and VW stamps the STALE value with the NEWER capture time, so the
+    # freshness resolver below picks the wrong one AND contested_fields never
+    # flags it (the two timestamps genuinely differ, so it is not a tie). The
+    # battery_level_HV pair is single-occurrence and VW marks it VALID/INVALID:
+    # when VALID it is the authoritative HV SoC (verified on the reporter's export
+    # — value 36 VALID vs the contested leaf's stale 18). Prefer it. Inert for the
+    # vast majority of cars that don't ship the HV pair or mark it non-VALID
+    # (falls through to the existing freshness resolution unchanged).
+    _hv_state = first("battery_level_HV.state")
+    _hv_val = _to_int(first("battery_level_HV.value",
+                            "battery_level_HV.battery_level_HV.value"))
+    _hv_soc = (
+        _hv_val
+        if (isinstance(_hv_state, str) and _hv_state.strip().upper() == "VALID"
+            and _hv_val is not None and 0 <= _hv_val <= 100)
+        else None
+    )
+
     # #465 — SoC is the one field observed to ship under disagreeing aliases
     # (a stale 57 vs the fresh 81); resolve it by capture time, not list order.
-    soc = _to_int(first_freshest("battery_state_report.soc", "soc", "stateOfChargeInPercent",
+    soc = _hv_soc if _hv_soc is not None else _to_int(first_freshest("battery_state_report.soc", "soc", "stateOfChargeInPercent",
                         "state_of_charge",
                         # self-audit (Enyaq / MEB-Entry, e-up): these cars ship the
                         # traction SoC under a bespoke leaf "currentSoc" whose
@@ -1402,6 +1421,16 @@ def map_dataset_to_vehicle_data(
                         # soc/battery_state_report.soc keys; just widens
                         # coverage for cars that report nothing else.
                         "hv_soc",
+                        # #1164 (morpheusbdf) — the charging-status message
+                        # carries its own HV SoC (dict: "Indicates the current
+                        # charging status for the battery", type number, unit %;
+                        # UUID 081f3121-0f89-3553-b7a2-f79bd5537479). Kept LAST-
+                        # resort like the other charger-dialect aliases so the
+                        # canonical soc / hv_soc keys always win when a car reports
+                        # both — that also makes it safe if a car ever ships it as
+                        # a setpoint rather than the live pack SoC (it can never
+                        # out-compete a real reading, only widen coverage).
+                        "battery_charging_status_soc",
                         # v2.18.0 (#702) — Touareg-era legacy Car-Net export.
                         # These cars ship a flat {dataFieldName, value} dataset
                         # whose names are fully qualified (RBC.*/RTS.*/RDT.*),

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -392,6 +392,13 @@ class WebsiteAuthProxyConnector:
         self._soh_available: bool = False
         self._soh_subpath: str | None = None
 
+        # #923/#1157 — last outcome of each experimental probe, surfaced in
+        # diagnostics so the test cohort can see WHY a probe yielded nothing (a
+        # 403/404/412 refusal vs a never-fired probe vs an empty 200). Values are
+        # bare status labels only ("404", "412", "200 no-value") — no PII. Without
+        # this a fail-soft probe left zero trace and the whole cohort was blind.
+        self.probe_outcomes: dict[str, str] = {}
+
     _POSITION_PROBE_MAX_TRIES = 4
     _SOH_PROBE_MAX_TRIES = 4
 
@@ -1107,6 +1114,7 @@ class WebsiteAuthProxyConnector:
         accept: str = "application/json",
         soft: bool = False,
         optional: bool = False,
+        record_as: str | None = None,
     ) -> Any:
         """GET a reverse-proxy endpoint and parse JSON.
 
@@ -1143,6 +1151,8 @@ class WebsiteAuthProxyConnector:
                         "Website authproxy GET %s → 412 precondition "
                         "(no data this poll)", url,
                     )
+                    if record_as:
+                        self.probe_outcomes[record_as] = "412 precondition (wrong-platform gdc?)"
                     return None
                 if resp.status in _AUTH_FAIL_STATUSES:
                     if optional:
@@ -1151,6 +1161,8 @@ class WebsiteAuthProxyConnector:
                             "unavailable for this car — not a session failure)",
                             url, resp.status,
                         )
+                        if record_as:
+                            self.probe_outcomes[record_as] = str(resp.status)
                         return None
                     raise AuthenticationError(
                         f"Website authproxy GET {url} → HTTP {resp.status}"
@@ -1168,12 +1180,18 @@ class WebsiteAuthProxyConnector:
                             "Website authproxy GET %s → HTTP %s "
                             "(soft; no data this poll)", url, resp.status,
                         )
+                        if record_as:
+                            self.probe_outcomes[record_as] = str(resp.status)
                         return None
                     raise AuthenticationError(
                         f"Website authproxy GET {url} → HTTP {resp.status}"
                     )
                 body = await resp.json(content_type=None)
                 self._capture_raw(url, body)
+                if record_as:
+                    # provisional; the caller refines to "200 no-value" when the
+                    # body carries no usable reading (a degraded 200).
+                    self.probe_outcomes[record_as] = "200"
                 return body
         return None
 
@@ -1329,11 +1347,13 @@ class WebsiteAuthProxyConnector:
         await self._ensure_backend(vin)
         body = await self._get_json(
             build_parkingposition_url(vin, self._gdc(vin)),
-            accept="*/*", soft=True, optional=True,
+            accept="*/*", soft=True, optional=True, record_as="parkingposition",
         )
         if body is None:
             return None
         parsed = parse_parking_position(body)
+        if parsed is None:  # a degraded 200 that carried no coordinates
+            self.probe_outcomes["parkingposition"] = "200 no-coords"
         _LOGGER.debug(
             "Website authproxy parkingposition %s → %s", vin[-6:],
             "coords" if parsed else "no coordinates in body",
@@ -1367,9 +1387,10 @@ class WebsiteAuthProxyConnector:
             (self._soh_subpath,) if self._soh_subpath else _SOH_PROBE_SUBPATHS
         )
         for subpath in candidates:
+            base = subpath.split("?")[0]
             body = await self._get_json(
                 build_batteryhealth_url(vin, subpath, self._gdc(vin)),
-                accept="*/*", soft=True, optional=True,
+                accept="*/*", soft=True, optional=True, record_as=f"soh:{base}",
             )
             if body is None:
                 continue
@@ -1378,9 +1399,10 @@ class WebsiteAuthProxyConnector:
                 self._soh_subpath = subpath
                 _LOGGER.debug(
                     "Website authproxy SoH %s via %s → %.1f%%",
-                    vin[-6:], subpath.split("?")[0], soh,
+                    vin[-6:], base, soh,
                 )
                 return soh
+            self.probe_outcomes[f"soh:{base}"] = "200 no-value"
         _LOGGER.debug("Website authproxy SoH probe %s → no usable value", vin[-6:])
         return None
 

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -318,6 +318,7 @@ DEEPLINK_SCHEMES: dict[str, str] = {
 # at upgrade — only the default for fresh installs changes.
 DEFAULT_SCAN_INTERVAL = 10   # minutes (was 5 — see v1.17.0 reasoning)
 MIN_SCAN_INTERVAL     = 5    # minutes (was 3 — quota protection)
+MAX_SCAN_INTERVAL     = 60   # minutes — the config-flow selectable ceiling (#1115)
 
 # #1078 — some brands hand out short-lived access tokens, so at the default
 # 10-min poll almost every cycle triggers a token refresh. The refresh-storm
@@ -348,13 +349,19 @@ _INTERVAL_STEP_UP_MIN = 15
 def advised_scan_interval(brand: str | None, current: int) -> int:
     """The interval to ADVISE in the refresh-storm repair, given *current*.
 
-    #1115 (starwarsfan) — the flat per-brand recommendation told a user already
-    running 31 minutes to "raise it to 30", which reads as nonsense and leaves
-    them nothing to act on. The advice has to beat what they already run: once
-    the configured interval meets or exceeds the brand recommendation, step up
-    from THEIR value instead of repeating ours.
+    #1115 (starwarsfan / Reluca / christianmhz) — the flat per-brand
+    recommendation told a user already running 31 minutes to "raise it to 30",
+    which reads as nonsense and leaves them nothing to act on. The advice has to
+    beat what they already run: once the configured interval meets or exceeds the
+    brand recommendation, step up from THEIR value instead of repeating ours.
+
+    ALWAYS clamped to ``MAX_SCAN_INTERVAL`` — the config-flow selectable ceiling.
+    The first pass stepped up unclamped and advised 61/75 minutes when the picker
+    caps at 60, i.e. an interval the user physically cannot select. When the
+    result equals ``current`` the caller sees there is no headroom left to advise
+    and suppresses the "raise it" repair instead of asking the impossible.
     """
-    base = recommended_scan_interval(brand)
+    base = min(recommended_scan_interval(brand), MAX_SCAN_INTERVAL)
     if not isinstance(current, int) or current < base:
         return base
-    return current + _INTERVAL_STEP_UP_MIN
+    return min(current + _INTERVAL_STEP_UP_MIN, MAX_SCAN_INTERVAL)

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -4681,14 +4681,23 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     self.entry.options.get(CONF_SCAN_INTERVAL)
                     or self.entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
                 )
-                # #1115 (starwarsfan) — advise an interval that actually beats
-                # the configured one (see ``advised_scan_interval``).
-                raise_issue_refresh_interval_too_frequent(
-                    self.hass, self.entry.entry_id,
-                    brand=brand,
-                    current=current_min,
-                    recommended=advised_scan_interval(brand, current_min),
-                )
+                # #1115 (starwarsfan / Reluca / christianmhz) — advise an
+                # interval that actually beats the configured one AND is
+                # selectable (advised_scan_interval clamps to MAX_SCAN_INTERVAL).
+                # When the user is already at the ceiling there is no higher value
+                # to advise, so suppress the repair rather than telling them to set
+                # an interval the picker can't reach — the storm guard already
+                # backs the polling off on its own.
+                advised = advised_scan_interval(brand, current_min)
+                if advised > current_min:
+                    raise_issue_refresh_interval_too_frequent(
+                        self.hass, self.entry.entry_id,
+                        brand=brand,
+                        current=current_min,
+                        recommended=advised,
+                    )
+                else:
+                    clear_refresh_interval_issue(self.hass, self.entry.entry_id)
             else:
                 clear_refresh_interval_issue(self.hass, self.entry.entry_id)
 

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -410,6 +410,14 @@ async def async_get_config_entry_diagnostics(
             except Exception as err:  # noqa: BLE001 — never let one channel break the export
                 raw_responses[str(channel)] = {"error": f"{type(err).__name__}"}
 
+    # #923/#1157 — surface the experimental vw.de probe outcomes so the test
+    # cohort can see WHY a probe yielded nothing (a 403/404/412 refusal vs an
+    # empty 200 vs a never-fired probe). Bare status labels only — no PII.
+    probe_outcomes: dict[str, str] = {}
+    _po = getattr(client, "probe_outcomes", None) if client is not None else None
+    if isinstance(_po, dict):
+        probe_outcomes = {str(k): str(v) for k, v in _po.items()}
+
     # #584 — surface the durable "no legacy MBB enrolment" verdict. These VINs
     # got the definitive ``gw.error.authentication`` reject on the MBB
     # operationList, i.e. the car/account is read-only (EU-DA / vw.de) and MBB
@@ -434,6 +442,7 @@ async def async_get_config_entry_diagnostics(
         "polling_active": coordinator.is_active,
         "unexpected_findings": unexpected,
         "raw_responses": raw_responses,
+        "probe_outcomes": probe_outcomes,
         "error_buffer": error_records,
         "parser_stats": parser_stats_diag,
         "capabilities": capabilities,

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -22,5 +22,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "3.0.4"
+  "version": "3.0.5"
 }

--- a/tests/test_1078_refresh_interval_repair.py
+++ b/tests/test_1078_refresh_interval_repair.py
@@ -61,13 +61,33 @@ class TestAdvisedIntervalBeatsTheConfiguredOne:
         # the reporter's exact case: 31 configured must never advise 30
         assert advised_scan_interval("skoda", 31) > 31
         assert advised_scan_interval("skoda", 30) > 30
-        assert advised_scan_interval("skoda", 60) > 60
 
-    def test_advice_always_exceeds_current(self) -> None:
+    def test_advice_never_exceeds_the_selectable_maximum(self) -> None:
+        """#1115 (Reluca / christianmhz) — the step-up must be clamped to the
+        config-flow ceiling; advising 61/75 min when the picker caps at 60 is an
+        instruction the user physically cannot follow. At the ceiling the advice
+        equals the max (the caller then suppresses the impossible repair)."""
+        from custom_components.vag_connect.const import (
+            MAX_SCAN_INTERVAL,
+            advised_scan_interval,
+        )
+
+        assert MAX_SCAN_INTERVAL == 60
+        for brand in ("skoda", "audi", "volkswagen", None):
+            for current in (1, 5, 10, 30, 31, 45, 55, 60, 120):
+                advised = advised_scan_interval(brand, current)
+                assert advised <= MAX_SCAN_INTERVAL, (
+                    f"{brand}/{current} advised {advised} above the {MAX_SCAN_INTERVAL} max"
+                )
+        # at the ceiling there is no headroom: advice pins to the max, not above
+        assert advised_scan_interval("skoda", 60) == 60
+        assert advised_scan_interval("skoda", 120) == 60
+
+    def test_advice_exceeds_current_while_headroom_remains(self) -> None:
         from custom_components.vag_connect.const import advised_scan_interval
 
         for brand in ("skoda", "audi", "volkswagen", None):
-            for current in (1, 5, 10, 30, 31, 45, 120):
+            for current in (1, 5, 10, 30, 31, 44):  # all below the 60 ceiling
                 assert advised_scan_interval(brand, current) > current, (
                     f"{brand}/{current} advised an interval that is not an increase"
                 )

--- a/tests/test_1088_valid_hv_soc.py
+++ b/tests/test_1088_valid_hv_soc.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1088 (ggfbrkt6mc-max, ID.Buzz) — VALID-gated HV level beats a contested SoC.
+
+The reporter's raw EU Data Act export shipped ``battery_state_report.soc`` TWICE
+(36 first/correct, 18 second/stale) — and VW stamped the STALE 18 with the NEWER
+capture time, so the freshness resolver picked 18 and ``contested_fields`` never
+flagged it (the two timestamps genuinely differ, so it is not a tie the reconcile
+hook can catch). ``battery_level_HV`` is single-occurrence and VW marks it
+VALID/INVALID; on this car it read ``value 36 / state VALID`` — the true pack SoC.
+So when ``battery_level_HV.state == VALID`` we trust its value over the contested
+leaf. Inert for cars that don't ship the HV pair or mark it non-VALID.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(fields: dict) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_valid_hv_level_wins_over_the_stale_contested_soc() -> None:
+    """The reporter's exact case: soc leaf resolved to the stale 18, HV says 36/VALID."""
+    d = _map({
+        "battery_state_report.soc": "18",       # the stale value that won freshness
+        "battery_level_HV.value": "36.0",
+        "battery_level_HV.state": "VALID",
+    })
+    assert d.battery_soc == 36
+    assert d.has_battery is True
+
+
+def test_hv_level_recovers_soc_when_the_leaf_is_absent() -> None:
+    d = _map({"battery_level_HV.value": "36.0", "battery_level_HV.state": "VALID"})
+    assert d.battery_soc == 36
+
+
+def test_non_valid_hv_state_falls_through_to_the_soc_leaf() -> None:
+    """VW marks the HV level INVALID → do NOT trust it; the soc leaf stands."""
+    d = _map({
+        "battery_state_report.soc": "50",
+        "battery_level_HV.value": "36.0",
+        "battery_level_HV.state": "INVALID",
+    })
+    assert d.battery_soc == 50
+
+
+def test_missing_hv_state_falls_through() -> None:
+    """No explicit VALID marker → don't promote the HV value (safety)."""
+    d = _map({
+        "battery_state_report.soc": "50",
+        "battery_level_HV.value": "36.0",
+    })
+    assert d.battery_soc == 50
+
+
+def test_canonical_soc_without_hv_pair_is_unchanged() -> None:
+    d = _map({"battery_state_report.soc": "80"})
+    assert d.battery_soc == 80
+
+
+def test_out_of_range_hv_value_is_ignored() -> None:
+    d = _map({
+        "battery_state_report.soc": "44",
+        "battery_level_HV.value": "255",   # implausible → not trusted
+        "battery_level_HV.state": "VALID",
+    })
+    assert d.battery_soc == 44

--- a/tests/test_1154_auxheating_requests_silenced.py
+++ b/tests/test_1154_auxheating_requests_silenced.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1154 (neuweddemer, Audi) — silence climatisation.auxiliaryHeatingStatus.requests.
+
+The Scout kept re-flagging ``climatisation.auxiliaryHeatingStatus.requests`` (an
+internal request-queue counter that arrives as an empty list). It slipped through
+because ``_path_matches`` is exact / equal-length — not prefix — so the 2-seg
+``auxiliaryHeatingStatus`` leaf and the 4-seg ``.value.*`` / ``.error.*`` globs
+never covered the 3-seg ``.requests`` path (exactly the case the sibling
+``climatisationTimers.climatisationTimersStatus.requests`` silencer already
+handles for #801). Now silenced — so the maintainer reply ("noted so the Scout
+stops flagging it") is actually true.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad._unexpected_keys import detect_unexpected
+
+
+def test_auxheating_requests_is_not_flagged() -> None:
+    payload = {"climatisation": {"auxiliaryHeatingStatus": {"requests": []}}}
+    flagged = [f.path for f in detect_unexpected("audi", "selectivestatus", payload)]
+    assert flagged == [], f"expected .requests silenced, got {flagged}"
+
+
+def test_a_genuinely_unknown_sibling_is_still_flagged() -> None:
+    """The silence is targeted — an unrelated new child must still surface."""
+    payload = {"climatisation": {"auxiliaryHeatingStatus": {"somethingBrandNew": 1}}}
+    flagged = [f.path for f in detect_unexpected("audi", "selectivestatus", payload)]
+    assert any("somethingBrandNew" in p for p in flagged)

--- a/tests/test_1164_battery_charging_status_soc.py
+++ b/tests/test_1164_battery_charging_status_soc.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1164 (morpheusbdf) — battery_charging_status_soc as a last-resort HV SoC.
+
+The Vehicle Data Scout surfaced a new VW EU Data Act field
+``battery_charging_status_soc`` ("70") — the dict describes it as "the current
+charging status for the battery" (%, UUID 081f3121-…). It is a genuine HV SoC, so
+it is wired as a LAST-resort fallback into the ``battery_soc`` candidate list:
+it recovers SoC for a car that ships nothing else, but can never out-compete a
+canonical ``soc`` reading (which also makes it safe if a car ever ships it as a
+setpoint instead of the live pack level).
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(fields: dict) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_charging_status_soc_recovers_soc_when_nothing_else_is_sent() -> None:
+    d = _map({"battery_charging_status_soc": "70"})
+    assert d.battery_soc == 70
+    assert d.has_battery is True
+
+
+def test_canonical_soc_still_wins_over_the_fallback() -> None:
+    d = _map({"soc": "80", "battery_charging_status_soc": "70"})
+    assert d.battery_soc == 80
+
+
+def test_hv_soc_still_wins_over_the_fallback() -> None:
+    d = _map({"hv_soc": "55", "battery_charging_status_soc": "70"})
+    assert d.battery_soc == 55

--- a/tests/test_923_probe_observability.py
+++ b/tests/test_923_probe_observability.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#923 / #1157 — probe outcomes are visible in diagnostics.
+
+The experimental vw.de probes (parkingposition GPS, battery SoH) run fail-soft:
+a 403/404/412 refusal or a degraded empty 200 returns None and never raises. That
+made them INVISIBLE — the GPS cohort's diagnostics carried no trace of why a probe
+yielded nothing, so we could not tell "the proxy refused (404)" from "the probe
+never fired" from "an empty 200". These tests pin the new ``probe_outcomes`` trail:
+``_get_json`` records the status, the callers refine a degraded 200 to a
+"no-value" label, and the supplementary read merges the connector's outcomes up to
+the client so they reach the diagnostics export — even when the read fail-softs.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+from custom_components.vag_connect.cariad.api.base import CariadBaseClient
+from custom_components.vag_connect.cariad.auth._website_authproxy import (
+    WebsiteAuthProxyConnector,
+)
+
+VIN = "WVWZZZAUZ1234567"
+
+
+class _Resp:
+    def __init__(self, status: int, json_data: Any = None) -> None:
+        self.status = status
+        self._json = json_data
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def json(self, content_type: Any = None) -> Any:
+        return self._json
+
+    async def text(self, errors: str | None = None) -> str:
+        return ""
+
+
+class _Session:
+    def __init__(self, status: int, json_data: Any = None) -> None:
+        self._status = status
+        self._json = json_data
+
+    def get(self, url: str, **_kw: Any) -> _Resp:
+        return _Resp(self._status, self._json)
+
+
+def _conn(status: int, json_data: Any = None) -> WebsiteAuthProxyConnector:
+    c = WebsiteAuthProxyConnector.__new__(WebsiteAuthProxyConnector)
+    c.probe_outcomes = {}
+    c.last_raw_responses = {}
+    c._headers = lambda d: d  # type: ignore[assignment]
+    c._session = _Session(status, json_data)  # type: ignore[assignment]
+    c._ensure_backend = AsyncMock(return_value=None)  # type: ignore[assignment]
+    c._gdc = lambda vin: "myvw-wcar-prod"  # type: ignore[assignment]
+    c._soh_subpath = None
+    return c
+
+
+# ── _get_json records the status of a probe ────────────────────────────────────
+
+def test_get_json_records_404_for_a_refused_soft_probe() -> None:
+    c = _conn(404)
+    out = asyncio.run(c._get_json(
+        "https://www.volkswagen.de/x/vehicles/V/parkingposition",
+        accept="*/*", soft=True, optional=True, record_as="parkingposition",
+    ))
+    assert out is None
+    assert c.probe_outcomes["parkingposition"] == "404"
+
+
+def test_get_json_records_403_on_the_optional_auth_branch() -> None:
+    c = _conn(403)
+    out = asyncio.run(c._get_json(
+        "https://x", accept="*/*", optional=True, record_as="soh:selectivestatus",
+    ))
+    assert out is None
+    assert c.probe_outcomes["soh:selectivestatus"] == "403"
+
+
+def test_get_json_records_412_precondition() -> None:
+    c = _conn(412)
+    out = asyncio.run(c._get_json("https://x", optional=True, record_as="parkingposition"))
+    assert out is None
+    assert "412" in c.probe_outcomes["parkingposition"]
+
+
+def test_get_json_records_200_on_success() -> None:
+    c = _conn(200, {"data": {"lat": 1.0, "lon": 2.0}})
+    body = asyncio.run(c._get_json("https://x", record_as="parkingposition"))
+    assert body == {"data": {"lat": 1.0, "lon": 2.0}}
+    assert c.probe_outcomes["parkingposition"] == "200"
+
+
+def test_no_record_without_record_as() -> None:
+    c = _conn(404)
+    asyncio.run(c._get_json("https://x", soft=True, optional=True))
+    assert c.probe_outcomes == {}  # nothing recorded when not asked
+
+
+# ── callers refine a degraded 200 to a "no-value" label ────────────────────────
+
+def test_parking_refines_a_degraded_200_to_no_coords() -> None:
+    c = _conn(200, {"data": {}})  # 200 but no coordinates
+    res = asyncio.run(c.get_parking_position(VIN))
+    assert res is None
+    assert c.probe_outcomes["parkingposition"] == "200 no-coords"
+
+
+def test_soh_refines_a_degraded_200_to_no_value() -> None:
+    c = _conn(200, {"nothing": "useful"})  # 200 but no ubeIndicator_pct
+    res = asyncio.run(c.get_battery_health(VIN))
+    assert res is None
+    # the first candidate is selectivestatus
+    assert c.probe_outcomes["soh:selectivestatus"] == "200 no-value"
+
+
+# ── the supplementary read merges outcomes up to the client (surfaces in diag) ──
+
+def test_read_authproxy_merges_outcomes_even_when_read_fails() -> None:
+    client = CariadBaseClient.__new__(CariadBaseClient)
+    client.probe_outcomes = {}
+
+    connector = WebsiteAuthProxyConnector.__new__(WebsiteAuthProxyConnector)
+    connector.probe_outcomes = {"parkingposition": "404", "soh:batteryhealthstate": "404"}
+    # the read itself raises → fail-soft to None, but outcomes must still surface
+    connector.get_vehicle_data = AsyncMock(side_effect=RuntimeError("boom"))
+
+    res = asyncio.run(client._read_authproxy(connector, VIN))
+    assert res is None
+    assert client.probe_outcomes["parkingposition"] == "404"
+    assert client.probe_outcomes["soh:batteryhealthstate"] == "404"


### PR DESCRIPTION
Post-v3.0.4 reliability batch, grounded in an exhaustive issue/discussion sweep.

**Fixed**
- #1088 — stale battery SoC on some EU cars (VALID-gated HV level beats a contested `soc` leaf; @ggfbrkt6mc-max).
- #1115 — interval advice clamped to the 60-min selectable max, suppressed at the ceiling (@Reluca, @christianmhz).
- #1154 — Audi `auxiliaryHeatingStatus.requests` silenced (@neuweddemer).

**Internal**
- #923/#1157 — vw.de probe outcomes (`probe_outcomes`) now surface in diagnostics so the GPS/SoH cohort can see WHY a probe yielded nothing (403/404/412/200-no-value). Grounded in 6 cohort diagnostics that returned no position AND no probe trace.
- #1164 — `battery_charging_status_soc` last-resort SoC fallback (@morpheusbdf).

Full suite green (4887 passed, 15 skipped), ruff + mypy strict clean. Tag `v3.0.5` follows on merge.