### PR TITLE
authproxy: durable-MBB two-way pre-flight from the relations read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ### Changed
 - **New app icon.** The project now uses the VW Group Connect ID.Buzz artwork — cut to a clean full-bleed rounded square with a crisp app-icon edge on all four sides — deep navy right to the edge, with the source's grey drop-shadow, glow and fringe fully removed — as its icon/logo across the integration and the README.
+- **Groundwork: a durable-MBB two-way pre-flight (internal, no user-visible change yet).** The volkswagen.de relations read now surfaces each car's Car-Net provisioning (`carnetIndicator`) alongside its platform, and a classifier decides up front — from that one cheap, guest-readable read — whether arming the durable MBB channel is even worth it for a car. This lets a later change stop running the MBB device-grant login on cars that could never command it (a guest on a shared/family car, or a WeConnect/ID car whose two-way is the BFF). Grounded on a live volkswagen.de session.
 
 ### Fixed
 - **The volkswagen.de profile block is now redacted in a diagnostics download (D#1231).** The number plate, the owner-chosen vehicle nickname and the render image URLs were written in the clear — a tester rightly had to hand-mask them before attaching the file. They now redact by default like the VIN and address already do; empty ones stay visibly empty. Thanks @Ra72xx.

--- a/custom_components/vag_connect/cariad/_authproxy.py
+++ b/custom_components/vag_connect/cariad/_authproxy.py
@@ -23,7 +23,7 @@ pure (no I/O) so it unit-tests against fixtures; the session/transport lives in
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 _AUTHPROXY_BASE = "https://www.volkswagen.de/app/authproxy"
 _REALM_VWDE = "vw-de"
@@ -329,6 +329,11 @@ class AuthproxyRelation:
     mod_backend: str | None = None  # "MBB" / "MEB" / …
     relation_id: str | None = None
     euda_scoped: bool = False
+    # Car-Net provisioning signals (live-verified 2026-08-26): a guest / not-yet-
+    # enrolled relation carries ``carnetIndicator: false`` even on an MBB car, so
+    # these gate the durable MBB two-way pre-flight (see :func:`mbb_eligibility`).
+    carnet_indicator: bool = False
+    carnet_allocation_type: str | None = None
 
 
 @dataclass
@@ -391,6 +396,8 @@ def parse_relations(raw: Any) -> AuthproxyRelations | None:
                 mod_backend=_s(veh.get("modBackend")),
                 relation_id=_s(rel.get("relationId")),
                 euda_scoped=isinstance(tags, list) and "EUDA_SCOPED" in tags,
+                carnet_indicator=rel.get("carnetIndicator") is True,
+                carnet_allocation_type=_s(rel.get("carnetAllocationType")),
             )
         )
     return out
@@ -426,7 +433,62 @@ def parse_relation_detail(raw: Any) -> AuthproxyRelation | None:
         mod_backend=_s(veh.get("modBackend")),
         relation_id=_s(rel.get("relationId")),
         euda_scoped=isinstance(tags, list) and "EUDA_SCOPED" in tags,
+        carnet_indicator=rel.get("carnetIndicator") is True,
+        carnet_allocation_type=_s(rel.get("carnetAllocationType")),
     )
+
+
+# ── durable MBB two-way pre-flight (from the guest-readable relations read) ────
+# The vw.de relations read returns a per-vehicle relation object — attestation-
+# free, one GET, readable even for a guest — that carries both the car's platform
+# (``modBackend``) and this account's Car-Net provisioning (``carnetIndicator`` /
+# role / enrollment). That is exactly the signal needed to decide, BEFORE any MBB
+# device-grant login + register→exchange round-trip, whether the durable MBB
+# Car-Net two-way channel is worth arming for a given car. Today that is only
+# learned post-hoc from the BFF operationList after the user has opted in and
+# logged in; this classifier turns the cheap relations read into a pre-flight.
+MbbEligibility = Literal["eligible", "not_provisioned", "not_mbb", "unknown"]
+
+
+def mbb_eligibility(relation: "AuthproxyRelation") -> MbbEligibility:
+    """Pre-flight the durable MBB Car-Net two-way for one related vehicle.
+
+    Verified live 2026-08-26 on a guest account: an MBB car whose relation shows
+    ``carnetIndicator=false`` + ``enrollmentStatus=NOT_STARTED`` + ``role=UNKNOWN``
+    cannot command — so blindly arming MBB there wastes a device-grant login. The
+    classifier reads that same relation up front:
+
+    * ``"eligible"`` — an MBB/Car-Net car this account can command: Car-Net is
+      provisioned (``carnetIndicator`` true), or it is a primary / genuinely
+      enrolled relation.
+    * ``"not_provisioned"`` — an MBB car, but this account has no Car-Net access
+      yet (a guest / not-enrolled relation). The MBB login would not command →
+      don't offer or attempt it.
+    * ``"not_mbb"`` — a WeConnect / MEB (ID.x) car. The legacy Car-Net path does
+      not apply (its two-way is the modern BFF, not MBB).
+    * ``"unknown"`` — the relation carries no platform signal to decide on.
+
+    Note: this only gates; the caller still pairs an ``"eligible"`` result with
+    the user-level ``mbbUserId`` (X-MbbUserId) from :class:`AuthproxyRelations`.
+    """
+    backend = (relation.mod_backend or "").strip().upper()
+    if not backend:
+        return "unknown"
+    # #632 parity — the sentinel is suffixed on real cars ("MBB_ODP"), so match
+    # the prefix, exactly as :func:`gdc_for_backend` does for the live-status gdc.
+    if not backend.startswith("MBB"):
+        return "not_mbb"
+    if relation.carnet_indicator:
+        return "eligible"
+    # No explicit Car-Net flag → fall back to the account's relationship. A guest
+    # sits at role=UNKNOWN / enrollment=NOT_STARTED; a real owner is the primary
+    # car or a PRIMARY_USER whose enrollment has actually started.
+    enrolled = (relation.enrollment_status or "").strip().upper()
+    has_enrollment = enrolled not in {"", "NOT_STARTED"}
+    role = (relation.role or "").strip().upper()
+    if has_enrollment and (relation.primary_car or role == "PRIMARY_USER"):
+        return "eligible"
+    return "not_provisioned"
 
 
 # ── live-status parsers (warning lights + lock history) ───────────────────────

