### PR TITLE
coordinator: drop-anchored poll scheduling for EU Data Act portal cars (Stage-0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ### Added
 - **A portal-feed health sensor for EU Data Act cars.** A new **Portal feed health** sensor says at a glance whether the portal is actually delivering — `ok`, `waiting_for_portal_data` (no data request set up yet), `empty_snapshots` (the car is asleep), `delivery_not_ready`, or `stale` (the poll keeps succeeding but the car's own capture time has frozen). That last one is the field's most common gotcha — a fresh delivery wrapping a stale payload — and it was previously invisible, looking like an integration bug rather than a portal one. A companion **Minutes since last snapshot** diagnostic (disabled by default) exposes the exact capture age so you can automate on a staleness threshold.
 
+### Changed
+- **EU Data Act polls now align to the portal's delivery cadence.** Instead of a fixed offset from the last poll, a portal car's next poll is anchored to when the portal's next ~15-minute snapshot should land (plus a short buffer), and retries faster when a drop is overdue — so fresh data is picked up shortly after it's delivered rather than drifting out of phase. It is bounded so it never polls faster than the 3-minute floor nor slower than your configured interval, applies only to cars actually read over the portal, and leaves the nightly power-saving cadence untouched.
+
 ## [4.4.0b1] - 2026-08-26 — Companion agent relay · MBB pre-flight · guest-car reads
 
 > [!IMPORTANT]

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -117,6 +117,33 @@ def _portal_health(
     ):
         return "stale"
     return "ok"
+# Drop-anchored poll scheduling for EU Data Act portal entries. The portal
+# delivers on its own ~15-min cadence; anchoring the next poll to the newest
+# snapshot's capture time (+ a short delivery buffer) instead of a fixed offset
+# from the last poll catches each drop shortly after it lands and retries fast
+# when one is overdue — bounded so it can never poll faster than the floor or
+# slower than the user's configured interval.
+_DROP_BUFFER_S = 60
+_DROP_RETRY_S = 60
+
+
+def _drop_anchored_sleep_s(
+    interval_s: int, newest_capture_at: datetime | None, now: datetime, floor_s: int,
+) -> float:
+    """Seconds to sleep until the next expected portal drop.
+
+    Anchored to ``newest_capture_at + interval + buffer``; a drop already overdue
+    (``<= now``) collapses to a short retry. The result is clamped to
+    ``[floor_s, interval_s]`` so alignment can never poll faster than the floor
+    nor slower than the configured interval. With no capture time it is a no-op
+    (returns ``interval_s``)."""
+    if newest_capture_at is None:
+        return float(interval_s)
+    target = newest_capture_at + timedelta(seconds=interval_s + _DROP_BUFFER_S)
+    remaining = (target - now).total_seconds()
+    if remaining <= 0:
+        remaining = float(_DROP_RETRY_S)  # drop overdue → poll again soon
+    return max(float(floor_s), min(remaining, float(interval_s)))
 
 
 def _is_selfhealing_poll_error(err: object) -> bool:
@@ -935,6 +962,9 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Per-VIN poll success tracking — entities use this for availability
         # so a single failing vehicle doesn't blank out the others.
         self.vehicle_success: dict[str, bool] = {}
+        # Drop-anchored scheduling — the freshest snapshot capture time seen so
+        # far, used to align the next portal poll to the ~15-min drop cadence.
+        self._newest_capture_at: datetime | None = None
 
         # Per-VIN consecutive-failure counter (v1.8.7). Reset to 0 on every
         # successful poll. Used by ``is_vehicle_available`` to apply
@@ -2708,10 +2738,30 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             )
             # Nightly reduction: double interval between 22:00 and 05:00
             hour = datetime.now().hour
-            if hour >= 22 or hour < 5:
+            nightly = hour >= 22 or hour < 5
+            if nightly:
                 interval_s = interval_s * 2
                 _LOGGER.debug("Nightly reduction active — interval doubled to %ds", interval_s)
-            await asyncio.sleep(interval_s)
+            # Drop-anchored scheduling for EU-DA portal entries (daytime only, so
+            # the nightly power-saving cadence is untouched): align the next poll
+            # to when the portal's next ~15-min snapshot should land, and retry
+            # fast when one is overdue. Bounded to [floor, interval]; a non-portal
+            # entry (no connector) or a car we've never captured falls straight
+            # through to the fixed interval.
+            _portal = getattr(self._cariad_client, "_eu_portal", None) or getattr(
+                self._cariad_client, "_supplementary_eu_portal", None
+            )
+            _cap_anchor = getattr(self, "_newest_capture_at", None)
+            if not nightly and _portal is not None and _cap_anchor is not None:
+                sleep_s: float = _drop_anchored_sleep_s(
+                    interval_s,
+                    _cap_anchor,
+                    datetime.now(tz=timezone.utc),
+                    _CC_MIN_INTERVAL_S,
+                )
+            else:
+                sleep_s = float(interval_s)
+            await asyncio.sleep(sleep_s)
             if not self._started:
                 break
             # v2.8.0 — pre-flight watchdog. If we are on the
@@ -2978,6 +3028,20 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         )
                 with self._vehicles_lock:
                     self.vehicles.update(fresh)
