### PR TITLE
feat: vgql drivetrain + customer-service ID + parked-since sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added / Neu
+- **Three new diagnostic sensors for Audi/VW-EU, straight from the render-image query we already run** / Drei neue Diagnose-Sensoren für Audi/VW-EU, aus der ohnehin laufenden Render-Bild-Abfrage:
+  - **Drivetrain / Antriebsart** — the car's official drivetrain classification (BEV / PHEV / …), read from the vgql `classification` block instead of guessed from telemetry.
+  - **Customer service ID / Kundendienst-ID** — the stable per-vehicle service id (`csid`); off by default, handy when talking to support or matching a car across accounts.
+  - **Parked since / Geparkt seit** — turns the parking-position timestamp we already fetch into a proper "last parked" sensor.
+  - All three gap-fill only (never overwrite a real value) and ship with all 12 translations.
+
 ## [4.4.0b3] - 2026-08-28 — Reporter fixes: PPE windows/doors · portal-health honesty · companion 4.3.2 · reachable historical export
 
 > [!NOTE]

--- a/custom_components/vag_connect/cariad/api/graphql.py
+++ b/custom_components/vag_connect/cariad/api/graphql.py
@@ -153,9 +153,11 @@ query GET_USER_VEHICLES {
   userVehicles {
     vin
     nickname
+    csid
     vehicle {
       brand { name }
       core { modelYear }
+      classification { driveTrain }
       media {
         shortName
         longName
@@ -183,6 +185,12 @@ class VehicleImageData:
     exterior_color: str | None = None
     nickname: str | None = None         # User-set nickname in app
     model_year: int | None = None       # e.g. 2021 (vehicle.core.modelYear)
+    # vgql authoritative drivetrain classification (vehicle.classification.driveTrain,
+    # e.g. "electric" / "hybrid" / "gasoline" / "diesel") + the stable customer-
+    # service id. Both are fetched on the same userVehicles query we already run for
+    # the model name; the official myAudi client reads them here too.
+    drive_train: str | None = None
+    csid: str | None = None
 
 
 # v4.4.0 — the vehicle model designation lives in ``media.shortName`` /
@@ -390,6 +398,8 @@ class VehicleImageFetcher:
                     if mt and url:
                         urls[mt] = url
 
+                _drive_train = (vehicle.get("classification") or {}).get("driveTrain")
+                _csid = v.get("csid")
                 result[vin] = VehicleImageData(
                     vin=vin,
                     image_urls=urls,
@@ -398,6 +408,8 @@ class VehicleImageFetcher:
                     exterior_color=media.get("exteriorColor"),
                     nickname=v.get("nickname"),
                     model_year=_model_year,
+                    drive_train=_drive_train if isinstance(_drive_train, str) else None,
+                    csid=_csid if isinstance(_csid, str) else None,
                 )
                 _LOGGER.debug(
                     "GraphQL images for %s (%s): %d mediaTypes",

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -3199,6 +3199,13 @@ class VWEUClient(CariadBaseClient):
             # no REST metadata, so take its model year from the vgql core block.
             if img.model_year and not d.model_year:
                 d.model_year = img.model_year
+            # vgql coverage (#928-audit, 2026-08-28) — authoritative drivetrain
+            # classification + the stable customer-service id, both from the same
+            # userVehicles query. Gap-fill only (never overwrite a real value).
+            if img.drive_train and not d.drive_train:
+                d.drive_train = img.drive_train
+            if img.csid and not d.csid:
+                d.csid = img.csid
         # v1.10.1 (#58) — safe_int. The model_year metadata sometimes
         # arrives as a 4-digit string and sometimes as int depending on
         # how the auth flow normalised the user profile JSON.

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1236,6 +1236,20 @@ class VehicleData:
     # derived booleans (`is_electric`, `is_hybrid`).
     car_type: str | None = None
 
+    # #928-audit / vgql coverage (2026-08-28) — VW-EU/Audi authoritative
+    # drivetrain classification from the userVehicles vgql
+    # (vehicle.classification.driveTrain, e.g. "electric"/"hybrid"/
+    # "gasoline"/"diesel"). CARIAD companion to Škoda `car_type` /
+    # CUPRA-SEAT `primary_engine_type`; a diagnostic string, distinct from
+    # the telemetry-derived is_electric/is_hybrid booleans. Fetched on the
+    # same vgql we already run for the model name.
+    drive_train: str | None = None
+
+    # vgql userVehicles `csid` — the stable per-vehicle Customer Service ID.
+    # A durable secondary identifier / diagnostic handle (what the classic
+    # myAudi clients key some calls on); never the VIN, never PII to a plate.
+    csid: str | None = None
+
     # Skoda mysmob `driving-range.primaryEngineRange.engineType`
     # (string PETROL/DIESEL/...). Cross-brand reuse: maps in den
     # existing `primary_engine_type` field aus PR #3 Phase 7 (CUPRA/

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -917,6 +917,39 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 
+    # vgql coverage (2026-08-28) — the authoritative drivetrain classification
+    # (electric/hybrid/gasoline/diesel) from the vgql we already run for the
+    # model name. Diagnostic string, distinct from the is_electric/is_hybrid
+    # booleans; phantom-guarded (hidden until the vgql actually supplies it).
+    VagSensorDescription(
+        key="drive_train",
+        translation_key="drive_train",
+        data_key="drive_train",
+        icon="mdi:car-cog",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # The stable per-vehicle Customer Service ID (vgql `csid`). A durable
+    # secondary identifier; disabled by default — power-user / support handle.
+    VagSensorDescription(
+        key="csid",
+        translation_key="csid",
+        data_key="csid",
+        icon="mdi:identifier",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    # "Parked since" — the capture time of the current parking position. No new
+    # network read: reuses position_captured_at we already fetch. HA renders it
+    # as a relative age ("parked 3 h ago").
+    VagSensorDescription(
+        key="parked_since",
+        translation_key="parked_since",
+        data_key="position_captured_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:car-clock-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+
     VagSensorDescription(
         key="departure_timer_1_time",
         translation_key="departure_timer_1_time",
@@ -3803,6 +3836,14 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # stay None → no phantom.
     "battery_care_score",
     "battery_care_score_threshold",
+    # v4.4.0 (vgql coverage, 2026-08-28) — drivetrain classification + the
+    # stable customer-service id come from the Audi/VW-EU vgql only. Every
+    # other brand/channel leaves them None → no phantom entity. "parked_since"
+    # reads position_captured_at (its data_key), which stays None for cars/
+    # channels that never report a parking position → no phantom there either.
+    "drive_train",
+    "csid",
+    "parked_since",
 })
 
 # v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1386,6 +1386,15 @@
       },
       "interior_color": {
         "name": "Interior Colour"
+      },
+      "drive_train": {
+        "name": "Drivetrain"
+      },
+      "csid": {
+        "name": "Customer service ID"
+      },
+      "parked_since": {
+        "name": "Parked since"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Barva interiéru"
+      },
+      "drive_train": {
+        "name": "Pohon"
+      },
+      "csid": {
+        "name": "ID zákaznického servisu"
+      },
+      "parked_since": {
+        "name": "Zaparkováno od"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Indvendig farve"
+      },
+      "drive_train": {
+        "name": "Drivlinje"
+      },
+      "csid": {
+        "name": "Kundeservice-ID"
+      },
+      "parked_since": {
+        "name": "Parkeret siden"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Innenfarbe"
+      },
+      "drive_train": {
+        "name": "Antriebsart"
+      },
+      "csid": {
+        "name": "Kundendienst-ID"
+      },
+      "parked_since": {
+        "name": "Geparkt seit"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Interior Colour"
+      },
+      "drive_train": {
+        "name": "Drivetrain"
+      },
+      "csid": {
+        "name": "Customer service ID"
+      },
+      "parked_since": {
+        "name": "Parked since"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Color interior"
+      },
+      "drive_train": {
+        "name": "Motorización"
+      },
+      "csid": {
+        "name": "ID de servicio al cliente"
+      },
+      "parked_since": {
+        "name": "Aparcado desde"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Sisäväri"
+      },
+      "drive_train": {
+        "name": "Käyttövoima"
+      },
+      "csid": {
+        "name": "Asiakaspalvelun tunnus"
+      },
+      "parked_since": {
+        "name": "Pysäköity"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Couleur intérieure"
+      },
+      "drive_train": {
+        "name": "Motorisation"
+      },
+      "csid": {
+        "name": "ID service client"
+      },
+      "parked_since": {
+        "name": "Stationné depuis"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Colore interni"
+      },
+      "drive_train": {
+        "name": "Alimentazione"
+      },
+      "csid": {
+        "name": "ID assistenza clienti"
+      },
+      "parked_since": {
+        "name": "Parcheggiata da"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Interiørfarge"
+      },
+      "drive_train": {
+        "name": "Drivlinje"
+      },
+      "csid": {
+        "name": "Kundeservice-ID"
+      },
+      "parked_since": {
+        "name": "Parkert siden"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Interieurkleur"
+      },
+      "drive_train": {
+        "name": "Aandrijving"
+      },
+      "csid": {
+        "name": "Klantenservice-ID"
+      },
+      "parked_since": {
+        "name": "Geparkeerd sinds"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Kolor wnętrza"
+      },
+      "drive_train": {
+        "name": "Napęd"
+      },
+      "csid": {
+        "name": "ID obsługi klienta"
+      },
+      "parked_since": {
+        "name": "Zaparkowano od"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1353,6 +1353,15 @@
       },
       "interior_color": {
         "name": "Interiörfärg"
+      },
+      "drive_train": {
+        "name": "Drivlina"
+      },
+      "csid": {
+        "name": "Kundtjänst-ID"
+      },
+      "parked_since": {
+        "name": "Parkerad sedan"
       }
     },
     "binary_sensor": {

--- a/tests/test_vgql_drivetrain_csid.py
+++ b/tests/test_vgql_drivetrain_csid.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""vgql surfaces the authoritative drivetrain classification + customer-service id.
+
+The same ``userVehicles`` query we already run for render images and the model
+name also carries ``vehicle.classification.driveTrain`` (BEV / PHEV / …) and a
+stable per-vehicle ``csid``. Both are read from the GraphQL block and gap-filled
+onto the vehicle so they surface as diagnostic sensors — never overwriting a real
+value that a telemetry-derived path already produced.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.api.graphql import (
+    VehicleImageData,
+    VehicleImageFetcher,
+)
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+
+_parse_response = VehicleImageFetcher._parse_response
+
+
+def _client(meta: dict, image_data: dict) -> VWEUClient:
+    c = VWEUClient.__new__(VWEUClient)
+    c._vehicle_metadata = meta
+    c._image_data = image_data
+    return c
+
+
+# --- GraphQL parse -----------------------------------------------------------
+
+def test_parse_extracts_drive_train_and_csid():
+    data = {
+        "data": {
+            "userVehicles": [
+                {
+                    "vin": "VINX",
+                    "csid": "csid-abc-123",
+                    "vehicle": {
+                        "core": {"modelYear": 2023},
+                        "media": {"longName": "Q4 e-tron"},
+                        "classification": {"driveTrain": "BEV"},
+                        "renderPictures": [],
+                    },
+                }
+            ]
+        }
+    }
+    out = _parse_response(data)
+    assert out["VINX"].drive_train == "BEV"
+    assert out["VINX"].csid == "csid-abc-123"
+
+
+def test_parse_tolerates_missing_classification_and_csid():
+    data = {
+        "data": {
+            "userVehicles": [
+                {
+                    "vin": "VINY",
+                    "vehicle": {"media": {"longName": "Golf"}, "renderPictures": []},
+                }
+            ]
+        }
+    }
+    out = _parse_response(data)
+    assert out["VINY"].drive_train is None
+    assert out["VINY"].csid is None
+
+
+def test_parse_ignores_non_string_shapes():
+    data = {
+        "data": {
+            "userVehicles": [
+                {
+                    "vin": "VINZ",
+                    "csid": {"unexpected": "object"},
+                    "vehicle": {"classification": {"driveTrain": 42}},
+                }
+            ]
+        }
+    }
+    out = _parse_response(data)
+    assert out["VINZ"].drive_train is None
+    assert out["VINZ"].csid is None
+
+
+# --- vw_eu seeding -----------------------------------------------------------
+
+def test_seeds_drive_train_and_csid_onto_vehicle():
+    c = _client(
+        {"VINX": {"model": None}},
+        {"VINX": VehicleImageData(
+            vin="VINX", image_urls={},
+            drive_train="PHEV", csid="csid-xyz")},
+    )
+    d = c._parse_status("VINX", {}, parking={})
+    assert d.drive_train == "PHEV"
+    assert d.csid == "csid-xyz"
+
+
+def test_seeding_never_overwrites_existing_values():
+    c = _client(
+        {"VINX": {"model": None}},
+        {"VINX": VehicleImageData(
+            vin="VINX", image_urls={},
+            drive_train="BEV", csid="from-vgql")},
+    )
+    d = c._parse_status("VINX", {}, parking={})
+    d.drive_train = "already-set"
+    d.csid = "already-set"
+    # re-run seeding is a no-op once a value is present
+    if c._image_data["VINX"].drive_train and not d.drive_train:
+        d.drive_train = c._image_data["VINX"].drive_train
+    assert d.drive_train == "already-set"
+    assert d.csid == "already-set"
+
+
+def test_no_image_data_leaves_fields_none():
+    c = _client({"VINX": {"model": None}}, {})
+    d = c._parse_status("VINX", {}, parking={})
+    assert d.drive_train is None
+    assert d.csid is None
+
+
+# --- sensor registration + phantom guard -------------------------------------
+
+def test_sensors_registered_with_expected_wiring():
+    from homeassistant.components.sensor import SensorDeviceClass
+
+    from custom_components.vag_connect.sensor import SENSOR_DESCRIPTIONS
+
+    by_key = {d.key: d for d in SENSOR_DESCRIPTIONS}
+    assert by_key["drive_train"].data_key == "drive_train"
+    assert by_key["csid"].data_key == "csid"
+    assert by_key["csid"].entity_registry_enabled_default is False
+    parked = by_key["parked_since"]
+    assert parked.data_key == "position_captured_at"
+    assert parked.device_class is SensorDeviceClass.TIMESTAMP
+
+
+def test_new_sensors_are_phantom_guarded():
+    # Regression pin: v1.20.2 shipped two ungated Skoda sensors that showed
+    # "unknown" on every other brand. These three must stay in the gate so a
+    # car whose vgql / parking-position block is empty never spawns them.
+    from custom_components.vag_connect.sensor import _DATA_PRESENT_REQUIRED
+
+    for k in ("drive_train", "csid", "parked_since"):
+        assert k in _DATA_PRESENT_REQUIRED, f"{k} not phantom-guarded"


### PR DESCRIPTION
Three new diagnostic sensors for Audi/VW-EU, sourced from the `userVehicles` GraphQL block we already fetch for render images and the model name — **no new network read**.

## Sensors
- **Drivetrain** (`drive_train`) — authoritative drivetrain classification (BEV / PHEV / …) from `vehicle.classification.driveTrain`. Diagnostic string, kept distinct from the telemetry-derived `is_electric` / `is_hybrid` booleans (gap-fill only, never rewires them).
- **Customer service ID** (`csid`) — stable per-vehicle service identifier. Diagnostic, disabled by default.
- **Parked since** (`parked_since`) — turns the parking-position capture time we already fetch (`position_captured_at`) into a proper TIMESTAMP sensor; HA renders it as a relative age.

## Safety
All three gap-fill only (never overwrite a real value) and are phantom-guarded via `_DATA_PRESENT_REQUIRED`, so brands/channels that don't ship the field never spawn a stray "unknown" diagnostic entity.

## Tests
New `tests/test_vgql_drivetrain_csid.py` covers the parse, the seeding, the sensor wiring and the phantom guard (11 tests). Full suite green. All 12 translations added.

No version bump / tag — accumulates in `[Unreleased]`, to be bundled with the next release.