### PR TITLE
New source: Audi plug&play (OBD dongle) — read-only cloud reads for pre-connectivity cars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **New source: Audi plug&play (OBD dongle) — cloud reads for pre-connectivity Audi cars.** Older Audis with no built-in connectivity that use a TEXA OBD dongle (pre-connectivity A4/A5/Golf, Touareg, e-up!, …) are invisible to the modern CARIAD backend and the EU Data Act portal — until now the integration had no way to reach them. Pick **"Audi plug&play — OBD dongle"** at setup and it reads the dongle's cloud snapshot: odometer, 12V battery voltage, warning lights and last parking position. Vehicles are discovered automatically, and it's read-only (no commands, its own token silo). Live-validated on a real enrolled car. VW We Connect Go dongles are mapped too but stay tester-gated for now — their legacy login isn't wired yet.
+
 ## [4.2.1] - 2026-08-24 — Honest diagnostics & a sweep of leaked `invalid` placeholders
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.3.0b1] - 2026-08-24 — Audi plug&play (OBD dongle), beta
+
 ### Added
 - **New source: Audi plug&play (OBD dongle) — cloud reads for pre-connectivity Audi cars.** Older Audis with no built-in connectivity that use a TEXA OBD dongle (pre-connectivity A4/A5/Golf, Touareg, e-up!, …) are invisible to the modern CARIAD backend and the EU Data Act portal — until now the integration had no way to reach them. Pick **"Audi plug&play — OBD dongle"** at setup and it reads the dongle's cloud snapshot: odometer, 12V battery voltage, warning lights and last parking position. Vehicles are discovered automatically, and it's read-only (no commands, its own token silo). Live-validated on a real enrolled car. VW We Connect Go dongles are mapped too but stay tester-gated for now — their legacy login isn't wired yet.
 

--- a/custom_components/vag_connect/cariad/_capabilities.py
+++ b/custom_components/vag_connect/cariad/_capabilities.py
@@ -314,6 +314,20 @@ DECLARED_CAPABILITIES: dict[str, dict[str, bool]] = {
         "fcm_push": True,
         "dag_login": False,
     },
