### PR TITLE
feat(ha): event, update, calendar platforms + per-device diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ### Added
 - **"Data hasn't refreshed" warning for a frozen vehicle feed (#465).** When the integration keeps polling successfully but the car's own data-capture time stops advancing (a lapsed EU Data Act feed presenting days-old data as live), a dismissible per-vehicle Repair now points it out — and explains it may just be a parked, sleeping car. Auto-clears the moment a fresher reading arrives. Grounded in @TomJonesGreggs's ID. Buzz freeze; complements the new "Vehicle Last Reported" sensor from 3.0.6.
+- **Push events are now first-class HA entities.** Manufacturer push notifications (Škoda / Audi / VW / CUPRA / SEAT) already fired on the event bus; each vehicle now also gets a proper `event` entity, so they show in the Logbook, drive automations without a YAML bus filter, and keep per-car history. Unknown backend event types are preserved verbatim under an `event_type_raw` attribute.
+- **Firmware `update` entity.** The car's installed software version + "update available" status now render as a native HA update card (with a release-notes link where provided) — read-only, since VAG firmware is flashed by the car, not by HA. Škoda today.
+- **Charging & service calendars.** Two read-only calendars per vehicle: a *charging schedule* (departure timers + charge/climate ETAs) and a *service schedule* (service/oil/brake due dates) — the scheduling data on a timeline instead of scattered across time/date sensors.
+- **Per-device diagnostics download.** You can now download diagnostics for a single car (from its device page) instead of the whole account — smaller, and easier to share for a bug report. Same redaction as the full export.
 
 ### Fixed
 - **Lifetime travel-time now records long-term statistics.** It was missing a `state_class`, so it produced no history — corrected to `TOTAL_INCREASING` like its distance siblings. (HA feature-coverage audit.)

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -36,7 +36,10 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
+    Platform.CALENDAR,
     Platform.DEVICE_TRACKER,
+    Platform.EVENT,
+    Platform.UPDATE,
     Platform.SWITCH,
     Platform.BUTTON,
     Platform.CLIMATE,

--- a/custom_components/vag_connect/calendar.py
+++ b/custom_components/vag_connect/calendar.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Calendar platform for VAG Connect — charging/departure schedule + service dates.
+
+Two read-only calendars per vehicle:
+- ``charging_schedule`` — departure timers, the next charge window, and charge /
+  climate ETAs (timed events, hours-to-days horizon).
+- ``service`` — service / oil / brake due dates (all-day events, months horizon).
+
+Departure timers are stored as a bare ``HH:MM`` wall-clock time with no weekday
+mask (the mask only exists on the write service, never read back), so an enabled
+timer is projected onto every day in the requested range — honest over-generation
+we document rather than guessing weekdays.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from .coordinator import VagConnectCoordinator
+from .entity_base import VagConnectEntity, register_dynamic_spawner
+
+_BLOCK = timedelta(minutes=15)  # non-zero duration for instant/timer events
+
+_CHARGE_FIELDS = (
+    "departure_timer_1_time", "departure_timer_2_time", "departure_timer_3_time",
+    "charge_target_time", "next_charge_timer_start_at", "climate_ready_at",
+)
+_SERVICE_FIELDS = (
+    "service_due_at", "oil_service_at", "brake_fluid_change_due_at",
+    "brake_pads_front_inspection_due_at", "brake_pads_rear_inspection_due_at",
+)
+
+
+def _parse_dt(val: Any) -> datetime | None:
+    """Parse an ISO-8601 datetime string; assume UTC when naive. None on failure."""
+    if not isinstance(val, str) or "T" not in val:
+        return None
+    try:
+        dt = datetime.fromisoformat(val.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=dt_util.UTC)
+
+
+def _parse_date(val: Any) -> date | None:
+    """Parse a date (or the date part of an ISO datetime). None on failure."""
+    if not isinstance(val, str) or len(val) < 10:
+        return None
+    try:
+        return date.fromisoformat(val[:10])
+    except ValueError:
+        return None
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the schedule + service calendars per vehicle.
+
+    Deliberately NOT gated on read-only mode — calendars are pure read surfaces,
+    and a portal/read-only car still has service dates + charge ETAs.
+    """
+    coordinator: VagConnectCoordinator = entry.runtime_data
+
+    def _build_for_vin(vin: str, vehicle: dict) -> list[Any]:
+        ents: list[Any] = []
+        if vehicle.get("has_battery") or any(vehicle.get(k) for k in _CHARGE_FIELDS):
+            ents.append(VagChargingScheduleCalendar(coordinator, vin))
+        if any(vehicle.get(k) for k in _SERVICE_FIELDS):
+            ents.append(VagServiceCalendar(coordinator, vin))
+        return ents
+
+    register_dynamic_spawner(entry, coordinator, async_add_entities, _build_for_vin)
+
+
+class VagChargingScheduleCalendar(VagConnectEntity, CalendarEntity):
+    """Departure timers + charge/climate ETAs for one vehicle (read-only)."""
+
+    _attr_translation_key = "charging_schedule"
+    _attr_icon = "mdi:calendar-clock"
+
+    def __init__(self, coordinator: VagConnectCoordinator, vin: str) -> None:
+        super().__init__(coordinator, vin, "charging_schedule")
+
+    def _events_between(self, start: datetime, end: datetime) -> list[CalendarEvent]:
+        v = self._vehicle
+        events: list[CalendarEvent] = []
+
+        # Next charge window (real duration when both ends are present).
+        cstart = _parse_dt(v.get("next_charge_timer_start_at"))
+        cfin = _parse_dt(v.get("next_charge_timer_finish_at"))
+        if cstart is not None:
+            cend = cfin if (cfin and cfin > cstart) else cstart + _BLOCK
+            if cstart < end and cend > start:
+                events.append(CalendarEvent(
+                    start=cstart, end=cend, summary="Charging (scheduled)",
+                    uid=f"{self._vin}-chargewindow"))
+
+        # Instant ETAs.
+        for field, summary, uid in (
+            ("charge_target_time", "Charge target reached", "chargetarget"),
+            ("climate_ready_at", "Cabin ready", "climateready"),
+        ):
+            t = _parse_dt(v.get(field))
+            if t is not None and t < end and t + _BLOCK > start:
+                events.append(CalendarEvent(
+                    start=t, end=t + _BLOCK, summary=summary,
+                    uid=f"{self._vin}-{uid}"))
+
+        # Departure timers — project the HH:MM wall-clock onto every day in range
+        # (no weekday mask is read back, so daily projection is the honest choice).
+        tz = dt_util.DEFAULT_TIME_ZONE
+        for n in (1, 2, 3):
+            if not v.get(f"departure_timer_{n}_enabled"):
+                continue
+            raw = v.get(f"departure_timer_{n}_time")
+            if not isinstance(raw, str) or ":" not in raw:
+                continue
+            try:
+                hh, mm = (int(x) for x in raw[:5].split(":"))
+            except ValueError:
+                continue
+            day = start.astimezone(tz).date()
+            last = end.astimezone(tz).date()
+            while day <= last:
+                s = datetime(day.year, day.month, day.day, hh, mm, tzinfo=tz)
+                e = s + _BLOCK
+                if s < end and e > start:
+                    events.append(CalendarEvent(
+                        start=s, end=e, summary=f"Departure timer {n}",
+                        uid=f"{self._vin}-departure{n}-{day.isoformat()}"))
+                day += timedelta(days=1)
+
+        return events
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        now = dt_util.now()
+        # A 3-day forward window is plenty to find the next timer/ETA cheaply.
+        upcoming = [
+            e for e in self._events_between(now - _BLOCK, now + timedelta(days=3))
+            if e.end > now
+        ]
+        upcoming.sort(key=lambda e: e.start)
+        return upcoming[0] if upcoming else None
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime,  # noqa: ARG002
+    ) -> list[CalendarEvent]:
+        return self._events_between(start_date, end_date)
+
+
+class VagServiceCalendar(VagConnectEntity, CalendarEntity):
+    """Service / oil / brake due dates for one vehicle (read-only, all-day)."""
+
+    _attr_translation_key = "service"
+    _attr_icon = "mdi:calendar-check"
+
+    def __init__(self, coordinator: VagConnectCoordinator, vin: str) -> None:
+        super().__init__(coordinator, vin, "service")
+
+    def _all_events(self) -> list[CalendarEvent]:
+        v = self._vehicle
+        out: list[CalendarEvent] = []
+        for field, summary in (
+            ("service_due_at", "Service due"),
+            ("oil_service_at", "Oil service due"),
+            ("brake_fluid_change_due_at", "Brake fluid change"),
+            ("brake_pads_front_inspection_due_at", "Front brake pads inspection"),
+            ("brake_pads_rear_inspection_due_at", "Rear brake pads inspection"),
+        ):
+            d = _parse_date(v.get(field))
+            if d is not None:
+                out.append(CalendarEvent(
+                    start=d, end=d + timedelta(days=1),  # all-day: end exclusive
+                    summary=summary, uid=f"{self._vin}-{field}"))
+        return out
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        today = dt_util.now().date()
+        upcoming = sorted(
+            (e for e in self._all_events() if e.end > today),
+            key=lambda e: e.start,
+        )
+        return upcoming[0] if upcoming else None
+
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime,  # noqa: ARG002
+    ) -> list[CalendarEvent]:
+        s, e = start_date.date(), end_date.date()
+        return [ev for ev in self._all_events() if ev.start < e and ev.end > s]

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -4,6 +4,10 @@
 
 DOMAIN = "vag_connect"
 
+# Bus event fired by coordinator._on_push_event for each manufacturer push
+# notification; consumed by the event platform (per-vehicle EventEntity).
+EVENT_PUSH = "vag_connect_push_event"
+
 # Config entry keys
 CONF_BRAND                    = "brand"
 CONF_USERNAME                 = "username"

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -42,6 +42,7 @@ from .const import (
     CONF_USERNAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    EVENT_PUSH,
     advised_scan_interval,
 )
 from homeassistant.helpers import device_registry as dr
@@ -3009,7 +3010,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # failure cannot break the refresh path.
             try:
                 self.hass.bus.async_fire(
-                    "vag_connect_push_event",
+                    EVENT_PUSH,
                     {
                         "vin": event.vin,
                         "event_type": event.event_type,

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .cariad._error_reporter import serialise_for_diagnostics
 # v2.8.0 quick win D — reuse the Scout module's PII regexes (VIN / JWT
@@ -45,6 +46,7 @@ from .const import (
     CONF_SUPPLEMENTARY_EU_PORTAL_PASSWORD,
     CONF_SUPPLEMENTARY_EU_PORTAL_USERNAME,
     CONF_USERNAME,
+    DOMAIN,
 )
 from .coordinator import VagConnectCoordinator
 
@@ -457,4 +459,52 @@ async def async_get_config_entry_diagnostics(
         "parser_stats": parser_stats_diag,
         "capabilities": capabilities,
         "mbb_no_legacy": mbb_no_legacy,
+    }
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device: DeviceEntry,
+) -> dict[str, Any]:
+    """Per-device (single-VIN) slice of the config-entry diagnostics.
+
+    Lets a reporter share ONE car instead of the whole account. Built by slicing
+    the already-redacted config-entry payload — identical redaction, no
+    duplication. Only the genuinely VIN-keyed sections are sliced (``vehicles`` /
+    ``unexpected_findings`` / ``mbb_no_legacy``, all keyed by ``mask_vin(vin)``);
+    the channel/probe/command-keyed sections carry no VIN dimension and are
+    account-scoped, so they are dropped from a single-car file rather than leaking
+    another car's data.
+    """
+    full = await async_get_config_entry_diagnostics(hass, entry)
+
+    vin = next((str(v) for d, v in device.identifiers if d == DOMAIN), None)
+    # The options/settings device (number.py) shares the DOMAIN but is not a car.
+    if not vin or vin.endswith("_settings"):
+        return {
+            "device_note": "non-vehicle device — no per-VIN slice",
+            "config": full.get("config"),
+            "options": full.get("options"),
+        }
+
+    masked = mask_vin(vin)  # the per-VIN diag sections are keyed by the masked VIN
+    veh = full.get("vehicles", {})
+    unexpected = full.get("unexpected_findings", {})
+    return {
+        "device_vin_masked": masked,
+        "config": full.get("config"),
+        "options": full.get("options"),
+        "vehicles": {masked: veh[masked]} if masked in veh else {},
+        "vehicle_count": 1 if masked in veh else 0,
+        "unexpected_findings": (
+            {masked: unexpected[masked]} if masked in unexpected else {}
+        ),
+        "mbb_no_legacy": (
+            [masked] if masked in full.get("mbb_no_legacy", []) else []
+        ),
+        "last_update_success": full.get("last_update_success"),
+        "cloud_push_active": full.get("cloud_push_active"),
+        "push_states": full.get("push_states"),
+        "polling_active": full.get("polling_active"),
     }

--- a/custom_components/vag_connect/event.py
+++ b/custom_components/vag_connect/event.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Event platform for VAG Connect — first-class push events per vehicle.
+
+The coordinator already fires manufacturer push notifications onto the HA bus as
+``vag_connect_push_event`` (``coordinator._on_push_event``). This platform gives
+each vehicle a first-class ``event`` entity so those pushes land in the Logbook,
+can trigger automations without a YAML bus filter, and carry per-car history.
+
+Each entity subscribes to the bus event, filters to its own VIN, and re-emits via
+``_trigger_event``. Push ``event_type`` values are backend-defined strings; the
+Audi/VW kebab ``type`` and CUPRA/SEAT OLA ``type`` cannot be enumerated
+off-device, so any value not in the declared list is fired under the ``other``
+catch-all with the real value preserved in ``event_type_raw`` — never dropping an
+event and never raising ``ValueError`` inside ``_trigger_event``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.event import EventEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .cariad._util import json_safe_dict
+from .const import CONF_BRAND, EVENT_PUSH
+from .coordinator import VagConnectCoordinator
+from .entity_base import VagConnectEntity, register_dynamic_spawner
+
+# Catch-all so an open-ended backend ``event_type`` can never raise inside
+# EventEntity._trigger_event (which rejects any type not in event_types).
+EVENT_TYPE_OTHER = "other"
+
+# Grounded event_type values per brand. ``other`` is appended as the safety net.
+_BRAND_EVENT_TYPES: dict[str, list[str]] = {
+    # Skoda MQTT topic category (myskoda BaseEvent categories).
+    "skoda": ["operation-request", "service-event", "account-event", "vehicle-event"],
+    # Audi/VW FCM legacy fallback keys; the primary kebab ``type`` is
+    # backend-defined → handled via OTHER.
+    "audi": ["lockState", "chargingState", "climateState", "alarm"],
+    "volkswagen": ["lockState", "chargingState", "climateState", "alarm"],
+    # CUPRA/SEAT OLA ``type`` is backend-defined and not enumerable from the
+    # codebase → declared empty; everything arrives via OTHER + event_type_raw.
+    "cupra": [],
+    "seat": [],
+}
+
+# Only brands with a real push manager get an event entity; the others
+# (volkswagen_na, porsche, vag) have no push source, so it would never fire.
+PUSH_CAPABLE_BRANDS = frozenset(_BRAND_EVENT_TYPES)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up one push-event entity per vehicle (push-capable brands only)."""
+    coordinator: VagConnectCoordinator = entry.runtime_data
+    brand = str(entry.data.get(CONF_BRAND, "")).strip().lower()
+    if brand not in PUSH_CAPABLE_BRANDS:
+        return
+
+    event_types = [*_BRAND_EVENT_TYPES[brand], EVENT_TYPE_OTHER]
+
+    def _build_for_vin(vin: str, _vehicle: dict) -> list[Any]:
+        # Not gated on any data field — the event stream exists for every
+        # vehicle of a push-capable brand, independent of poll contents.
+        return [VagConnectPushEventEntity(coordinator, vin, event_types)]
+
+    register_dynamic_spawner(entry, coordinator, async_add_entities, _build_for_vin)
+
+
+class VagConnectPushEventEntity(VagConnectEntity, EventEntity):
+    """First-class push-event entity for a single vehicle."""
+
+    _attr_translation_key = "push_event"
+    _attr_icon = "mdi:car-connected"
+
+    def __init__(
+        self,
+        coordinator: VagConnectCoordinator,
+        vin: str,
+        event_types: list[str],
+    ) -> None:
+        super().__init__(coordinator, vin, "push_event")
+        self._attr_event_types = event_types
+
+    @property
+    def available(self) -> bool:
+        """Always available — a push can arrive while the last poll failed, which
+        is exactly when it matters; gating on poll success would drop it."""
+        return True
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                EVENT_PUSH, self._handle_push_event, event_filter=self._match_vin,
+            )
+        )
+
+    @callback
+    def _match_vin(self, event: Event[Any]) -> bool:
+        """Bus event_filter — only wake this entity for its own VIN."""
+        return bool(event.data.get("vin") == self._vin)
+
+    @callback
+    def _handle_push_event(self, event: Event[Any]) -> None:
+        """Re-emit a matching bus event as this entity's native event."""
+        data = event.data
+        raw_type = data.get("event_type") or EVENT_TYPE_OTHER
+        attributes: dict[str, Any] = {
+            "topic": data.get("topic"),
+            "timestamp": data.get("timestamp"),
+            "brand": data.get("brand"),
+            "event_type_raw": raw_type,
+        }
+        payload = data.get("raw_payload")
+        if isinstance(payload, dict):
+            attributes["payload"] = json_safe_dict(payload)
+
+        event_type = raw_type if raw_type in self.event_types else EVENT_TYPE_OTHER
+        self._trigger_event(event_type, attributes)
+        self.async_write_ha_state()

