### PR TITLE
Companion: read charging + climate state from the real 4.3.2 screens (#968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ### Fixed
 - **Portal feed health no longer says `ok` when the portal has never delivered.** For a car where the EU Data Act portal is a *supplementary* channel (the primary read is vw.de or the BFF), the health sensor was checking the merged data's no-data flag — which the primary channel sets — instead of the portal connector's own status, so a portal that had never produced a single snapshot showed as `ok` (#1273, @riteman: `source_channel: website_authproxy`, no snapshot ever received). It now reads the portal's own reason directly and correctly reports `empty_snapshots` / `waiting_for_portal_data`.
+- **Companion channel (We Connect 4.3.2): a charging car now reads as charging, and the climate switches show their real state.** Grounded on live 4.3.2 dumps (#968, @plainmad): the app narrates the active state as "Currently charging" (not "Charging active"), which the charge-state read now recognises; and the climate toggles are non-checkable rows whose real state lives in their description text ("Active"/"Off"), so that is read now (the old `checked` path stays as a fallback for other layouts). The two write controls — charge Stop/Start and climate `cta_start`/`cta_stop` — are located from the same dumps but stay disabled until confirmed on a real device.
 
 ## [4.4.0b2] - 2026-08-27 — Audi model names · EU Data Act portal health & cadence
 

--- a/custom_components/vag_connect/companion/presets.py
+++ b/custom_components/vag_connect/companion/presets.py
@@ -347,6 +347,7 @@ _VW = BrandPreset(
             content_desc_re=(
                 r"Charging\s*status\b.*?\.\s*"
                 r"(Charging\s*(?:stopped|paused|complete[d]?|active)?"
+                r"|Currently\s*charging"
                 r"|Not\s*(?:charging|connected)|Ready\s*to\s*charge)\s*\.?\s*$"
             ),
             parse="str",
@@ -394,6 +395,17 @@ _VW = BrandPreset(
     # command entities that never work, this preset carries NO actions (so
     # ``writable`` is False and no command entities spawn) until the 2-step nav
     # is confirmed on a real device. Reads are unaffected.
+    #
+    # #968 (plainmad, 4.3.2 "while charging" + "climate active" dumps) — the two
+    # write controls are now LOCATED (not yet wired, because a wrong tap is a
+    # physical action on the car — they move into ``actions`` only once confirmed
+    # on-device and the preset is marked ``verified``):
+    #   • charge stop/start = the detail-sheet control whose content-desc flips
+    #     "Start charging" ⇄ "Stop charging" (bounds [85,1278][635,1380]).
+    #   • climate stop/start = the CTA whose resource-id itself flips
+    #     ``cta_start`` (text "Start") ⇄ ``cta_stop`` (text "Stop").
+    # Both are reached via the existing open_charge_detail / open_climate_detail
+    # nav. NOT on the sheet at all on 4.3.2: charge target-% and live kW power.
     actions=(),
     # v2.26.0 (C9) — charge target / power / remaining-time live behind the
     # range tile (ckomma's set_charging taps range_tile_center to reach the
@@ -445,6 +457,7 @@ _VW = BrandPreset(
                     content_desc_re=(
                         r"Charging\s*status\b.*?\.\s*"
                         r"(Charging\s*(?:stopped|paused|complete[d]?|active)?"
+                r"|Currently\s*charging"
                         r"|Not\s*(?:charging|connected)|Ready\s*to\s*charge)\s*\.?\s*$"
                     ),
                     parse="str",
@@ -586,17 +599,35 @@ _VW = BrandPreset(
                     value_from="self",
                     parse="temp_c",
                 ),
-                # #968 (plainmad, live 4.3.2 dump) — the two switches on this
-                # screen carry their state in ``checked``, not in any text.
+                # #968 — the switch state is read from two possible shapes, most
+                # reliable last (read_selectors keeps the last non-None). Older /
+                # other layouts expose a checkable ``*_toggle`` whose ``checked``
+                # is the state; but plainmad's live 4.3.2 "climate active" dump
+                # shows the toggle row is ``clima_``-prefixed, NOT checkable, and
+                # carries ``checked="false"`` even while air conditioning is on —
+                # there the real state is the sibling ``*_description`` text
+                # ("Active" / "Off"). Try ``checked`` first, then let the
+                # description win (bool_climate maps Active/On→True, Off→False), so
+                # both layouts read correctly.
                 FieldSelector(
                     target="window_heating_enabled",
                     checked_of_rid="window_heating_toggle",
                     parse="bool_switch",
                 ),
                 FieldSelector(
+                    target="window_heating_enabled",
+                    resource_id="window_heating_description",
+                    parse="bool_climate",
+                ),
+                FieldSelector(
                     target="climatisation_active",
                     checked_of_rid="air_conditioning_toggle",
                     parse="bool_switch",
+                ),
+                FieldSelector(
+                    target="climatisation_active",
+                    resource_id="air_conditioning_description",
+                    parse="bool_climate",
                 ),
             ),
             back_presses=1,

--- a/tests/test_968_companion_43_live_dumps.py
+++ b/tests/test_968_companion_43_live_dumps.py
@@ -221,6 +221,11 @@ class TestLiveChargeSheet:
         )
         fields = read_selectors(parse_ui_dump(charging), self._nav_values())
         assert fields["is_charging"] is True
+        # #968 (plainmad, live 4.3.2 "while charging" dump) — the active wording
+        # is "Currently charging", not "Charging active"; the state string must
+        # capture it rather than reading blank.
+        assert "charging" in str(fields["charging_state"]).lower()
+        assert "stopped" not in str(fields["charging_state"]).lower()
 
     def test_absent_values_stay_absent_rather_than_reading_zero(self) -> None:
         # The car was unplugged, so there is no target SoC, power or remaining
@@ -267,6 +272,42 @@ class TestLiveClimateSheet:
         fields = read_selectors(parse_ui_dump(CLIMATE_SHEET), self._nav_values())
         assert fields["climatisation_active"] is True    # air conditioning on
         assert fields["window_heating_enabled"] is False  # window heating off
+
+    def test_switch_state_reads_from_description_when_toggle_is_not_checkable(self) -> None:
+        # #968 (plainmad, real 4.3.2 "climate active" dump) — the live toggle row
+        # is ``clima_``-prefixed, NOT checkable, and reads ``checked="false"`` even
+        # while air conditioning is ON. The real state is the sibling
+        # ``*_description`` text; reading only ``checked`` would call an active
+        # car's AC off.
+        from custom_components.vag_connect.companion.screen import read_selectors
+
+        real = _dump(
+            _n(
+                rid="clima_air_conditioning_toggle",
+                checkable="false",
+                checked="false",
+                bounds="[43,813][677,951]",
+            )
+            + _n(
+                rid="air_conditioning_description",
+                text="Active",
+                bounds="[558,866][634,899]",
+            )
+            + _n(
+                rid="clima_window_heating_toggle",
+                checkable="false",
+                checked="false",
+                bounds="[43,953][677,1091]",
+            )
+            + _n(
+                rid="window_heating_description",
+                text="Off",
+                bounds="[595,1006][634,1039]",
+            )
+        )
+        fields = read_selectors(parse_ui_dump(real), self._nav_values())
+        assert fields["climatisation_active"] is True
+        assert fields["window_heating_enabled"] is False
 
     def test_a_container_sharing_a_switch_id_cannot_read_as_off(self) -> None:
         from custom_components.vag_connect.companion.screen import read_selectors


### PR DESCRIPTION
## Companion channel: read charging + climate state from the real 4.3.2 screens (#968)

Grounded on @plainmad's live 4.3.2 dumps (charging while active, climate while active, overview while charging), which answered both open read questions and one write-side one.

### Fixed (reads)
- **`charging_state` recognises "Currently charging".** The 4.3.2 regex only knew "Charging stopped / paused / active", so a *charging* car's state string read blank (`is_charging` already worked via the bare-verb match). It now captures the active wording.
- **The climate switch state comes from the description text.** On 4.3.2 the toggle rows are `clima_`-prefixed, **not checkable**, and read `checked="false"` even while air conditioning is on — the real state is the sibling `*_description` text ("Active" / "Off"). That's read now, with the old `checked` path kept as a fallback for other layouts (`read_selectors` keeps the last non-None, so the description wins where present).

### Located, not wired (writes stay off)
- Charge Stop/Start (the detail control whose description flips "Start charging" ⇄ "Stop charging") and climate `cta_start` ⇄ `cta_stop` are documented from the same dumps, but `writable` stays **False** until confirmed on a real device — a wrong tap is a physical action on the car, so the version gate holds.
- Honest note: charge **target-%** and **live kW power** are **not** on the 4.3.2 sheet at all (it carries only SoC, state, a worded remaining time, range and the Stop control).

### Verification
- `test_968_companion_43_live_dumps.py`: 23 passed (2 added — the "Currently charging" state, and description-based switch state on a non-checkable toggle).
- All companion tests: **201 passed**.

No manifest bump / no tag — reads-only, accumulates under `[Unreleased]`.