+                    # Drop-anchored scheduling — remember the freshest snapshot
+                    # capture time across all cars, so the next sleep aligns to
+                    # the portal's ~15-min cadence. Reconstructed from the same
+                    # capture-age helper the staleness watchdog uses.
+                    _now_cap = datetime.now(tz=timezone.utc)
+                    _newest_cap: datetime | None = None
+                    for _vd in self.vehicles.values():
+                        _cap_age = _capture_age_s(_vd)
+                        if _cap_age is not None and _cap_age >= 0:
+                            _cap_ts = _now_cap - timedelta(seconds=_cap_age)
+                            if _newest_cap is None or _cap_ts > _newest_cap:
+                                _newest_cap = _cap_ts
+                    if _newest_cap is not None:
+                        self._newest_capture_at = _newest_cap
                 # b13 — Portal-safety: persist the merged snapshot (debounced)
                 # so the recorded values survive a HA restart. Best-effort.
                 try:

--- a/tests/test_euda_drop_anchored_scheduler.py
+++ b/tests/test_euda_drop_anchored_scheduler.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Stage-0 EU Data Act — drop-anchored poll scheduling.
+
+The portal delivers on its own ~15-min cadence. Anchoring the next poll to the
+newest snapshot's capture time (+ a buffer) catches each drop shortly after it
+lands and retries fast when one is overdue — bounded so it can never poll faster
+than the floor nor slower than the configured interval.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from custom_components.vag_connect.coordinator import (
+    _DROP_BUFFER_S,
+    _DROP_RETRY_S,
+    _drop_anchored_sleep_s,
+)
+
+_INTERVAL = 900   # 15 min
+_FLOOR = 180      # 3 min
+_NOW = datetime(2026, 8, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _sleep(capture_offset_s: float | None) -> float:
+    cap = None if capture_offset_s is None else _NOW - timedelta(seconds=capture_offset_s)
+    return _drop_anchored_sleep_s(_INTERVAL, cap, _NOW, _FLOOR)
+
+
+def test_no_capture_time_falls_back_to_interval():
+    assert _sleep(None) == float(_INTERVAL)
+
+
+def test_fresh_capture_sleeps_at_most_the_interval():
+    # captured just now → next drop ~interval+buffer away, clamped to interval
+    assert _sleep(0) == float(_INTERVAL)
+
+
+def test_capture_one_interval_old_polls_at_the_floor_to_catch_the_drop():
+    # target = now + buffer (60s) → below the floor → floor wins
+    assert _sleep(_INTERVAL) == float(_FLOOR)
+
+
+def test_overdue_drop_retries_fast_but_not_below_the_floor():
+    # captured 2 intervals ago → target in the past → retry, clamped to floor
+    assert _sleep(2 * _INTERVAL) == float(_FLOOR)
+    assert _DROP_RETRY_S <= _FLOOR  # so the retry always clamps up to the floor
+
+
+def test_mid_window_returns_the_aligned_remaining():
+    # captured 500s ago → target = 500s-ago + interval + buffer = now + 460s
+    assert _sleep(500) == float(_INTERVAL + _DROP_BUFFER_S - 500)  # 460
+
+
+def test_result_is_always_within_bounds():
+    for off in (None, 0, 100, 500, 899, 900, 901, 1800, 100000):
+        s = _sleep(off)
+        assert _FLOOR <= s <= _INTERVAL, off


### PR DESCRIPTION
Second EU Data Act Stage-0 item. The portal delivers on its own ~15-minute cadence; a fixed offset from the last poll drifts out of phase with it, so data is often read minutes before the next drop and again minutes after — never *right* after.

## What

A portal car's next poll is now anchored to when the portal's next snapshot should land: `newest_capture_time + interval + buffer`, with a fast retry when a drop is overdue. So fresh data is picked up shortly after it's delivered.

> [!WARNING]
> **Honest trade-off.** Aligning to drops means that in the short window *before* a drop, the poll can tighten down toward the **3-minute floor** — i.e. a few more polls than a flat interval would make there — in exchange for phase-aligned, fresher data and a fast catch-up when a drop is late. It is bounded to `[3 min, your configured interval]`, and the account rate-lockout + daily budget cap it further.

> [!NOTE]
> **Scoped tightly.** It applies **only** to cars actually read over the EU-DA portal (a connector is present and we've seen a capture time), and **only during the day** — the 22:00–05:00 nightly power-saving cadence is left exactly as it was. A non-portal / BFF / MBB entry is unchanged. The core `_drop_anchored_sleep_s` is a pure, bounded function.

## Tests

`tests/test_euda_drop_anchored_scheduler.py` — no-capture fallback, fresh-capture ≤ interval, one-interval-old polls at the floor, overdue retries at the floor, mid-window alignment, and an always-within-`[floor, interval]` bounds check. Rebased on the portal-health sensor; full suite **5431 passed**.