### PR TITLE
eu_data_act: a blocked login is not invalid_credentials (#1234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **A blocked or incomplete VW EU portal login is no longer reported as "invalid credentials" (#1234).** When the sign-in server bounced the automated login back to a login-flow step (`loginIdentifier` / `loginAuthenticate`, status 200) or served one of its own block/error pages (`browserFeaturesMissingError`, `generalErrorBranded`), the classifier's catch-all labelled it a bad password — sending users to re-enter credentials that were already correct. These now surface as a portal/login-interaction with the real reason, while a genuine wrong password (which carries a password errorCode) still maps to invalid credentials. A debug line was added at the classification point so the cause is visible with debug logging on. Thanks @eddieari for the detailed diagnostics.
+
 ### Changed
 - **New app icon.** The project now uses the VW Group Connect ID.Buzz artwork — cut to a clean full-bleed rounded square with a crisp app-icon edge on all four sides — deep navy right to the edge, with the source's grey drop-shadow, glow and fringe fully removed — as its icon/logo across the integration and the README.
 

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -361,6 +361,19 @@ _RATELIMIT_MARKERS = ("too-many", "rate-limit", "ratelimit", "throttl")
 _GENERIC_CONSENT_MARKERS = ("/signin-service/v1/consent/", "/consent/users/")
 _GENERIC_CONSENT_PAGETYPES = ("consent",)
 
+# #1234 (@eddieari, ID.7 GTX) — pageTypes that must NOT be bucketed as
+# "invalid_credentials". A genuine wrong password re-renders a login step WITH a
+# password errorCode (caught by the cred_codes branch below); these are different
+# failure modes and telling the user to "check your password" sends them down the
+# wrong path. Confirmed live: the same, re-verified credentials cycled through
+# loginIdentifier / loginAuthenticate (status 200) and browserFeaturesMissingError
+# / generalErrorBranded (400) across polls — the IDP was blocking the automated
+# login, not rejecting the password.
+#   • login-flow STEP pages re-served at status 200 = the flow never completed
+_LOGIN_FLOW_STEP_PAGETYPES = ("loginidentifier", "loginauthenticate")
+#   • the IDP's own block/error pages (browser-feature / bot detection, generic)
+_NONCRED_ERROR_PAGETYPES = ("browserfeaturesmissingerror", "generalerrorbranded")
+
 
 def _is_generic_consent_page(
     landing_url: str, page_type: str, blob: str
@@ -417,6 +430,14 @@ def classify_portal_login_failure(
 
     blob = f"{haystack} {str(err_code).lower()} {str(page_type).lower()}"
 
+    # #1234 — a DEBUG line at the classification point itself. The failure path
+    # used to emit only the caller's single WARNING with no preceding DEBUG, so a
+    # reporter who enabled debug logging saw nothing about WHY it was classified.
+    _LOGGER.debug(
+        "EU-DA portal login classify: pageType=%r errorCode=%r url=%s",
+        str(page_type)[:80], str(err_code)[:80], landing_url[:100],
+    )
+
     # 1. Interstitials we recognise — reuse the main-chain exceptions.
     if any(m in blob for m in _TC_MARKERS):
         log_ctx.setdefault("classified", "terms_and_conditions")
@@ -469,6 +490,35 @@ def classify_portal_login_failure(
             PortalInteractionRequiredError(f"portal error {err_code}"),
             log_ctx,
         )
+
+    # 2b. #1234 — a login-flow STEP page or an IDP block/error page, WITHOUT a
+    #     password errorCode (those are caught above). These are not a wrong
+    #     password: the flow simply never completed, or the IDP blocked the
+    #     automated login. Surface the real reason instead of "check your
+    #     password" so the reporter isn't sent to re-enter correct credentials.
+    #     GUARD: only when there is NO credential errorCode — a genuine wrong
+    #     password re-renders the authenticate step WITH ``password_invalid``
+    #     (err_code_l is in cred_codes), and that must still be invalid_credentials.
+    _page_l = str(page_type).lower()
+    if err_code_l not in cred_codes:
+        if _page_l in _LOGIN_FLOW_STEP_PAGETYPES:
+            log_ctx.setdefault("classified", "portal_interaction_required")
+            return (
+                PortalInteractionRequiredError(
+                    f"login flow did not complete — the IDP re-served the "
+                    f"{page_type} step (not a wrong password)"
+                ),
+                log_ctx,
+            )
+        if _page_l in _NONCRED_ERROR_PAGETYPES:
+            log_ctx.setdefault("classified", "portal_interaction_required")
+            return (
+                PortalInteractionRequiredError(
+                    f"VW login was blocked before the password could be checked "
+                    f"({page_type})"
+                ),
+                log_ctx,
+            )
 
     # 3. Genuine bad-credential re-render (or no machine-readable reason at
     #    all): let the caller raise the credential catch-all.

--- a/tests/test_1234_login_flow_classify.py
+++ b/tests/test_1234_login_flow_classify.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1234 (@eddieari, ID.7 GTX) — login-flow step pages and IDP block pages must
+not be reported as "invalid_credentials".
+
+With freshly re-verified credentials the portal login cycled through
+loginIdentifier / loginAuthenticate (status 200) and browserFeaturesMissingError
+/ generalErrorBranded (400), all bucketed as invalid_credentials — sending the
+reporter to re-enter a password that was already correct. A genuine wrong password
+re-renders the authenticate step WITH a password errorCode, which must still map to
+invalid_credentials.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    classify_portal_login_failure,
+)
+from custom_components.vag_connect.cariad.exceptions import (
+    PortalInteractionRequiredError,
+)
+
+_URL = "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/authenticate"
+
+
+def _html(template: str, errorcode: str | None = None) -> str:
+    err = f',"error":{{"errorCode":"{errorcode}"}}' if errorcode else ""
+    return f'<script>window._IDK = {{templateModel: {{"template":"{template}"{err}}}}};</script>'
+
+
+def test_login_flow_step_pages_are_not_invalid_credentials():
+    for tpl in ("loginIdentifier", "loginAuthenticate"):
+        exc, ctx = classify_portal_login_failure(_URL, _html(tpl))
+        assert isinstance(exc, PortalInteractionRequiredError), tpl
+        assert ctx["classified"] == "portal_interaction_required", tpl
+
+
+def test_idp_block_pages_are_not_invalid_credentials():
+    for tpl in ("browserFeaturesMissingError", "generalErrorBranded"):
+        exc, ctx = classify_portal_login_failure(_URL, _html(tpl))
+        assert isinstance(exc, PortalInteractionRequiredError), tpl
+        assert ctx["classified"] == "portal_interaction_required", tpl
+
+
+def test_wrong_password_on_authenticate_step_still_invalid_credentials():
+    # the crucial guard: a real bad password re-renders loginAuthenticate WITH a
+    # password errorCode → must NOT be swallowed as portal_interaction_required.
+    exc, ctx = classify_portal_login_failure(
+        _URL, _html("loginAuthenticate", "login.error.password_invalid")
+    )
+    assert exc is None
+    assert ctx["classified"] == "invalid_credentials"
+
+
+def test_pagetype_reason_is_surfaced_and_secret_free():
+    exc, ctx = classify_portal_login_failure(_URL, _html("browserFeaturesMissingError"))
+    assert "browserFeaturesMissingError" in str(exc)
+    assert {"email", "password", "relayState", "code"}.isdisjoint(ctx.keys())


### PR DESCRIPTION
@eddieari's diagnostics showed loginIdentifier/loginAuthenticate (200) and browserFeaturesMissingError/generalErrorBranded (400) all bucketed as invalid_credentials by the classifier's catch-all, on an account whose credentials were confirmed correct (VIN fully provisioned, 16 files). These now classify as portal_interaction_required with the real reason, guarded so a genuine password errorCode still maps to invalid_credentials, plus a DEBUG line at the classification point. Untagged, [Unreleased]. Suite 5315.