### PR TITLE
diagnostics: redact the volkswagen.de profile block (D#1231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **The volkswagen.de profile block is now redacted in a diagnostics download (D#1231).** The number plate, the owner-chosen vehicle nickname and the render image URLs were written in the clear — a tester rightly had to hand-mask them before attaching the file. They now redact by default like the VIN and address already do; empty ones stay visibly empty. Thanks @Ra72xx.
+
 ## [4.3.0] - 2026-08-25 — Audi plug&play OBD dongle, V6.0 dictionary & live-telemetry
 
 ### Added

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -74,6 +74,14 @@ _REDACT_KEYS = frozenset({
     "parking_address",
     "user_id",
     "account_id",
+    # D#1231 — the volkswagen.de profile block is personal: the number plate
+    # identifies the car, the owner-chosen nickname is personal, and the render
+    # image URLs encode the exact model/colour/config. A tester rightly had to
+    # hand-mask these before attaching a diagnostics file, so redact them by
+    # default. (Empty ones stay visibly empty via the _is_empty_value guard.)
+    "license_plate",
+    "vehicle_nickname",
+    "image_urls",
     # v1.13.0 (#62) — explicit token field names. Defensive registration:
     # today these only live in coordinator's in-memory cache, but if a
     # future change adds them to entry.data they'll automatically

--- a/tests/test_1231_vwde_metadata_redaction.py
+++ b/tests/test_1231_vwde_metadata_redaction.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""D#1231 — the volkswagen.de profile block (number plate, owner nickname, render
+image URLs) is personal and must be redacted in a diagnostics download, like the
+VIN and address already are. A tester had to hand-mask these before attaching the
+file. Empty ones stay visibly empty so "no data" never looks like "hidden".
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.diagnostics import _scrub
+
+
+def test_vwde_profile_metadata_is_redacted():
+    scrubbed = _scrub(
+        {
+            "license_plate": "M-AB 1234",
+            "vehicle_nickname": "Graue Ratte",
+            "image_urls": {"back_left": "https://media.volkswagen.com/Vilma/x.png"},
+            "battery_soc": 53,  # genuine telemetry — must NOT be touched
+        },
+        gps_round=False,
+    )
+    assert scrubbed["license_plate"] == "**REDACTED**"
+    assert scrubbed["vehicle_nickname"] == "**REDACTED**"
+    assert scrubbed["image_urls"] == "**REDACTED**"
+    assert scrubbed["battery_soc"] == 53
+
+
+def test_empty_vwde_metadata_stays_visibly_empty():
+    scrubbed = _scrub(
+        {"license_plate": "", "vehicle_nickname": None, "image_urls": {}},
+        gps_round=False,
+    )
+    assert scrubbed["license_plate"] == ""
+    assert scrubbed["vehicle_nickname"] is None
+    assert scrubbed["image_urls"] == {}


### PR DESCRIPTION
A tester (D#1231) had to hand-mask the number plate, owner nickname and render image URLs before attaching a diagnostics file. Add license_plate, vehicle_nickname and image_urls to _REDACT_KEYS so they redact by default like the VIN; empty ones stay visibly empty. Untagged — accumulates in [Unreleased]. Suite 5311.