### PR TITLE
sensor: portal-feed health sensor for EU Data Act cars (Stage-0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **A portal-feed health sensor for EU Data Act cars.** A new **Portal feed health** sensor says at a glance whether the portal is actually delivering — `ok`, `waiting_for_portal_data` (no data request set up yet), `empty_snapshots` (the car is asleep), `delivery_not_ready`, or `stale` (the poll keeps succeeding but the car's own capture time has frozen). That last one is the field's most common gotcha — a fresh delivery wrapping a stale payload — and it was previously invisible, looking like an integration bug rather than a portal one. A companion **Minutes since last snapshot** diagnostic (disabled by default) exposes the exact capture age so you can automate on a staleness threshold.
+
 ## [4.4.0b1] - 2026-08-26 — Companion agent relay · MBB pre-flight · guest-car reads
 
 > [!IMPORTANT]

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -817,6 +817,15 @@ class VehicleData:
     # they grow analogous parsing.
     last_seen_at: Any | None = None
 
+    # Stage-0 EU-DA observability. portal_health: one of ok / waiting_for_portal_data
+    # / empty_snapshots / delivery_not_ready / stale — computed in coordinator._enrich
+    # from the portal connector's last_no_data_reason + capture-age, so a user can tell
+    # "the portal snapshot is stale/empty" apart from "the integration is broken". None
+    # for a car that isn't read over the EU Data Act portal. minutes_since_last_snapshot:
+    # the car's own data-capture age in whole minutes (diagnostic).
+    portal_health: str | None = None
+    minutes_since_last_snapshot: int | None = None
+
     # Service
     service_km: int | None = None
     service_due_at: Any | None = None

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -84,6 +84,41 @@ def _capture_age_s(data: dict[str, Any]) -> float | None:
     return (datetime.now(tz=timezone.utc) - ts).total_seconds()
 
 
+# Stage-0 EU-DA observability — map the portal connector's ``last_no_data_reason``
+# to the user-facing portal-health enum. The reasons are set in
+# ``_eu_data_act.py`` (no_request / no_content / empty); "" means data flowed.
+_PORTAL_HEALTH_BY_REASON: dict[str, str] = {
+    "no_request": "waiting_for_portal_data",  # no customised data request set up yet
+    "no_content": "empty_snapshots",          # car asleep → only *_no_content_found.zip
+    "empty": "delivery_not_ready",            # listing/metadata empty or not yet ready
+}
+PORTAL_HEALTH_STATES = (
+    "ok", "waiting_for_portal_data", "empty_snapshots", "delivery_not_ready", "stale",
+)
+
+
+def _portal_health(
+    data: dict[str, Any], reason: str, age_s: float | None, stale_threshold_s: float | None,
+) -> str:
+    """Classify the EU Data Act portal feed's health for one vehicle.
+
+    ``ok`` when data flowed and is within the staleness floor; ``stale`` when the
+    poll succeeds but the car's own capture time has frozen past the floor (a
+    lapsed feed presenting old data as live); otherwise the specific no-data
+    reason from the connector. Distinguishes "the portal is stale/empty" from
+    "the integration is broken", which is the whole point of the sensor.
+    """
+    if data.get("no_data"):
+        return _PORTAL_HEALTH_BY_REASON.get(reason, "waiting_for_portal_data")
+    if (
+        age_s is not None
+        and stale_threshold_s is not None
+        and age_s >= stale_threshold_s
+    ):
+        return "stale"
+    return "ok"
+
+
 def _is_selfhealing_poll_error(err: object) -> bool:
     """True for a poll error that must NOT be escalated to the public Error
     Reporter, because it self-heals and is not our bug:
@@ -5186,6 +5221,24 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 )
             else:
                 clear_stale_data_issue(self.hass, self.entry.entry_id, _vin_sd)
+
+            # Stage-0 — surface the EU-DA portal feed's health + snapshot age as
+            # sensors, so a user can tell "the portal snapshot is stale/empty"
+            # from "the integration is broken". Only for a car actually read over
+            # the portal; a BFF/MBB/brand-native read has no portal connector and
+            # leaves both unset (the sensors stay unavailable → hidden).
+            _portal = (
+                getattr(self._cariad_client, "_eu_portal", None)
+                or getattr(self._cariad_client, "_supplementary_eu_portal", None)
+            )
+            if _portal is not None:
+                _reason = getattr(_portal, "last_no_data_reason", "") or ""
+                data["portal_health"] = _portal_health(
+                    data, _reason, _age, _threshold_s
+                )
+                data["minutes_since_last_snapshot"] = (
+                    int(_age // 60) if _age is not None else None
+                )
 
         # Fix #32: Defensive is_charging reset.
         # When plug is disconnected, charging MUST be False regardless of API state.

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -179,6 +179,38 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         device_class=SensorDeviceClass.ENUM,
         options=["connected", "disconnected"],
     ),
+    # Stage-0 EU Data Act observability. portal_health tells a user whether the
+    # PORTAL is delivering, apart from whether the integration is working — the
+    # single most visible signal for the field's #1 problem (a fresh delivery
+    # wrapping a stale payload). Enum so HA localizes the state; enabled by
+    # default; computed in coordinator._enrich and only set for a portal read.
+    VagSensorDescription(
+        key="portal_health",
+        translation_key="portal_health",
+        data_key="portal_health",
+        icon="mdi:cloud-check-variant",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "ok",
+            "waiting_for_portal_data",
+            "empty_snapshots",
+            "delivery_not_ready",
+            "stale",
+        ],
+    ),
+    # The car's own data-capture age in minutes — how old the newest portal
+    # snapshot is. Diagnostic + disabled by default (portal_health is the at-a-
+    # glance version); enable it to automate on a staleness threshold.
+    VagSensorDescription(
+        key="minutes_since_last_snapshot",
+        translation_key="minutes_since_last_snapshot",
+        data_key="minutes_since_last_snapshot",
+        icon="mdi:timer-sand",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
     # v2.22.0 (evcc) — normalized IEC-61851 charge status (A=unplugged /
     # B=plugged-idle / C=charging) for the evcc connector's custom-vehicle
     # `status` field (our raw charging_state strings don't map to A/B/C).

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -388,6 +388,19 @@
           "disconnected": "Disconnected"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "evcc_charge_status": {
         "name": "evcc charge status"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -355,6 +355,19 @@
           "disconnected": "Odpojeno"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Cíl nabíjení"
       },

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -355,6 +355,19 @@
           "disconnected": "Frakoblet"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Lademål"
       },

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -355,6 +355,19 @@
           "disconnected": "Getrennt"
         }
       },
+      "portal_health": {
+        "name": "Portal-Feed-Zustand",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Warte auf Portaldaten",
+          "empty_snapshots": "Leere Snapshots",
+          "delivery_not_ready": "Lieferung nicht bereit",
+          "stale": "Veraltet"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minuten seit letztem Snapshot"
+      },
       "target_soc": {
         "name": "Ladeziel"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -355,6 +355,19 @@
           "disconnected": "Disconnected"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Charge Target"
       },

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -355,6 +355,19 @@
           "disconnected": "Desconectado"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Objetivo de carga"
       },

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -355,6 +355,19 @@
           "disconnected": "Irrotettu"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Lataustavoite"
       },

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -355,6 +355,19 @@
           "disconnected": "Débranché"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Objectif de charge"
       },

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -355,6 +355,19 @@
           "disconnected": "Scollegato"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Obiettivo di ricarica"
       },

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -355,6 +355,19 @@
           "disconnected": "Frakoblet"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Lademål"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -355,6 +355,19 @@
           "disconnected": "Losgekoppeld"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Laaddoel"
       },

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -355,6 +355,19 @@
           "disconnected": "Odłączony"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Cel ładowania"
       },

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -355,6 +355,19 @@
           "disconnected": "Frånkopplad"
         }
       },
+      "portal_health": {
+        "name": "Portal feed health",
+        "state": {
+          "ok": "OK",
+          "waiting_for_portal_data": "Waiting for portal data",
+          "empty_snapshots": "Empty snapshots",
+          "delivery_not_ready": "Delivery not ready",
+          "stale": "Stale"
+        }
+      },
+      "minutes_since_last_snapshot": {
+        "name": "Minutes since last snapshot"
+      },
       "target_soc": {
         "name": "Laddningsmål"
       },

--- a/tests/test_euda_portal_health.py
+++ b/tests/test_euda_portal_health.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Stage-0 EU Data Act observability — the portal_health enum.
+
+A user needs to tell "the portal snapshot is stale/empty" apart from "the
+integration is broken". _portal_health maps the portal connector's
+last_no_data_reason + capture-age onto a small enum the sensor localizes.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.coordinator import (
+    PORTAL_HEALTH_STATES,
+    _portal_health,
+)
+
+_HOUR = 3600.0
+
+
+def test_ok_when_data_flows_and_fresh():
+    assert _portal_health({"no_data": False}, "", 60.0, 72 * _HOUR) == "ok"
+    # no age / no threshold available → still ok (cannot prove stale)
+    assert _portal_health({"no_data": False}, "", None, None) == "ok"
+
+
+def test_stale_when_capture_age_past_the_floor():
+    assert _portal_health({"no_data": False}, "", 80 * _HOUR, 72 * _HOUR) == "stale"
+    # exactly at the floor counts as stale (>=)
+    assert _portal_health({"no_data": False}, "", 72 * _HOUR, 72 * _HOUR) == "stale"
+
+
+def test_no_data_reasons_map_to_their_states():
+    assert _portal_health({"no_data": True}, "no_request", None, None) == "waiting_for_portal_data"
+    assert _portal_health({"no_data": True}, "no_content", None, None) == "empty_snapshots"
+    assert _portal_health({"no_data": True}, "empty", None, None) == "delivery_not_ready"
+
+
+def test_unknown_no_data_reason_defaults_to_waiting():
+    assert _portal_health({"no_data": True}, "", None, None) == "waiting_for_portal_data"
+    assert _portal_health({"no_data": True}, "weird", None, None) == "waiting_for_portal_data"
+
+
+def test_no_data_wins_over_a_stale_age():
+    # if the portal reports no data this poll, that reason is more informative
+    # than a stale capture age from a previous snapshot
+    assert _portal_health({"no_data": True}, "no_content", 99 * _HOUR, 72 * _HOUR) == "empty_snapshots"
+
+
+def test_every_result_is_a_declared_state():
+    for data, reason in (
+        ({"no_data": False}, ""),
+        ({"no_data": True}, "no_request"),
+        ({"no_data": True}, "no_content"),
+        ({"no_data": True}, "empty"),
+        ({"no_data": True}, ""),
+    ):
+        assert _portal_health(data, reason, 99 * _HOUR, 72 * _HOUR) in PORTAL_HEALTH_STATES


### PR DESCRIPTION
First of the EU Data Act read-path Stage-0 hardening items — the highest-value one, and the observability substrate the later scheduler + one-time-export work builds on.

## Why

The field's #1 EU-DA complaint is a **fresh delivery wrapping a stale payload** — the poll keeps succeeding, the ZIP is new, but the values inside are hours old. Today that is invisible: it looks like the integration is broken when it's the portal that's stale.

## What

A new **Portal feed health** sensor (enum, enabled by default) computed in `coordinator._enrich`:

| State | Meaning |
|---|---|
| `ok` | data flowing, within the staleness floor |
| `waiting_for_portal_data` | no customised data request set up yet |
| `empty_snapshots` | car asleep → only `*_no_content_found.zip` |
| `delivery_not_ready` | listing/metadata empty or not ready |
| `stale` | poll succeeds but the car's own capture time has frozen past the floor |

Plus a **Minutes since last snapshot** diagnostic (disabled by default) for automating on a staleness threshold.

> [!NOTE]
> **Pure-additive, low-risk.** It reuses the connector's existing `last_no_data_reason` and the existing #465 capture-age staleness floor. It is only set for a car actually read over the EU-DA portal; a BFF/MBB/brand-native read leaves it unset (sensor stays hidden). Nothing in the poll/command path depends on it.

## Tests

`tests/test_euda_portal_health.py` — the enum mapping (reasons → states, stale-age, no-data-wins-over-stale, every result is a declared state). 13 locales added (DE translated, others fall back to English). Full suite **5425 passed**.