### PR TITLE
scout: silence automation.climatisationTimer.requests re-leak (#1237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **The Vehicle Data Scout no longer re-flags a climatisation-timer field it already reads (#1237).** On some Audis the singular `automation.climatisationTimer.requests` queue counter kept surfacing as a "new field" even though its value is already parsed into the climatisation-timers sensor — a silencer-registry gap, not a missing feature. Thanks @arcticMariner.
+
 ## [4.3.0b1] - 2026-08-24 — Audi plug&play (OBD dongle), beta
 
 ### Added

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -932,6 +932,13 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             # v2.18.0 — Scout #799: now CONSUMED into charging_profiles_pending
             # (vw_eu.py). 3-seg path, not covered by automation.chargingProfiles.*
             "automation.chargingProfiles.requests",
+            # Scout #1030/#1237 (@arcticMariner, audi): the SINGULAR
+            # "climatisationTimer" audi variant is CONSUMED into
+            # climatisation_timers_pending (vw_eu.py), mirroring the
+            # chargingProfiles.requests sibling above. 3-seg path, not covered
+            # by the 2-seg climatisationTimers.* wildcard — so it re-leaked to
+            # Scout despite its value already being parsed.
+            "automation.climatisationTimer.requests",
             # v2.18.0 — Scout #801: now CONSUMED into climatisation_timers_pending.
             # 3-seg path, not covered by the 2-seg climatisationTimers.* wildcard.
             "climatisationTimers.climatisationTimersStatus.requests",

--- a/tests/test_1237_climatisation_timer_requests_silenced.py
+++ b/tests/test_1237_climatisation_timer_requests_silenced.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1237 (@arcticMariner, Audi) — silence automation.climatisationTimer.requests.
+
+The Scout kept re-flagging the SINGULAR-"Timer" Audi variant
+``automation.climatisationTimer.requests`` — an internal request-queue counter
+whose value is ALREADY consumed into ``climatisation_timers_pending`` (vw_eu.py).
+It slipped through because ``_path_matches`` is exact / equal-length, so the
+2-seg ``climatisationTimers.*`` wildcard never covered this 3-seg ``automation.``
+path — exactly the case the sibling ``automation.chargingProfiles.requests``
+silencer already handles for #799. Now silenced, so a maintainer "noted, it's
+already parsed" reply is actually true.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad._unexpected_keys import detect_unexpected
+
+
+def test_climatisation_timer_requests_is_not_flagged() -> None:
+    payload = {"automation": {"climatisationTimer": {"requests": []}}}
+    flagged = [f.path for f in detect_unexpected("audi", "selectivestatus", payload)]
+    assert flagged == [], f"expected .requests silenced, got {flagged}"
+
+
+def test_a_genuinely_unknown_sibling_is_still_flagged() -> None:
+    """The silence is targeted — an unrelated new child must still surface."""
+    payload = {"automation": {"climatisationTimer": {"somethingBrandNew": 1}}}
+    flagged = [f.path for f in detect_unexpected("audi", "selectivestatus", payload)]
+    assert any("somethingBrandNew" in p for p in flagged)


### PR DESCRIPTION
Fixes #1237. The singular-Timer Audi variant `automation.climatisationTimer.requests` is already consumed into `climatisation_timers_pending` (vw_eu.py) but re-leaked to the Vehicle Data Scout because that 3-segment path was missing from `EXPECTED_KEYS`, next to its `automation.chargingProfiles.requests` sibling. 1-line silence + 2 regression tests. Thanks @arcticMariner.