### PR TITLE
Portal feed health: honour the connector's own no-data reason (#1273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **Portal feed health no longer says `ok` when the portal has never delivered.** For a car where the EU Data Act portal is a *supplementary* channel (the primary read is vw.de or the BFF), the health sensor was checking the merged data's no-data flag — which the primary channel sets — instead of the portal connector's own status, so a portal that had never produced a single snapshot showed as `ok` (#1273, @riteman: `source_channel: website_authproxy`, no snapshot ever received). It now reads the portal's own reason directly and correctly reports `empty_snapshots` / `waiting_for_portal_data`.
+
 ## [4.4.0b2] - 2026-08-27 — Audi model names · EU Data Act portal health & cadence
 
 > [!IMPORTANT]

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -108,6 +108,14 @@ def _portal_health(
     reason from the connector. Distinguishes "the portal is stale/empty" from
     "the integration is broken", which is the whole point of the sensor.
     """
+    # The portal connector's own ``last_no_data_reason`` is authoritative. When
+    # EU-DA is a SUPPLEMENTARY channel the merged ``data`` comes from the primary
+    # (BFF / vw.de) and carries no ``no_data`` flag, so gating the reason behind
+    # ``data["no_data"]`` mis-read a portal that had never delivered as ``ok``
+    # (#1273 @riteman: source_channel=website_authproxy, no snapshot ever received,
+    # yet the health sensor said ``ok``). Honour the reason directly.
+    if reason in _PORTAL_HEALTH_BY_REASON:
+        return _PORTAL_HEALTH_BY_REASON[reason]
     if data.get("no_data"):
         return _PORTAL_HEALTH_BY_REASON.get(reason, "waiting_for_portal_data")
     if (

--- a/tests/test_euda_portal_health.py
+++ b/tests/test_euda_portal_health.py
@@ -39,6 +39,26 @@ def test_unknown_no_data_reason_defaults_to_waiting():
     assert _portal_health({"no_data": True}, "weird", None, None) == "waiting_for_portal_data"
 
 
+def test_supplementary_portal_reason_honoured_without_no_data_flag():
+    # #1273 (@riteman): EU-DA is a SUPPLEMENTARY channel, so the merged data comes
+    # from the primary (vw.de / BFF) and carries no ``no_data`` flag — yet the
+    # portal never delivered a snapshot. The connector's own reason must still
+    # classify it instead of falling through to ``ok``.
+    assert _portal_health({"no_data": False}, "no_request", None, None) == "waiting_for_portal_data"
+    assert _portal_health({"no_data": False}, "no_content", None, None) == "empty_snapshots"
+    assert _portal_health({"no_data": False}, "empty", None, None) == "delivery_not_ready"
+    # a merged dict with no ``no_data`` key at all (primary never set it) also honours the reason
+    assert _portal_health({}, "no_content", None, None) == "empty_snapshots"
+    # even with a fresh-looking capture age from the primary channel, the portal's
+    # own no-data reason wins — this sensor reports on the portal, not on vw.de
+    assert _portal_health({"no_data": False}, "no_content", 60.0, 72 * _HOUR) == "empty_snapshots"
+
+
+def test_reason_cleared_stays_ok_when_data_present():
+    # a genuinely delivered portal (reason cleared back to "") is still ok
+    assert _portal_health({"no_data": False}, "", 60.0, 72 * _HOUR) == "ok"
+
+
 def test_no_data_wins_over_a_stale_age():
     # if the portal reports no data this poll, that reason is more informative
     # than a stale capture age from a previous snapshot


### PR DESCRIPTION
## Portal feed health: honour the connector's own no-data reason (#1273)

The **Portal feed health** sensor (shipped in v4.4.0b2) reported **`ok`** for a car whose EU Data Act portal had *never delivered a single snapshot* — the exact case the sensor exists to name.

**Root cause** (from @riteman's diagnostics on #1273: `source_channel: website_authproxy`, `minutes_since_last_snapshot: null`, `data_act_no_data` present): for that user the EU-DA portal is a **supplementary** channel — the primary read is vw.de — so the merged vehicle data the sensor inspects comes from the primary and carries no `no_data` flag. `_portal_health` gated the portal's own reason behind `data["no_data"]`, so when that flag was absent it fell straight through to `ok`, even though the connector had recorded exactly why it had nothing.

**Fix:** read the portal connector's `last_no_data_reason` directly (it's already passed in), before the `data["no_data"]` gate. A portal that recorded `no_request` / `no_content` / `empty` now maps to `waiting_for_portal_data` / `empty_snapshots` / `delivery_not_ready` regardless of whether the merged data happens to carry the flag — so a supplementary-channel car reports the truth.

### Verification
- `test_euda_portal_health.py`: **8 passed** (2 new — the supplementary case + the reason-cleared-stays-ok guard).
- euda/portal/coordinator slice: **230 passed**.
- A genuinely delivered portal (`reason` cleared to `""`) still reports `ok`; existing behaviour unchanged.

No manifest bump / no tag — accumulates under `[Unreleased]` for the next beta (sensor display only, not auth/data-bricking, so no hotfix needed).
