### PR TITLE
coordinator: portal-interaction block no longer reauth-clobbers all vehicles (#1234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ## [Unreleased]
 
 ### Fixed
+- **One vehicle's portal block no longer takes every vehicle on the account offline (#1234).** A non-credential portal interaction (e.g. the IDP's browser-feature block) surfacing at the account level was treated like stale credentials and tore the whole entry into reauth — taking a second, healthy vehicle on the same account down with it. It is now handled as a transient poll failure: the working vehicles stay available and the next poll retries, while only a genuine credential failure triggers reauth. Thanks @eddieari.
 - **A blocked or incomplete VW EU portal login is no longer reported as "invalid credentials" (#1234).** When the sign-in server bounced the automated login back to a login-flow step (`loginIdentifier` / `loginAuthenticate`, status 200) or served one of its own block/error pages (`browserFeaturesMissingError`, `generalErrorBranded`), the classifier's catch-all labelled it a bad password — sending users to re-enter credentials that were already correct. These now surface as a portal/login-interaction with the real reason, while a genuine wrong password (which carries a password errorCode) still maps to invalid credentials. A debug line was added at the classification point so the cause is visible with debug logging on. Thanks @eddieari for the detailed diagnostics.
 
 ### Changed

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -3054,7 +3054,34 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 # fallback means the credentials are stale. Trigger HA reauth.
                 from .cariad.exceptions import (  # noqa: PLC0415
                     AuthenticationError,
+                    PortalInteractionRequiredError,
                 )
+                # #1234 (@eddieari) — a non-credential portal interaction (a
+                # transient IDP block such as browserFeaturesMissingError, or an
+                # interstitial that needs a one-off browser action) is NOT stale
+                # credentials. It subclasses AuthenticationError, so without this
+                # guard it tore the whole entry into reauth and took every working
+                # vehicle on the same account offline with it. Treat it as a
+                # transient poll failure: keep the working vehicles up via the
+                # failure-tolerance window and retry on the next poll, instead of
+                # clobbering the shared account session for all VINs at once.
+                if isinstance(err, PortalInteractionRequiredError):
+                    _LOGGER.warning(
+                        "VW Group Connect: portal needs interaction (not stale "
+                        "credentials) — keeping working vehicles up, retrying: %s",
+                        err,
+                    )
+                    if not hasattr(self, "vehicle_success"):
+                        self.vehicle_success = {}
+                    if not hasattr(self, "vehicle_failure_count"):
+                        self.vehicle_failure_count = {}
+                    for vin in list(self.vehicles.keys()):
+                        self.vehicle_success[vin] = False
+                        self.vehicle_failure_count[vin] = (
+                            self.vehicle_failure_count.get(vin, 0) + 1
+                        )
+                    await self._async_push_update({}, success=False)
+                    return
                 if isinstance(err, AuthenticationError):
                     self._trigger_reauth(str(err) or type(err).__name__)
                     await self._async_push_update({}, success=False)

--- a/tests/test_1234_shared_session_clobber.py
+++ b/tests/test_1234_shared_session_clobber.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1234 (@eddieari) — a non-credential portal interaction on the shared account
+session must NOT tear the whole config entry into reauth and take every working
+vehicle offline. Only genuine stale credentials trigger reauth.
+
+The failure is injected at an ACCOUNT-level poll step (not a per-VIN get_status,
+which is already isolated) so it reaches the outer poll-loop handler where the
+reauth decision lives.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.exceptions import (
+    AuthenticationError,
+    PortalInteractionRequiredError,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+from tests.test_v2159_transient_and_interaction_deescalation import (
+    _build_coordinator,
+    _run_one_poll,
+)
+
+
+def _account_step_raises(exc):
+    # per-VIN read would succeed (VehicleData); the failure comes from a shared
+    # account-level step, so it reaches the outer handler, not the per-VIN gate.
+    coord, vin = _build_coordinator(VehicleData(vin="WVWZZZ1KZAW000596"))
+    coord.hass = MagicMock()
+    coord._refresh_mbb_command_capabilities = AsyncMock(side_effect=exc)
+    coord.entry.async_start_reauth = MagicMock()
+    return coord, vin
+
+
+@pytest.mark.asyncio
+async def test_portal_interaction_does_not_clobber_into_reauth():
+    coord, vin = _account_step_raises(
+        PortalInteractionRequiredError("browserFeaturesMissingError")
+    )
+    await _run_one_poll(coord)
+    # the whole entry is NOT dragged into reauth (working vehicles stay up)
+    coord.entry.async_start_reauth.assert_not_called()
+    # the poll is still counted as failed → failure-tolerance keeps the car
+    # available for a few cycles and the next poll retries
+    assert coord.vehicle_success[vin] is False
+    assert coord.vehicle_failure_count[vin] == 1
+    # a transient block is not our bug → not error-reported
+    assert len(coord.error_buffer) == 0
+
+
+@pytest.mark.asyncio
+async def test_genuine_stale_credentials_still_reauth():
+    coord, _ = _account_step_raises(AuthenticationError("invalid_credentials"))
+    await _run_one_poll(coord)
+    coord.entry.async_start_reauth.assert_called_once()


### PR DESCRIPTION
PortalInteractionRequiredError subclasses AuthenticationError, so a transient IDP block at the account-level poll handler triggered entry-wide reauth and took every working vehicle on the account offline (@eddieari's ID.3 went down when the ID.7 GTX hit the block). The handler now treats it as a transient poll failure — working vehicles stay available via the failure-tolerance window, next poll retries — while genuine stale credentials still reauth. 2 tests, suite 5317. Untagged, [Unreleased].