+    "audi_acpp": {
+        # plug&play OBD-dongle cloud reader — a read-only snapshot silo (its
+        # token is not BFF/DAG-whitelisted, there is no command backend and no
+        # push). It declares nothing: every capability is False so diagnostics
+        # never imply a command it can't do.
+        "auxiliary_heating": False,
+        "charging": False,
+        "climatisation": False,
+        "trip_statistics": False,
+        "brake_service": False,
+        "ola_push": False,
+        "fcm_push": False,
+        "dag_login": False,
+    },
     "volkswagen": {
         "auxiliary_heating": True,
         "charging": True,

--- a/custom_components/vag_connect/cariad/api/factory.py
+++ b/custom_components/vag_connect/cariad/api/factory.py
@@ -15,6 +15,7 @@ from .porsche import PorscheClient
 from .vw_na import VWNAClient
 from .audi_na import AudiNAClient
 from .bentley import BentleyClient
+from .plugandplay import PlugAndPlayCloudClient
 
 
 class CariadClientFactory:
@@ -30,7 +31,7 @@ class CariadClientFactory:
         country: str = "us",
         ola_app_version_override: str | None = None,
         ola_user_agent_override: str | None = None,
-    ) -> CariadBaseClient | PorscheClient | VWNAClient:
+    ) -> CariadBaseClient | PorscheClient | VWNAClient | PlugAndPlayCloudClient:
         """Return an authenticated-ready client for the given brand.
 
         Supported brands:
@@ -75,6 +76,14 @@ class CariadClientFactory:
             # v2.14.11 — Bentley on the Audi IDK client/tenant; read-only
             # until the qmauth two-way gates include "bentley" (live-test).
             return BentleyClient(session, email, password, spin)
+        if lower == "audi_acpp":
+            # plug&play OBD-dongle cloud reader (Audi acpp). Read-only and its
+            # own silo (token is NOT BFF-whitelisted). Takes a BrandConfig, not a
+            # brand string, so IDKAuth uses the plain-OAuth (no x-qmauth) branch.
+            from ..models import BRAND_AUDI_ACPP
+            return PlugAndPlayCloudClient(
+                session, BRAND_AUDI_ACPP, email, password, spin
+            )
         raise ValueError(
             f"Unknown brand '{brand}'. Supported: "
             "volkswagen, audi, skoda, seat, cupra, volkswagen_na, audi_na, "

--- a/custom_components/vag_connect/cariad/api/plugandplay.py
+++ b/custom_components/vag_connect/cariad/api/plugandplay.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""DataPlug / plug&play cloud reader — Audi connect plug&play (acpp) + VW We Connect Go (wcg).
+
+The plug&play apps (``de.audi.connectplugandplay`` / ``de.volkswagen.vwconnect``) pair a
+TEXA OBD dongle with OLD cars that have **no built-in connectivity**. Those cars are invisible
+to the modern CARIAD BFF and to the EU-Data-Act portal, so this is the ONLY cloud read path for
+a dongle-equipped Touareg / e-up! / pre-connectivity A4/A5/Golf, etc.
+
+Auth is a plain OAuth2 ``authorization_code``+PKCE against the VW-Group IDP, exchanged at the
+plug&play backend's OWN token endpoint — crucially WITHOUT the Play-Integrity / ``x-qmauth``
+attestation the BFF token endpoint requires, and it returns a durable ``refresh_token``.
+
+Coverage / validation
+---------------------
+* **Audi (acpp)** — LIVE-VALIDATED 2026-08-24 against a real enrolled A5 B8. Reads the
+  enroll/sync SNAPSHOT (odometer, 12V battery voltage, fuel litres, service dates, tyres,
+  warning lights). NOT the live PIDs — those stay dongle-local (read over Bluetooth).
+* **VW (wcg)** — client + endpoints mapped from the APK but the login is NOT wired: it uses
+  the LEGACY ``signin-service`` IDP (``identity.legacy.vwgroup.io``), not Auth0, so
+  ``IDKAuth.authenticate()`` returns HTTP 400 at the identifier step. TESTER-GATED — see
+  ``docs/research/plugandplay_cloud_reader.md`` for the signin-service legs to implement.
+
+The acpp access token is NOT BFF-whitelisted (``emea.bff.cariad.digital`` → 403 "clientId in
+the token claim is either unknown or not whitelisted"), so this does not open the modern data
+plane — it is its own silo.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiohttp import ClientSession, ClientTimeout
+
+from ..auth.idk import IDKAuth
+from ..exceptions import APIError, AuthenticationError
+from ..models import BrandConfig, TokenSet, VehicleData
+
+_LOGGER = logging.getLogger(__name__)
+
+_TIMEOUT = ClientTimeout(total=30)
+
+
+class PlugAndPlayCloudClient:
+    """Read-only cloud client for the Audi connect plug&play (acpp) backend.
+
+    Interface-compatible with the brand clients the coordinator drives
+    (``authenticate()`` + ``get_status(vin)``) so it can be slotted into
+    ``api/factory.py`` once a config-flow picker exposes the source. The
+    constructor mirrors ``BaseClient.__init__`` — ``(session, brand, email,
+    password, spin="")``.
+    """
+
+    #: acpp backend that serves BOTH the token exchange and the vehicle data.
+    API_BASE = "https://prod.acpp.cariad.digital"
+
+    def __init__(
+        self,
+        session: ClientSession,
+        brand: BrandConfig,
+        email: str,
+        password: str,
+        spin: str = "",
+    ) -> None:
+        self._session = session
+        self._brand = brand
+        self._email = email
+        self._password = password
+        self._spin = spin  # unused (read-only source); kept for interface parity
+        self._tokens: TokenSet | None = None
+        # brand.name is deliberately NOT 'audi'/'volkswagen' (see BRAND_AUDI_ACPP)
+        # so IDKAuth._exchange_code() takes the plain-OAuth branch (no CARIAD
+        # x-qmauth attestation) and honours token_url_override below.
+        self._auth = IDKAuth(session, brand, token_url_override=f"{self.API_BASE}/token")
+
+    async def authenticate(self, mfa_code: str | None = None) -> None:
+        """Log in (authorization_code+PKCE) and cache the durable token set."""
+        self._tokens = await self._auth.authenticate(
+            self._email, self._password, mfa_code=mfa_code
+        )
+
+    @property
+    def tokens(self) -> TokenSet | None:
+        return self._tokens
+
+    async def _get(self, path: str) -> tuple[int, Any]:
+        if not self._tokens or not self._tokens.access_token:
+            raise AuthenticationError("plug&play client is not authenticated")
+        headers = {
+            "Authorization": f"Bearer {self._tokens.access_token}",
+            "Accept": "application/json",
+            "User-Agent": self._brand.user_agent,
+        }
+        async with self._session.get(
+            f"{self.API_BASE}/{path}", headers=headers, timeout=_TIMEOUT
+        ) as resp:
+            try:
+                body = await resp.json(content_type=None)
+            except Exception:  # noqa: BLE001 — error bodies may be text
+                body = await resp.text()
+            return resp.status, body
+
+    async def get_raw_snapshot(self, vin: str) -> dict[str, Any]:
+        """Return the full acpp snapshot for a VIN.
+
+        Only VINs enrolled in THIS account exist; an unknown VIN returns HTTP 404
+        ``{"message": "Vehicle with vin ... does not exist"}``. Live engine PIDs
+        are never here (dongle-local) — this is the odometer / 12V-battery / fuel /
+        service / tyre / warning snapshot the dongle uploads on sync.
+
+        Shape (observed on a real A5 B8, 2026-08-24)::
+
+            {"vehicle": {"vehicle": {"id", "vin", "carPlatform": "KWP2000"},
+                         "odometer": 369290.0, "batteryVoltage": 11.76,
+                         "tankFuelAmount": 3.0, "registrationDate", "mainCheck",
+                         "vehicleSpecificDealer": {...}},
+             "tires": [...], "warning_lights": {"warningLights": []},
+             "last_parking_position": {"gpsLocation": {...}}, "app_services": {...}}
+        """
+        status, body = await self._get(f"vehicle/{vin}")
+        if status != 200 or not isinstance(body, dict):
+            # 404 here specifically means the VIN is not enrolled in THIS account
+            # ("Vehicle with vin: '...' does not exist").
+            raise APIError(status, f"{self.API_BASE}/vehicle/{vin}", str(body))
+        snap: dict[str, Any] = {"vehicle": body}
+        # Best-effort sub-resources; a missing one must not fail the whole read.
+        for key, sub in (
+            ("tires", f"vehicle/{vin}/tires"),
+            ("warning_lights", f"vehicle/{vin}/warning-lights"),
+            ("last_parking_position", f"vehicle/{vin}/last-parking-position"),
+            ("app_services", f"vehicle/{vin}/vehicle_app_services"),
+        ):
+            try:
+                s, b = await self._get(sub)
+                if s == 200:
+                    snap[key] = b
+            except Exception as exc:  # noqa: BLE001 — defence-in-depth
+                _LOGGER.debug("plug&play sub-resource %s failed: %s", sub, exc)
+        return snap
+
+    async def get_status(self, vin: str) -> VehicleData:
+        """Map the acpp snapshot onto :class:`VehicleData` (fields acpp actually provides).
+
+        acpp exposes only a coarse snapshot, so most ``VehicleData`` columns stay
+        ``None``. Fields WITHOUT a home in the current model — the 12V
+        ``batteryVoltage``, ``tankFuelAmount`` in litres, service/registration dates,
+        per-tyre records — are returned by :meth:`get_raw_snapshot` for the
+        coordinator to surface. See the mapping TODOs in
+        ``docs/research/plugandplay_cloud_reader.md`` (add columns, or expose via
+        an extra-attributes dict).
+        """
+        snap = await self.get_raw_snapshot(vin)
+        veh: dict[str, Any] = snap.get("vehicle", {}) or {}
+        warnings = (snap.get("warning_lights") or {}).get("warningLights") or []
+
+        data = VehicleData(vin=vin)
+        odometer = veh.get("odometer")
+        if isinstance(odometer, (int, float)):
+            data.odometer_km = int(round(odometer))
+        # carPlatform (e.g. "KWP2000") = a pre-connectivity combustion/PHEV car.
+        if (veh.get("vehicle") or {}).get("carPlatform"):
+            data.has_combustion = True
+        data.warning_count = len(warnings)
+        data.warning_active = len(warnings) > 0
+        my = _vin_model_year(vin)
+        if my is not None:
+            data.model_year = my
+        return data
+
+
+class WCGCloudClient(PlugAndPlayCloudClient):
+    """VW We Connect Go (wcg) variant — **TESTER-GATED, login NOT wired**.
+
+    Same shape as acpp but the VW backend authenticates against the LEGACY
+    ``signin-service`` IDP (``identity.legacy.vwgroup.io``), not Auth0, so
+    ``IDKAuth.authenticate()`` returns HTTP 400 at the identifier step. Implement
+    the signin-service legs (identifier → authenticate → code, see
+    ``auth/_vweu_twoway_login.py``) before enabling.
+
+    Data lives at ``prod.wcg.cariad.digital/vehicles/{vin}/...`` — note the
+    ``vehicles`` **plural** and the ``measurements`` / ``warnings`` / ``config`` /
+    ``series/measurements`` sub-paths — and the garage is listed via
+    ``api/v1/users/{user_id}/vehicles``.
+    """
+
+    API_BASE = "https://prod.wcg.cariad.digital"
+
+    async def authenticate(self, mfa_code: str | None = None) -> None:
+        raise NotImplementedError(
+            "VW We Connect Go uses the legacy signin-service login flow, which is "
+            "not implemented yet. See docs/research/plugandplay_cloud_reader.md."
+        )
+
+
+def _vin_model_year(vin: str) -> int | None:
+    """Decode SAE VIN position 10 → model year (coarse hint).
+
+    Digits 1-9 map to 2001-2009 (the pre-connectivity era these dongle cars live
+    in). Letters A..Y map to 2010..2030. The 2031+ digit reuse is ignored — refine
+    in integration if a >2030 car ever appears here.
+    """
+    if len(vin) < 10:
+        return None
+    code = vin[9].upper()
+    letters = "ABCDEFGHJKLMNPRSTVWXY"  # SAE year letters (no I,O,Q,U,Z)
+    if code.isdigit():
+        return 2000 + int(code)
+    if code in letters:
+        return 2010 + letters.index(code)
+    return None

--- a/custom_components/vag_connect/cariad/api/plugandplay.py
+++ b/custom_components/vag_connect/cariad/api/plugandplay.py
@@ -139,6 +139,27 @@ class PlugAndPlayCloudClient:
                 _LOGGER.debug("plug&play sub-resource %s failed: %s", sub, exc)
         return snap
 
+    async def get_vehicles(self) -> list[str]:
+        """Return the VINs enrolled in this account (the coordinator's entry point).
+
+        acpp exposes no per-user ``user/…`` garage resource (all data endpoints
+        are VIN-addressed). The enrolled cars are listed by ``GET /vehicles``
+        — grounded live against a real account, 2026-08-24 — which returns an
+        array of the same snapshot shape as ``vehicle/{vin}``. We take just the
+        VINs; the coordinator then calls :meth:`get_status` per car.
+        """
+        status, body = await self._get("vehicles")
+        if status != 200 or not isinstance(body, list):
+            return []
+        vins: list[str] = []
+        for entry in body:
+            if not isinstance(entry, dict):
+                continue
+            vin = (entry.get("vehicle") or {}).get("vin")
+            if isinstance(vin, str) and vin:
+                vins.append(vin)
+        return vins
+
     async def get_status(self, vin: str) -> VehicleData:
         """Map the acpp snapshot onto :class:`VehicleData` (fields acpp actually provides).
 
@@ -166,6 +187,26 @@ class PlugAndPlayCloudClient:
         my = _vin_model_year(vin)
         if my is not None:
             data.model_year = my
+
+        # 12V battery voltage — the dongle reads the OBD 12V rail on sync
+        # (observed 11.76 on the B8). A real reading is a positive float; a
+        # missing/zero value means the dongle had no sample.
+        bv = veh.get("batteryVoltage")
+        if isinstance(bv, (int, float)) and not isinstance(bv, bool) and bv > 0:
+            data.voltage_12v = float(bv)
+
+        # Last parking position the dongle uploaded. Some dongles report 0/0
+        # ("null island") when they never got a fix — treat that as no position
+        # so the device tracker stays unknown instead of pinning to the Atlantic.
+        gps = (snap.get("last_parking_position") or {}).get("gpsLocation") or {}
+        lat, lon = gps.get("latitude"), gps.get("longitude")
+        if (
+            isinstance(lat, (int, float)) and not isinstance(lat, bool)
+            and isinstance(lon, (int, float)) and not isinstance(lon, bool)
+            and (lat, lon) != (0, 0)
+        ):
+            data.latitude = float(lat)
+            data.longitude = float(lon)
         return data
 
 

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -70,6 +70,37 @@ BRAND_VW_EU = BrandConfig(
     android_package_name="de.volkswagen.weconnect",
 )
 
+# ── DataPlug / plug&play cloud (OBD-dongle cars WITHOUT built-in connectivity) ──
+# A separate read source served by api/plugandplay.py. Reaches OLD dongle-equipped
+# cars that the BFF + EU-Data-Act portal do not serve. Auth is plain
+# authorization_code+PKCE exchanged at the plug&play backend's OWN /token endpoint
+# (no Play-Integrity/x-qmauth). ``name`` is deliberately NOT 'audi'/'volkswagen' so
+# IDKAuth._exchange_code() takes the plain-OAuth branch. See
+# docs/research/plugandplay_cloud_reader.md.
+#
+# Audi (acpp): LIVE-VALIDATED 2026-08-24 against an enrolled A5 B8.
+BRAND_AUDI_ACPP = BrandConfig(
+    name="audi_acpp",
+    client_id="ec6198b1-b31e-41ec-9a69-95d42d6497ed@apps_vw-dilab_com",
+    redirect_uri="acpp://de.audi.connectplugandplay/oauth2redirect/identitykit",
+    user_agent="Audi-connect-plug-and-play/3.6.4-android",
+    api_base="https://prod.acpp.cariad.digital",
+    # 'openid email profile' ONLY — adding 'https://audiid.vwgroup.io/account'
+    # (also present in the APK) makes /authorize return consent_required.
+    scope="openid email profile",
+    android_package_name="de.audi.connectplugandplay",
+)
+# VW (wcg): TESTER-GATED — legacy signin-service login not wired (see WCGCloudClient).
+BRAND_VW_WCG = BrandConfig(
+    name="vw_wcg",
+    client_id="ac42b0fa-3b11-48a0-a941-43a399e7ef84@apps_vw-dilab_com",
+    redirect_uri="vwconnect://de.volkswagen.vwconnect/oauth2redirect/identitykit",
+    user_agent="WeConnect-Go/2.28.5-android",
+    api_base="https://prod.wcg.cariad.digital",
+    scope="openid profile address email phone",
+    android_package_name="de.volkswagen.vwconnect",
+)
+
 # b13 (RE dismantle 2026-06) — known-good FALLBACK OAuth client_ids harvested
 # from the current brand APKs. Each app ships more dilab clients than we model;
 # if VW ever blocklists a primary client_id, a user can set one of these via the

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -336,6 +336,10 @@ BRANDS: dict[str, BrandConfig] = {
     "porsche":       BRAND_PORSCHE,
     # v2.14.11 — Bentley wired (login+read; runs on the Audi IDK client/tenant).
     "bentley":       BRAND_BENTLEY,
+    # plug&play OBD-dongle cloud reader (Audi acpp) — read-only, its own silo
+    # (token is NOT BFF-whitelisted). For pre-connectivity Audi cars paired with
+    # a TEXA dongle, the only cloud read path. Live-validated on a real A5 B8.
+    "audi_acpp":     BRAND_AUDI_ACPP,
 }
 
 

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -96,6 +96,8 @@ _BRAND_OPTIONS: list[SelectOptionDict] = [
     SelectOptionDict(value="porsche",       label="Porsche (My Porsche) — experimental, login may fail"),
     # v2.14.11 — Bentley (login+read; Audi IDK tenant). Two-way live-test gated.
     SelectOptionDict(value="bentley",       label="Bentley (My Bentley)"),
+    # plug&play OBD-dongle cloud reader for pre-connectivity Audi cars (read-only).
+    SelectOptionDict(value="audi_acpp",     label="Audi plug&play — OBD dongle (older cars)"),
 ]
 
 _BRAND_SELECTOR = SelectSelector(

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -293,6 +293,7 @@ BRANDS = {
     "volkswagen_na":  "Volkswagen US/CA",
     "audi_na":        "Audi US/CA",
     "porsche":        "Porsche (My Porsche)",
+    "audi_acpp":      "Audi plug&play (OBD dongle)",
 }
 
 # v2.8.0 quick-win B — native-app deeplink schemes per brand. Used by
@@ -324,6 +325,7 @@ DEEPLINK_SCHEMES: dict[str, str] = {
     "porsche":       "porsche-app://",     # DEX: Porsche One 12.24.27 (was myporsche://)
     "volkswagen_na": "myvw://",            # DEX: myVW 2026.5.27 (was vwapp://)
     "audi_na":       "myaudi://",          # US Audi = same global myAudi app
+    "audi_acpp":     "acpp://",            # Audi connect plug&play (de.audi.connectplugandplay)
 }
 
 # Polling interval limits

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -22,5 +22,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.2.1"
+  "version": "4.3.0b1"
 }

--- a/docs/research/plugandplay_cloud_reader.md
+++ b/docs/research/plugandplay_cloud_reader.md
@@ -1,0 +1,105 @@
+# DataPlug / plug&play cloud reader — handoff
+
+**Status:** Audi (acpp) **live-validated** 2026-08-24 (real enrolled A5 B8). VW (wcg) **tester-gated**
+(endpoints mapped, login not wired). New source; foundation committed on
+`feat/plugandplay-cloud-reader`. Integration (config-flow / factory / coordinator / sensors) is
+left for the main OBD-solution work — see **Integration TODO** below.
+
+## Why this exists
+
+The plug&play apps — `de.audi.connectplugandplay` (Audi connect plug&play) and
+`de.volkswagen.vwconnect` (VW We Connect Go) — pair a **TEXA OBD dongle** with OLD cars that have
+**no built-in connectivity**. Those cars are invisible to the modern CARIAD BFF and to the
+EU-Data-Act portal, so **this is the only cloud read path** for a dongle-equipped Touareg / e-up! /
+pre-connectivity A4/A5/Golf, etc. It is attestation-free and hands out a **durable refresh token**.
+
+The dongle uploads a **snapshot** on sync (odometer, 12V battery, fuel, service, tyres, warnings).
+Live engine PIDs (speed/rpm/coolant/boost/…) are **not** in the cloud — they stay dongle-local and
+are read over Bluetooth (that is the separate `dataplug-reconnect` local reader project).
+
+## Audi (acpp) — validated flow
+
+| step | value |
+|---|---|
+| client_id | `ec6198b1-b31e-41ec-9a69-95d42d6497ed@apps_vw-dilab_com` |
+| authorize | `https://identity.vwgroup.io/oidc/v1/authorize` (authorization_code + PKCE) |
+| scope | `openid email profile` — **not** `… https://audiid.vwgroup.io/account` (→ `consent_required`) |
+| redirect | `acpp://de.audi.connectplugandplay/oauth2redirect/identitykit` |
+| token | `https://prod.acpp.cariad.digital/token` — plain OAuth, **no x-qmauth**, returns refresh_token |
+| data base | `https://prod.acpp.cariad.digital` |
+
+Reuse of the existing auth stack (no new login code needed for Audi):
+
+```python
+IDKAuth(session, BRAND_AUDI_ACPP, token_url_override="https://prod.acpp.cariad.digital/token")
+```
+
+`BRAND_AUDI_ACPP.name == "audi_acpp"` (NOT `"audi"`) so `IDKAuth._exchange_code()` takes the
+plain-OAuth branch instead of the CARIAD BFF x-qmauth branch, and honours the `token_url_override`.
+
+### Data endpoints (Bearer <acpp access token>)
+
+Only VINs **enrolled in the account** exist — an unknown VIN returns
+`404 {"message":"Vehicle with vin ... does not exist"}` (Prash's S6 was not enrolled → 404).
+
+| path | method | returns (observed on the B8) |
+|---|---|---|
+| `vehicle/{vin}` | GET 200 | `{"vehicle":{"id","vin","carPlatform":"KWP2000"},"odometer":369290.0,"batteryVoltage":11.76,"tankFuelAmount":3.0,"registrationDate","mainCheck","vehicleSpecificDealer":{...}}` |
+| `vehicle/{vin}/tires` | GET 200 | `[{"id","mileage","manufacturer","changeDate","tireActive",...}]` |
+| `vehicle/{vin}/warning-lights` | GET 200 | `{"warningLights":[]}` |
+| `vehicle/{vin}/last-parking-position` | GET 200 | `{"gpsLocation":{"latitude","longitude"}}` (0/0 with this dongle) |
+| `vehicle/{vin}/driverlogs` | GET 200 | paginated logbook |
+| `vehicle/{vin}/appointment` | GET 200 | `[]` |
+| `vehicle/{vin}/vehicle_app_services` | GET 200 | notification settings |
+| `user/fuellog/{vin}` | GET 200 | paginated fuel log |
+| `user/achievements/v2` | GET 200 | gamification points |
+| `vehicle/{vin}/details` | 405 (POST) · `vehicle/{vin}/carport` | 500 without a `lang` param (query `?lang=de` did **not** satisfy it — likely a header/param name mismatch, TODO) |
+| `vehicle/{vin}/{status,state,measurements,statistics,...}` | 404 | **live PIDs are NOT stored** — dongle-local only |
+| `user/cars/{vin}/…` | 404 | wrong family (early dead end); the live family is `vehicle/{vin}/…` |
+
+### Token does NOT open the BFF
+
+The acpp access token (`aud` = the acpp client itself, `scp: profile email openid`) is **not
+BFF-whitelisted**: `emea.bff.cariad.digital/vehicle/v1/*` → `403 "clientId in the token claim is
+either unknown or not whitelisted"`. Confirms the BFF client-whitelist gate; this is not a wall
+bypass, it is its own silo. (Consistent with `vag_connect_apk_sweep` client sweep.)
+
+## VW (wcg) — mapped, tester-gated
+
+| | value |
+|---|---|
+| client_id | `ac42b0fa-3b11-48a0-a941-43a399e7ef84@apps_vw-dilab_com` |
+| IDP | `identity.legacy.vwgroup.io` — **legacy `signin-service`, not Auth0** |
+| data base | `https://prod.wcg.cariad.digital` |
+| data paths | `vehicles/{vin}/{measurements,warnings,config,series/measurements}` (note `vehicles` **plural**) |
+| garage list | `api/v1/users/{user_id}/vehicles` |
+
+**Blocker:** `IDKAuth.authenticate()` targets Auth0 Universal Login; against the legacy
+signin-service it returns `HTTP 400` at the identifier POST
+(`identity.legacy.vwgroup.io/signin-service/v1/{client_id}/login/identifier`). Implement the
+signin-service legs (identifier → authenticate → code) — `auth/_vweu_twoway_login.py` already has
+this pattern — then point `token_url_override` at the legacy token endpoint. Not live-testable here
+(no VW dongle car available); gate behind a tester like the other unvalidated paths.
+
+## Integration TODO (for the main OBD-solution work)
+
+1. **config-flow**: add a "DataPlug / plug&play (OBD dongle)" source option (email+password; Audi
+   ready, VW behind a tester flag).
+2. **factory.py**: register `PlugAndPlayCloudClient` (acpp) — it already mirrors the
+   `(session, brand, email, password, spin="")` constructor and exposes `authenticate()` +
+   `get_status(vin)`.
+3. **VehicleData mapping**: `get_status()` fills `odometer_km`, `warning_active/count`,
+   `model_year`, `has_combustion`. acpp fields with **no current column** — 12V `batteryVoltage`,
+   `tankFuelAmount` (litres), `registrationDate`, `mainCheck`, per-tyre records — come back via
+   `get_raw_snapshot()`. Decide: add columns (e.g. `battery_12v_voltage`, `fuel_litres`,
+   `service_due_date`) or surface them as extra state attributes.
+4. **Poll cadence**: snapshot only updates when the dongle syncs (i.e. after a drive); a slow poll
+   is fine. No live PIDs here — pair with the local BT reader for real-time data.
+5. **wcg**: implement the legacy signin-service login + wire `WCGCloudClient`, tester-gated.
+
+## Reference
+
+Working, credential-driven probes used to validate this live are in the session scratchpad
+(`acpp_login.py`, `acpp_read.sh`, `acpp_bff.sh`) — not committed (they read `~/.claude/private`
+creds and cache a token in `~/.claude/private/acpp_token.json`). The committed code
+(`api/plugandplay.py`) is the clean-room equivalent that reuses `IDKAuth`.

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -39,6 +39,8 @@ class TestModels:
             "bentley",
             # v2.19.0 — Audi US/CA (CARIAD-BFF NA login foundation).
             "audi_na",
+            # plug&play OBD-dongle cloud reader (Audi acpp; read-only silo).
+            "audi_acpp",
         }
 
     def test_brand_vw_client_id(self):

--- a/tests/test_plugandplay_cloud.py
+++ b/tests/test_plugandplay_cloud.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for the DataPlug / plug&play cloud reader (api/plugandplay.py).
+
+Covers the parts that are validated + deterministic: VIN → model-year decode, the
+acpp snapshot → VehicleData mapping, the "VIN not enrolled" 404 → APIError, and the
+tester-gated VW (wcg) login guard. No network — the HTTP layer (`_get`) is stubbed.
+Synthetic VINs only (never a real one).
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.cariad.api.plugandplay import (
+    PlugAndPlayCloudClient,
+    WCGCloudClient,
+    _vin_model_year,
+)
+from custom_components.vag_connect.cariad.models import BRAND_AUDI_ACPP, BRAND_VW_WCG
+from custom_components.vag_connect.cariad.exceptions import APIError
+
+# Synthetic VINs (generic A5-B8 / e-Golf prefixes; position 10 = model-year code).
+VIN_2009 = "WAUZZZ8T99A000000"   # pos10 = "9" → 2009
+VIN_2020 = "WVWZZZAUZLW000000"   # pos10 = "L" → 2020
+
+
+def _client(brand=BRAND_AUDI_ACPP) -> PlugAndPlayCloudClient:
+    c = PlugAndPlayCloudClient(MagicMock(), brand, "user@example.com", "pw")
+    c._tokens = MagicMock(access_token="fake-access-token")
+    return c
+
+
+def _stub_get(client, responses):
+    """Replace client._get with a canned dispatcher: path -> (status, body)."""
+    async def fake_get(path):
+        return responses.get(path, (404, {"message": f"No static resource {path}"}))
+    client._get = fake_get  # type: ignore[assignment]
+
+
+def test_vin_model_year():
+    assert _vin_model_year(VIN_2009) == 2009
+    assert _vin_model_year(VIN_2020) == 2020
+    assert _vin_model_year("SHORT") is None
+
+
+async def test_get_status_maps_snapshot():
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2009}": (200, {
+            "vehicle": {"id": 1, "vin": VIN_2009, "carPlatform": "KWP2000"},
+            "odometer": 369290.4, "batteryVoltage": 11.76, "tankFuelAmount": 3.0,
+        }),
+        f"vehicle/{VIN_2009}/warning-lights": (200, {"warningLights": ["OIL", "TYRE"]}),
+    })
+    data = await c.get_status(VIN_2009)
+    assert data.vin == VIN_2009
+    assert data.odometer_km == 369290          # rounded from float
+    assert data.has_combustion is True          # carPlatform present
+    assert data.warning_count == 2
+    assert data.warning_active is True
+    assert data.model_year == 2009
+
+
+async def test_get_status_no_warnings():
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2020}": (200, {"vehicle": {"vin": VIN_2020}, "odometer": 12000}),
+        f"vehicle/{VIN_2020}/warning-lights": (200, {"warningLights": []}),
+    })
+    data = await c.get_status(VIN_2020)
+    assert data.warning_count == 0
+    assert data.warning_active is False
+    assert data.odometer_km == 12000
+
+
+async def test_unenrolled_vin_raises():
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2009}": (404, {"message": f"Vehicle with vin: '{VIN_2009}' does not exist"}),
+    })
+    with pytest.raises(APIError):
+        await c.get_raw_snapshot(VIN_2009)
+
+
+async def test_wcg_login_is_tester_gated():
+    c = WCGCloudClient(MagicMock(), BRAND_VW_WCG, "user@example.com", "pw")
+    assert c.API_BASE == "https://prod.wcg.cariad.digital"
+    with pytest.raises(NotImplementedError):
+        await c.authenticate()

