### PR TITLE
Real model names & plug&play master-data (queued for 4.3.0b3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.3.0b3] - 2026-08-25 — Real model names & plug&play master-data
+
 ### Added
-- **Audi plug&play (OBD dongle) now surfaces the real vehicle identity and fuel level.** The dongle's factory master-data record gives the proper "ab Haus" model designation — e.g. **"A5 TDI CR · 239 PS"** — and a clean manufacturer (**Audi**, not "Audi_Acpp"), so the device is named correctly. Also adds a **fuel-level sensor in litres** (localized in all 12 languages) and surfaces the real **first-registration / delivery date** as a service-calendar event. (acpp exposes no vehicle image, and no reliable inspection date, so those are deliberately omitted.)
+- **Audi plug&play (OBD dongle) now surfaces the real vehicle identity and fuel level.** The dongle's factory master-data record gives the proper "ab Haus" model designation — e.g. **"A5 TDI CR · 239 PS"** — and a clean manufacturer (**Audi**, not "Audi_Acpp"), so the device is named correctly. Also adds a **fuel-level sensor in litres** (localized in all 12 languages), the **exterior colour, engine power (kW), torque and cylinder count** as diagnostic sensors, and the real **first-registration / delivery date** plus the **warranty-end date** as service-calendar events. (acpp exposes no vehicle image, and no reliable inspection date, so those are deliberately omitted.)
+- **Optional fuel-level percentage for litres-only sources.** A new **fuel-tank capacity (litres)** option lets the plug&play reader — which reports litres, not a percentage — derive a fuel-level % for the nicer gauge/bar UX. Off by default; it only fills the percentage when the car itself reports none.
+
+### Fixed
+- **Audi and VW EU cars now show their real model name instead of just "Audi (2024)".** When the vehicles-list gave no model name (e.g. an Audi S6 returned an empty one), the device fell back to the brand + year. The proper localized designation ("S6 Avant TDI") — and the exterior colour — are already fetched from the vgql media block for render images; those are now used as the model name and colour when the list has none.
 
 ## [4.3.0b2] - 2026-08-24 — Live telemetry beats the stale portal feed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **Audi plug&play (OBD dongle) now surfaces the real vehicle identity and fuel level.** The dongle's factory master-data record gives the proper "ab Haus" model designation — e.g. **"A5 TDI CR · 239 PS"** — and a clean manufacturer (**Audi**, not "Audi_Acpp"), so the device is named correctly. Also adds a **fuel-level sensor in litres** (localized in all 12 languages) and surfaces the real **first-registration / delivery date** as a service-calendar event. (acpp exposes no vehicle image, and no reliable inspection date, so those are deliberately omitted.)
+
 ## [4.3.0b2] - 2026-08-24 — Live telemetry beats the stale portal feed
 
 ### Fixed

--- a/custom_components/vag_connect/calendar.py
+++ b/custom_components/vag_connect/calendar.py
@@ -35,6 +35,8 @@ _CHARGE_FIELDS = (
 _SERVICE_FIELDS = (
     "service_due_at", "oil_service_at", "brake_fluid_change_due_at",
     "brake_pads_front_inspection_due_at", "brake_pads_rear_inspection_due_at",
+    # acpp plug&play — main inspection (HU/TÜV) + first registration.
+    "main_inspection_due_at", "registration_date",
 )
 
 
@@ -177,6 +179,8 @@ class VagServiceCalendar(VagConnectEntity, CalendarEntity):
             ("brake_fluid_change_due_at", "Brake fluid change"),
             ("brake_pads_front_inspection_due_at", "Front brake pads inspection"),
             ("brake_pads_rear_inspection_due_at", "Rear brake pads inspection"),
+            ("main_inspection_due_at", "Main inspection (HU / TÜV)"),
+            ("registration_date", "First registration"),
         ):
             d = _parse_date(v.get(field))
             if d is not None:

--- a/custom_components/vag_connect/calendar.py
+++ b/custom_components/vag_connect/calendar.py
@@ -35,8 +35,8 @@ _CHARGE_FIELDS = (
 _SERVICE_FIELDS = (
     "service_due_at", "oil_service_at", "brake_fluid_change_due_at",
     "brake_pads_front_inspection_due_at", "brake_pads_rear_inspection_due_at",
-    # acpp plug&play — main inspection (HU/TÜV) + first registration.
-    "main_inspection_due_at", "registration_date",
+    # acpp plug&play — main inspection (HU/TÜV) + first registration + warranty.
+    "main_inspection_due_at", "registration_date", "warranty_until",
 )
 
 
@@ -181,6 +181,7 @@ class VagServiceCalendar(VagConnectEntity, CalendarEntity):
             ("brake_pads_rear_inspection_due_at", "Rear brake pads inspection"),
             ("main_inspection_due_at", "Main inspection (HU / TÜV)"),
             ("registration_date", "First registration"),
+            ("warranty_until", "Warranty ends"),
         ):
             d = _parse_date(v.get(field))
             if d is not None:

--- a/custom_components/vag_connect/cariad/api/plugandplay.py
+++ b/custom_components/vag_connect/cariad/api/plugandplay.py
@@ -251,11 +251,15 @@ class PlugAndPlayCloudClient:
             eng = str(cp.get("engType") or "").strip()
             hp: int | None = None
             for p in (cp.get("power") or []):
