### PR TITLE
SEAT/CUPRA en_GB locale A/B — opt-in test-cohort probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **SEAT/CUPRA locale check (opt-in test cohort).** For a cohort member with a SEAT/CUPRA car, a once-per-vehicle diagnostic samples the `mycar` localized strings with our default headers vs `Accept-Language: en_GB` (the value the reference client sends) and includes both in the diagnostics download — so a real account can tell us whether adding that header would localise strings or just force English, before we change anything. Off unless you're in the cohort; the values are VIN/email-masked.
+
 ## [4.4.0b2] - 2026-08-27 — Audi model names · EU Data Act portal health & cadence
 
 > [!IMPORTANT]

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -136,6 +137,16 @@ class SeatCupraClient(CariadBaseClient):
         # revisions (pycupra references both ``model`` + ``modelName``,
         # ``modelYear`` + ``year``, etc.).
         self._vin_to_static_info: dict[str, dict[str, Any]] = {}
+        # v4.4.0b3 — opt-in test-cohort locale A/B probe. The competitor lib
+        # pycupra sends a STATIC ``Accept-Language: en_GB`` on every OLA read,
+        # while we currently send none; grounding could not decide from source
+        # whether adding it fixes localized strings (warning texts, service
+        # labels, model) or merely FORCES English on a non-English account. This
+        # captures, ONCE per VIN for opted-in users, the localized fields from a
+        # default read vs an ``en_GB`` read so a real SEAT/CUPRA account settles
+        # it. Off unless the coordinator flips ``_test_cohort`` (CONF_TEST_COHORT).
+        self._test_cohort = False
+        self.ola_locale_captures: dict[str, Any] = {}
 
     async def authenticate(self, mfa_code: str | None = None) -> None:
         """IDK auth + capture user_id from redirect chain."""
@@ -535,6 +546,73 @@ class SeatCupraClient(CariadBaseClient):
             except Exception:  # noqa: BLE001
                 _LOGGER.debug("Could not fetch renders for %s", vin[-6:])
 
+    # ── v4.4.0b3 test-cohort: SEAT/CUPRA en_GB locale A/B ──────────────────
+    _LOCALE_KEY_HINTS = (
+        "name", "title", "desc", "text", "label", "model", "message", "type",
+    )
+
+    @staticmethod
+    def _collect_localized_strings(obj: Any) -> dict[str, str]:
+        """Curated, bounded, VIN/email-masked map of candidate *localized* leaf
+        strings — human-readable text under name/title/desc/… keys. Codes,
+        UUIDs, timestamps and pure numbers are skipped so the capture stays
+        small and privacy-safe."""
+        out: dict[str, str] = {}
+
+        def _mask(s: str) -> str:
+            s = re.sub(r"[A-HJ-NPR-Z0-9]{11,17}", lambda m: "***" + m.group(0)[-4:], s)
+            return re.sub(r"[\w.+-]+@[\w.-]+\.\w+", "***@***", s)[:120]
+
+        def _walk(o: Any, path: str, depth: int) -> None:
+            if len(out) >= 40 or depth > 6:
+                return
+            if isinstance(o, dict):
+                for k, v in o.items():
+                    _walk(v, f"{path}.{k}" if path else str(k), depth + 1)
+            elif isinstance(o, list):
+                for i, v in enumerate(o[:10]):
+                    _walk(v, f"{path}[{i}]", depth + 1)
+            elif isinstance(o, str):
+                key_l = path.rsplit(".", 1)[-1].lower()
+                s = o.strip()
+                if (
+                    any(h in key_l for h in SeatCupraClient._LOCALE_KEY_HINTS)
+                    and 2 <= len(s) <= 80
+                    and re.search(r"[A-Za-z]", s)
+                    and not re.fullmatch(r"[A-Z0-9_.:-]{8,}", s)   # skip codes/UUIDs
+                    and not re.fullmatch(r"\d[\d.:T +-]*Z?", s)    # skip timestamps
+                ):
+                    out[path] = _mask(s)
+
+        _walk(obj, "", 0)
+        return out
+
+    async def _probe_ola_locale(self, vin: str) -> None:
+        """Opt-in A/B: read ``mycar`` once with our default headers and once with
+        pycupra's static ``Accept-Language: en_GB``, and record the localized
+        leaf strings from each. Lets a real SEAT/CUPRA account settle whether
+        adding en_GB fixes localized strings or merely forces English. Runs once
+        per VIN; fail-soft (never affects the real status read)."""
+        if not getattr(self, "_test_cohort", False) or vin in self.ola_locale_captures:
+            return
+        url = f"{_BASE}/v5/users/{self._user_id}/vehicles/{vin}/mycar"
+        try:
+            default = await self._get(url)
+            en_gb = await self._request("GET", url, headers={"Accept-Language": "en_GB"})
+        except Exception as err:  # noqa: BLE001
+            self.ola_locale_captures[vin] = {"error": type(err).__name__}
+            return
+        self.ola_locale_captures[vin] = {
+            "note": (
+                "mycar localized strings — 'default' = no Accept-Language (what we "
+                "send today), 'en_GB' = what pycupra sends. If these differ, en_GB "
+                "changes the language; compare against your app's language to see "
+                "whether it would be a fix or a regression."
+            ),
+            "default": self._collect_localized_strings(default),
+            "en_GB": self._collect_localized_strings(en_gb),
+        }
+
     async def get_status(self, vin: str) -> VehicleData:
         """Fetch full status from OLA server."""
         # v2.12.6 — EU Data Act portal mode (read-only fallback). Route the