--- a/custom_components/vag_connect/event.py
+++ b/custom_components/vag_connect/event.py
@@ -32,14 +32,23 @@ from .entity_base import VagConnectEntity, register_dynamic_spawner
 # EventEntity._trigger_event (which rejects any type not in event_types).
 EVENT_TYPE_OTHER = "other"
 
+# HA translation state keys must match [a-z0-9-_], so the Audi/VW FCM
+# camelCase fallback keys are normalised to snake_case for the entity's declared
+# types; the original value is still preserved verbatim in ``event_type_raw``.
+_NORMALIZE: dict[str, str] = {
+    "lockState": "lock_state",
+    "chargingState": "charging_state",
+    "climateState": "climate_state",
+}
+
 # Grounded event_type values per brand. ``other`` is appended as the safety net.
 _BRAND_EVENT_TYPES: dict[str, list[str]] = {
     # Skoda MQTT topic category (myskoda BaseEvent categories).
     "skoda": ["operation-request", "service-event", "account-event", "vehicle-event"],
-    # Audi/VW FCM legacy fallback keys; the primary kebab ``type`` is
-    # backend-defined → handled via OTHER.
-    "audi": ["lockState", "chargingState", "climateState", "alarm"],
-    "volkswagen": ["lockState", "chargingState", "climateState", "alarm"],
+    # Audi/VW FCM legacy fallback keys (normalised to snake_case via _NORMALIZE);
+    # the primary kebab ``type`` is backend-defined → handled via OTHER.
+    "audi": ["lock_state", "charging_state", "climate_state", "alarm"],
+    "volkswagen": ["lock_state", "charging_state", "climate_state", "alarm"],
     # CUPRA/SEAT OLA ``type`` is backend-defined and not enumerable from the
     # codebase → declared empty; everything arrives via OTHER + event_type_raw.
     "cupra": [],
@@ -121,6 +130,7 @@ class VagConnectPushEventEntity(VagConnectEntity, EventEntity):
         if isinstance(payload, dict):
             attributes["payload"] = json_safe_dict(payload)
 
-        event_type = raw_type if raw_type in self.event_types else EVENT_TYPE_OTHER
+        norm = _NORMALIZE.get(raw_type, raw_type)
+        event_type = norm if norm in self.event_types else EVENT_TYPE_OTHER
         self._trigger_event(event_type, attributes)
         self.async_write_ha_state()

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -298,11 +298,11 @@
               "service-event": "Service event",
               "account-event": "Account event",
               "vehicle-event": "Vehicle event",
-              "lockState": "Lock state",
-              "chargingState": "Charging state",
-              "climateState": "Climate state",
               "alarm": "Alarm",
-              "other": "Other"
+              "other": "Other",
+              "lock_state": "Lock state",
+              "charging_state": "Charging state",
+              "climate_state": "Climate state"
             }
           }
         }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -288,6 +288,39 @@
     }
   },
   "entity": {
+    "event": {
+      "push_event": {
+        "name": "Push event",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Operation request",
+              "service-event": "Service event",
+              "account-event": "Account event",
+              "vehicle-event": "Vehicle event",
+              "lockState": "Lock state",
+              "chargingState": "Charging state",
+              "climateState": "Climate state",
+              "alarm": "Alarm",
+              "other": "Other"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Software update"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Charging schedule"
+      },
+      "service": {
+        "name": "Service schedule"
+      }
+    },
     "sensor": {
       "fuel_level": {
         "name": "Fuel Level"

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1721,11 +1721,11 @@
               "service-event": "Servisní událost",
               "account-event": "Událost účtu",
               "vehicle-event": "Událost vozidla",
-              "lockState": "Stav zamčení",
-              "chargingState": "Stav nabíjení",
-              "climateState": "Stav klimatizace",
               "alarm": "Alarm",
-              "other": "Ostatní"
+              "other": "Ostatní",
+              "lock_state": "Stav zamčení",
+              "charging_state": "Stav nabíjení",
+              "climate_state": "Stav klimatizace"
             }
           }
         }

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Zámek dveří"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Push událost",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Požadavek operace",
+              "service-event": "Servisní událost",
+              "account-event": "Událost účtu",
+              "vehicle-event": "Událost vozidla",
+              "lockState": "Stav zamčení",
+              "chargingState": "Stav nabíjení",
+              "climateState": "Stav klimatizace",
+              "alarm": "Alarm",
+              "other": "Ostatní"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Aktualizace softwaru"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Plán nabíjení"
+      },
+      "service": {
+        "name": "Plán servisu"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1721,11 +1721,11 @@
               "service-event": "Service-hændelse",
               "account-event": "Kontohændelse",
               "vehicle-event": "Køretøjshændelse",
-              "lockState": "Låsetilstand",
-              "chargingState": "Opladningstilstand",
-              "climateState": "Klimatilstand",
               "alarm": "Alarm",
-              "other": "Andet"
+              "other": "Andet",
+              "lock_state": "Låsetilstand",
+              "charging_state": "Opladningstilstand",
+              "climate_state": "Klimatilstand"
             }
           }
         }

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Centrallås"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Push-hændelse",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Betjeningsanmodning",
+              "service-event": "Service-hændelse",
+              "account-event": "Kontohændelse",
+              "vehicle-event": "Køretøjshændelse",
+              "lockState": "Låsetilstand",
+              "chargingState": "Opladningstilstand",
+              "climateState": "Klimatilstand",
+              "alarm": "Alarm",
+              "other": "Andet"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Softwareopdatering"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Opladningsplan"
+      },
+      "service": {
+        "name": "Serviceplan"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Zentralverriegelung"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Push-Ereignis",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Vorgangsanfrage",
+              "service-event": "Serviceereignis",
+              "account-event": "Kontoereignis",
+              "vehicle-event": "Fahrzeugereignis",
+              "lockState": "Verriegelungsstatus",
+              "chargingState": "Ladestatus",
+              "climateState": "Klimastatus",
+              "alarm": "Alarm",
+              "other": "Sonstiges"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Software-Update"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Ladeplan"
+      },
+      "service": {
+        "name": "Serviceplan"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1721,11 +1721,11 @@
               "service-event": "Serviceereignis",
               "account-event": "Kontoereignis",
               "vehicle-event": "Fahrzeugereignis",
-              "lockState": "Verriegelungsstatus",
-              "chargingState": "Ladestatus",
-              "climateState": "Klimastatus",
               "alarm": "Alarm",
-              "other": "Sonstiges"
+              "other": "Sonstiges",
+              "lock_state": "Verriegelungsstatus",
+              "charging_state": "Ladestatus",
+              "climate_state": "Klimastatus"
             }
           }
         }

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Central Locking"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Push event",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Operation request",
+              "service-event": "Service event",
+              "account-event": "Account event",
+              "vehicle-event": "Vehicle event",
+              "lockState": "Lock state",
+              "chargingState": "Charging state",
+              "climateState": "Climate state",
+              "alarm": "Alarm",
+              "other": "Other"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Software update"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Charging schedule"
+      },
+      "service": {
+        "name": "Service schedule"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1721,11 +1721,11 @@
               "service-event": "Service event",
               "account-event": "Account event",
               "vehicle-event": "Vehicle event",
-              "lockState": "Lock state",
-              "chargingState": "Charging state",
-              "climateState": "Climate state",
               "alarm": "Alarm",
-              "other": "Other"
+              "other": "Other",
+              "lock_state": "Lock state",
+              "charging_state": "Charging state",
+              "climate_state": "Climate state"
             }
           }
         }

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Cerradura"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Evento push",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Solicitud de operación",
+              "service-event": "Evento de servicio",
+              "account-event": "Evento de cuenta",
+              "vehicle-event": "Evento del vehículo",
+              "lockState": "Estado de bloqueo",
+              "chargingState": "Estado de carga",
+              "climateState": "Estado de climatización",
+              "alarm": "Alarma",
+              "other": "Otro"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Actualización de software"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Programación de carga"
+      },
+      "service": {
+        "name": "Programación de servicio"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1721,11 +1721,11 @@
               "service-event": "Evento de servicio",
               "account-event": "Evento de cuenta",
               "vehicle-event": "Evento del vehículo",
-              "lockState": "Estado de bloqueo",
-              "chargingState": "Estado de carga",
-              "climateState": "Estado de climatización",
               "alarm": "Alarma",
-              "other": "Otro"
+              "other": "Otro",
+              "lock_state": "Estado de bloqueo",
+              "charging_state": "Estado de carga",
+              "climate_state": "Estado de climatización"
             }
           }
         }

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1721,11 +1721,11 @@
               "service-event": "Huoltotapahtuma",
               "account-event": "Tilitapahtuma",
               "vehicle-event": "Ajoneuvotapahtuma",