-                if (isinstance(p, dict)
-                        and str(p.get("unit") or "").lower() in ("hp", "ps")
+                if not (isinstance(p, dict)
                         and isinstance(p.get("value"), (int, float))
                         and not isinstance(p.get("value"), bool)):
+                    continue
+                unit = str(p.get("unit") or "").lower()
+                if unit in ("hp", "ps"):
                     hp = int(round(p["value"]))
+                elif unit == "kw":
+                    data.engine_power_kw = int(round(p["value"]))
             model = " ".join(x for x in (desc, eng) if x)
             if model and hp:
                 model = f"{model} · {hp} PS"   # e.g. "A5 TDI CR · 239 PS"
@@ -267,6 +271,19 @@ class PlugAndPlayCloudClient:
             reg = _epoch_ms_to_date(cp.get("deliveryDate"))
             if reg:
                 data.registration_date = reg
+            # bonus master-data
+            col = str(cp.get("exteriorColor") or "").strip()
+            if col:
+                data.exterior_color = col
+            tq = cp.get("torque")
+            if isinstance(tq, (int, float)) and not isinstance(tq, bool):
+                data.engine_torque_nm = int(round(tq))
+            cyl = cp.get("cylinderCount")
+            if isinstance(cyl, int) and not isinstance(cyl, bool):
+                data.engine_cylinders = cyl
+            war = _epoch_ms_to_date(cp.get("warranty"))
+            if war:
+                data.warranty_until = war
         return data
 
 

--- a/custom_components/vag_connect/cariad/api/plugandplay.py
+++ b/custom_components/vag_connect/cariad/api/plugandplay.py
@@ -29,6 +29,7 @@ plane — it is its own silo.
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 from aiohttp import ClientSession, ClientTimeout
@@ -40,6 +41,26 @@ from ..models import BrandConfig, TokenSet, VehicleData
 _LOGGER = logging.getLogger(__name__)
 
 _TIMEOUT = ClientTimeout(total=30)
+
+# carport ``brandCode`` → proper manufacturer name (A = Audi, confirmed live).
+_ACPP_BRAND_CODES = {"A": "Audi", "V": "Volkswagen"}
+
+
+def _epoch_ms_to_date(val: Any) -> str | None:
+    """acpp carport dates (deliveryDate/warranty) are epoch-millisecond strings.
+
+    Return the ISO date (``YYYY-MM-DD``), or None on anything unparseable.
+    """
+    try:
+        ms = int(str(val))
+    except (TypeError, ValueError):
+        return None
+    if ms <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).date().isoformat()
+    except (OverflowError, OSError, ValueError):
+        return None
 
 
 class PlugAndPlayCloudClient:
@@ -90,6 +111,9 @@ class PlugAndPlayCloudClient:
         headers = {
             "Authorization": f"Bearer {self._tokens.access_token}",
             "Accept": "application/json",
+            # The carport (master-data) endpoint 500s without an Accept-Language;
+            # all other endpoints ignore it, so send it on every request.
+            "Accept-Language": "de-DE, en-US;q=0.9",
             "User-Agent": self._brand.user_agent,
         }
         async with self._session.get(
@@ -130,6 +154,9 @@ class PlugAndPlayCloudClient:
             ("warning_lights", f"vehicle/{vin}/warning-lights"),
             ("last_parking_position", f"vehicle/{vin}/last-parking-position"),
             ("app_services", f"vehicle/{vin}/vehicle_app_services"),
+            # carport = factory master data (model, engine, fuel, power) for the
+            # proper "ab Haus" model designation.
+            ("carport", f"vehicle/{vin}/carport"),
         ):
             try:
                 s, b = await self._get(sub)
@@ -207,6 +234,39 @@ class PlugAndPlayCloudClient:
         ):
             data.latitude = float(lat)
             data.longitude = float(lon)
+
+        # Absolute fuel in the tank (litres) — the dongle reports litres, not %.
+        tank = veh.get("tankFuelAmount")
+        if isinstance(tank, (int, float)) and not isinstance(tank, bool) and tank >= 0:
+            data.fuel_level_liters = float(tank)
+
+        # Factory ("ab Haus") model designation from the carport master-data
+        # record — e.g. brandCode "A" + modelDesc "A5" + engType "TDI CR".
+        cp = snap.get("carport") or {}
+        if isinstance(cp, dict):
+            brand_name = _ACPP_BRAND_CODES.get(str(cp.get("brandCode") or "").upper())
+            if brand_name:
+                data.manufacturer = brand_name
+            desc = str(cp.get("modelDesc") or "").strip()
+            eng = str(cp.get("engType") or "").strip()
+            hp: int | None = None
+            for p in (cp.get("power") or []):
+                if (isinstance(p, dict)
+                        and str(p.get("unit") or "").lower() in ("hp", "ps")
+                        and isinstance(p.get("value"), (int, float))
+                        and not isinstance(p.get("value"), bool)):
+                    hp = int(round(p["value"]))
+            model = " ".join(x for x in (desc, eng) if x)
+            if model and hp:
+                model = f"{model} · {hp} PS"   # e.g. "A5 TDI CR · 239 PS"
+            if model:
+                data.model = model
+            # deliveryDate = the real first-delivery date (epoch-ms string, e.g.
+            # 2008 for this A5) — reliable, unlike the /vehicles registrationDate
+            # which is just the dongle-enrollment time. Feeds the service calendar.
+            reg = _epoch_ms_to_date(cp.get("deliveryDate"))
+            if reg:
+                data.registration_date = reg
         return data
 
 

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -3165,6 +3165,22 @@ class VWEUClient(CariadBaseClient):
         meta = getattr(self, "_vehicle_metadata", {}).get(vin, {})
         if meta.get("model"):
             d.model = meta["model"]