@@ -553,6 +631,12 @@ class SeatCupraClient(CariadBaseClient):
             return data
         v = self._val
         d = VehicleData(vin=vin)
+
+        # v4.4.0b3 — opt-in en_GB locale A/B (once per VIN, fail-soft, no effect
+        # on the real read below). Off unless the coordinator flipped
+        # ``_test_cohort`` on from CONF_TEST_COHORT.
+        if getattr(self, "_test_cohort", False) and vin not in self.ola_locale_captures:
+            await self._probe_ola_locale(vin)
 
         # v2.4.1 — Scout Policy Compliance Audit T1: surface the
         # garage-cached license plate + nickname per VIN. No extra

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2482,7 +2482,15 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if has_bff:
             client._test_cohort = cohort
 
-        if cohort and (has_web or has_bff):
+        # v4.4.0b3 — SEAT/CUPRA en_GB locale A/B probe. The OLA client captures a
+        # localized-string sample (default vs en_GB) once per VIN when opted in;
+        # count it toward the share prompt so a SEAT/CUPRA reporter (no vw.de / BFF
+        # channel) is still asked to share the capture, or it never reaches us.
+        has_ola = client is not None and hasattr(client, "ola_locale_captures")
+        if has_ola:
+            client._test_cohort = cohort
+
+        if cohort and (has_web or has_bff or has_ola):
             raise_issue_test_cohort_share(self.hass, self.entry.entry_id)
         else:
             clear_issue_test_cohort_share(self.hass, self.entry.entry_id)

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -515,6 +515,17 @@ async def async_get_config_entry_diagnostics(
             except Exception as err:  # noqa: BLE001
                 raw_responses[f"command:{k}"] = {"error": f"{type(err).__name__}"}
 
+    # v4.4.0b3 — opt-in SEAT/CUPRA en_GB locale A/B capture (default vs en_GB
+    # localized strings from mycar). Values are already VIN/email-masked at
+    # capture; route through the same scrub for defense-in-depth.
+    olc = getattr(client, "ola_locale_captures", None) if client is not None else None
+    if isinstance(olc, dict):
+        for vin_key, payload in olc.items():
+            try:
+                raw_responses[f"ola_locale:{str(vin_key)[-6:]}"] = _scrub_raw(payload)
+            except Exception as err:  # noqa: BLE001
+                raw_responses[f"ola_locale:{str(vin_key)[-6:]}"] = {"error": f"{type(err).__name__}"}
+
     # #923/#1157 — surface the experimental vw.de probe outcomes so the test
     # cohort can see WHY a probe yielded nothing (a 403/404/412 refusal vs an
     # empty 200 vs a never-fired probe). Bare status labels only — no PII.

--- a/tests/test_seatcupra_locale_cohort_probe.py
+++ b/tests/test_seatcupra_locale_cohort_probe.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""SEAT/CUPRA en_GB locale A/B cohort probe.
+
+The competitor lib pycupra sends a static ``Accept-Language: en_GB`` on every
+OLA read; we send none. Source-grounding couldn't decide whether adding it
+localises strings (fix) or forces English on a non-English account (regression),
+so this opt-in probe captures the ``mycar`` localized strings from a default read
+vs an ``en_GB`` read, once per VIN, for a real account to settle it.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.seat_cupra import SeatCupraClient
+
+_VIN = "VSSZZZ5FZLR000123"
+
+# German (default, no Accept-Language) vs English (en_GB) mycar samples
+_MYCAR_DE = {"vehicle": {"model": {"name": "León e-Hybrid"}},
+             "services": [{"title": "Standheizung"}],
+             "vin": _VIN, "code": "ABCD1234EFGH5678"}
+_MYCAR_EN = {"vehicle": {"model": {"name": "Leon e-Hybrid"}},
+             "services": [{"title": "Auxiliary heating"}],
+             "vin": _VIN, "code": "ABCD1234EFGH5678"}
+
+
+def _client() -> SeatCupraClient:
+    c = SeatCupraClient(MagicMock(), "cupra", "e@x.com", "pw")
+    c._user_id = "user-123"
+    return c
+
+
+# ── the collector ────────────────────────────────────────────────────────────
+
+def test_collector_keeps_localized_text_masks_vin_skips_codes():
+    got = SeatCupraClient._collect_localized_strings(_MYCAR_DE)
+    vals = list(got.values())
+    assert "León e-Hybrid" in vals
+    assert "Standheizung" in vals
+    # the raw VIN is masked, never emitted verbatim
+    assert all(_VIN not in v for v in vals)
+    # a pure code under a non-localized key ("code") is skipped
+    assert "ABCD1234EFGH5678" not in vals
+
+
+def test_collector_masks_email_and_vin_in_values():
+    got = SeatCupraClient._collect_localized_strings(
+        {"label": "owner me@example.com VSSZZZ5FZLR000999 here"}
+    )
+    v = got["label"]
+    assert "me@example.com" not in v and "VSSZZZ5FZLR000999" not in v
+
+
+# ── the A/B probe ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_probe_captures_default_vs_en_gb_and_sends_en_gb_header():
+    c = _client()
+    c._test_cohort = True
+    c._get = AsyncMock(return_value=_MYCAR_DE)
+    seen_headers: list[Any] = []
+
+    async def _req(method, url, **kw):
+        seen_headers.append(kw.get("headers"))
+        return _MYCAR_EN
+
+    c._request = _req  # type: ignore[assignment]
+
+    await c._probe_ola_locale(_VIN)
+
+    cap = c.ola_locale_captures[_VIN]
+    assert "León e-Hybrid" in cap["default"].values()
+    assert "Leon e-Hybrid" in cap["en_GB"].values()
+    assert "Standheizung" in cap["default"].values()
+    assert "Auxiliary heating" in cap["en_GB"].values()
+    # the variant read carried pycupra's exact header (underscore form)
+    assert {"Accept-Language": "en_GB"} in seen_headers
+
+
+@pytest.mark.asyncio
+async def test_probe_is_self_limiting_once_per_vin():
+    c = _client()
+    c._test_cohort = True
+    c._get = AsyncMock(return_value=_MYCAR_DE)
+    c._request = AsyncMock(return_value=_MYCAR_EN)
+
+    await c._probe_ola_locale(_VIN)
+    await c._probe_ola_locale(_VIN)  # second call must be a no-op
+
+    assert c._get.await_count == 1  # not re-fetched
+
+
+@pytest.mark.asyncio
+async def test_probe_off_when_not_in_cohort():
+    c = _client()  # _test_cohort defaults False
+    c._get = AsyncMock(return_value=_MYCAR_DE)
+    c._request = AsyncMock(return_value=_MYCAR_EN)
+
+    await c._probe_ola_locale(_VIN)
+
+    assert _VIN not in c.ola_locale_captures
+    c._get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_probe_failsoft_records_error_not_raise():
+    c = _client()
+    c._test_cohort = True
+    c._get = AsyncMock(side_effect=RuntimeError("boom"))
+    c._request = AsyncMock(return_value=_MYCAR_EN)
+
+    await c._probe_ola_locale(_VIN)  # must not raise
+
+    assert c.ola_locale_captures[_VIN] == {"error": "RuntimeError"}


### PR DESCRIPTION
## SEAT/CUPRA en_GB locale A/B — opt-in test-cohort probe

Follow-up to the Audi model-name locale fix (v4.4.0b2). Grounding each brand's locale handling against its reference client showed the other brands already match best practice (Škoda/Porsche/VW-NA send Bearer-only or already hardcode exactly what their reference client sends), so **no blind cross-brand header change was warranted** — the grounding actually prevented a couple of regressions.

The one open question was SEAT/CUPRA: the reference client sends a static `Accept-Language: en_GB` on every OLA read while we send none. But because the OLA backend returns *localized* strings (warning texts, service labels, model), adding `en_GB` could either localise those or **force English** on a non-English account — and that can't be decided from source alone.

So instead of guessing, this ships a **once-per-vehicle, opt-in diagnostic**: for a test-cohort member with a SEAT/CUPRA car it reads `mycar` with our default headers and again with `Accept-Language: en_GB`, and records the localized leaf strings from each into the diagnostics download. A real account's capture tells us whether `en_GB` is a fix or a regression before we touch the live header.

> [!NOTE]
> Off unless `test_cohort` is enabled; self-limiting to once per VIN; fail-soft (never affects the real status read). Captured values are VIN/email-masked at capture and re-scrubbed on export, and it counts toward the existing test-cohort share prompt so a SEAT/CUPRA reporter is asked to share.

### Verification
- Full local suite: **5462 passed, 15 skipped**.
- New `test_seatcupra_locale_cohort_probe.py` (6 tests): collector masking, A/B capture + exact `en_GB` header, self-limiting once/VIN, off-when-not-cohort, fail-soft.

No manifest bump / no tag — accumulates under `[Unreleased]` for the next beta.