--- a/tests/test_plugandplay_cloud.py
+++ b/tests/test_plugandplay_cloud.py
@@ -88,3 +88,77 @@ async def test_wcg_login_is_tester_gated():
     assert c.API_BASE == "https://prod.wcg.cariad.digital"
     with pytest.raises(NotImplementedError):
         await c.authenticate()
+
+
+# ── get_vehicles — grounded GET /vehicles (no per-user garage resource) ───────
+
+async def test_get_vehicles_parses_the_list():
+    c = _client()
+    _stub_get(c, {
+        "vehicles": (200, [
+            {"vehicle": {"id": 1, "vin": VIN_2009, "carPlatform": "KWP2000"}, "odometer": 100},
+            {"vehicle": {"id": 2, "vin": VIN_2020}},
+        ]),
+    })
+    assert await c.get_vehicles() == [VIN_2009, VIN_2020]
+
+
+async def test_get_vehicles_empty_on_unexpected_shape():
+    c = _client()
+    _stub_get(c, {"vehicles": (200, {"message": "not a list"})})
+    assert await c.get_vehicles() == []
+
+
+async def test_get_vehicles_empty_on_error():
+    c = _client()
+    _stub_get(c, {"vehicles": (503, "upstream down")})
+    assert await c.get_vehicles() == []
+
+
+# ── get_status: 12V battery + last-parking GPS ───────────────────────────────
+
+async def test_get_status_maps_12v_and_parking_gps():
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2020}": (200, {
+            "vehicle": {"vin": VIN_2020}, "odometer": 1000, "batteryVoltage": 12.4}),
+        f"vehicle/{VIN_2020}/warning-lights": (200, {"warningLights": []}),
+        f"vehicle/{VIN_2020}/last-parking-position": (
+            200, {"gpsLocation": {"latitude": 48.137, "longitude": 11.575}}),
+    })
+    data = await c.get_status(VIN_2020)
+    assert data.voltage_12v == 12.4
+    assert data.latitude == 48.137
+    assert data.longitude == 11.575
+
+
+async def test_get_status_zero_voltage_and_null_island_ignored():
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2020}": (200, {"vehicle": {"vin": VIN_2020}, "batteryVoltage": 0}),
+        f"vehicle/{VIN_2020}/warning-lights": (200, {"warningLights": []}),
+        f"vehicle/{VIN_2020}/last-parking-position": (
+            200, {"gpsLocation": {"latitude": 0, "longitude": 0}}),
+    })
+    data = await c.get_status(VIN_2020)
+    assert data.voltage_12v is None     # a zero reading = no dongle sample
+    assert data.latitude is None        # 0/0 = "null island" = no GPS fix
+    assert data.longitude is None
+
+
+# ── integration wiring: factory + brand registration ─────────────────────────
+
+def test_factory_creates_acpp_client():
+    from custom_components.vag_connect.cariad.api.factory import CariadClientFactory
+    client = CariadClientFactory.create("audi_acpp", MagicMock(), "u@e.com", "pw")
+    assert isinstance(client, PlugAndPlayCloudClient)
+    assert client._brand.name == "audi_acpp"
+
+
+def test_audi_acpp_registered_across_wiring():
+    from custom_components.vag_connect.const import BRANDS as CONST_BRANDS
+    from custom_components.vag_connect.cariad.models import BRANDS as MODEL_BRANDS
+    from custom_components.vag_connect.config_flow import _BRAND_OPTIONS
+    assert "audi_acpp" in CONST_BRANDS
+    assert "audi_acpp" in MODEL_BRANDS
+    assert any(o["value"] == "audi_acpp" for o in _BRAND_OPTIONS)