+        # The REST vehicles-list often carries NO model name (e.g. an Audi S6
+        # returns an empty ``model``, so the device fell back to "Audi (2021)").
+        # The vgql media block we already fetch for render images also carries
+        # the proper localized designation — media.longName ("S6 Avant TDI") —
+        # plus the exterior colour. Surface those, and fall back the model to the
+        # media long/short name when the REST list gave nothing.
+        img = getattr(self, "_image_data", {}).get(vin)
+        if img is not None:
+            if img.short_name and not d.media_short_name:
+                d.media_short_name = img.short_name
+            if img.long_name and not d.media_long_name:
+                d.media_long_name = img.long_name
+            if not d.model and (img.long_name or img.short_name):
+                d.model = img.long_name or img.short_name
+            if img.exterior_color and not d.exterior_color:
+                d.exterior_color = img.exterior_color
         # v1.10.1 (#58) — safe_int. The model_year metadata sometimes
         # arrives as a 4-digit string and sometimes as int depending on
         # how the auth flow normalised the user profile JSON.

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -475,6 +475,9 @@ class VehicleData:
     battery_soh_pct: int | None = None
     battery_temp: float | None = None
     fuel_level: int | None = None
+    # acpp plug&play — absolute fuel in the tank (litres). Distinct from the
+    # percentage ``fuel_level``; the dongle reports litres, not a %.
+    fuel_level_liters: float | None = None
     range_km: int | None = None
     # v1.10.0 (#94 — PHEV range triple).
     # ``range_km`` stays as the headline number (back-compat — existing
@@ -807,6 +810,10 @@ class VehicleData:
     service_due_at: Any | None = None
     oil_service_km: int | None = None
     oil_service_at: Any | None = None
+    # acpp plug&play — main inspection (HU / TÜV) + first-registration dates from
+    # the dongle's carport record; surfaced as service-calendar events.
+    main_inspection_due_at: Any | None = None
+    registration_date: Any | None = None
     # v1.11.0 (#91 closure) — explicit "raw int days" sensors complementing
     # the existing DATE sensors. The DATE conversion (sensor.py) loses the
     # exact day count; users who want "5 days remaining" instead of

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -411,6 +411,12 @@ class VehicleData:
     manufacturer: str | None = None
     firmware_version: str | None = None
     license_plate: str | None = None
+    # acpp plug&play — factory master-data (carport) bonus fields.
+    exterior_color: str | None = None
+    engine_power_kw: int | None = None
+    engine_torque_nm: int | None = None
+    engine_cylinders: int | None = None
+    warranty_until: Any | None = None
 
     # Render images — dict of mediaType → public URL (fetched via GraphQL, no auth needed to GET)
     # e.g. {"MYAPN8NB": "https://mediaservice.audi.com/media/fast/v3_...", ...}

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_ABRP_ENABLE,
     CONF_ABRP_USER_TOKEN,
     CONF_BATTERY_NOMINAL_KWH,
+    CONF_FUEL_TANK_CAPACITY,
     CONF_KEEP_RAW_DATASETS,
     CONF_BRAND,
     CONF_CLIENT_ID_OVERRIDE,
@@ -159,6 +160,16 @@ _KWH_SELECTOR = NumberSelector(
         step=0.1,
         mode=NumberSelectorMode.BOX,
         unit_of_measurement="kWh",
+    )
+)
+
+_LITERS_SELECTOR = NumberSelector(
+    NumberSelectorConfig(
+        min=0,
+        max=200,
+        step=1,
+        mode=NumberSelectorMode.BOX,
+        unit_of_measurement="L",
     )
 )
 
@@ -2018,6 +2029,15 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                         current_data.get(CONF_BATTERY_NOMINAL_KWH, 0),
                     ),
                 ): _KWH_SELECTOR,