--- a/tests/test_mbb_eligibility_preflight.py
+++ b/tests/test_mbb_eligibility_preflight.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Durable-MBB two-way pre-flight from the guest-readable relations read.
+
+Whether the durable MBB Car-Net two-way is worth arming for a car is, today,
+only learned post-hoc from the BFF operationList after the user opts in and logs
+in. The vw.de relations read carries the deciding signal up front — attestation-
+free, one GET, readable even for a guest. This pins the classifier + the parser
+fields it needs, grounded on the exact shapes captured live on 2026-08-26:
+
+  * a GUEST on a family MBB Golf → carnetIndicator=false, enrollment=NOT_STARTED,
+    role=UNKNOWN, primaryCar=false → the MBB login could not command → skip it.
+  * an enrolled owner / Car-Net car → eligible.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad._authproxy import (
+    AuthproxyRelation,
+    mbb_eligibility,
+    parse_relation_detail,
+    parse_relations,
+)
+
+# The exact live guest shape (values are the account's own; no third-party PII).
+_DETAIL_GUEST = {
+    "relation": {
+        "vehicleNickname": None,
+        "licensePlate": None,
+        "role": "UNKNOWN",
+        "roleStatus": None,
+        "enrollmentStatus": "NOT_STARTED",
+        "primaryCar": False,
+        "carnetIndicator": False,
+        "carnetAllocationType": None,
+        "vehicle": {"vin": "WVWZZZTESTVHN0001", "modBackend": "MBB"},
+    }
+}
+_DETAIL_OWNER = {
+    "relation": {
+        "role": "PRIMARY_USER",
+        "enrollmentStatus": "COMPLETED",
+        "primaryCar": True,
+        "carnetIndicator": True,
+        "carnetAllocationType": "CARNET",
+        "vehicle": {"vin": "WVWZZZTESTVHN0002", "modBackend": "MBB"},
+    }
+}
+
+
+def _rel(**kw) -> AuthproxyRelation:
+    kw.setdefault("vin", "V")
+    return AuthproxyRelation(**kw)
+
+
+class TestParserSurfacesCarnetFields:
+    def test_guest_detail_carnet_false(self) -> None:
+        rel = parse_relation_detail(_DETAIL_GUEST)
+        assert rel is not None
+        assert rel.mod_backend == "MBB"
+        assert rel.carnet_indicator is False
+        assert rel.carnet_allocation_type is None
+
+    def test_owner_detail_carnet_true(self) -> None:
+        rel = parse_relation_detail(_DETAIL_OWNER)
+        assert rel is not None
+        assert rel.carnet_indicator is True
+        assert rel.carnet_allocation_type == "CARNET"
+
+    def test_list_parser_also_surfaces_carnet(self) -> None:
+        body = {
+            "user": {"mbbUserId": "MMxxx"},
+            "relations": [
+                {
+                    "carnetIndicator": True,
+                    "carnetAllocationType": "CARNET",
+                    "vehicle": {"vin": "WVWZZZTESTVHN0003", "modBackend": "MBB"},
+                }
+            ],
+        }
+        rels = parse_relations(body)
+        assert rels is not None
+        assert rels.vehicles[0].carnet_indicator is True
+        assert rels.vehicles[0].carnet_allocation_type == "CARNET"
+        # a body without the field defaults to False, never crashes
+        rels2 = parse_relations({"relations": [{"vehicle": {"vin": "WVWZZZTESTVHN0004"}}]})
+        assert rels2 is not None
+        assert rels2.vehicles[0].carnet_indicator is False
+
+
+class TestMbbEligibility:
+    def test_live_guest_is_not_provisioned(self) -> None:
+        rel = parse_relation_detail(_DETAIL_GUEST)
+        assert rel is not None
+        assert mbb_eligibility(rel) == "not_provisioned"
+
+    def test_live_owner_is_eligible(self) -> None:
+        rel = parse_relation_detail(_DETAIL_OWNER)
+        assert rel is not None
+        assert mbb_eligibility(rel) == "eligible"
+
+    def test_carnet_indicator_alone_is_eligible(self) -> None:
+        assert mbb_eligibility(_rel(mod_backend="MBB", carnet_indicator=True)) == "eligible"
+
+    def test_primary_and_enrolled_without_flag_is_eligible(self) -> None:
+        assert mbb_eligibility(_rel(
+            mod_backend="MBB", primary_car=True, enrollment_status="COMPLETED",
+        )) == "eligible"
+        assert mbb_eligibility(_rel(
+            mod_backend="MBB", role="PRIMARY_USER", enrollment_status="ENROLLED",
+        )) == "eligible"
+
+    def test_mbb_odp_suffix_matches_like_gdc(self) -> None:
+        # real cars carry a suffixed sentinel ("MBB_ODP") — prefix match, not ==
+        assert mbb_eligibility(_rel(mod_backend="MBB_ODP", carnet_indicator=True)) == "eligible"
+
+    def test_meb_car_is_not_mbb(self) -> None:
+        assert mbb_eligibility(_rel(mod_backend="MEB", carnet_indicator=True)) == "not_mbb"
+
+    def test_primary_but_not_started_is_not_provisioned(self) -> None:
+        # primaryCar true but enrollment NOT_STARTED → no Car-Net access yet
+        assert mbb_eligibility(_rel(
+            mod_backend="MBB", primary_car=True, enrollment_status="NOT_STARTED",
+        )) == "not_provisioned"
+
+    def test_missing_backend_is_unknown(self) -> None:
+        assert mbb_eligibility(_rel(mod_backend=None)) == "unknown"
+        assert mbb_eligibility(_rel(mod_backend="")) == "unknown"