-              "lockState": "Lukituksen tila",
-              "chargingState": "Latauksen tila",
-              "climateState": "Ilmastoinnin tila",
               "alarm": "Hälytys",
-              "other": "Muu"
+              "other": "Muu",
+              "lock_state": "Lukituksen tila",
+              "charging_state": "Latauksen tila",
+              "climate_state": "Ilmastoinnin tila"
             }
           }
         }

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Keskuslukitus"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Push-tapahtuma",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Toimintopyyntö",
+              "service-event": "Huoltotapahtuma",
+              "account-event": "Tilitapahtuma",
+              "vehicle-event": "Ajoneuvotapahtuma",
+              "lockState": "Lukituksen tila",
+              "chargingState": "Latauksen tila",
+              "climateState": "Ilmastoinnin tila",
+              "alarm": "Hälytys",
+              "other": "Muu"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Ohjelmistopäivitys"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Latausaikataulu"
+      },
+      "service": {
+        "name": "Huoltoaikataulu"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1721,11 +1721,11 @@
               "service-event": "Événement d'entretien",
               "account-event": "Événement de compte",
               "vehicle-event": "Événement du véhicule",
-              "lockState": "État de verrouillage",
-              "chargingState": "État de charge",
-              "climateState": "État de climatisation",
               "alarm": "Alarme",
-              "other": "Autre"
+              "other": "Autre",
+              "lock_state": "État de verrouillage",
+              "charging_state": "État de charge",
+              "climate_state": "État de climatisation"
             }
           }
         }

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Verrouillage"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Événement push",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Demande d'opération",
+              "service-event": "Événement d'entretien",
+              "account-event": "Événement de compte",
+              "vehicle-event": "Événement du véhicule",
+              "lockState": "État de verrouillage",
+              "chargingState": "État de charge",
+              "climateState": "État de climatisation",
+              "alarm": "Alarme",
+              "other": "Autre"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Mise à jour logicielle"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Programmation de charge"
+      },
+      "service": {
+        "name": "Calendrier d'entretien"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1721,11 +1721,11 @@
               "service-event": "Evento assistenza",
               "account-event": "Evento account",
               "vehicle-event": "Evento veicolo",
-              "lockState": "Stato blocco",
-              "chargingState": "Stato ricarica",
-              "climateState": "Stato clima",
               "alarm": "Allarme",
-              "other": "Altro"
+              "other": "Altro",
+              "lock_state": "Stato blocco",
+              "charging_state": "Stato ricarica",
+              "climate_state": "Stato clima"
             }
           }
         }

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Chiusura centralizzata"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Evento push",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Richiesta operazione",
+              "service-event": "Evento assistenza",
+              "account-event": "Evento account",
+              "vehicle-event": "Evento veicolo",
+              "lockState": "Stato blocco",
+              "chargingState": "Stato ricarica",
+              "climateState": "Stato clima",
+              "alarm": "Allarme",
+              "other": "Altro"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Aggiornamento software"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Programmazione ricarica"
+      },
+      "service": {
+        "name": "Programmazione assistenza"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1721,11 +1721,11 @@
               "service-event": "Servicehendelse",
               "account-event": "Kontohendelse",
               "vehicle-event": "Kjøretøyhendelse",
-              "lockState": "Låsestatus",
-              "chargingState": "Ladestatus",
-              "climateState": "Klimastatus",
               "alarm": "Alarm",
-              "other": "Annet"
+              "other": "Annet",
+              "lock_state": "Låsestatus",
+              "charging_state": "Ladestatus",
+              "climate_state": "Klimastatus"
             }
           }
         }

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Sentrallås"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Push-hendelse",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Operasjonsforespørsel",
+              "service-event": "Servicehendelse",
+              "account-event": "Kontohendelse",
+              "vehicle-event": "Kjøretøyhendelse",
+              "lockState": "Låsestatus",
+              "chargingState": "Ladestatus",
+              "climateState": "Klimastatus",
+              "alarm": "Alarm",
+              "other": "Annet"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Programvareoppdatering"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Ladeplan"
+      },
+      "service": {
+        "name": "Serviceplan"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Deurslot"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Push-gebeurtenis",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Bedieningsverzoek",
+              "service-event": "Service-gebeurtenis",
+              "account-event": "Account-gebeurtenis",
+              "vehicle-event": "Voertuiggebeurtenis",
+              "lockState": "Vergrendelingsstatus",
+              "chargingState": "Laadstatus",
+              "climateState": "Klimaatstatus",
+              "alarm": "Alarm",
+              "other": "Overig"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Software-update"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Laadschema"
+      },
+      "service": {
+        "name": "Serviceschema"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1721,11 +1721,11 @@
               "service-event": "Service-gebeurtenis",
               "account-event": "Account-gebeurtenis",
               "vehicle-event": "Voertuiggebeurtenis",
-              "lockState": "Vergrendelingsstatus",
-              "chargingState": "Laadstatus",
-              "climateState": "Klimaatstatus",
               "alarm": "Alarm",
-              "other": "Overig"
+              "other": "Overig",
+              "lock_state": "Vergrendelingsstatus",
+              "charging_state": "Laadstatus",
+              "climate_state": "Klimaatstatus"
             }
           }
         }

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Zamek drzwi"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Zdarzenie push",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Żądanie operacji",
+              "service-event": "Zdarzenie serwisowe",
+              "account-event": "Zdarzenie konta",
+              "vehicle-event": "Zdarzenie pojazdu",
+              "lockState": "Stan zamków",
+              "chargingState": "Stan ładowania",
+              "climateState": "Stan klimatyzacji",
+              "alarm": "Alarm",
+              "other": "Inne"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Aktualizacja oprogramowania"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Harmonogram ładowania"
+      },
+      "service": {
+        "name": "Harmonogram serwisowy"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1721,11 +1721,11 @@
               "service-event": "Zdarzenie serwisowe",
               "account-event": "Zdarzenie konta",
               "vehicle-event": "Zdarzenie pojazdu",
-              "lockState": "Stan zamków",
-              "chargingState": "Stan ładowania",
-              "climateState": "Stan klimatyzacji",
               "alarm": "Alarm",
-              "other": "Inne"
+              "other": "Inne",
+              "lock_state": "Stan zamków",
+              "charging_state": "Stan ładowania",
+              "climate_state": "Stan klimatyzacji"
             }
           }
         }

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1710,6 +1710,39 @@
       "door_lock": {
         "name": "Dörrlås"
       }