+                # Optional fuel-tank capacity (litres) so a litres-only source
+                # (acpp plug&play) can show a fuel-level %. 0 = off (litres only).
+                vol.Optional(
+                    CONF_FUEL_TANK_CAPACITY,
+                    default=current_options.get(
+                        CONF_FUEL_TANK_CAPACITY,
+                        current_data.get(CONF_FUEL_TANK_CAPACITY, 0),
+                    ),
+                ): _LITERS_SELECTOR,
                 vol.Optional(
                     CONF_ENABLE_REVERSE_GEOCODING,
                     default=current_options.get(

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -92,6 +92,9 @@ CONF_ENABLE_REVERSE_GEOCODING = "enable_reverse_geocoding"
 # model name maps to several battery options). When the user supplies it we
 # publish battery_soh_pct = current max capacity / nominal. 0 / unset = no SoH.
 CONF_BATTERY_NOMINAL_KWH      = "battery_nominal_kwh"
+# Optional fuel-tank capacity (litres) — lets a litres-only source (acpp
+# plug&play) derive a fuel-level percentage. 0 = off (litres only).
+CONF_FUEL_TANK_CAPACITY       = "fuel_tank_capacity"
 # P1-5 — opt-in diagnostic archive of raw EU Data Act dataset ZIPs. Default
 # off: a raw dataset carries GPS + VIN + telemetry, so keeping the last few on
 # disk is a privacy cost the user opts into knowingly. When on, the coordinator

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_ENABLE_REVERSE_GEOCODING,
     CONF_FORCE_PPE_CLIMATE,
     CONF_BATTERY_NOMINAL_KWH,
+    CONF_FUEL_TANK_CAPACITY,
     CONF_KEEP_RAW_DATASETS,
     CONF_MBB_COMMAND_CHANNEL,
     CONF_MEB_COMMANDS_UNAVAILABLE,
@@ -4763,6 +4764,20 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if isinstance(_plug_state, str):
             _psl = _plug_state.strip().lower()
             data["plug_state"] = _psl if _psl in ("connected", "disconnected") else None
+
+        # Fuel-level % from a user-configured tank capacity + the litres reading.
+        # acpp plug&play reports litres, not a %, and the tank size isn't in the
+        # feed — so the user supplies it in Options (0 = off, litres only). Only
+        # fills fuel_level when the source gave none; never overwrites a real %.
+        _tank_cap = self.entry.data.get(CONF_FUEL_TANK_CAPACITY, 0)
+        _fuel_l = data.get("fuel_level_liters")
+        if (isinstance(_tank_cap, (int, float)) and not isinstance(_tank_cap, bool)
+                and _tank_cap > 0 and isinstance(_fuel_l, (int, float))
+                and not isinstance(_fuel_l, bool) and _fuel_l >= 0):
+            data["fuel_tank_capacity_liters"] = int(round(_tank_cap))
+            if data.get("fuel_level") is None:
+                data["fuel_level"] = max(
+                    0, min(100, int(round(_fuel_l / _tank_cap * 100))))
 
         # Battery State of Health. Audi device-grant cars now carry a REAL SoH read
         # from the batteryHealthState BFF job (set upstream in the API layer), so we

--- a/custom_components/vag_connect/entity_base.py
+++ b/custom_components/vag_connect/entity_base.py
@@ -176,7 +176,10 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
             identifiers={(DOMAIN, self._vin)},
             name=name,
             model=_model_str,
-            manufacturer=brand.title(),
+            # Prefer an explicit manufacturer the reader resolved (e.g. acpp maps
+            # brandCode "A" → "Audi"); else the config brand, title-cased. This
+            # avoids ugly labels like "Audi_Acpp" for the plug&play source.
+            manufacturer=vehicle.get("manufacturer") or brand.title(),
             serial_number=self._vin,
             hw_version=(str(_year) if _year else None),
             sw_version=vehicle.get("firmware_version"),

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1572,6 +1572,16 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         suggested_display_precision=0,
         condition="combustion",
     ),
+    # acpp plug&play — absolute fuel in the tank (litres) from the OBD dongle.
+    VagSensorDescription(
+        key="fuel_level_liters",
+        translation_key="fuel_level_liters",
+        data_key="fuel_level_liters",
+        native_unit_of_measurement="L",
+        icon="mdi:gas-station",
+        suggested_display_precision=1,
+        condition="combustion",
+    ),
     # v2.2.0 Phase 7 PR #4 — Skoda tier-B from scout-audit.
     # Climate-timer count (parity to VW EU/Audi PR #2 departure
     # timer count) + running-requests count (diagnostic for

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1582,6 +1582,29 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         suggested_display_precision=1,
         condition="combustion",
     ),
+    # acpp plug&play — factory master-data (carport) bonus sensors.
+    VagSensorDescription(
+        key="exterior_color", translation_key="exterior_color",
+        data_key="exterior_color", icon="mdi:palette",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="engine_power_kw", translation_key="engine_power_kw",
+        data_key="engine_power_kw", native_unit_of_measurement="kW",
+        icon="mdi:engine", entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
+    ),
+    VagSensorDescription(
+        key="engine_torque_nm", translation_key="engine_torque_nm",
+        data_key="engine_torque_nm", native_unit_of_measurement="Nm",
+        icon="mdi:engine", entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
+    ),
+    VagSensorDescription(
+        key="engine_cylinders", translation_key="engine_cylinders",
+        data_key="engine_cylinders", icon="mdi:engine",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.2.0 Phase 7 PR #4 — Skoda tier-B from scout-audit.
     # Climate-timer count (parity to VW EU/Audi PR #2 departure
     # timer count) + running-requests count (diagnostic for

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -654,6 +654,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Fuel Tank Capacity"
       },
+      "fuel_level_liters": {
+        "name": "Fuel Level (litres)"
+      },
       "climate_running_requests_count": {
         "name": "Climate Requests Pending"
       },

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -194,6 +194,7 @@
           "scan_interval": "Update Interval",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Battery nameplate capacity (kWh, for State of Health)",
+          "fuel_tank_capacity": "Fuel tank capacity (litres, for fuel level %)",
           "enable_reverse_geocoding": "Reverse Geocoding (parking address)",
           "read_only_mode": "Read-only Mode",
           "companion_read_charge_detail": "Companion: read charge target (navigates the app)",
@@ -1313,6 +1314,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Tyre repair kit reminder"
+      },
+      "exterior_color": {
+        "name": "Exterior Colour"
+      },
+      "engine_power_kw": {
+        "name": "Engine Power"
+      },
+      "engine_torque_nm": {
+        "name": "Engine Torque"
+      },
+      "engine_cylinders": {
+        "name": "Cylinders"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -531,6 +531,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Objem nádrže"
       },