### PR DESCRIPTION
## Why

Whether the durable **MBB Car-Net two-way** channel is worth arming for a car is, today, only learned **post-hoc**: the user opts in, the integration runs an MBB device-grant login + register→exchange, and only then does the per-poll BFF operationList reveal whether any command is actually granted. There is no cheap pre-flight — so a car that can never command (a guest on a family car, or a WeConnect/MEB car where the legacy Car-Net path doesn't apply) still triggers the full login round-trip.

The **relations read** already carries the deciding signal, per vehicle, up front — attestation-free, one GET, readable even for a guest: the car's platform (`modBackend`) and this account's Car-Net provisioning (`carnetIndicator` / role / enrollment). The connector comment has long noted this as an intended source; this wires the classifier for it.

## Grounding

Verified on a **live volkswagen.de session** (2026-08-26) against a guest account on a family MBB Golf: the relation returned `modBackend=MBB` **but** `carnetIndicator=false`, `enrollmentStatus=NOT_STARTED`, `role=UNKNOWN`, `primaryCar=false` — i.e. the car is a Car-Net type, but this account has no command access. The classifier returns `not_provisioned` for exactly that shape, so a pre-flight would skip the doomed MBB login.

## What this adds

- `AuthproxyRelation` now surfaces `carnet_indicator` + `carnet_allocation_type` (populated by both the list and the singular relation parsers).
- `mbb_eligibility(relation)` → `eligible` / `not_provisioned` / `not_mbb` / `unknown`:
  - `eligible` — an MBB car with Car-Net provisioned, or a primary/enrolled relation.
  - `not_provisioned` — an MBB car this account can't yet command (guest/not-enrolled).
  - `not_mbb` — a WeConnect/MEB car (its two-way is the BFF, not MBB).
  - `unknown` — no platform signal.

**Classifier + parser fields only** — not yet wired into the config flow or the poll path. Wiring it (gate the MBB offer, pre-seed the `mbbUserId`, skip the attempt for non-eligible cars) is a deliberate follow-up.

## Tests

`tests/test_mbb_eligibility_preflight.py` — parser surfaces the carnet fields from both endpoints; the classifier over the live guest shape, a Car-Net owner, `MBB_ODP` prefix, a MEB car, a primary-but-not-started relation, and a missing backend. Full suite: **5328 passed, 15 skipped**.