+    },
+    "event": {
+      "push_event": {
+        "name": "Push-händelse",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "operation-request": "Åtgärdsbegäran",
+              "service-event": "Servicehändelse",
+              "account-event": "Kontohändelse",
+              "vehicle-event": "Fordonshändelse",
+              "lockState": "Låsstatus",
+              "chargingState": "Laddningsstatus",
+              "climateState": "Klimatstatus",
+              "alarm": "Larm",
+              "other": "Övrigt"
+            }
+          }
+        }
+      }
+    },
+    "update": {
+      "software_update": {
+        "name": "Programvaruuppdatering"
+      }
+    },
+    "calendar": {
+      "charging_schedule": {
+        "name": "Laddningsschema"
+      },
+      "service": {
+        "name": "Serviceschema"
+      }
     }
   },
   "issues": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1721,11 +1721,11 @@
               "service-event": "Servicehändelse",
               "account-event": "Kontohändelse",
               "vehicle-event": "Fordonshändelse",
-              "lockState": "Låsstatus",
-              "chargingState": "Laddningsstatus",
-              "climateState": "Klimatstatus",
               "alarm": "Larm",
-              "other": "Övrigt"
+              "other": "Övrigt",
+              "lock_state": "Låsstatus",
+              "charging_state": "Laddningsstatus",
+              "climate_state": "Klimatstatus"
             }
           }
         }