### PR DESCRIPTION
## New source: Audi plug&play (OBD dongle) — cloud reads for pre-connectivity cars

Older Audis with **no built-in connectivity** that use a **TEXA OBD dongle** (pre-connectivity A4/A5/Golf, Touareg, e-up!, …) are invisible to the modern CARIAD BFF and to the EU Data Act portal — the integration had no way to reach them at all. This adds the **Audi connect plug&play (`acpp`)** backend as a selectable, read-only source.

### What it does
- Pick **"Audi plug&play — OBD dongle (older cars)"** at setup (email + password).
- Reads the dongle's cloud snapshot: **odometer, 12V battery voltage, warning lights, and last parking position** (with a `0/0` null-island guard for dongles that never got a fix).
- **Automatic VIN discovery** — the enrolled cars are listed via `GET /vehicles` (grounded live against a real account; acpp has no per-user garage resource, so this is the one endpoint that lists them). No manual VIN entry.
- **Read-only** — no command backend, no push, its own token silo (the acpp token is not BFF/DAG-whitelisted). `DECLARED_CAPABILITIES` is all-False, and the config-flow validates via `authenticate()` only, so a capability-less client can't drive commands.

### How it's wired
`api/plugandplay.py` (`get_vehicles` + `get_status` mapping) · `factory.create` · `models.BRANDS` · `const.BRANDS` + `DEEPLINK_SCHEMES` · `config_flow` brand picker · `_capabilities.DECLARED_CAPABILITIES`. The coordinator's optional-method calls are all `hasattr`-guarded, so setup never crashes on the minimal client.

### Auth
Reuses the existing `IDKAuth` stack via a plain-OAuth branch (`token_url_override`, no `x-qmauth` attestation), and returns a durable refresh token.

### Not included
- **VW We Connect Go (`wcg`)** dongles are mapped but **tester-gated** — VW uses the legacy `signin-service` IDP, which isn't wired yet.
- Fuel-level (litres), registration date and service records are already fetched by `get_vehicles`/`get_raw_snapshot` but not yet surfaced as sensors — a clean follow-up.

### Tests
`test_plugandplay_cloud.py` — `get_vehicles` parsing, 12V + parking-GPS mapping (incl. null-island / zero-voltage rejection), factory creation, and cross-registry brand parity. Full suite green.