+      "fuel_level_liters": {
+        "name": "Množství paliva (l)"
+      },
       "climate_running_requests_count": {
         "name": "Čekající klima-požadavky"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -194,6 +194,7 @@
           "scan_interval": "Interval aktualizace",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Jmenovitá kapacita baterie (kWh, pro State of Health)",
+          "fuel_tank_capacity": "Objem nádrže (litry, pro % paliva)",
           "enable_reverse_geocoding": "Reverzní geokódování (adresa parkování)",
           "read_only_mode": "Režim jen pro čtení",
           "companion_read_charge_detail": "Companion: číst cíl nabíjení (naviguje v aplikaci)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Připomínka opravné sady"
+      },
+      "exterior_color": {
+        "name": "Barva karoserie"
+      },
+      "engine_power_kw": {
+        "name": "Výkon motoru"
+      },
+      "engine_torque_nm": {
+        "name": "Točivý moment"
+      },
+      "engine_cylinders": {
+        "name": "Válce"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -537,6 +537,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Tankkapacitet"
       },
+      "fuel_level_liters": {
+        "name": "Brændstofmængde (liter)"
+      },
       "climate_running_requests_count": {
         "name": "Klimaanmodninger afventende"
       },

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -194,6 +194,7 @@
           "scan_interval": "Opdateringsinterval",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Nominel batterikapacitet (kWh, til State of Health)",
+          "fuel_tank_capacity": "Tankkapacitet (liter, for brændstof %)",
           "enable_reverse_geocoding": "Omvendt geokodning (parkeringsadresse)",
           "read_only_mode": "Skrivebeskyttet tilstand",
           "companion_read_charge_detail": "Companion: læs lademål (navigerer i appen)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Påmindelse om dækreparationssæt"
+      },
+      "exterior_color": {
+        "name": "Udvendig farve"
+      },
+      "engine_power_kw": {
+        "name": "Motoreffekt"
+      },
+      "engine_torque_nm": {
+        "name": "Drejningsmoment"
+      },
+      "engine_cylinders": {
+        "name": "Cylindre"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -194,6 +194,7 @@
           "scan_interval": "Aktualisierungsintervall (Minuten)",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Netto-Nennkapazität der Batterie (kWh, für Batteriezustand)",
+          "fuel_tank_capacity": "Tankgröße (Liter, für Tankfüllung %)",
           "enable_reverse_geocoding": "Adress-Auflösung (Parkposition)",
           "force_ppe_climate": "Audi PPE/PPC Klima-Body (Q6/A6 e-tron, RS e-tron GT Facelift, A3 2024+ PHEV)",
           "enable_push_mqtt": "Skoda Push-Updates (MQTT, EXPERIMENTELL)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Reifen-Reparaturset (Erinnerung)"
+      },
+      "exterior_color": {
+        "name": "Außenfarbe"
+      },
+      "engine_power_kw": {
+        "name": "Motorleistung"
+      },
+      "engine_torque_nm": {
+        "name": "Drehmoment"
+      },
+      "engine_cylinders": {
+        "name": "Zylinder"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -537,6 +537,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Tankvolumen"
       },
+      "fuel_level_liters": {
+        "name": "Tankfüllung (Liter)"
+      },
       "climate_running_requests_count": {
         "name": "Klima-Anfragen offen"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -537,6 +537,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Fuel Tank Capacity"
       },
+      "fuel_level_liters": {
+        "name": "Fuel Level (litres)"
+      },
       "climate_running_requests_count": {
         "name": "Climate Requests Pending"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -194,6 +194,7 @@
           "scan_interval": "Update Interval",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Battery nameplate capacity (kWh, for State of Health)",
+          "fuel_tank_capacity": "Fuel tank capacity (litres, for fuel level %)",
           "enable_reverse_geocoding": "Reverse Geocoding (parking address)",
           "read_only_mode": "Read-only Mode",
           "companion_read_charge_detail": "Companion: read charge target (navigates the app)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Tyre repair kit reminder"
+      },
+      "exterior_color": {
+        "name": "Exterior Colour"
+      },
+      "engine_power_kw": {
+        "name": "Engine Power"
+      },
+      "engine_torque_nm": {
+        "name": "Engine Torque"
+      },
+      "engine_cylinders": {
+        "name": "Cylinders"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -194,6 +194,7 @@
           "scan_interval": "Intervalo de actualización",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Capacidad nominal de la batería (kWh, para el estado de salud)",
+          "fuel_tank_capacity": "Capacidad del depósito (litros, para % de combustible)",
           "enable_reverse_geocoding": "Geocodificación inversa (dirección de aparcamiento)",
           "read_only_mode": "Modo solo lectura",
           "companion_read_charge_detail": "Companion: leer el objetivo de carga (navega por la app)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Recordatorio de kit de reparación"
+      },
+      "exterior_color": {
+        "name": "Color exterior"
+      },
+      "engine_power_kw": {
+        "name": "Potencia del motor"
+      },
+      "engine_torque_nm": {
+        "name": "Par motor"
+      },
+      "engine_cylinders": {
+        "name": "Cilindros"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -531,6 +531,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Capacidad depósito"
       },
+      "fuel_level_liters": {
+        "name": "Nivel de combustible (litros)"
+      },
       "climate_running_requests_count": {
         "name": "Solicitudes climatización pendientes"
       },

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -194,6 +194,7 @@
           "scan_interval": "Päivitysväli",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Akun nimelliskapasiteetti (kWh, SoH-laskentaan)",
+          "fuel_tank_capacity": "Polttoainesäiliön tilavuus (litraa, polttoaine-%)",
           "enable_reverse_geocoding": "Käänteinen geokoodaus (pysäköintiosoite)",
           "read_only_mode": "Vain luku -tila",
           "companion_read_charge_detail": "Companion: lue lataustavoite (navigoi sovelluksessa)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Renkaankorjaussarjan muistutus"
