### PR TITLE
fix(auth): coalesce refresh fan-out + budget-aware interval advice (#1078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ### Added
 - **CUPRA remaining-charge-time now reads (#1202).** SEAT/CUPRA ship the time-until-charging-finishes as a `remaining_time_finished` value + `TIME_UNIT_*` unit pair (a dictionary field that wasn't wired to a sensor). It now feeds the remaining-charge-time sensor, converted to minutes from whatever unit the car sends — as a last-resort fallback that never overrides a canonical `remaining_charging_time`. Both leaves are consumed so they stop surfacing to the Scout. First surfaced by a CUPRA Raval.
 
+### Fixed
+- **Škoda sensors no longer drop to "unknown" from a false token-refresh storm (#1078).** A single poll fans out ~14 concurrent requests; when they all hit a just-expired token at once, each one independently refreshed it, so one expiry event burned the whole "3 refreshes/hour" safety budget in seconds and tripped the storm guard at a perfectly healthy 30-minute interval. Refreshes now coalesce — a request that finds the token already rotated by a sibling reuses it instead of refreshing again, so one expiry costs one refresh. A genuine storm (a refresh that keeps failing) still trips. Grounded in @foobarth's report.
+
+### Changed
+- **The "raise your update interval" advice now uses VW's real per-account budget when it's available (#1078).** Instead of a blunt fixed step-up, when VW sends its `X-RateLimit-Remaining` header (already surfaced as the "requests remaining today" sensor) the recommendation spreads the remaining calls over the time until the budget resets. It can only tighten the advice, never drop it below the existing guard, and falls back to the guard unchanged when the header isn't present.
+
 ## [3.1.1] - 2026-08-15 — iOS charging Live Activity, PPE false-OK fix, Scout SoC de-dup + docs/i18n polish
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -1365,7 +1365,8 @@ class CariadBaseClient:
                 f"rate-limit lockout active — {locked}s remaining (account cooldown)",
             )
         headers = kwargs.pop("headers", {})
-        headers["Authorization"] = f"Bearer {self._access_token}"
+        token_used = self._access_token
+        headers["Authorization"] = f"Bearer {token_used}"
         headers["Accept"] = "application/json"
         headers["Content-Type"] = headers.get("Content-Type", "application/json")
         # v2.14.11 — setdefault, not unconditional assignment. The OLA brands
@@ -1380,7 +1381,7 @@ class CariadBaseClient:
                 method, url, headers=headers, timeout=ClientTimeout(total=_REQUEST_TIMEOUT), **kwargs
             ) as resp:
                 if resp.status == 401 and retry:
-                    await self._refresh_tokens()
+                    await self._refresh_tokens(stale_access_token=token_used)
                     return await self._request(method, url, retry=False, **kwargs)
                 if resp.status == 429 and _attempt < 3:
                     wait = (2 ** _attempt) * 5
@@ -1425,7 +1426,9 @@ class CariadBaseClient:
                 )
             raise APIError(0, url, f"transient: {type(err).__name__}: {err}") from err
 
-    async def _refresh_tokens(self, *, for_command: bool = False) -> None:
+    async def _refresh_tokens(
+        self, *, for_command: bool = False, stale_access_token: str | None = None
+    ) -> None:
         """Attempt token refresh; fall back to full re-login.
 
         Uses a lock to prevent concurrent refresh attempts from racing.
@@ -1448,6 +1451,25 @@ class CariadBaseClient:
         if self._refresh_lock is None:
             self._refresh_lock = asyncio.Lock()
         async with self._refresh_lock:
+            # #1078 single-flight: one Škoda poll fires ~14 concurrent GETs
+            # (get_status asyncio.gather); on a just-expired bearer they all 401
+            # at once and each lands here. They serialise on this lock, but
+            # without this guard each still books a refresh, so a SINGLE expiry
+            # event spends the whole _REFRESH_MAX_PER_HOUR budget in seconds and
+            # self-trips the storm guard at a perfectly healthy interval. If a
+            # concurrent waiter already rotated the bearer while we queued, our
+            # 401 is already resolved: return so the caller retries with the fresh
+            # token, without counting an attempt. A genuine storm (refresh fails,
+            # or the new bearer is itself rejected) leaves the token unchanged, so
+            # this never suppresses a real one. Only the reactive _request 401
+            # path passes stale_access_token; the command/pre-flight callers keep
+            # stale_access_token=None and are unchanged.
+            if (
+                stale_access_token is not None
+                and self._tokens is not None
+                and self._tokens.access_token != stale_access_token
+            ):
+                return
             now = time.monotonic()
             cutoff = now - _REFRESH_WINDOW_S
             history = (

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Constants for VAG Connect."""
 
+import math
+from datetime import datetime, timezone
+
 DOMAIN = "vag_connect"
 
 # Bus event fired by coordinator._on_push_event for each manufacturer push
@@ -369,3 +372,77 @@ def advised_scan_interval(brand: str | None, current: int) -> int:
     if not isinstance(current, int) or current < base:
         return base
     return min(current + _INTERVAL_STEP_UP_MIN, MAX_SCAN_INTERVAL)
+
+
+# An X-RateLimit-Reset at/above this looks like an absolute epoch second (year
+# 2001+); a smaller numeric is treated as delta-seconds-until-reset.
+_RESET_EPOCH_THRESHOLD = 1_000_000_000
+
+
+def _seconds_until_reset(
+    reset_at: str | int | float | None, now: float
+) -> float | None:
+    """Normalise an opaque ``X-RateLimit-Reset`` value to seconds from *now*.
+
+    Accepts what the clients actually store: epoch seconds (int/float, or a
+    numeric string — base.py stores ``str``, porsche.py an ``int``), an ISO-8601
+    timestamp, or a small delta-seconds value. Returns ``None`` when unusable.
+    Pure: *now* (epoch seconds) is injected so it is clock-free and testable.
+    """
+    if reset_at is None:
+        return None
+    num: float | None
+    if isinstance(reset_at, (int, float)):
+        num = float(reset_at)
+    else:
+        try:
+            num = float(str(reset_at).strip())
+        except (TypeError, ValueError):
+            num = None
+    if num is not None:
+        return (num - now) if num >= _RESET_EPOCH_THRESHOLD else num
+    text = str(reset_at).strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(text)
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp() - now
+
+
+def advised_scan_interval_from_budget(
+    remaining: int | None,
+    reset_at: str | int | float | None,
+    now: float,
+    current: int,
+    *,
+    brand: str | None = None,
+) -> int:
+    """Budget-aware interval advice: spread the REAL remaining calls over the
+    time left until the rate-limit window resets.
+
+    Falls back to :func:`advised_scan_interval` (unchanged) whenever the live
+    signal is missing — ``remaining is None`` (the ``X-RateLimit-Remaining``
+    header was never seen, the default for most installs), or ``reset_at`` gives
+    no positive horizon. The budget may only ever *tighten* the advice, never
+    drop it below the storm guard (``max(guard, budget_advice)``), so the
+    refresh-storm Repair fires in exactly the same cases as before. Clamped to
+    ``[MIN_SCAN_INTERVAL, MAX_SCAN_INTERVAL]``.
+
+    NOTE: the model assumes ~1 API call per poll cycle; a fan-out poll spends
+    more, so this advice is a *lower bound* on the safe interval — safe because
+    it can never advise below the guard, but a future ``calls_per_poll`` factor
+    could tighten it further.
+    """
+    guard = advised_scan_interval(brand, current)
+    if remaining is None:
+        return guard
+    seconds = _seconds_until_reset(reset_at, now)
+    if seconds is None or seconds <= 0:
+        return guard
+    if remaining <= 0:
+        return MAX_SCAN_INTERVAL
+    spread = math.ceil((seconds / 60.0) / remaining)
+    budget_advice = max(MIN_SCAN_INTERVAL, min(spread, MAX_SCAN_INTERVAL))
+    return max(guard, budget_advice)

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -43,7 +43,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     EVENT_PUSH,
-    advised_scan_interval,
+    advised_scan_interval_from_budget,
 )
 from homeassistant.helpers import device_registry as dr
 from .cariad._error_reporter import ErrorRingBuffer, record_error
