### PR TITLE
v4.3.0b2 — live telemetry supersedes the stale EU-DA batch feed (D#1231, #1195-family)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.3.0b2] - 2026-08-24 — Live telemetry beats the stale portal feed
+
 ### Fixed
 - **Battery, charging and climate readings no longer step backwards when the EU Data Act portal re-sends a stale block (D#1231, #1195-family).** The portal's 15-minute feed re-sends a frozen "stop-charging" snapshot — sometimes re-stamped with a fresh timestamp — which could out-rank a genuinely live channel (volkswagen.de, the brand app backend) in the cross-channel merge. That let state-of-charge, charge power/rate, remaining time, plug state, range and climate state jump backwards mid-charge while a live channel had the correct value. A live channel's reading now always supersedes the batch feed's for those fields, across every brand; cars that only have the portal are unchanged.
 - **The Vehicle Data Scout no longer re-flags a climatisation-timer field it already reads (#1237).** On some Audis the singular `automation.climatisationTimer.requests` queue counter kept surfacing as a "new field" even though its value is already parsed into the climatisation-timers sensor — a silencer-registry gap, not a missing feature. Thanks @arcticMariner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ## [Unreleased]
 
 ### Fixed
+- **Battery, charging and climate readings no longer step backwards when the EU Data Act portal re-sends a stale block (D#1231, #1195-family).** The portal's 15-minute feed re-sends a frozen "stop-charging" snapshot — sometimes re-stamped with a fresh timestamp — which could out-rank a genuinely live channel (volkswagen.de, the brand app backend) in the cross-channel merge. That let state-of-charge, charge power/rate, remaining time, plug state, range and climate state jump backwards mid-charge while a live channel had the correct value. A live channel's reading now always supersedes the batch feed's for those fields, across every brand; cars that only have the portal are unchanged.
 - **The Vehicle Data Scout no longer re-flags a climatisation-timer field it already reads (#1237).** On some Audis the singular `automation.climatisationTimer.requests` queue counter kept surfacing as a "new field" even though its value is already parsed into the climatisation-timers sensor — a silencer-registry gap, not a missing feature. Thanks @arcticMariner.
 
 ## [4.3.0b1] - 2026-08-24 — Audi plug&play (OBD dongle), beta

--- a/custom_components/vag_connect/cariad/_channel_merge.py
+++ b/custom_components/vag_connect/cariad/_channel_merge.py
@@ -46,6 +46,35 @@ _SKIP_FIELDS = frozenset(
      "has_combustion", "is_electric", "is_hybrid"}
 )
 
+# The EU Data Act portal's continuous feed is a ~15-minute BATCH export that
+# ships frozen stop-charging blocks (a snapshot from the last charge, re-sent —
+# sometimes re-stamped with a fresh capture time). Every other channel (vw.de
+# web, the CARIAD BFF, MBB, SEAT/CUPRA OLA, the brand-native reads) is a LIVE
+# read. For live telemetry — SoC, charging, plug, range, climate — a live
+# channel's reading must therefore always beat the batch feed's, regardless of
+# which channel is configured as primary; otherwise a stale batch value wins the
+# gap-fill and the reading jumps backwards mid-charge (Ra72xx, #1195-family).
+# This mirrors a competing integration's portal-supersedes-EU-DA dedup, but is
+# brand-agnostic (keyed on channel + field, never on brand).
+_BATCH_SOURCES = frozenset({"eu_data_act"})
+
+_LIVE_TELEMETRY = frozenset({
+    # battery / SoC / range
+    "battery_soc", "target_soc", "electric_range_km",
+    # charging live state
+    "charging_state", "is_charging", "charging_scenario", "charging_reason",
+    "charging_preferred_mode",
+    # charge power / rate / time / energy
+    "charging_power_kw", "charging_rate_kmh", "actual_charge_rate_kw",
+    "charge_complete_eta", "remaining_time_target_soc", "charge_session_energy_kwh",
+    # plug / connector
+    "plug_state", "plug_connected", "connector_locked",
+    # power flow
+    "external_power_supply_state", "energy_flow_active",
+    # climate live state
+    "climatisation_state", "climatisation_active",
+})
+
 
 def merge_channels(
     sources: list[tuple[str, "VehicleData"]],
@@ -104,6 +133,26 @@ def merge_channels(
                     contributors.add(name)
                     # This channel filled the gap, so it owns the reading.
                     field_sources[f.name] = name
+
+    # Live-telemetry supersede: a stale EU-DA batch value must never outrank a
+    # live channel's reading. For every live-telemetry field the batch feed
+    # currently owns, hand it to the highest-priority live channel that actually
+    # has a reading. No-op when no live channel is present (EU-DA-only cars keep
+    # their value) or when a live channel already owns the field. Order-preserving
+    # (walks ``sources`` in priority order) and provenance-correct.
+    if any(nm not in _BATCH_SOURCES for nm, _ in sources):
+        for f_name in _LIVE_TELEMETRY:
+            if field_sources.get(f_name) not in _BATCH_SOURCES:
+                continue  # a live channel already owns it, or nobody set it
+            for nm, vd in sources:
+                if nm in _BATCH_SOURCES:
+                    continue
+                live_val = getattr(vd, f_name, None)
+                if not _unset(f_name, live_val):
+                    setattr(merged, f_name, copy.deepcopy(live_val))
+                    field_sources[f_name] = nm
+                    contributors.add(nm)
+                    break
 
     _merge_drivetrain(merged, sources)
 

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -22,5 +22,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.3.0b1"
+  "version": "4.3.0b2"
 }

--- a/tests/test_live_telemetry_supersede.py
+++ b/tests/test_live_telemetry_supersede.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""D#1231 / #1195-family — a live channel's live-telemetry reading must always
+beat the EU Data Act batch feed's, regardless of which channel is primary.
+
+The EU-DA continuous feed ships frozen stop-charging blocks (a snapshot from the
+last charge, re-sent, sometimes re-stamped fresh). Under the plain gap-fill merge
+that stale value could win — making SoC/charge readings jump backwards mid-charge
+while a competing single-live-source integration stayed steady. The cross-channel
+merge now hands every live-telemetry field the batch feed owns to the highest-
+priority LIVE channel that actually has a reading. Brand-agnostic: keyed on the
+channel name (``eu_data_act`` = batch, everything else = live) and the field,
+never on brand. EU-DA-only cars, and fields no live channel reports, are
+untouched.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad._channel_merge import (
+    _LIVE_TELEMETRY,
+    merge_channels,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _v(**kw) -> VehicleData:
+    return VehicleData(vin="V1", **kw)
+
+
+class TestLiveBeatsBatch:
+    def test_eu_da_primary_live_supplementary_overrides(self):
+        # EU-DA (primary) carries a stale frozen block; vw.de (live) is fresh.
+        eu = _v(battery_soc=94, charging_state="charging", charging_power_kw=11.0,
+                plug_state="connected", electric_range_km=300)
+        live = _v(battery_soc=73, charging_state="off", charging_power_kw=0.0,
+                  plug_state="disconnected", electric_range_km=210)
+        m = merge_channels([("eu_data_act", eu), ("website_authproxy", live)])
+        assert m.battery_soc == 73                 # live wins, not the stale 94
+        assert m.charging_state == "off"
+        assert m.charging_power_kw == 0.0
+        assert m.plug_state == "disconnected"
+        assert m.electric_range_km == 210
+        assert m.field_sources["battery_soc"] == "website_authproxy"
+
+    def test_live_primary_eu_da_supplementary_keeps_live(self):
+        live = _v(battery_soc=73, charging_state="off")
+        eu = _v(battery_soc=94, charging_state="charging")
+        m = merge_channels([("website_authproxy", live), ("eu_data_act", eu)])
+        assert m.battery_soc == 73
+        assert m.charging_state == "off"
+        assert m.field_sources["battery_soc"] == "website_authproxy"
+
+    def test_cross_brand_bff_channel_also_supersedes(self):
+        # any non-eu_data_act channel counts as live (Audi/VW BFF, mbb, OLA…)
+        eu = _v(battery_soc=94)
+        bff = _v(battery_soc=55)
+        m = merge_channels([("eu_data_act", eu), ("audi", bff)])
+        assert m.battery_soc == 55
+        assert m.field_sources["battery_soc"] == "audi"
+
+
+class TestScopedAndSafe:
+    def test_eu_da_only_car_is_untouched(self):
+        # no live channel present → EU-DA value survives (the #1195-only case)
+        eu = _v(battery_soc=94, charging_state="charging")
+        m = merge_channels([("eu_data_act", eu)])
+        assert m.battery_soc == 94
+        assert m.charging_state == "charging"
+
+    def test_live_channel_without_the_field_leaves_eu_da_value(self):
+        # a command-only live channel (mbb) that doesn't report SoC must NOT
+        # blank EU-DA's SoC — EU-DA is the only source for it here.
+        eu = _v(battery_soc=94)
+        mbb = _v(odometer_km=12000)  # no SoC
+        m = merge_channels([("eu_data_act", eu), ("mbb", mbb)])
+        assert m.battery_soc == 94
+        assert m.field_sources["battery_soc"] == "eu_data_act"
+
+    def test_non_live_telemetry_field_is_not_superseded(self):
+        # odometer is monotonic-protected elsewhere and is NOT in the live set:
+        # the plain gap-fill (primary wins) must still stand.
+        assert "odometer_km" not in _LIVE_TELEMETRY
+        eu = _v(odometer_km=1000)
+        live = _v(odometer_km=1005)
+        m = merge_channels([("eu_data_act", eu), ("website_authproxy", live)])
+        assert m.odometer_km == 1000  # EU-DA primary keeps it (not superseded)
+
+    def test_batch_fills_gap_when_live_lacks_the_field(self):
+        # live channel present but silent on a live-telemetry field → EU-DA may
+        # still fill the gap (better a batch value than nothing on that field).
+        live = _v(charging_state="off")          # no SoC
+        eu = _v(battery_soc=80)                    # only SoC
+        m = merge_channels([("website_authproxy", live), ("eu_data_act", eu)])
+        assert m.battery_soc == 80
+        assert m.charging_state == "off"

--- a/tests/test_v2180_field_provenance.py
+++ b/tests/test_v2180_field_provenance.py
@@ -41,12 +41,15 @@ def test_gap_filled_field_is_attributed_to_the_filler() -> None:
 
 
 def test_primary_keeps_ownership_when_both_carry_the_field() -> None:
-    # A supplementary never overwrites the primary, so it never owns the field.
-    primary = VehicleData(vin="V", battery_soc=55)
-    supp = VehicleData(vin="V", battery_soc=99)
+    # A supplementary never overwrites the primary for an ordinary field, so it
+    # never owns it. (Live-telemetry fields like battery_soc are the deliberate
+    # exception — a live channel supersedes the EU-DA batch feed there; see
+    # test_live_telemetry_supersede.py. odometer is not live-telemetry.)
+    primary = VehicleData(vin="V", odometer_km=55000)
+    supp = VehicleData(vin="V", odometer_km=99000)
     m = merge_channels([("eu_data_act", primary), ("vw_de", supp)])
-    assert m.battery_soc == 55
-    assert m.field_sources["battery_soc"] == "eu_data_act"
+    assert m.odometer_km == 55000
+    assert m.field_sources["odometer_km"] == "eu_data_act"
 
 
 def test_unset_fields_are_absent_not_guessed() -> None:


### PR DESCRIPTION
## v4.3.0b2 (beta)

Fixes the class of bug where the EU Data Act portal's 15-minute **batch** feed re-sends a frozen "stop-charging" snapshot (sometimes re-stamped with a fresh timestamp) that could out-rank a genuinely **live** channel (volkswagen.de, the brand app backend, MBB, OLA) in the cross-channel merge — making state-of-charge, charge power/rate, remaining time, plug state, range and climate state **jump backwards mid-charge** while a live channel held the correct value.

A post-merge pass in `_channel_merge` now hands every live-telemetry field the batch feed owns to the highest-priority **live** channel that actually has a reading. Brand-agnostic (keyed on channel name — `eu_data_act` = batch, everything else = live — and the field, never on brand). Scoped + safe: EU-DA-only cars are untouched, fields no live channel reports keep the portal value, and non-live-telemetry fields (e.g. odometer, which is monotonic-protected elsewhere) are unchanged.

20 live-telemetry fields covered: SoC/target-SoC/range, charging state/is-charging/scenario/reason/preferred-mode, charge power/rate/actual-rate/complete-eta/remaining-time/session-energy, plug state/connected/connector-locked, external-power/energy-flow, climate state/active.

### Tests
8 new merge tests (EU-DA-primary override, live-primary keeps, cross-brand BFF, EU-DA-only untouched, live-without-field, non-live scoping, gap-fill) + updated the provenance invariant test to a non-live field. Full suite green (5290 passed).

Also includes #1237 (Scout climatisation-timer silence, already merged to main).