+      },
+      "exterior_color": {
+        "name": "Ulkoväri"
+      },
+      "engine_power_kw": {
+        "name": "Moottorin teho"
+      },
+      "engine_torque_nm": {
+        "name": "Vääntömomentti"
+      },
+      "engine_cylinders": {
+        "name": "Sylinterit"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -537,6 +537,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Polttoainesäiliön tilavuus"
       },
+      "fuel_level_liters": {
+        "name": "Polttoaineen määrä (litraa)"
+      },
       "climate_running_requests_count": {
         "name": "Ilmastointipyyntöjä odottamassa"
       },

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -194,6 +194,7 @@
           "scan_interval": "Intervalle de mise à jour",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Capacité nominale de la batterie (kWh, pour l'état de santé)",
+          "fuel_tank_capacity": "Capacité du réservoir (litres, pour % carburant)",
           "enable_reverse_geocoding": "Géocodage inverse (adresse de stationnement)",
           "read_only_mode": "Mode lecture seule",
           "companion_read_charge_detail": "Companion : lire l'objectif de charge (navigue dans l'application)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Rappel kit réparation pneus"
+      },
+      "exterior_color": {
+        "name": "Couleur extérieure"
+      },
+      "engine_power_kw": {
+        "name": "Puissance moteur"
+      },
+      "engine_torque_nm": {
+        "name": "Couple moteur"
+      },
+      "engine_cylinders": {
+        "name": "Cylindres"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -531,6 +531,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Capacité réservoir"
       },
+      "fuel_level_liters": {
+        "name": "Niveau de carburant (litres)"
+      },
       "climate_running_requests_count": {
         "name": "Requêtes climat en attente"
       },

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -537,6 +537,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Capacità serbatoio carburante"
       },
+      "fuel_level_liters": {
+        "name": "Livello carburante (litri)"
+      },
       "climate_running_requests_count": {
         "name": "Richieste clima in sospeso"
       },

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -194,6 +194,7 @@
           "scan_interval": "Intervallo di aggiornamento",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Capacità nominale della batteria (kWh, per lo stato di salute)",
+          "fuel_tank_capacity": "Capacità serbatoio (litri, per % carburante)",
           "enable_reverse_geocoding": "Geocodifica inversa (indirizzo di parcheggio)",
           "read_only_mode": "Modalità sola lettura",
           "companion_read_charge_detail": "Companion: leggi l'obiettivo di ricarica (naviga nell'app)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Promemoria kit riparazione gomme"
+      },
+      "exterior_color": {
+        "name": "Colore esterno"
+      },
+      "engine_power_kw": {
+        "name": "Potenza motore"
+      },
+      "engine_torque_nm": {
+        "name": "Coppia motore"
+      },
+      "engine_cylinders": {
+        "name": "Cilindri"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -194,6 +194,7 @@
           "scan_interval": "Oppdateringsintervall",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Nominell batterikapasitet (kWh, for helsetilstand)",
+          "fuel_tank_capacity": "Tankkapasitet (liter, for drivstoff %)",
           "enable_reverse_geocoding": "Omvendt geokoding (parkeringsadresse)",
           "read_only_mode": "Skrivebeskyttet modus",
           "companion_read_charge_detail": "Companion: les lademål (navigerer i appen)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Påminnelse om dekkreparasjonssett"
+      },
+      "exterior_color": {
+        "name": "Utvendig farge"
+      },
+      "engine_power_kw": {
+        "name": "Motoreffekt"
+      },
+      "engine_torque_nm": {
+        "name": "Dreiemoment"
+      },
+      "engine_cylinders": {
+        "name": "Sylindre"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -537,6 +537,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Drivstofftankkapasitet"
       },
+      "fuel_level_liters": {
+        "name": "Drivstoffnivå (liter)"
+      },
       "climate_running_requests_count": {
         "name": "Klimaforespørsler ventende"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -531,6 +531,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Tankinhoud"
       },
+      "fuel_level_liters": {
+        "name": "Brandstofniveau (liter)"
+      },
       "climate_running_requests_count": {
         "name": "Klimaatverzoeken in behandeling"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -194,6 +194,7 @@
           "scan_interval": "Update-interval",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Nominale accucapaciteit (kWh, voor State of Health)",
+          "fuel_tank_capacity": "Tankinhoud (liter, voor brandstof %)",
           "enable_reverse_geocoding": "Reverse geocoding (parkeeradres)",
           "read_only_mode": "Alleen-lezen modus",
           "companion_read_charge_detail": "Companion: laaddoel lezen (navigeert in de app)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Bandenreparatieset-herinnering"
+      },
+      "exterior_color": {
+        "name": "Exterieurkleur"
+      },
+      "engine_power_kw": {
+        "name": "Motorvermogen"
+      },
+      "engine_torque_nm": {
+        "name": "Koppel"
+      },
+      "engine_cylinders": {
+        "name": "Cilinders"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -531,6 +531,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Pojemność baku"
       },
+      "fuel_level_liters": {
+        "name": "Poziom paliwa (litry)"
+      },
       "climate_running_requests_count": {
         "name": "Oczekujące żądania klimatyzacji"
       },

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -194,6 +194,7 @@
           "scan_interval": "Interwał aktualizacji",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Pojemność znamionowa akumulatora (kWh, do stanu zdrowia)",
+          "fuel_tank_capacity": "Pojemność zbiornika (litry, dla % paliwa)",
           "enable_reverse_geocoding": "Geokodowanie odwrotne (adres parkowania)",
           "read_only_mode": "Tryb tylko do odczytu",
           "companion_read_charge_detail": "Companion: odczyt celu ładowania (nawiguje w aplikacji)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Przypomnienie o zestawie naprawczym"