@@ -4721,7 +4721,18 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 # to advise, so suppress the repair rather than telling them to set
                 # an interval the picker can't reach — the storm guard already
                 # backs the polling off on its own.
-                advised = advised_scan_interval(brand, current_min)
+                # #1078 — when VW's real per-account budget is visible (the
+                # X-RateLimit-Remaining header, already captured on the client),
+                # advise from that instead of the blunt guard; falls back to the
+                # guard byte-for-byte when the header was never seen.
+                import time  # noqa: PLC0415
+                advised = advised_scan_interval_from_budget(
+                    getattr(client, "last_rate_limit_remaining", None),
+                    getattr(client, "last_rate_limit_reset_at", None),
+                    time.time(),
+                    current_min,
+                    brand=brand,
+                )
                 if advised > current_min:
                     raise_issue_refresh_interval_too_frequent(
                         self.hass, self.entry.entry_id,

--- a/tests/test_1078_refresh_coalesce.py
+++ b/tests/test_1078_refresh_coalesce.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1078 single-flight refresh coalescing.
+
+One Škoda poll fires ~14 concurrent GETs (get_status asyncio.gather). On a
+just-expired bearer they all 401 at once and each calls ``_refresh_tokens`` with
+the same stale token. They serialise on the refresh lock, but before this fix
+each still booked a refresh, so ONE expiry event spent the whole 3/hour budget in
+seconds and self-tripped the storm guard at a perfectly healthy interval (foobarth
+#1078). The single-flight guard collapses them to one real rotation; a genuine
+storm (the token never changes) still trips.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.api import base as _base
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+from custom_components.vag_connect.cariad.auth import _mbboauth
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+from custom_components.vag_connect.cariad.models import TokenSet
+
+
+class _Sess:
+    def get(self, url: str, headers: Any = None) -> Any:  # pragma: no cover
+        raise AssertionError("no network in these tests")
+
+
+def _mbb_client() -> VWEUClient:
+    c = VWEUClient(_Sess(), "u@t.de", "pw")
+    c._tokens = TokenSet(
+        access_token="STALE_BEARER", refresh_token="RT", id_token="i",
+        expires_at=0.0, strategy="mbb",
+    )
+    c._mbb_client_id = "CID"
+    return c
+
+
+def test_concurrent_401s_coalesce_to_one_refresh(monkeypatch) -> None:
+    """The fan-out case: many concurrent 401s carrying the same expired bearer
+    collapse to exactly one real rotation and one budget slot; no storm."""
+    c = _mbb_client()
+    old = c._tokens.access_token
+    calls: list[int] = []
+
+    async def _fake(session, refresh_token, *, client_id):
+        calls.append(1)  # rotate to a NEW token so queued waiters see the change
+        return _mbboauth.MbbTokenSet(
+            access_token=f"NEW{len(calls)}", refresh_token="RT",
+            token_type="Bearer", expires_at=0.0,
+        )
+
+    monkeypatch.setattr(_mbboauth, "refresh", _fake)
+
+    async def _run() -> None:
+        await asyncio.gather(*[
+            c._refresh_tokens(stale_access_token=old)
+            for _ in range(_base._REFRESH_MAX_PER_HOUR + 3)  # 6 concurrent 401s
+        ])
+
+    asyncio.run(_run())
+
+    assert len(calls) == 1                    # one real rotation, not six
+    assert len(c._refresh_history) == 1       # one budget slot spent
+    assert c.refresh_storm_detected is False
+    assert c._tokens.access_token == "NEW1"
+
+
+def test_genuine_storm_still_trips(monkeypatch) -> None:
+    """When rotation is a no-op (token keeps coming back unchanged, i.e. a real
+    storm), the guard is NOT suppressed and still raises after the cap."""
+    c = _mbb_client()
+    old = c._tokens.access_token
+
+    async def _noop(session, refresh_token, *, client_id):
+        # returns the SAME bearer → self._tokens.access_token stays == old,
+        # so the coalesce guard never fires and each attempt is counted.
+        return _mbboauth.MbbTokenSet(
+            access_token=old, refresh_token="RT",
+            token_type="Bearer", expires_at=0.0,
+        )
+
+    monkeypatch.setattr(_mbboauth, "refresh", _noop)
+
+    for _ in range(_base._REFRESH_MAX_PER_HOUR):
+        asyncio.run(c._refresh_tokens(stale_access_token=old))
+    with pytest.raises(AuthenticationError, match="storm"):
+        asyncio.run(c._refresh_tokens(stale_access_token=old))
+    assert c.refresh_storm_detected is True
+
+
+def test_no_stale_token_keeps_old_behaviour(monkeypatch) -> None:
+    """Command / pre-flight callers pass no stale token, so the guard is inert
+    and every attempt still counts (byte-for-byte the previous behaviour)."""
+    c = _mbb_client()
+
+    async def _fake(session, refresh_token, *, client_id):
+        return _mbboauth.MbbTokenSet(
+            access_token="ROT", refresh_token="RT",
+            token_type="Bearer", expires_at=0.0,
+        )
+
+    monkeypatch.setattr(_mbboauth, "refresh", _fake)
+    asyncio.run(c._refresh_tokens())          # stale_access_token=None
+    asyncio.run(c._refresh_tokens())
+    assert len(c._refresh_history) == 2       # both counted, no coalesce

--- a/tests/test_1078_refresh_interval_repair.py
+++ b/tests/test_1078_refresh_interval_repair.py
@@ -145,3 +145,53 @@ class TestRepair:
         with patch.object(repairs.ir, "async_delete_issue") as m:
             repairs.clear_refresh_interval_issue(hass, "entry1")
         m.assert_called_once()
+
+
+class TestBudgetAwareAdvice:
+    """#1078 — advise from VW's real X-RateLimit budget when we have it, and
+    fall back byte-for-byte to the blunt guard when we don't."""
+
+    def _fn(self):
+        from custom_components.vag_connect.const import (
+            advised_scan_interval_from_budget,
+        )
+        return advised_scan_interval_from_budget
+
+    def test_tight_budget_widens_beyond_the_blunt_guard(self) -> None:
+        now = 1_700_000_000.0
+        # 10 calls left, resets in 10 h → 600 min / 10 = 60; guard(skoda,30)=45.
+        assert self._fn()(10, now + 10 * 3600, now, 30, brand="skoda") == 60
+
+    def test_epoch_iso_and_delta_reset_parse_alike(self) -> None:
+        from datetime import datetime, timezone
+
+        now = 1_700_000_000.0
+        reset = now + 3600  # +1 h → spread 1 → clamps up to the guard floor (30)
+        assert self._fn()(60, reset, now, 10, brand="skoda") == 30       # epoch
+        assert self._fn()(60, 3600, now, 10, brand="skoda") == 30        # delta-s
+        iso = datetime.fromtimestamp(reset, tz=timezone.utc).isoformat()
+        assert self._fn()(60, iso, now, 10, brand="skoda") == 30         # ISO-8601
+
+    def test_exhausted_budget_backs_off_to_max(self) -> None:
+        from custom_components.vag_connect.const import MAX_SCAN_INTERVAL
+
+        now = 1_700_000_000.0
+        assert self._fn()(0, now + 3600, now, 10, brand="skoda") == MAX_SCAN_INTERVAL
+
+    def test_fallback_when_header_never_seen(self) -> None:
+        from custom_components.vag_connect.const import advised_scan_interval
+
+        now = 1_700_000_000.0
+        for brand in ("skoda", "audi", None):
+            for cur in (10, 30, 31, 60):
+                assert self._fn()(None, now + 3600, now, cur, brand=brand) == \
+                    advised_scan_interval(brand, cur)
+
+    def test_fallback_when_reset_unusable(self) -> None:
+        from custom_components.vag_connect.const import advised_scan_interval
+
+        now = 1_700_000_000.0
+        g = advised_scan_interval("skoda", 30)
+        assert self._fn()(10, "not-a-time", now, 30, brand="skoda") == g  # unparseable
+        assert self._fn()(10, now - 60, now, 30, brand="skoda") == g      # reset passed
+        assert self._fn()(10, None, now, 30, brand="skoda") == g          # missing


### PR DESCRIPTION
Two grounded fixes for @foobarth's token-refresh-storm (#1078), the deeper decouple I promised him.

### 1. Single-flight refresh coalescing (the root cause)
One Škoda poll fans out **~14 concurrent GETs** (`get_status` `asyncio.gather`). On a just-expired bearer they all 401 at the same instant and each independently called `_refresh_tokens`, so **one expiry event spent the whole 3-refreshes/hour budget in seconds** and self-tripped the storm guard at a perfectly healthy 30-minute interval, dropping sensors to `unknown`.

`_request` now threads the exact bearer it used as `stale_access_token`; inside the refresh lock, if a sibling already rotated the token we return **without counting an attempt**, collapsing the fan-out to one refresh. A genuine storm (the token never changes) still trips. `stale_access_token` defaults to `None`, so the command / pre-flight callers are byte-for-byte unchanged. Verified: the ~14-request fan-out, the lock's missing rotation re-check, and that the rotation sets `self._tokens` **inside** the lock (race-free).

### 2. Budget-aware interval advice
The "raise your update interval" recommendation now spreads the **real remaining calls over the time to reset** when VW sends its `X-RateLimit-Remaining` header (already surfaced as the *requests remaining today* sensor), via a pure `advised_scan_interval_from_budget` helper. It can only **tighten** the advice (`max(guard, budget)`), never drops below the existing guard, and falls back to the guard unchanged when the header was never seen.

### Tests
9 new (`test_1078_refresh_coalesce` + `TestBudgetAwareAdvice`): fan-out coalesces to one refresh, genuine storm still trips, no-stale-token keeps old behaviour; budget widen/floor/exhausted/parse-forms/fallbacks. Full suite **4947 passed**. No tag.