--- a/custom_components/vag_connect/update.py
+++ b/custom_components/vag_connect/update.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Update platform for VAG Connect — read-only vehicle-firmware status.
+
+The car reports its installed software version and whether an over-the-air update
+is available (Škoda's software-version endpoint today). This surfaces that as a
+native HA ``UpdateEntity`` — the "update available / release notes" card — but
+WITHOUT an Install button (``UpdateEntityFeature(0)``): VAG firmware is flashed by
+the vehicle itself, not by Home Assistant.
+
+The backend gives us a boolean "update available", not a target version string, so
+``latest_version`` is synthesised: a sentinel (guaranteed to differ from installed)
+when an update is available, the installed version when confirmed up to date, and
+``None`` when we only know the installed version (info-only, no false "up to date").
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import VagConnectCoordinator
+from .entity_base import VagConnectEntity, register_dynamic_spawner
+
+# No target-version field exists in the source payload; a sentinel that differs
+# from any real installed version makes HA render state ON = "update available".
+# The human meaning lives in the release-notes link + the card title.
+_UPDATE_AVAILABLE_SENTINEL = "update_available"
+
+# software_update_status tokens that mean an install is running on the car
+# (best-effort — reflects the vehicle's own OTA, not an HA install).
+_IN_PROGRESS_STATES = frozenset({
+    "installing", "in_progress", "processing", "downloading", "readytoinstall",
+})
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up one firmware-update entity per vehicle that reports OTA data."""
+    coordinator: VagConnectCoordinator = entry.runtime_data
+
+    def _build_for_vin(vin: str, vehicle: dict) -> list[Any]:
+        # Only spawn when the car actually reports firmware/OTA data (Škoda
+        # today) — otherwise the entity would sit permanently unknown.
+        if (
+            vehicle.get("software_version") is not None
+            or vehicle.get("ota_update_available") is not None
+        ):
+            return [VagUpdateEntity(coordinator, vin)]
+        return []
+
+    register_dynamic_spawner(entry, coordinator, async_add_entities, _build_for_vin)
+
+
+class VagUpdateEntity(VagConnectEntity, UpdateEntity):
+    """Read-only firmware-update status for a single vehicle."""
+
+    _attr_translation_key = "software_update"
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = UpdateEntityFeature(0)  # info-only, no Install
+
+    def __init__(self, coordinator: VagConnectCoordinator, vin: str) -> None:
+        super().__init__(coordinator, vin, "software_update")
+
+    @property
+    def installed_version(self) -> str | None:
+        return self._vehicle.get("software_version")
+
+    @property
+    def latest_version(self) -> str | None:
+        avail = self._vehicle.get("ota_update_available")
+        installed = self._vehicle.get("software_version")
+        if avail is True:
+            return _UPDATE_AVAILABLE_SENTINEL   # differs from installed → ON
+        if avail is False:
+            return installed                    # confirmed up to date → OFF
+        return None                             # unknown → info-only
+
+    @property
+    def release_url(self) -> str | None:
+        return self._vehicle.get("ota_release_notes_url")
+
+    @property
+    def in_progress(self) -> bool:
+        status = self._vehicle.get("software_update_status")
+        if not isinstance(status, str):
+            return False
+        return status.strip().lower().replace("_", "") in {
+            s.replace("_", "") for s in _IN_PROGRESS_STATES
+        }

--- a/tests/test_ha_platform_pickups.py
+++ b/tests/test_ha_platform_pickups.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""HA feature-coverage pickups — update / event / calendar / device diagnostics."""
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from custom_components.vag_connect.cariad._util import mask_vin
+from custom_components.vag_connect.const import DOMAIN
+from custom_components.vag_connect.update import VagUpdateEntity
+from custom_components.vag_connect.event import (
+    EVENT_TYPE_OTHER,
+    VagConnectPushEventEntity,
+)
+from custom_components.vag_connect.calendar import (
+    VagChargingScheduleCalendar,
+    VagServiceCalendar,
+    _parse_date,
+    _parse_dt,
+)
+
+VIN = "WVWZZZAUZ1234567"
+
+
+def _entity(cls, vehicle: dict, *args):
+    e = cls.__new__(cls)
+    e._vin = VIN
+    e.coordinator = MagicMock(data={VIN: vehicle})
+    for a in args:
+        pass
+    return e
+
+
+# ── update ─────────────────────────────────────────────────────────────────────
+
+def _upd(vehicle: dict) -> VagUpdateEntity:
+    return _entity(VagUpdateEntity, vehicle)
+
+
+def test_update_available_renders_on() -> None:
+    e = _upd({"software_version": "1.2", "ota_update_available": True})
+    assert e.installed_version == "1.2"
+    assert e.latest_version != e.installed_version  # → HA state ON
+
+
+def test_update_confirmed_up_to_date_renders_off() -> None:
+    e = _upd({"software_version": "1.2", "ota_update_available": False})
+    assert e.latest_version == "1.2"  # == installed → OFF
+
+
+def test_update_unknown_is_info_only() -> None:
+    e = _upd({"software_version": "1.2"})  # ota_update_available absent → None
+    assert e.latest_version is None
+
+
+def test_update_in_progress_mapping() -> None:
+    assert _upd({"software_update_status": "INSTALLING"}).in_progress is True
+    assert _upd({"software_update_status": "readyToInstall"}).in_progress is True
+    assert _upd({"software_update_status": "NO_UPDATE_AVAILABLE"}).in_progress is False
+    assert _upd({}).in_progress is False
+
+
+def test_update_release_url_passthrough() -> None:
+    e = _upd({"ota_release_notes_url": "https://x/notes"})
+    assert e.release_url == "https://x/notes"
+
+
+# ── event ──────────────────────────────────────────────────────────────────────
+
+def _evt(event_types: list[str]) -> VagConnectPushEventEntity:
+    e = VagConnectPushEventEntity.__new__(VagConnectPushEventEntity)
+    e._vin = VIN
+    e._attr_event_types = event_types
+    e._trigger_event = MagicMock()
+    e.async_write_ha_state = MagicMock()
+    return e
+
+
+def _bus_event(data: dict):
+    return SimpleNamespace(data=data)
+
+
+def test_event_known_type_passes_through() -> None:
+    e = _evt(["chargingState", EVENT_TYPE_OTHER])
+    e._handle_push_event(_bus_event({"vin": VIN, "event_type": "chargingState"}))
+    assert e._trigger_event.call_args.args[0] == "chargingState"
+
+
+def test_event_unknown_type_coerced_to_other_with_raw_preserved() -> None:
+    e = _evt(["chargingState", EVENT_TYPE_OTHER])
+    e._handle_push_event(_bus_event({"vin": VIN, "event_type": "some-backend-kebab"}))
+    typ, attrs = e._trigger_event.call_args.args
+    assert typ == EVENT_TYPE_OTHER
+    assert attrs["event_type_raw"] == "some-backend-kebab"
+
+
+def test_event_filter_matches_only_its_vin() -> None:
+    e = _evt([EVENT_TYPE_OTHER])
+    assert e._match_vin(_bus_event({"vin": VIN})) is True
+    assert e._match_vin(_bus_event({"vin": "OTHERVIN0000000AA"})) is False
+
+
+# ── calendar ────────────────────────────────────────────────────────────────────
+
+def test_calendar_parse_helpers() -> None:
+    assert _parse_dt("2026-08-14T10:00:00Z").tzinfo is not None
+    assert _parse_dt("HH:MM") is None
+    assert _parse_dt(None) is None
+    assert _parse_date("2026-09-01") == date(2026, 9, 1)
+    assert _parse_date("2026-09-01T00:00:00Z") == date(2026, 9, 1)
+    assert _parse_date("bad") is None
+
+
+def test_service_calendar_builds_all_day_events() -> None:
+    e = _entity(VagServiceCalendar, {
+        "service_due_at": "2026-12-01",
+        "oil_service_at": "2026-11-15T00:00:00Z",
+    })
+    evs = e._all_events()
+    summaries = {ev.summary for ev in evs}
+    assert "Service due" in summaries and "Oil service due" in summaries
+    svc = next(ev for ev in evs if ev.summary == "Service due")
+    assert svc.start == date(2026, 12, 1)
+    assert svc.end == date(2026, 12, 2)  # all-day: end exclusive
+
+
+def test_charging_calendar_projects_departure_timer() -> None:
+    e = _entity(VagChargingScheduleCalendar, {
+        "departure_timer_1_enabled": True,
+        "departure_timer_1_time": "07:30",
+    })
+    start = datetime(2026, 8, 14, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(days=2)
+    evs = e._events_between(start, end)
+    dep = [ev for ev in evs if ev.summary == "Departure timer 1"]
+    assert len(dep) >= 2  # projected onto each day in the 2-day range
+    assert all(ev.end > ev.start for ev in dep)  # non-zero blocks
+
+
+def test_charging_calendar_ignores_disabled_timer() -> None:
+    e = _entity(VagChargingScheduleCalendar, {
+        "departure_timer_1_enabled": False,
+        "departure_timer_1_time": "07:30",
+    })
+    start = datetime(2026, 8, 14, tzinfo=timezone.utc)
+    evs = e._events_between(start, start + timedelta(days=2))
+    assert not [ev for ev in evs if ev.summary == "Departure timer 1"]
+
+
+# ── device diagnostics ──────────────────────────────────────────────────────────
+
+def test_device_diagnostics_slices_to_one_vin() -> None:
+    from custom_components.vag_connect import diagnostics as diag_mod
+
+    masked = mask_vin(VIN)
+    other = mask_vin("WVWZZZOTHER99999X")
+    full = {
+        "config": {"brand": "skoda"},
+        "options": {},
+        "vehicles": {masked: {"soc": 50}, other: {"soc": 90}},
+        "unexpected_findings": {masked: [{"path": "x"}]},
+        "mbb_no_legacy": [masked, other],
+        "last_update_success": True,
+        "cloud_push_active": False,
+        "push_states": {},
+        "polling_active": True,
+        "raw_responses": {"selectivestatus": {"a": 1}},  # account-scoped → dropped
+    }
+    device = SimpleNamespace(identifiers={(DOMAIN, VIN)})
+    with patch.object(
+        diag_mod, "async_get_config_entry_diagnostics",
+        MagicMock(return_value=_afut(full)),
+    ):
+        out = asyncio.run(
+            diag_mod.async_get_device_diagnostics(MagicMock(), MagicMock(), device)
+        )
+    assert out["device_vin_masked"] == masked
+    assert out["vehicles"] == {masked: {"soc": 50}}      # other VIN not included
+    assert out["vehicle_count"] == 1
+    assert out["unexpected_findings"] == {masked: [{"path": "x"}]}
+    assert out["mbb_no_legacy"] == [masked]
+    assert "raw_responses" not in out                     # account-scoped, dropped
+
+
+def test_device_diagnostics_settings_device_gets_no_slice() -> None:
+    from custom_components.vag_connect import diagnostics as diag_mod
+
+    device = SimpleNamespace(identifiers={(DOMAIN, "entryid_settings")})
+    with patch.object(
+        diag_mod, "async_get_config_entry_diagnostics",
+        MagicMock(return_value=_afut({"config": {}, "options": {}})),
+    ):
+        out = asyncio.run(
+            diag_mod.async_get_device_diagnostics(MagicMock(), MagicMock(), device)
+        )
+    assert "device_note" in out
+    assert "vehicles" not in out
+
+
+def _afut(value):
+    async def _coro():
+        return value
+    return _coro()

--- a/tests/test_ha_platform_pickups.py
+++ b/tests/test_ha_platform_pickups.py
@@ -83,14 +83,16 @@ def _bus_event(data: dict):
     return SimpleNamespace(data=data)
 
 
-def test_event_known_type_passes_through() -> None:
-    e = _evt(["chargingState", EVENT_TYPE_OTHER])
+def test_event_known_type_is_normalized_and_passes_through() -> None:
+    e = _evt(["charging_state", EVENT_TYPE_OTHER])
     e._handle_push_event(_bus_event({"vin": VIN, "event_type": "chargingState"}))
-    assert e._trigger_event.call_args.args[0] == "chargingState"
+    typ, attrs = e._trigger_event.call_args.args
+    assert typ == "charging_state"                     # camelCase → snake for HA
+    assert attrs["event_type_raw"] == "chargingState"  # original preserved
 
 
 def test_event_unknown_type_coerced_to_other_with_raw_preserved() -> None:
-    e = _evt(["chargingState", EVENT_TYPE_OTHER])
+    e = _evt(["charging_state", EVENT_TYPE_OTHER])
     e._handle_push_event(_bus_event({"vin": VIN, "event_type": "some-backend-kebab"}))
     typ, attrs = e._trigger_event.call_args.args
     assert typ == EVENT_TYPE_OTHER


### PR DESCRIPTION
The four HA feature-coverage pickups (from the audit), all on data we already have. **[Unreleased], not tagged.**

**Added**
- **event platform** — per-vehicle EventEntity from the existing push bus (Logbook + automation triggers + history). Unknown backend types → `other` catch-all with `event_type_raw` preserved (can't raise). Brand-gated.
- **update platform** — read-only firmware UpdateEntity (Škoda OTA), no Install button; `latest_version` from the tri-state availability flag.
- **calendar platform** — two read-only calendars/vehicle: charging schedule (departure timers projected + charge/climate ETAs) + service dates.
- **per-device diagnostics** — `async_get_device_diagnostics` slices the redacted config-entry payload to one VIN; account-scoped raw sections dropped.

+12-language i18n for the new entity names + event-type labels. 14 new tests. Full suite green (4928 passed), ruff + mypy strict + Hassfest-schema clean, 12-lang parity green.

Platinum quality scale unaffected; these are un-graded platform features that make the integration 'use HA fully'.