### PR TITLE
docs: community-health files (Code of Conduct, governance, triage, PR template)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+Thanks for sending a patch — this integration is one person's spare-time
+project, and a focused PR with the boxes ticked is the fastest path to merge.
+Fill in the three short sections, then run through the checklist. The commands
+match CI exactly, so if they pass locally the PR usually goes green.
+-->
+
+## Summary
+
+<!-- One line: what does this PR do? -->
+
+## What & why
+
+<!--
+What changed, and why. What was broken or missing before?
+If you changed how a payload is parsed or how a command is sent, say what you
+grounded it against — captured app traffic, a diagnostics dump, an issue. If a
+path works but isn't semantically verified against the official app, mark it
+`[Inference]` in the code (see CONTRIBUTING.md).
+-->
+
+## Linked issue
+
+<!-- "Closes #123" ties this to a report. Small self-explanatory fixes can say "no issue". -->
+
+Closes #
+
+## Checklist
+
+These run in CI on every PR to `main` — running them locally first keeps the round-trip short (see CONTRIBUTING.md → *Pull requests*):
+
+- [ ] `python -m pytest tests/` passes (CI also enforces coverage ≥ 65%)
+- [ ] `python -m ruff check custom_components/` is clean
+- [ ] `mypy` strict is clean on `custom_components/vag_connect/` (full flags in CONTRIBUTING.md; CI runs the same checks)
+- [ ] Added a `## [Unreleased]` entry in `CHANGELOG.md` — CI rejects a code change without one — and credited the work (yourself, plus the reporter if this fixes their issue)
+- [ ] All `*.json` under `custom_components/` still parse (translations and `manifest.json` load at HA startup)
+
+Review rules from CONTRIBUTING.md:
+
+- [ ] New feature has tests — a new sensor needs a parser test **plus** an entity test; a new command needs a coordinator dispatch test
+- [ ] Changed a user-facing string? Updated `strings.json` (the English source of truth) and mirrored it into **every** `translations/*.json`, in everyday driver vocabulary
+- [ ] No new runtime dependencies — `manifest.json` `requirements` stays empty (we bundle our own CARIAD client)
+- [ ] **No secrets in the diff** — no tokens, S-PIN, full 17-char VINs, user-IDs, e-mail, or exact GPS (round to 1 decimal), even from your own car (see CONTRIBUTING.md → *Privacy & data handling*)
+- [ ] **No AI / co-author trailers** in any commit (`Co-Authored-By:`, `Generated with …`, etc.)
+- [ ] One PR = one concern; commit messages use a `feat|fix|refactor|docs|test|chore|ci|i18n:` prefix
+
+<!--
+hassfest and HACS validation also run automatically. PRs merge against main with
+green CI — no direct pushes to main. Thanks again.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Code of Conduct
+
+> Be civil. Be specific. Don't paste secrets. The maintainer is one person
+> on their own time — patches and patience travel further than demands.
+
+That short version is the whole spirit of this document. Everything below
+just spells it out so GitHub, newcomers, and anyone who needs to point at a
+rule has something concrete to point at.
+
+---
+
+## Our pledge
+
+VW Group Connect is a small, community-maintained project. We want it to be a
+place where anyone — whatever their experience, background, identity, or car —
+can file a good bug report, share anonymised diagnostics, ask a question, or
+send a patch without being talked down to.
+
+As contributors and as the maintainer, we pledge to make taking part in this
+project a harassment-free experience for everyone, and to interact in ways
+that are open, welcoming, and respectful.
+
+---
+
+## Expected behaviour
+
+Things that keep this project healthy:
+
+- **Be civil.** Assume good faith. Disagree about code, not people.
+- **Be specific.** "It doesn't work" helps no one; a version, a brand, a
+  region, and a sanitised log do. Good reports and focused patches are the
+  most valuable thing you can bring.
+- **Respect that this is spare-time work.** One person maintains this, for
+  free, against a moving target. Nudges are fine; demands and entitlement
+  are not.
+- **Protect other people's privacy.** Don't paste tokens, full VINs, exact
+  GPS, S-PIN values, or email addresses — yours or anyone else's — into
+  public issues, discussions, or pull requests. See
+  [`CONTRIBUTING.md`](CONTRIBUTING.md) for how to redact before posting.
+- **Give and take feedback gracefully.** Review comments are about the work.
+  Say thanks, learn, move on.
+
+---
+
+## Unacceptable behaviour
+
+- Harassment of any kind: insults, personal or political attacks,
+  demeaning or discriminatory comments.
+- Sexualised language or imagery, or unwelcome sexual attention.
+- Trolling, deliberately derailing threads, or sustained disruption of
+  discussions, issues, or reviews.
+- Publishing someone else's private information — a home or parking
+  address, license plate, real name, email, or vehicle identifiers —
+  without their explicit permission.
+- Pasting another person's tokens, VINs, coordinates, or other sensitive
+  data lifted from a log or screenshot.
+- Aggressive entitlement: abusive demands for support, fixes, or free
+  labour, or pressuring the maintainer or contributors.
+- Any other conduct that would reasonably be considered inappropriate in a
+  collaborative, professional setting.
+
+---
+
+## Scope
+
+This Code of Conduct applies in all project spaces — the repository, issues,
+pull requests, discussions, and Vehicle Data Scout reports — and any time
+someone is representing the project in a public space (for example, posting
+as the project on a community forum or in social media).
+
+---
+
+## Enforcement
+
+This project has a single maintainer, [@its-me-prash](https://github.com/its-me-prash),
+who is responsible for clarifying and enforcing these standards, and who may
+remove, edit, or reject comments, commits, code, issues, and other
+contributions that don't align with this Code of Conduct.
+
+### Reporting
+
+If you experience or witness unacceptable behaviour — or have any other
+concern about conduct here — report it privately to the maintainer. **Please
+don't open a public issue for it.**
+
+- **Preferred:** reach the maintainer through the contact details on their
+  GitHub profile, [@its-me-prash](https://github.com/its-me-prash).
+- **If you'd rather keep it fully confidential** and out of any public
+  thread, you can open a private
+  [GitHub Security Advisory](https://github.com/its-me-prash/vwgroup-connect-ha/security/advisories/new).
+  It's built for security issues, but it's a working private channel to the
+  same person — just say up front that it's a conduct report.
+
+All reports are handled discreetly. The maintainer will respect the privacy
+and safety of anyone who reports in good faith, and will acknowledge a report
+as soon as is reasonable — this is a one-person, spare-time project, so a
+little patience is appreciated.
+
+### Consequences
+
+The maintainer will follow these guidelines in deciding what a violation
+deserves. They scale with severity and intent:
+
+1. **A quiet word.** For a first, minor, or likely-unintentional lapse: a
+   private note explaining what was out of line, and what's expected instead.
+   A public apology may be requested.
+2. **A warning.** For a clearer or repeated violation: a warning, with the
+   understanding that continuing means a break from the project. This can
+   include being asked to stop interacting with specific people for a while.
+3. **A temporary ban.** For a serious violation or sustained bad behaviour:
+   a temporary ban from any interaction with the project.
+4. **A permanent ban.** For a pattern of violations, harassment of an
+   individual, or aggression toward a group: a permanent ban from the
+   project's spaces.
+
+Good faith matters. Honest mistakes, handled well, don't end contributions —
+they're how everyone learns the norms.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>. It
+has been shortened and adapted for a single-maintainer project; the
+Contributor Covenant FAQ is at <https://www.contributor-covenant.org/faq>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@
 Use the issue templates:
 <https://github.com/its-me-prash/vwgroup-connect-ha/issues/new/choose>
 
+For how a report travels from filing to fix — templates, triage flow, labels, crediting — see [docs/TRIAGE.md](docs/TRIAGE.md).
+
 A good bug report contains:
 
 - VW Group Connect version (`manifest.json`)
@@ -262,3 +264,7 @@ template.
 
 Be civil. Be specific. Don't paste secrets. The maintainer is one person
 on their own time — patches and patience travel further than demands.
+
+The full version lives in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+How the project is run and how influence is earned: see [`GOVERNANCE.md`](GOVERNANCE.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,123 @@
+# Governance
+
+How decisions get made in VW Group Connect, who makes them, and what happens
+if the person making them steps back. Short and honest — this is a one-person
+project, not a foundation.
+
+---
+
+## The model: single maintainer
+
+VW Group Connect is maintained by one person — **Prash
+([@its-me-prash](https://github.com/its-me-prash))**. He has the final say on
+scope, on what gets merged, and on what ships. [`.github/CODEOWNERS`](.github/CODEOWNERS)
+reflects this literally: until brand captains are recruited, the maintainer
+owns every file.
+
+That is a "benevolent dictator" setup, and it's deliberate. A small
+integration chasing constant Volkswagen backend changes moves faster with one
+clear decision-maker than with a committee. It also means there is no SLA, no
+guaranteed review time, and no promise that any given feature will land.
+Patches and patience travel further than demands.
+
+---
+
+## How decisions get made
+
+1. **It starts in the open** — a GitHub [issue](https://github.com/its-me-prash/vwgroup-connect-ha/issues)
+   or [discussion](https://github.com/its-me-prash/vwgroup-connect-ha/discussions).
+   Bug reports, feature requests, Vehicle Data Scout findings and real-car test
+   results all feed the same queue.
+2. **Evidence beats assertion.** Claims about official-app behaviour want
+   captured traffic or a diagnostics attachment behind them, not a hunch. The
+   maintainer-side rules in [`CONTRIBUTING.md`](CONTRIBUTING.md) (privacy,
+   `[Inference]` markers, self-checks before replying) are binding on the
+   maintainer too.
+3. **The maintainer calls it.** After weighing the report, the code, and the
+   house rules, Prash decides. Larger direction lives in
+   [`docs/ROADMAP.md`](docs/ROADMAP.md), but the roadmap is a plan, not a
+   promise.
+4. **Reporters get a real answer.** No issue is closed silently. Contributors
+   are answered warmly and specifically — every commenter on a thread, not just
+   the author — and credited (see below).
+
+There is no vote and no tie-break procedure, because there is no tie to break.
+
+---
+
+## Earning influence
+
+Influence here is earned by showing up, not by being appointed. The concrete
+first rung is documented in [`BRAND_CAPTAINS.md`](BRAND_CAPTAINS.md):
+
+- File at least one **Vehicle Data Scout** report, run the integration on a
+  real car for a couple of weeks, and say you'll captain a brand.
+- A **Brand Captain** is then added as a co-owner for that brand's API client
+  in [`.github/CODEOWNERS`](.github/CODEOWNERS) — so they're auto-requested on
+  relevant PRs — and thanked by name in release notes. No coding required;
+  live-testing and verifying is the job.
+
+Beyond that, the path toward **co-maintainership** is the same one every small
+project runs on: land good, focused pull requests over time. A contributor who
+consistently respects the house rules — one PR = one concern, tests for new
+behaviour, privacy first, green CI — and shows they understand the codebase
+earns review trust, then merge trust. If the project grows enough to need it,
+co-maintainer access is extended to someone who has already proven all of that
+in practice. It is a matter of demonstrated track record, not a form to fill in.
+
+---
+
+## Release & versioning discipline
+
+The rules that keep releases predictable are not up for negotiation per-PR:
+
+- **SemVer** ([Semantic Versioning 2.0.0](https://semver.org/)), post-1.0.0
+  strict: PATCH for fixes, MINOR for new entities/services/brands, MAJOR for
+  breaking changes. Betas ship as `X.Y.0bN` on the HACS beta channel.
+- **PR-first, not direct-to-main.** Contributions come as pull requests and
+  merge only with green CI. The gate runs `ruff`, `mypy` (strict flags), the pytest
+  suite with a coverage floor, and JSON validation; a change under
+  `custom_components/` that omits a `CHANGELOG.md` entry is rejected by the
+  `changelog_check.yml` workflow. Full procedure in
+  [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md).
+- **No fixed cadence.** A release goes out whenever a coherent, atomic batch is
+  on `main` and CI is green — in busy stretches that is roughly a release a
+  day, but nothing is owed on a timetable.
+- **Every release credits its reporters.** Contributors are listed in
+  [`CONTRIBUTORS.md`](CONTRIBUTORS.md) and thanked in the relevant
+  [`CHANGELOG.md`](CHANGELOG.md) entry.
+
+**Security** decisions follow their own track: report privately via
+[GitHub Security Advisories](https://github.com/its-me-prash/vwgroup-connect-ha/security/advisories/new),
+never a public issue. [`SECURITY.md`](SECURITY.md) states the one place we do
+commit to a target (acknowledge within 72 hours, fix high-severity within 14
+days).
+
+---
+
+## Continuity — if the maintainer steps back
+
+This is a one-person project, so it is worth being plain: if Prash stops
+maintaining it, no one is contractually next. But the project is built so it
+can outlive any single person.
+
+- It is licensed **[GNU AGPL-3.0-or-later](LICENSE)**. Anyone may fork it and
+  continue, subject to the mandatory-attribution and name/trademark terms in
+  [`ATTRIBUTION.md`](ATTRIBUTION.md).
+- There are **no external runtime dependencies** — the CARIAD client is
+  bundled — so a fork has the whole surface in one repo, nothing to reassemble.
+- A successor should start with [`CONTRIBUTING.md`](CONTRIBUTING.md) (especially
+  *Adding a new brand* and the privacy rules), [`RELEASE_PROCESS.md`](RELEASE_PROCESS.md),
+  and [`docs/ROADMAP.md`](docs/ROADMAP.md). Between them they describe how the
+  code is laid out, how it ships, and where it was heading.
+
+If a wind-down ever becomes real, the intent is to hand the project to an
+active co-maintainer or clearly point the README at a maintained fork rather
+than let it rot silently. That is an intention, not a guarantee.
+
+---
+
+*Governance questions that aren't security-sensitive belong in a
+[Discussion](https://github.com/its-me-prash/vwgroup-connect-ha/discussions).
+This document describes how the project is run today; it will change as the
+project does.*

--- a/README.md
+++ b/README.md
@@ -236,6 +236,31 @@ This is a one-person project — and VW doesn't make it easy: every backend chan
 
 ---
 
+## Community & Support
+
+Where to go depends on what you need:
+
+- **Questions, setup help, dashboard examples, "is this normal?"** → [GitHub Discussions](https://github.com/its-me-prash/vwgroup-connect-ha/discussions). General Home Assistant questions that aren't specific to this integration land better on the [HA Community Forum](https://community.home-assistant.io).
+- **A bug, an error, or an unknown API field** → open an issue via [New issue → choose a template](https://github.com/its-me-prash/vwgroup-connect-ha/issues/new/choose). The **Vehicle Data Scout** pre-fills most of the report for you. A useful report names your brand, region, Home Assistant + integration version, and whether the same action works in the manufacturer's official app — the short checklist is in [`CONTRIBUTING.md`](CONTRIBUTING.md); how a report travels from filing to fix is in [`docs/TRIAGE.md`](docs/TRIAGE.md).
+- **A security vulnerability** → please **don't** open a public issue. Report it privately through [GitHub Security Advisories](https://github.com/its-me-prash/vwgroup-connect-ha/security/advisories/new); the process is in [`SECURITY.md`](SECURITY.md).
+
+### What to expect
+
+This is a one-person project, maintained in spare time. Replies are **best-effort** — sometimes same-day, sometimes slower when VW breaks something and a fix jumps the queue. There's no SLA, and there won't be one. The more specific your report (sanitised logs, redacted diagnostics, exact steps), the quicker it gets sorted. The house rule, short version: **be civil, be specific, don't paste secrets — patches and patience travel further than demands.**
+
+### Ways to help
+
+You don't have to write code to move this forward:
+
+- **File good bug reports** and attach redacted diagnostics — one Scout download is often everything needed to map a new field.
+- **Test on a real car.** Several brands are implemented but waiting on first live confirmation — see the [live-testers list](CONTRIBUTING.md#live-testers-wanted).
+- **Improve translations.** Entity names ship in 12 languages; corrections and help with a new language are welcome.
+- **Send a patch.** One PR, one concern — see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+Everyone who helps is credited in [`CONTRIBUTORS.md`](CONTRIBUTORS.md) and thanked by name in the release notes. How decisions get made — and who has the final call on a one-maintainer project — is written down in [`GOVERNANCE.md`](GOVERNANCE.md); the ground rules for taking part are in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+---
+
 ## Contributing
 
 PRs welcome, see [`CONTRIBUTING.md`](CONTRIBUTING.md). Common questions are answered in [docs/FAQ.md](docs/FAQ.md). The **Vehicle Data Scout** turns unknown API fields into a one-click, pre-filled bug report, so you can help improve coverage without reading code.

--- a/docs/TRIAGE.md
+++ b/docs/TRIAGE.md
@@ -1,0 +1,194 @@
+# How issues get triaged
+
+> This integration is maintained by one person, on their own time, against
+> a backend that Volkswagen keeps changing. This page explains — honestly —
+> how a report travels from your Home Assistant instance to a fix in a
+> release, so you know what to expect and can help the process along.
+
+It's descriptive, not a promise: there are no service-level guarantees here.
+Good reports get fixed faster, and every reporter gets a real reply and a
+credit. That's the deal.
+
+---
+
+## Pick the right template
+
+Open a report at
+[**Issues → New issue**](https://github.com/its-me-prash/vwgroup-connect-ha/issues/new/choose).
+Blank issues are disabled on purpose — the templates ask the handful of
+questions that otherwise cost a round-trip to get answers to.
+
+| Template | Use it when | Auto-label |
+|---|---|---|
+| 🐛 **Bug Report** | A feature works in the manufacturer app but not here, or an entity shows something wrong. | `bug` |
+| 💡 **Feature Request** | A sensor, command or capability is missing and you'd like it added. | `enhancement` |
+| 🚗 **Brand live-test report** | You want to report whether your brand/model works — especially the ones still short on real-car testing (Porsche, VW US/CA, VW Commercial, broader Škoda). | `testing` |
+| 🚨 **Error Reporter** | You clicked "Mehr erfahren" on the HA Error-Reporter repair notification — it opens this pre-filled. | `error-report`, `needs-triage` |
+| 🛰️ **Vehicle Data Scout Report** | You clicked "Mehr erfahren" on the Scout repair notification — the integration found a backend field it doesn't recognise yet. | `scout-report`, `needs-triage` |
+
+Not a bug and not sure where it fits? The template chooser also links out to:
+
+- **Discussions** — general questions, dashboard examples, community exchange.
+- **HA Community Forum** — general Home Assistant questions.
+- **Security vulnerability** — report it *privately* (see [Security](#security-goes-somewhere-else) below), never as a public issue.
+
+The two auto-generated templates (Error Reporter, Vehicle Data Scout) come
+from features inside the integration: the report is built on your device,
+masked there, and nothing leaves HA until you click through and submit.
+
+---
+
+## What a good report contains
+
+The Bug Report template asks for these because each one changes the answer:
+
+- **VW Group Connect version** (from `manifest.json` / the integration page)
+- **Home Assistant version**
+- **Brand, model + year**
+- **Country / region** — some endpoints and entitlements differ by market
+- **Does the same action work in the official manufacturer app?**
+- **Is the connected-services subscription active?** — some brands block
+  commands server-side when a plan lapses; that isn't a bug here
+- **Is an S-PIN configured?** — required for lock and some other commands
+- **Sanitised logs** — HA → Settings → System → Logs, filter `vag_connect`
+  (enable *Enable debug logging* on the integration first)
+- **Diagnostics** — Settings → Devices & Services → VW Group Connect → ⋮ →
+  *Download diagnostics*. Sensitive fields auto-redact on current versions.
+
+Logs and diagnostics are what make a report reproducible. A one-line "it
+doesn't work" almost always comes back with "can you attach the debug log?",
+so attaching it up front saves a day.
+
+### Redact before you paste
+
+**Diagnostics redact the sensitive fields for you.** A raw HA log does not —
+so if you paste log text, mask it yourself first. The templates require you
+to confirm you've done this:
+
+- **VIN** → keep only the last 6 characters, e.g. `***003577`. A full VIN
+  ties to registration, insurance and ownership records.
+- **Tokens** (`access_token`, `refresh_token`, `id_token`) → remove entirely.
+- **S-PIN** → never share, not even masked.
+- **Email** → mask the local part, e.g. `u***@***.com`.
+- **GPS** (`latitude`, `longitude`) → round to 1 decimal, or remove.
+- **Account ID / user_id** (UUIDs) → remove.
+
+If something slips through, say so in the issue and the maintainer will edit
+it out — but the masking is on the reporter first. The full maintainer-side
+data-handling rules live in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md#privacy--data-handling-added-2026-04-30-after-53-review).
+
+---
+
+## Triage yourself first (it might not be a bug)
+
+A "command failed" isn't always a code defect. The
+[FAQ in CONTRIBUTING.md](../CONTRIBUTING.md#faq--subscription--service-plus--paid-plans-closes-47)
+carries the full decision table; the short version — check the error body:
+
+| What you see | Likely cause | Who fixes it |
+|---|---|---|
+| `missing-capability` | The server says this VIN doesn't have the feature (region / trim / firmware). | Not fixable here — the entity gets hidden, like the app hides the button. |
+| `subscription_expired` / `not_entitled` | Paid plan lapsed. | Renew in the manufacturer portal. |
+| `spin_error` with `spinState: "DEFINED"` | The command needs an S-PIN. | Configure the S-PIN in the integration options. |
+| `Bad Gateway` / `4007` / `4111` | Transient backend hiccup. | Usually clears on retry. |
+| `404 Not Found` | Endpoint doesn't exist for that vehicle's API profile. | May need new code — worth a bug report. |
+| `403`, no body | Auth token expired, retry budget exceeded, or a temporary rate limit. | Restart the integration; report if it persists. |
+
+If your case is genuinely one of the top three, a Discussion or a comment is
+usually a faster path to an answer than a bug report. If it's a `404`, a
+scout finding, or the official app clearly does something we don't — that's a
+real bug and very welcome.
+
+---
+
+## How the maintainer works a report
+
+Once a report lands, the loop is roughly:
+
+1. **Read it and reply.** Every reporter gets a substantive answer — a
+   question, a diagnosis, or "reproduced, fixing it" — not a canned close.
+   Replies are written in the reporter's own language where it's inferable
+   from the Country field or how the issue was written; English otherwise.
+2. **Reproduce.** With the log/diagnostics, against a fixture where possible.
+   A real-world payload that gets turned into a regression test is first
+   anonymised (VIN, tokens, IDs, GPS stripped) — and only with the reporter's
+   consent. See the fixture rules in
+   [`CONTRIBUTING.md`](../CONTRIBUTING.md#what-goes-in-the-repo--fixtures--commits).
+3. **Locate it in code.** Find the brand client, parser, or coordinator path
+   that's actually wrong — not a symptom patch.
+4. **Fix on a branch, with a test.** One PR = one concern. New behaviour
+   ships with a test (a parser test, an entity test, or a coordinator
+   dispatch test), the CHANGELOG is updated, and CI has to be green:
+   `ruff`, `mypy --strict`, JSON validation, and a check that the CHANGELOG
+   mentions the version. Fixes go through a PR, not straight to `main`.
+5. **Release and credit.** When the fix ships, the issue is closed with a
+   note (never silently), the reporter is thanked in the release, and their
+   handle is added to the contributor list.
+
+Scout reports have their own handling rules — a new field is *parsed and
+surfaced*, not just silenced. That policy is written up in full in
+[`docs/SCOUT_POLICY.md`](SCOUT_POLICY.md).
+
+---
+
+## Labels you'll see
+
+Labels here are lightweight. Picking a template applies the first one for
+you:
+
+| Label | Meaning |
+|---|---|
+| `bug` | A defect to reproduce and fix. |
+| `enhancement` | A requested feature or new capability. |
+| `testing` | A live-test / brand-verification report. |
+| `error-report` | Auto-generated from the in-app Error Reporter. |
+| `scout-report` | Auto-generated from the Vehicle Data Scout. |
+| `needs-triage` | New auto-generated report, not yet looked at. |
+
+A few more come from automation rather than issue triage — `ci` and
+`dependencies` on Dependabot's grouped Action-bump PRs, and internal
+watcher workflows raise their own tracking issues (e.g. `auth-status-change`
+when the VW EU login state shifts). You don't need to touch those.
+
+There's deliberately no sprawling priority/severity taxonomy — with one
+maintainer, an elaborate label scheme would be theatre. The state that
+matters is "has this been reproduced and is there a branch," and that lives
+in the issue thread.
+
+---
+
+## Every reporter gets credited
+
+This isn't a courtesy afterthought, it's a rule:
+
+- **A real reply** on the issue, in the reporter's language where possible —
+  full coverage, meaning everyone who added information gets addressed, not
+  just the original poster.
+- **A Thanks line in the [CHANGELOG](../CHANGELOG.md)** for the release that
+  carries the fix — e.g. *"Thanks @yourhandle"* right next to the change.
+- **An entry in [CONTRIBUTORS.md](../CONTRIBUTORS.md)** — everyone who filed a
+  report, sent diagnostics, requested a feature, tested on a real car, or
+  took part in a discussion.
+
+If you contributed and don't see yourself listed, that's an oversight, not a
+snub — open an issue and it gets fixed.
+
+---
+
+## Security goes somewhere else
+
+Please don't file a suspected vulnerability as a public issue. Report it
+privately through
+[**GitHub Security Advisories**](https://github.com/its-me-prash/vwgroup-connect-ha/security/advisories/new),
+as described in [`SECURITY.md`](../SECURITY.md). That keeps users safe while
+a fix is prepared.
+
+---
+
+## A note on pace
+
+There's no SLA and there won't be one — this is one person against a moving
+backend. What travels furthest is a well-redacted report with a debug log and
+the template fields filled in. Patches and patience go a long way; demands
+don't. Thanks for helping keep it alive.


### PR DESCRIPTION
Closes the community-health gaps from an opensource.guide audit — every doc grounded against the repo's **actual** practices, not boilerplate.

## New files
- **`CODE_OF_CONDUCT.md`** — a standalone, discoverable Code of Conduct (previously only a three-line paragraph inside `CONTRIBUTING.md`). Contributor Covenant v2.1 structure, adapted honestly for a single-maintainer project. Private reports route through GitHub; no email address is exposed.
- **`GOVERNANCE.md`** — the real single-maintainer / BDFL model, how decisions get made, the brand-captain → co-maintainer path, the release + versioning discipline, and an honest continuity note (AGPL fork, zero runtime deps).
- **`docs/TRIAGE.md`** — how a report travels from filing to a fix: which template to use, redaction rules, the error-body decision table (is it even a bug?), the real label set, and the credit-every-reporter rule.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — a checklist mirroring the real merge gate (pytest, ruff, mypy strict, CHANGELOG entry, JSON validity, no secrets, no AI/co-author trailers).

## Wiring
- `README.md` gains a **Community & Support** section (help channels, honest no-SLA expectation, ways to help) linking the new files.
- `CONTRIBUTING.md` points to `docs/TRIAGE.md` and to the standalone `CODE_OF_CONDUCT.md` + `GOVERNANCE.md`.

All 47 internal links and anchors resolve. Docs-only — no integration/runtime change.

Deliberately skipped: a stale-bot (auto-closing issues fights the answer-every-reporter rule) and a metrics cadence (process, not a committed artifact).