### PR TITLE
release: v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-08-15 — iOS charging Live Activity, PPE false-OK fix, Scout SoC de-dup + docs/i18n polish
+
 ### Added
 - **iOS Live Activity — charging countdown on the Lock Screen + Dynamic Island.** A shipped automation blueprint (*"Live Activity — EV charging countdown (iOS)"*) drives a native iOS Live Activity from the existing charging sensors: a live-ticking countdown to the absolute `charge_target_time`, plus a state-of-charge progress bar. Starts when charging begins, refreshes as the ETA / SoC move, clears when it stops. Needs the Companion app's Live Activities (iOS 17.2+, HA Core 2026.7+ — currently a Labs/TestFlight feature); ships now so it's ready the day it goes public.
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -22,5 +22,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "3.1.0"
+  "version": "3.1.1"
 }


### PR DESCRIPTION
Cuts **v3.1.1** (patch) from the accumulated `[Unreleased]` work. No new entities/platforms — a shipped blueprint plus fixes and polish.

### Added
- **iOS Live Activity — charging countdown** on the Lock Screen + Dynamic Island (automation blueprint, driven by the existing charging sensors; Companion Live Activities iOS 17.2+/HA 2026.7+, currently Labs/TestFlight).

### Fixed
- **#912/#940** — a PPE command the car accepts but never carries out (`e:CV.PA.29`) is now reported **unconfirmed** instead of a false "OK"; fast commands unaffected.
- **#1179–#1185** — Scout stops re-filing the already-mapped `battery_state_report.soc` (VALID-HV short-circuit skipped its consumption).
- **ADB companion setup step** localised into all 11 non-English locales.

### Docs
- README accuracy pass (Škoda login, dependency count, MBB toggle, + document the 3.1.0 event/update/calendar platforms).

Suite 4932 green. Tag pushed after merge → release workflow auto-publishes.
