### PR TITLE
feat: map CUPRA remaining_time_finished to remaining charge time (#1202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **CUPRA remaining-charge-time now reads (#1202).** SEAT/CUPRA ship the time-until-charging-finishes as a `remaining_time_finished` value + `TIME_UNIT_*` unit pair (a dictionary field that wasn't wired to a sensor). It now feeds the remaining-charge-time sensor, converted to minutes from whatever unit the car sends — as a last-resort fallback that never overrides a canonical `remaining_charging_time`. Both leaves are consumed so they stop surfacing to the Scout. First surfaced by a CUPRA Raval.
+
 ## [3.1.1] - 2026-08-15 — iOS charging Live Activity, PPE false-OK fix, Scout SoC de-dup + docs/i18n polish
 
 ### Added

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1080,6 +1080,33 @@ def _dur_to_min(raw: str | None) -> int | None:
     return int(f) if f is not None else None
 
 
+# #1202 (CUPRA Raval) — SEAT/CUPRA ship the remaining charge time as a value+unit
+# pair, the unit being the dictionary enum TIME_UNIT_* (not the "2400s" form that
+# _dur_to_min handles).
+_TIME_UNIT_TO_MIN: dict[str, float] = {
+    "time_unit_milliseconds": 1.0 / 60000.0,
+    "time_unit_seconds": 1.0 / 60.0,
+    "time_unit_minutes": 1.0,
+    "time_unit_hours": 60.0,
+    "time_unit_days": 1440.0,
+}
+
+
+def _finished_time_to_min(value: str | None, unit: str | None) -> int | None:
+    """Convert a ``remaining_time_finished`` value+unit pair to whole minutes.
+
+    #1202 (CUPRA Raval) — the SEAT/CUPRA dialect for "time until charging
+    finishes": a number plus a separate ``TIME_UNIT_*`` enum. An unknown or
+    ``TIME_UNIT_UNDEFINED`` unit is treated as minutes (the portal's usual scale
+    for a bare number), matching ``_dur_to_min``.
+    """
+    f = _to_float(value)
+    if f is None:
+        return None
+    factor = _TIME_UNIT_TO_MIN.get(str(unit or "").strip().lower(), 1.0)
+    return int(f * factor)
+
+
 def _epoch_or_iso(raw: str | None) -> str | None:
     """Normalise a capture timestamp to ISO-8601 UTC.
 
@@ -2113,6 +2140,17 @@ def map_dataset_to_vehicle_data(
     ))
     if _rch is not None and d.remaining_charge_time_min is None:
         d.remaining_charge_time_min = _rch
+    # #1202 (CUPRA Raval) — SEAT/CUPRA dialect: remaining_time_finished is a
+    # value+unit pair (TIME_UNIT_* enum) for the time until charging completes.
+    # Consume BOTH leaves unconditionally (so they leave raw_unmapped / the Scout
+    # even when a canonical source already set the value), but only USE it as a
+    # LAST fallback so it never out-competes a real remaining_charging_time.
+    _rtf_val = first("remaining_time_finished.remaining_time_finished_value")
+    _rtf_unit = first("remaining_time_finished.remaining_time_finished_unit")
+    if d.remaining_charge_time_min is None:
+        _rtf = _finished_time_to_min(_rtf_val, _rtf_unit)
+        if _rtf is not None:
+            d.remaining_charge_time_min = _rtf
 
     # b1/A2 — distance-unit conversion. UK/US cars report distances in miles
     # plus a companion unit field; our sensors are km-typed, so convert once

--- a/tests/test_1202_remaining_time_finished.py
+++ b/tests/test_1202_remaining_time_finished.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1202 (CUPRA Raval) — map the SEAT/CUPRA `remaining_time_finished` value+unit
+pair to the remaining-charge-time sensor.
+
+The Raval ships the time-until-charging-finishes as a number plus a separate
+`TIME_UNIT_*` enum (dict UUIDs 0901e6d5… / 6f7f6a6d…), unlike the `"2400s"` form
+other cars use. It's wired as a LAST fallback (never out-competes a canonical
+`remaining_charging_time`), and BOTH leaves are consumed so they stop surfacing
+to the Vehicle Data Scout.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+_VAL = "remaining_time_finished.remaining_time_finished_value"
+_UNIT = "remaining_time_finished.remaining_time_finished_unit"
+
+
+def _map(fields: dict) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_minutes_pass_through() -> None:
+    assert _map({_VAL: "45", _UNIT: "TIME_UNIT_MINUTES"}).remaining_charge_time_min == 45
+
+
+def test_seconds_convert_to_minutes() -> None:
+    assert _map({_VAL: "2400", _UNIT: "TIME_UNIT_SECONDS"}).remaining_charge_time_min == 40
+
+
+def test_hours_convert_to_minutes() -> None:
+    assert _map({_VAL: "2", _UNIT: "TIME_UNIT_HOURS"}).remaining_charge_time_min == 120
+
+
+def test_undefined_unit_treated_as_minutes() -> None:
+    assert _map({_VAL: "30", _UNIT: "TIME_UNIT_UNDEFINED"}).remaining_charge_time_min == 30
+    assert _map({_VAL: "20"}).remaining_charge_time_min == 20  # unit absent → minutes
+
+
+def test_zero_means_done() -> None:
+    assert _map({_VAL: "0", _UNIT: "TIME_UNIT_MINUTES"}).remaining_charge_time_min == 0
+
+
+def test_canonical_source_still_wins() -> None:
+    d = _map({"remaining_charging_time": "30", _VAL: "99", _UNIT: "TIME_UNIT_MINUTES"})
+    assert d.remaining_charge_time_min == 30  # canonical wins, not the 99 fallback
+
+
+def test_both_leaves_leave_the_scout() -> None:
+    """Consumed unconditionally — even when a canonical source set the value —
+    so neither leaf re-surfaces to the Scout (the first()-consume trap)."""
+    d = _map({"remaining_charging_time": "30", _VAL: "99", _UNIT: "TIME_UNIT_MINUTES"})
+    assert not any("remaining_time_finished" in k for k in d.raw_unmapped_fields)
+    d2 = _map({_VAL: "45", _UNIT: "TIME_UNIT_MINUTES"})
+    assert not any("remaining_time_finished" in k for k in d2.raw_unmapped_fields)


### PR DESCRIPTION
Wires the `remaining_time_finished` field a **CUPRA Raval** surfaced (#1202) to the remaining-charge-time sensor.

SEAT/CUPRA ship the time-until-charging-finishes as a **value + `TIME_UNIT_*` unit** pair (dict UUIDs `0901e6d5…` / `6f7f6a6d…`), not the `"2400s"` form other cars use — so it was in the dictionary but never mapped, and re-surfaced to the Scout every poll.

- Converts value+unit → minutes (ms/s/min/h/days; unknown or `TIME_UNIT_UNDEFINED` → minutes, matching `_dur_to_min`).
- Feeds `remaining_charge_time_min` as a **last-resort fallback** — never overrides a canonical `remaining_charging_time`.
- Both leaves are **consumed unconditionally**, so they leave `raw_unmapped_fields` / the Scout even when a canonical source already set the value (the first()-consume trap).

7 new tests (unit conversions, canonical precedence, Scout de-leak). Full suite **4939 passed**. No tag — accumulates under `[Unreleased]`.
