### PR TITLE
release: v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-08-14 — Logbook events, firmware & calendar cards, freeze warning + HA coverage sweep
+
 ### Added
 - **"Data hasn't refreshed" warning for a frozen vehicle feed (#465).** When the integration keeps polling successfully but the car's own data-capture time stops advancing (a lapsed EU Data Act feed presenting days-old data as live), a dismissible per-vehicle Repair now points it out — and explains it may just be a parked, sleeping car. Auto-clears the moment a fresher reading arrives. Grounded in @TomJonesGreggs's ID. Buzz freeze; complements the new "Vehicle Last Reported" sensor from 3.0.6.
 - **Push events are now first-class HA entities.** Manufacturer push notifications (Škoda / Audi / VW / CUPRA / SEAT) already fired on the event bus; each vehicle now also gets a proper `event` entity, so they show in the Logbook, drive automations without a YAML bus filter, and keep per-car history. Unknown backend event types are preserved verbatim under an `event_type_raw` attribute.

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -22,5 +22,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "3.0.6"
+  "version": "3.1.0"
 }


### PR DESCRIPTION
Cuts **v3.1.0** from the accumulated `[Unreleased]` work. Minor bump (3.0.6 → 3.1.0) because four new Home Assistant platforms landed.

### What ships
- **event** entity — manufacturer push notifications now show in the Logbook + drive automations without a bus filter (`event_type_raw` preserves the raw backend type).
- **update** entity — installed firmware version + "update available" as a read-only HA update card (Škoda today; no Install button, the car flashes itself).
- **calendar** entities — charging schedule (departure timers + ETAs) and service schedule (service/oil/brake due dates) on a timeline.
- **Per-device diagnostics** — download diagnostics for a single car from its device page, same redaction as the full export.
- **#465 stale-feed repair** — dismissible per-vehicle warning when the car's own capture time stops advancing (lapsed EU Data Act feed), auto-clears on a fresher reading.
- **#912 opt-in command capture** — test-cohort users can hand over the redacted `pendingrequests` shape (`E:CV.PA.31`) for Audi PPE climate-confirm.
- **HA statistics fixes** — lifetime travel-time `TOTAL_INCREASING`, 12 V SoC `battery` device-class, `system_health` dead-branch cleanup.

Full detail in `CHANGELOG.md` under `[3.1.0]`. Tag pushed after merge → release workflow auto-publishes notes + zip.