+      },
+      "exterior_color": {
+        "name": "Kolor nadwozia"
+      },
+      "engine_power_kw": {
+        "name": "Moc silnika"
+      },
+      "engine_torque_nm": {
+        "name": "Moment obrotowy"
+      },
+      "engine_cylinders": {
+        "name": "Cylindry"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -194,6 +194,7 @@
           "scan_interval": "Uppdateringsintervall",
           "spin": "S-PIN",
           "battery_nominal_kwh": "Batteriets märkkapacitet (kWh, för hälsotillstånd)",
+          "fuel_tank_capacity": "Tankvolym (liter, för bränsle-%)",
           "enable_reverse_geocoding": "Omvänd geokodning (parkeringsadress)",
           "read_only_mode": "Skrivskyddat läge",
           "companion_read_charge_detail": "Companion: läs laddningsmål (navigerar i appen)",
@@ -1280,6 +1281,18 @@
       },
       "reminder_tyre_repair_kit": {
         "name": "Påminnelse om däckreparationssats"
+      },
+      "exterior_color": {
+        "name": "Utvändig färg"
+      },
+      "engine_power_kw": {
+        "name": "Motoreffekt"
+      },
+      "engine_torque_nm": {
+        "name": "Vridmoment"
+      },
+      "engine_cylinders": {
+        "name": "Cylindrar"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -531,6 +531,9 @@
       "fuel_tank_capacity_liters": {
         "name": "Tankvolym"
       },
+      "fuel_level_liters": {
+        "name": "Bränslenivå (liter)"
+      },
       "climate_running_requests_count": {
         "name": "Väntande klimatförfrågningar"
       },

--- a/tests/test_acpp_fuel_percent.py
+++ b/tests/test_acpp_fuel_percent.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""acpp plug&play — optional fuel-level % from a user-configured tank capacity.
+
+The dongle reports litres, not a %, and the tank size isn't in the feed. When
+the user sets ``fuel_tank_capacity`` in Options, ``_enrich`` derives a % from the
+litres reading (better gauge/UX) — but only fills ``fuel_level`` when the source
+gave none, never overwriting a real percentage.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+
+def _coord(tank_cap):
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    coord.hass = MagicMock()
+    coord.hass.async_add_executor_job = AsyncMock(return_value=None)
+    coord.entry = MagicMock()
+    coord.entry.data = {"brand": "audi_acpp", "username": "t@t.com", "password": "x",
+                        "spin": "", "update_interval": 300,
+                        "fuel_tank_capacity": tank_cap}
+    coord._vehicles_lock = threading.Lock()
+    coord._cariad_client = MagicMock()
+    coord._cariad_client._image_data = {}
+    coord.vehicle_static_info = {}
+    coord._was_available = True
+    coord.data = None
+    return coord
+
+
+def _enrich(coord, data):
+    return asyncio.run(coord._enrich(data))
+
+
+def test_fuel_percent_derived_from_configured_tank():
+    out = _enrich(_coord(65), {"vin": "V", "fuel_level_liters": 32.5})
+    assert out["fuel_tank_capacity_liters"] == 65
+    assert out["fuel_level"] == 50            # 32.5 / 65 * 100
+
+
+def test_no_tank_config_leaves_percent_unset():
+    out = _enrich(_coord(0), {"vin": "V", "fuel_level_liters": 32.5})
+    assert out.get("fuel_level") is None
+    assert out.get("fuel_tank_capacity_liters") is None
+
+
+def test_real_percent_is_not_overwritten():
+    out = _enrich(_coord(65), {"vin": "V", "fuel_level_liters": 32.5, "fuel_level": 48})
+    assert out["fuel_level"] == 48            # a real reading wins
+
+
+def test_percent_clamped_0_100():
+    out = _enrich(_coord(50), {"vin": "V", "fuel_level_liters": 60.0})  # over-full edge
+    assert out["fuel_level"] == 100

--- a/tests/test_audi_model_from_vgql.py
+++ b/tests/test_audi_model_from_vgql.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Audi/VW-EU model name falls back to the vgql media designation.
+
+The REST vehicles-list often carries no ``model`` (an Audi S6 returns an empty
+one), so the device fell back to "Audi (2021)". The vgql GraphQL block we
+already fetch for render images also carries ``media.longName`` ("S6 Avant TDI")
+and the exterior colour — surface them, and use the media name as the model
+fallback when the REST list gave nothing (parity with what the SEAT/CUPRA path
+and a competing Audi integration already do).
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.api.graphql import VehicleImageData
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+
+
+def _client(meta: dict, image_data: dict) -> VWEUClient:
+    c = VWEUClient.__new__(VWEUClient)
+    c._vehicle_metadata = meta
+    c._image_data = image_data
+    return c
+
+
+def test_model_falls_back_to_vgql_long_name():
+    c = _client(
+        {"VINX": {"model": None, "model_year": 2021}},  # REST list has no model
+        {"VINX": VehicleImageData(
+            vin="VINX", image_urls={}, long_name="S6 Avant TDI",
+            short_name="S6", exterior_color="Daytona Grey")},
+    )
+    d = c._parse_status("VINX", {}, parking={})
+    assert d.model == "S6 Avant TDI"
+    assert d.media_long_name == "S6 Avant TDI"
+    assert d.media_short_name == "S6"
+    assert d.exterior_color == "Daytona Grey"
+
+
+def test_rest_model_still_wins_when_present():
+    c = _client(
+        {"VINX": {"model": "Golf GTE"}},   # user nickname / REST model present
+        {"VINX": VehicleImageData(vin="VINX", image_urls={}, long_name="VW Golf")},
+    )
+    d = c._parse_status("VINX", {}, parking={})
+    assert d.model == "Golf GTE"           # REST wins, media only fills gaps
+    assert d.media_long_name == "VW Golf"  # media still surfaced as its own field
+
+
+def test_no_image_data_is_graceful():
+    c = _client({"VINX": {"model": None}}, {})
+    d = c._parse_status("VINX", {}, parking={})
+    assert d.model is None                 # nothing to fall back to → device uses brand+year

--- a/tests/test_plugandplay_cloud.py
+++ b/tests/test_plugandplay_cloud.py
@@ -161,13 +161,21 @@ async def test_get_status_enriches_from_carport():
             "brandCode": "A", "modelDesc": "A5", "engType": "TDI CR",
             "fuelType": "Diesel", "power": [{"unit": "kW", "value": 176},
                                             {"unit": "hp", "value": 239}],
-            "deliveryDate": "1219795200000"}),  # 2008-08-27
+            "deliveryDate": "1219795200000",  # 2008-08-27
+            "exteriorColor": "Phantom Black Pearlescent", "torque": 500,
+            "cylinderCount": 6, "warranty": "1282867200000"}),  # 2010-08-27
     })
     data = await c.get_status(VIN_2009)
     assert data.model == "A5 TDI CR · 239 PS"
     assert data.manufacturer == "Audi"
     assert data.fuel_level_liters == 3.0
     assert data.registration_date == "2008-08-27"
