### PR TITLE
chore(release): v3.0.6 — charging state, climate confirm, staleness + Scout tidy-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [3.0.6] - 2026-08-14 — charging state, climate confirm, staleness + Scout tidy-up
+
+### Fixed
+- **CUPRA (and other EU-DA cars) no longer show "not charging" while actively charging (#632).** Some portal firmwares send a charge *scenario* but not the raw charge-state, so `is_charging` stayed off and the plug read "not connected" mid-charge. An in-progress scenario (`…_ACTIVE`) now lifts charging and infers the plug — without ever overriding a real reading. Thanks @gr6803.
+- **Audi PPE climate no longer reports a false "OK" when the car rejects it (#912).** The rich `start_climate_control` path skipped the command-confirmation poll the basic climate command already runs, so an asynchronous backend rejection (e.g. `E:CV.PA.31` on A6/Q6 e-tron) looked like success. It now confirms through the same poll — best-effort, so it can't regress a working command. Thanks @Mirjam9 (and #940 @loeildubush).
+
+### Added
+- **"Vehicle Last Reported" diagnostic sensor (#465).** Shows the car's own data-capture time, distinct from the poll time ("Last Update"). On a frozen-but-non-empty EU Data Act feed the poll keeps succeeding while the data is days old — now "reported 2 days ago" next to "updated 1 minute ago" makes a silent freeze obvious. Reporter's own idea; thanks @TomJonesGreggs.
+
+### Internal
+- **The Scout stops spamming a new GitHub issue per user for fields we intentionally never map (#1151/#1156/#1164/#1166/#1167, #1140/#1149/#1152/#1161/#1168).** `scope_potential_total` (PPE-opaque) and the ownerless opening UUIDs `c0bb1348`/`d5dc7c87` are kept out of the user-facing "report this" repair while staying fully Scout-visible in diagnostics; a genuinely-new field or opening UUID still raises it.
+- **Mapped the remaining Scout fields from #1164 (@morpheusbdf).** `state_ext_cond_available_*` (static per-zone climate availability) and `tank_accuracy` (folds into the existing fuel-level-estimated flag) are now consumed, so the Scout stops re-flagging them.
+
 ## [3.0.5] - 2026-08-14 — cohort probe observability + SoC / interval fixes
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/_reporter_pipeline.py
+++ b/custom_components/vag_connect/cariad/_reporter_pipeline.py
@@ -67,6 +67,34 @@ ISSUE_ID_UNEXPECTED_KEYS = "vehicle_data_scout_findings"
 ISSUE_ID_ERROR_REPORTER = "error_reporter_findings"
 
 
+# ── Intentional-skip allowlist — REPAIR suppression, NOT data suppression ──
+# Matching findings stay fully Scout-VISIBLE in diagnostics (they remain in
+# VehicleData.raw_unmapped_fields → the raw_api_fields sensor, and in the
+# coordinator's unexpected_findings count) but are kept OUT of the user-facing
+# Scout repair, so they stop prompting every reporter to hand-file the same
+# already-investigated issue. Distinct from EXPECTED_KEYS / EU-DA first()-reclaim,
+# which remove the field from raw_unmapped_fields entirely — these must NOT be
+# data-suppressed (scope_potential_total is intentionally-unmapped-but-visible per
+# _eu_data_act.py; the ownerless openings are kept Scout-visible per #1100).
+# Spam so far: scope_potential_total → #1151/#1156/#1164/#1166/#1167;
+#              c0bb1348/d5dc7c87 → #1140/#1149/#1152/#1161/#1168.
+_SCOUT_REPAIR_SKIP_LEAVES: frozenset[str] = frozenset({"scope_potential_total"})
+# Substring match on the (masked) sample: #1100's UUID annotation rides in the
+# value as ``... (uuid c0bb1348)``; keying on the UUID (not the eu_data_act.open
+# PATH) preserves discovery — a genuinely-new opening UUID on the same leaf still
+# raises the repair.
+_SCOUT_REPAIR_SKIP_UUIDS: frozenset[str] = frozenset({"c0bb1348", "d5dc7c87"})
+
+
+def _is_scout_repair_skipped(f: UnexpectedField) -> bool:
+    """True if a finding is known/intentionally-unmapped and must not spawn the
+    user-facing Scout repair. It stays in raw_unmapped_fields regardless."""
+    if f.path.rsplit(".", 1)[-1] in _SCOUT_REPAIR_SKIP_LEAVES:
+        return True
+    sample = f.sample_masked or ""
+    return any(u in sample for u in _SCOUT_REPAIR_SKIP_UUIDS)
+
+
 # ---------------------------------------------------------------------------
 # Privacy guard — the model-name choke point
 # ---------------------------------------------------------------------------
@@ -316,7 +344,11 @@ def ensure_unexpected_keys_issue(
     report. The Markdown body is also embedded in the description so
     Facebook/forum users can copy-paste without leaving HA.
     """
-    findings_list = list(findings)
+    # Drop the intentional-skip set from the REPAIR only (they stay in
+    # raw_unmapped_fields / diagnostics). If a poll's findings are *only* the
+    # skipped set, findings_list is empty and the empty-case below deletes the
+    # repair — no more per-user spam for scope_potential_total / c0bb1348.
+    findings_list = [f for f in findings if not _is_scout_repair_skipped(f)]
     issue_id = f"{entry_id}_{ISSUE_ID_UNEXPECTED_KEYS}"
 
     if not findings_list:

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -993,8 +993,17 @@ class VWEUClient(CariadBaseClient):
             body["climatizationAtUnlock"] = bool(climatisation_at_unlock)
         if climatisation_mode is not None:
             body["climatisationMode"] = str(climatisation_mode)
-        url = f"{self._base_for_vin(vin)}/vehicle/v1/vehicles/{vin}/climatisation/start"
-        await self._post(url, json=body)
+        base = self._base_for_vin(vin)
+        url = f"{base}/vehicle/v1/vehicles/{vin}/climatisation/start"
+        resp = await self._post(url, json=body)
+        # #912 (@Mirjam9, Audi A6 PPE) — the *basic* climate command confirms via
+        # the pendingrequests poll, but this rich path used a raw _post and skipped
+        # it, so an async backend rejection (e.g. the PPE E:CV.PA.31) surfaced as a
+        # false "OK". Route it through the same confirmation the basic path already
+        # trusts. Best-effort: only raises on an EXPLICIT terminal rejection, so it
+        # can never regress a working command (a rejection whose payload shape we
+        # can't yet sample just falls through to accept, exactly as today).
+        await self._await_bff_command(vin, base, resp)
 
     async def command_stop_climate(self, vin: str) -> None:
         """Stop pre-conditioning — separate endpoint (primary), combined 404-fallback."""

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -2505,6 +2505,20 @@ def map_dataset_to_vehicle_data(
                   "charging_scenario", "chargingScenario")
     if _cscn is not None:
         d.charging_scenario = _shorten_enum(_cscn)
+        # #632 (@gr6803, CUPRA) — this portal firmware ships charging_scenario but
+        # NOT current_charge_state, so the cs-derived is_charging above stayed OFF
+        # while an *_ACTIVE scenario proved the car was charging (plug_connected
+        # read null too). The three in-progress scenarios all end _ACTIVE
+        # (IMMEDIATELY_CHARGING_ACTIVE / CHARGING_TO_DEPARTURE_TIME_ACTIVE /
+        # OPTIMISED_CHARGING_ACTIVE); OFF / INVALID / *_FINISHED are idle. Lift
+        # ONLY (never clear) so a correctly-read car is untouched; an _ACTIVE
+        # scenario also proves the cable is in, so infer plug_connected only when
+        # the granular plug field was absent (read null).
+        if isinstance(d.charging_scenario, str) and \
+                d.charging_scenario.upper().endswith("_ACTIVE"):
+            d.is_charging = True
+            if d.plug_connected is None:
+                d.plug_connected = True
 
     _icas = first("charging_state_report.immediate_action_state",
                   "immediate_charge_action_state", "immediate_action_state")
@@ -2783,7 +2797,13 @@ def map_dataset_to_vehicle_data(
     if _scr is not None and d.adblue_range_km is None:
         d.adblue_range_km = _scr
     # fuel_level__accuracy (double underscore): 0=measured 1=calculated.
-    _fla = _to_int(first("fuel_level__accuracy"))
+    # #1164 (@morpheusbdf) — tank_accuracy (672acc16) is the tank-dialect twin of
+    # the same 0/1 byte ("Accuracy of the fuel level with 0 or 1"); alias it as a
+    # fallback so it is CONSUMED (leaves the Scout) and reuses the existing
+    # fuel_level_estimated diagnostic — no new entity. Same 0=measured/1=calculated
+    # polarity assumed from the parallel wording; would invert only if a live
+    # payload proves otherwise.
+    _fla = _to_int(first("fuel_level__accuracy", "tank_accuracy"))
     if _fla is not None:
         d.fuel_level_estimated = _fla == 1
 
@@ -3059,6 +3079,22 @@ def map_dataset_to_vehicle_data(
     _zarr = _setting_bool(first("state_zone_active_rear_right"))
     if _zarr is not None and d.climate_zone_active_rear_right is None:
         d.climate_zone_active_rear_right = _zarr
+    # #1164 (@morpheusbdf) — STATIC per-zone availability (state_ext_cond_available_*,
+    # dict type=string → _setting_bool). Consumed whenever present so the field
+    # leaves raw_unmapped_fields (Scout stops re-flagging) and is visible in
+    # diagnostics; no dedicated entity (see models.py note).
+    _eafl = _setting_bool(first("state_ext_cond_available_front_left"))
+    if _eafl is not None and d.climate_zone_available_front_left is None:
+        d.climate_zone_available_front_left = _eafl
+    _eafr = _setting_bool(first("state_ext_cond_available_front_right"))
+    if _eafr is not None and d.climate_zone_available_front_right is None:
+        d.climate_zone_available_front_right = _eafr
+    _earl = _setting_bool(first("state_ext_cond_available_rear_left"))
+    if _earl is not None and d.climate_zone_available_rear_left is None:
+        d.climate_zone_available_rear_left = _earl
+    _earr = _setting_bool(first("state_ext_cond_available_rear_right"))
+    if _earr is not None and d.climate_zone_available_rear_right is None:
+        d.climate_zone_available_rear_right = _earr
 
     # start_stop_action — dict type=string, "Indicates the action related to
     # charging". No dict-listed enum values → no confirmed prefix; _shorten_enum

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1805,6 +1805,16 @@ class VehicleData:
     climate_zone_active_front_right: bool | None = None
     climate_zone_active_rear_left: bool | None = None
     climate_zone_active_rear_right: bool | None = None
+    # #1164 (@morpheusbdf) — static per-zone extended-conditioning AVAILABILITY
+    # (state_ext_cond_available_*): whether the zone physically exists on this car.
+    # Never changes per VIN → mapped to named fields (so they leave the Scout and
+    # show in diagnostics) but deliberately not surfaced as their own entities
+    # (four static capability flags would be entity clutter with no automation
+    # value). The third sibling of the *_enabled / *_active twins above.
+    climate_zone_available_front_left: bool | None = None
+    climate_zone_available_front_right: bool | None = None
+    climate_zone_available_rear_left: bool | None = None
+    climate_zone_available_rear_right: bool | None = None
     # Charging-related action (start_stop_action — dict type=string, no enum
     # list; _shorten_enum passes unprefixed values through). LOW —
     # disabled-by-default. sensor, diagnostic.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -22,5 +22,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "3.0.5"
+  "version": "3.0.6"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -850,6 +850,20 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:clock-check-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # #465 (@TomJonesGreggs) — the car's own data-capture time, distinct from the
+    # poll time above. On a frozen-but-non-empty EU-DA feed the poll keeps
+    # succeeding (last_updated_at stays fresh) while the car's data is days old;
+    # HA renders this TIMESTAMP as a relative age, so "last reported 2 days ago"
+    # next to "last updated 1 minute ago" makes a silent freeze obvious. The value
+    # is already captured (last_seen_at) on every channel — this just surfaces it.
+    VagSensorDescription(
+        key="last_seen_at",
+        translation_key="last_seen_at",
+        data_key="last_seen_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:car-clock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 
     VagSensorDescription(
         key="departure_timer_1_time",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -550,6 +550,9 @@
       "last_updated_at": {
         "name": "Last Update"
       },
+      "last_seen_at": {
+        "name": "Vehicle Last Reported"
+      },
       "adblue_range_km": {
         "name": "AdBlue Range"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -451,6 +451,9 @@
       "last_updated_at": {
         "name": "Naposledy aktualizováno"
       },
+      "last_seen_at": {
+        "name": "Vozidlo naposledy nahlášeno"
+      },
       "adblue_range_km": {
         "name": "Dojezd AdBlue"
       },

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -457,6 +457,9 @@
       "last_updated_at": {
         "name": "Seneste opdatering"
       },
+      "last_seen_at": {
+        "name": "Køretøj sidst rapporteret"
+      },
       "adblue_range_km": {
         "name": "AdBlue-rækkevidde"
       },

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -466,6 +466,9 @@
       "last_updated_at": {
         "name": "Letzte Aktualisierung"
       },
+      "last_seen_at": {
+        "name": "Fahrzeug zuletzt gemeldet"
+      },
       "adblue_range_km": {
         "name": "AdBlue Reichweite"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -457,6 +457,9 @@
       "last_updated_at": {
         "name": "Last Update"
       },
+      "last_seen_at": {
+        "name": "Vehicle Last Reported"
+      },
       "adblue_range_km": {
         "name": "AdBlue Range"
       },

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -451,6 +451,9 @@
       "last_updated_at": {
         "name": "Última actualización"
       },
+      "last_seen_at": {
+        "name": "Vehículo informado por última vez"
+      },
       "adblue_range_km": {
         "name": "Alcance AdBlue"
       },

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -457,6 +457,9 @@
       "last_updated_at": {
         "name": "Viimeisin päivitys"
       },
+      "last_seen_at": {
+        "name": "Ajoneuvo viimeksi raportoinut"
+      },
       "adblue_range_km": {
         "name": "AdBlue-toimintamatka"
       },

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -451,6 +451,9 @@
       "last_updated_at": {
         "name": "Dernière mise à jour"
       },
+      "last_seen_at": {
+        "name": "Véhicule vu la dernière fois"
+      },
       "adblue_range_km": {
         "name": "Autonomie AdBlue"
       },

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -457,6 +457,9 @@
       "last_updated_at": {
         "name": "Ultimo aggiornamento"
       },
+      "last_seen_at": {
+        "name": "Veicolo ultimo report"
+      },
       "adblue_range_km": {
         "name": "Autonomia AdBlue"
       },

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -457,6 +457,9 @@
       "last_updated_at": {
         "name": "Siste oppdatering"
       },
+      "last_seen_at": {
+        "name": "Kjøretøy sist rapportert"
+      },
       "adblue_range_km": {
         "name": "AdBlue-rekkevidde"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -451,6 +451,9 @@
       "last_updated_at": {
         "name": "Laatste update"
       },
+      "last_seen_at": {
+        "name": "Voertuig laatst gemeld"
+      },
       "adblue_range_km": {
         "name": "AdBlue bereik"
       },

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -451,6 +451,9 @@
       "last_updated_at": {
         "name": "Ostatnia aktualizacja"
       },
+      "last_seen_at": {
+        "name": "Pojazd ostatnio zgłoszony"
+      },
       "adblue_range_km": {
         "name": "Zasięg AdBlue"
       },

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -451,6 +451,9 @@
       "last_updated_at": {
         "name": "Senast uppdaterad"
       },
+      "last_seen_at": {
+        "name": "Fordon senast rapporterat"
+      },
       "adblue_range_km": {
         "name": "AdBlue-räckvidd"
       },

--- a/tests/test_1164_corners_and_tank.py
+++ b/tests/test_1164_corners_and_tank.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1164 (@morpheusbdf) — remaining mappable Scout fields.
+
+`state_ext_cond_available_*` (static per-zone climate availability) map to named
+model fields so they leave the Scout and show in diagnostics — deliberately no
+dedicated entities (four static flags = clutter). `tank_accuracy` folds into the
+existing `fuel_level_estimated` diagnostic (0=measured / 1=calculated), reusing an
+entity rather than adding one.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(fields: dict) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_ext_cond_available_zones_map_to_fields() -> None:
+    d = _map({
+        "state_ext_cond_available_front_left": "true",
+        "state_ext_cond_available_front_right": "false",
+        "state_ext_cond_available_rear_left": "true",
+        "state_ext_cond_available_rear_right": "false",
+    })
+    assert d.climate_zone_available_front_left is True
+    assert d.climate_zone_available_front_right is False
+    assert d.climate_zone_available_rear_left is True
+    assert d.climate_zone_available_rear_right is False
+
+
+def test_tank_accuracy_folds_into_fuel_level_estimated() -> None:
+    assert _map({"tank_accuracy": "1"}).fuel_level_estimated is True
+    assert _map({"tank_accuracy": "0"}).fuel_level_estimated is False
+
+
+def test_native_fuel_level_accuracy_still_wins_over_the_tank_alias() -> None:
+    d = _map({"fuel_level__accuracy": "0", "tank_accuracy": "1"})
+    assert d.fuel_level_estimated is False  # the primary key resolves first

--- a/tests/test_632_cupra_scenario_charging.py
+++ b/tests/test_632_cupra_scenario_charging.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#632 (@gr6803, CUPRA) — derive is_charging from an *_ACTIVE charge scenario.
+
+gr6803's CUPRA reads over the EU Data Act portal and ships `charging_scenario`
+but NOT `current_charge_state`, so the cs-derived `is_charging` stayed False while
+the car was actively charging (and `plug_connected` read null). The three
+in-progress scenarios all end `_ACTIVE`; they now lift `is_charging` (and infer
+`plug_connected` only when the granular field is absent). OFF / INVALID /
+`_FINISHED` are idle and never lift.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+_SCN = "charging_state_report.charging_scenario"
+
+
+def _map(fields: dict) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+@pytest.mark.parametrize("scenario", [
+    "CHARGING_SCENARIO_IMMEDIATELY_CHARGING_ACTIVE",
+    "CHARGING_SCENARIO_CHARGING_TO_DEPARTURE_TIME_ACTIVE",
+    "CHARGING_SCENARIO_OPTIMISED_CHARGING_ACTIVE",
+])
+def test_active_scenario_lifts_is_charging_and_infers_plug(scenario: str) -> None:
+    d = _map({_SCN: scenario})
+    assert d.is_charging is True
+    assert d.plug_connected is True
+
+
+@pytest.mark.parametrize("scenario", [
+    "CHARGING_SCENARIO_IMMEDIATELY_CHARGING_FINISHED",
+    "CHARGING_SCENARIO_OFF",
+    "CHARGING_SCENARIO_INVALID",
+])
+def test_idle_scenarios_do_not_lift(scenario: str) -> None:
+    d = _map({_SCN: scenario})
+    assert d.is_charging is not True   # stays False/None
+    assert d.plug_connected is None
+
+
+def test_active_scenario_never_overrides_an_explicit_disconnected_plug() -> None:
+    """The plug inference must not clobber a real granular reading."""
+    d = _map({
+        _SCN: "CHARGING_SCENARIO_IMMEDIATELY_CHARGING_ACTIVE",
+        "charging_plug1_connectionstate": "disconnected",
+    })
+    assert d.is_charging is True          # scenario still lifts charging
+    assert d.plug_connected is False      # but the explicit plug reading wins
+
+
+def test_explicit_charge_state_still_wins_for_a_normal_car() -> None:
+    """A car that DOES ship current_charge_state is unaffected by the scenario lift."""
+    d = _map({
+        "charging_state_report.current_charge_state": "charging",
+        _SCN: "CHARGING_SCENARIO_IMMEDIATELY_CHARGING_ACTIVE",
+    })
+    assert d.is_charging is True

--- a/tests/test_912_climate_confirm_parity.py
+++ b/tests/test_912_climate_confirm_parity.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#912 (@Mirjam9, Audi A6 PPE) — the rich climate-start confirms like the basic one.
+
+`command_start_climate_control` used a raw `_post` and skipped the pendingrequests
+confirmation that the basic `command_start_climate` already runs, so an async
+backend rejection (the PPE `E:CV.PA.31`) surfaced as a false "OK". The rich path
+now routes its response through the same `_await_bff_command` poll — best-effort,
+only raising on an explicit terminal rejection, so it can never regress a working
+command.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+
+VIN = "WVWZZZAUZ1234567"
+
+
+def _client() -> VWEUClient:
+    c = VWEUClient.__new__(VWEUClient)
+    c._base_for_vin = lambda vin: "https://bff.test"  # type: ignore[assignment]
+    c._post = AsyncMock(return_value={"data": {"requestId": "req-1"}})  # type: ignore[assignment]
+    c._await_bff_command = AsyncMock(return_value=None)  # type: ignore[assignment]
+    if hasattr(VWEUClient, "_mbb_command_target"):
+        c._mbb_command_target = lambda: None  # type: ignore[assignment]
+    return c
+
+
+def test_rich_climate_start_confirms_via_pendingrequests() -> None:
+    c = _client()
+    asyncio.run(c.command_start_climate_control(VIN, temp_c=21.0))
+    c._post.assert_awaited_once()
+    c._await_bff_command.assert_awaited_once()
+    # the confirmation is fed the actual POST response (so it can match the req id)
+    _args = c._await_bff_command.await_args
+    assert _args.args[0] == VIN
+    assert _args.args[2] == {"data": {"requestId": "req-1"}}

--- a/tests/test_scout_intentional_skip_repair.py
+++ b/tests/test_scout_intentional_skip_repair.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Scout intentional-skip — repair suppression WITHOUT data suppression.
+
+`scope_potential_total` (PPE-opaque) and the ownerless opening UUIDs
+`c0bb1348` / `d5dc7c87` are deliberately kept Scout-VISIBLE in diagnostics, but
+they spawned a fresh hand-filed GitHub issue per reporter (#1151/#1156/#1164/…,
+#1140/#1149/#1152/#1161/#1168). The intentional-skip allowlist keeps them out of
+the user-facing Scout *repair* only — a genuinely-new field or a new opening UUID
+still raises it.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad._reporter_pipeline import (
+    _is_scout_repair_skipped,
+)
+from custom_components.vag_connect.cariad._unexpected_keys import UnexpectedField
+
+
+def _f(path: str, sample: str = "") -> UnexpectedField:
+    return UnexpectedField(
+        path=path, sample_masked=sample,
+        endpoint="eu_data_act", first_seen_at="2026-08-14T00:00:00Z",
+    )
+
+
+def test_scope_potential_total_is_repair_skipped() -> None:
+    assert _is_scout_repair_skipped(_f("eu_data_act.scope_potential_total", "0"))
+
+
+def test_ownerless_opening_uuids_are_repair_skipped() -> None:
+    assert _is_scout_repair_skipped(_f("eu_data_act.open", "true (uuid c0bb1348)"))
+    assert _is_scout_repair_skipped(_f("eu_data_act.open", "true (uuid d5dc7c87)"))
+
+
+def test_a_new_opening_uuid_still_raises_the_repair() -> None:
+    """Keying on the UUID (not the `open` path) preserves discovery."""
+    assert not _is_scout_repair_skipped(_f("eu_data_act.open", "true (uuid deadbeef)"))
+
+
+def test_an_unrelated_new_field_still_raises_the_repair() -> None:
+    assert not _is_scout_repair_skipped(_f("eu_data_act.some_new_field", "42"))


### PR DESCRIPTION
Rest-of-tail batch from the exhaustive sweep, grounded + verified.

**Fixed**
- #632 — CUPRA/EU-DA cars showing `is_charging: false` mid-charge (active scenario now lifts it; @gr6803).
- #912 — Audi PPE climate false "OK" (rich start now confirms via pendingrequests like the basic path; @Mirjam9 / #940).

**Added**
- #465 — "Vehicle Last Reported" diagnostic sensor (data-capture time vs poll time) so a frozen EU-DA feed is visible; @TomJonesGreggs. +12 langs.

**Internal**
- Scout stops spawning a per-user issue for intentional-skip fields (scope_potential_total, c0bb1348/d5dc7c87) — repair-suppression only, still Scout-visible.
- #1164 remaining fields mapped (state_ext_cond_available_*, tank_accuracy; @morpheusbdf).

Full suite green (4903 passed, 15 skipped), ruff + mypy strict clean, 12-lang parity green. Tag `v3.0.6` follows on merge.