### PR TITLE
coordinator: transient BFF gateway 404 self-heals (no error report)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **A transient VW gateway "404" no longer raises an error report (#1233, #1242, #1244).** The CARIAD edge (`emea.bff.cariad.digital`) intermittently returns a generic "404 page not found" for the main status read and recovers on the next poll — three Audi owners hit the exact same blip within a 16-second window. That kind of transient gateway 404 now self-heals quietly the way a 5xx already does, instead of surfacing as a user-facing error report. A structured, per-vehicle 404 still reports as before.
+
 ## [4.3.0b4] - 2026-08-25 — V6.0 data dictionary & window positions
 
 ### Added

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -115,6 +115,15 @@ def _is_selfhealing_poll_error(err: object) -> bool:
             "transient:"
         ):
             return True
+        # A transient GATEWAY 404 on the main BFF read (#1233/#1242/#1244): the
+        # emea.bff.cariad.digital edge intermittently returns the generic router
+        # "404 page not found" for a selectivestatus call — a routing/deploy blip
+        # that clears on the next poll (three Audi owners hit it inside the same
+        # 16-second window on 2026-08-25), not a per-vehicle not-found. Same class
+        # as a 5xx, so don't escalate it to the public Error Reporter. A STRUCTURED
+        # 404 (a real "vehicle not found") has a different body and still reports.
+        if status == 404 and isinstance(body, str) and "404 page not found" in body:
+            return True
     return False
 
 # v2.17.2 (#666) — how long an optimistically-set command value is held across

--- a/tests/test_v2190_814_transient_dns_not_reported.py
+++ b/tests/test_v2190_814_transient_dns_not_reported.py
@@ -49,3 +49,19 @@ def test_status0_without_transient_tag_not_blanket_suppressed() -> None:
 def test_parse_and_other_exceptions_still_reported() -> None:
     assert _is_selfhealing_poll_error(ValueError("bad parse")) is False
     assert _is_selfhealing_poll_error(KeyError("missing")) is False
+
+
+def test_transient_gateway_404_not_reported() -> None:
+    # #1233/#1242/#1244 — the emea.bff.cariad.digital edge intermittently returns
+    # the generic router "404 page not found" for selectivestatus; it clears next
+    # poll, so it must NOT spam the public Error Reporter.
+    body = ('{"error":{"message":"Upstream service responded with 404 Not Found",'
+            '"info":"404 page not found\\n"}}')
+    assert _is_selfhealing_poll_error(APIError(404, "u", body)) is True
+
+
+def test_structured_404_still_reported() -> None:
+    # a real per-vehicle not-found (different body) is our concern → still escalated
+    assert _is_selfhealing_poll_error(
+        APIError(404, "u", '{"error":"vehicle not found"}')
+    ) is False


### PR DESCRIPTION
A transient CARIAD gateway "404 page not found" on the main status read (three Audi owners hit the same 16-second blip, #1233/#1242/#1244) now self-heals quietly like a 5xx instead of surfacing as an error report. A structured per-vehicle 404 still reports. Untagged — accumulates in [Unreleased]. Suite 5309.