+    # bonus master-data
+    assert data.exterior_color == "Phantom Black Pearlescent"
+    assert data.engine_power_kw == 176
+    assert data.engine_torque_nm == 500
+    assert data.engine_cylinders == 6
+    assert data.warranty_until == "2010-08-27"
 
 
 async def test_get_status_carport_missing_is_graceful():

--- a/tests/test_plugandplay_cloud.py
+++ b/tests/test_plugandplay_cloud.py
@@ -148,6 +148,50 @@ async def test_get_status_zero_voltage_and_null_island_ignored():
 
 # ── integration wiring: factory + brand registration ─────────────────────────
 
+async def test_get_status_enriches_from_carport():
+    # carport master-data → clean "ab Haus" model (with PS), manufacturer, and
+    # the real first-delivery date; /vehicles → fuel litres.
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2009}": (200, {
+            "vehicle": {"vin": VIN_2009, "carPlatform": "KWP2000"},
+            "odometer": 369290.0, "batteryVoltage": 11.76, "tankFuelAmount": 3.0}),
+        f"vehicle/{VIN_2009}/warning-lights": (200, {"warningLights": []}),
+        f"vehicle/{VIN_2009}/carport": (200, {
+            "brandCode": "A", "modelDesc": "A5", "engType": "TDI CR",
+            "fuelType": "Diesel", "power": [{"unit": "kW", "value": 176},
+                                            {"unit": "hp", "value": 239}],
+            "deliveryDate": "1219795200000"}),  # 2008-08-27
+    })
+    data = await c.get_status(VIN_2009)
+    assert data.model == "A5 TDI CR · 239 PS"
+    assert data.manufacturer == "Audi"
+    assert data.fuel_level_liters == 3.0
+    assert data.registration_date == "2008-08-27"
+
+
+async def test_get_status_carport_missing_is_graceful():
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2020}": (200, {"vehicle": {"vin": VIN_2020}, "odometer": 12000}),
+        f"vehicle/{VIN_2020}/warning-lights": (200, {"warningLights": []}),
+        # no carport stub → 404 → no model/manufacturer, but no crash
+    })
+    data = await c.get_status(VIN_2020)
+    assert data.model is None
+    assert data.manufacturer is None
+    assert data.odometer_km == 12000  # the rest still maps
+
+
+def test_epoch_ms_to_date():
+    from custom_components.vag_connect.cariad.api.plugandplay import _epoch_ms_to_date
+    assert _epoch_ms_to_date("1219795200000") == "2008-08-27"
+    assert _epoch_ms_to_date("0") is None
+    assert _epoch_ms_to_date("") is None
+    assert _epoch_ms_to_date(None) is None
+    assert _epoch_ms_to_date("not-a-number") is None
+
+
 def test_factory_creates_acpp_client():
     from custom_components.vag_connect.cariad.api.factory import CariadClientFactory
     client = CariadClientFactory.create("audi_acpp", MagicMock(), "u@e.com", "pw")


### PR DESCRIPTION
Merges toward the next beta (no tag yet).

**Audi plug&play (acpp):** proper factory model designation with PS ("A5 TDI CR · 239 PS"), clean manufacturer ("Audi"), fuel-level litres sensor, exterior colour / engine power / torque / cylinders as diagnostic sensors, delivery + warranty dates as service-calendar events. All grounded live against a real A5 B8; acpp has no vehicle image (endpoints 404).

**Optional fuel %:** a fuel-tank-capacity (litres) Options field lets the litres-only reader derive a fuel-level % for a gauge/bar UX (off by default, never overwrites a real %).

**Audi/VW-EU model name fix:** cars whose REST vehicles-list has no model (e.g. an Audi S6 → "Audi (2021)") now use the vgql media.longName ("S6 Avant TDI") + exterior colour we already fetch for render images — parity with the SEAT/CUPRA path and the reference Audi integration.

Full suite green (5300 passed).