### PR TITLE
docs: fix stale references (12 languages, real README list, reporter credit)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,12 +21,16 @@ custom_components/vag_connect/cariad/auth/                          @its-me-pras
 .github/                                                            @its-me-prash
 RELEASE_PROCESS.md                                                  @its-me-prash
 
-# Documentation in 8 languages — keep in sync at every release
+# READMEs (English source + 11 translations) — keep in sync at every release
 README.md                                                           @its-me-prash
-README.en.md                                                        @its-me-prash
 README.cs.md                                                        @its-me-prash
+README.da.md                                                        @its-me-prash
+README.de.md                                                        @its-me-prash
 README.es.md                                                        @its-me-prash
+README.fi.md                                                        @its-me-prash
 README.fr.md                                                        @its-me-prash
+README.it.md                                                        @its-me-prash
+README.nb.md                                                        @its-me-prash
 README.nl.md                                                        @its-me-prash
 README.pl.md                                                        @its-me-prash
 README.sv.md                                                        @its-me-prash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Changed / Geändert
+- Docs & metadata housekeeping: corrected stale "8 languages" references (the
+  quality-scale notes and the contributor guide) to the 12 that actually ship.
+  Danish, Finnish, Italian and Norwegian were added a while back — only the
+  counts lagged behind. No functional change.
+
 ## [4.4.0b3] - 2026-08-28 — Reporter fixes: PPE windows/doors · portal-health honesty · companion 4.3.2 · reachable historical export
 
 > [!NOTE]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,7 @@ The `changelog_check.yml` workflow rejects PRs that touch
 ### Translations
 
 `strings.json` is the **English source of truth**. Mirror every change
-into all 8 language files (`translations/{de,en,cs,es,fr,nl,pl,sv}.json`).
+into all 12 language files (`translations/{cs,da,de,en,es,fi,fr,it,nb,nl,pl,sv}.json`).
 Use everyday driver vocabulary, not API jargon: e.g. *Lichthupe*, not
 *Lichtsignal*.
 
@@ -228,7 +228,7 @@ Use everyday driver vocabulary, not API jargon: e.g. *Lichthupe*, not
 4. `const.py` — `BRANDS` dict
 5. `config_flow.py` — `_BRAND_OPTIONS`
 6. `tests/test_cariad.py` — at minimum: factory routing, status parser
-7. README feature table (mirror in all 8 languages)
+7. README feature table (mirror across all 11 translated READMEs)
 8. `_private/research-archive/VAG_GROUP_ECOSYSTEM.md` — add the brand to the map
 
 **Capability-first:** the new client must implement a capability check

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -86,14 +86,14 @@ bodies, inline code comments, and `docs/CHANGELOG_TECHNICAL.md`.
 - Issue numbers in parentheses at the end: `(#281, #282)`
 - Plain language — avoid project-internal jargon (`*_pending family`,
   `T1 audit`, brand-vererbung) in the user-facing changelog
+- Credit the reporter: a short `Thanks @handle` next to their fix, plus
+  an ack-comment on the closed issue **in the reporter's native
+  language** (see below)
 
 **Don't**:
 - Cite reference implementations (`per matpoulin`, `mirroring
   CarConnectivity v0.6.3`) — that's commit-message territory
 - List file paths, LoC counts, function/class names
-- Quote reporter usernames inside the changelog body (we credit them
-  in the ack-comment on the closed issue instead — **in the reporter's
-  native language**, see below)
 - Document tier classifications, audit methodology, or migration
   rationale (those live in `docs/SCOUT_POLICY.md`, `MIGRATION.md`)
 - Repeat the same info in a top quote-block AND a per-section bullet

--- a/custom_components/vag_connect/quality_scale.yaml
+++ b/custom_components/vag_connect/quality_scale.yaml
@@ -47,7 +47,7 @@ rules:
 
   docs-installation-instructions:
     status: done
-    comment: README.md (8 languages) documents HACS and manual installation.
+    comment: README.md (12 languages) documents HACS and manual installation.
 
   docs-removal-instructions:
     status: done
@@ -199,7 +199,7 @@ rules:
     status: done
     comment: |
       All entities use translation_key via has_entity_name=True.
-      Names defined in strings.json entity section, translated in 8 languages.
+      Names defined in strings.json entity section, translated in 12 languages.
 
   exception-translations:
     status: done


### PR DESCRIPTION
Stale-reference cleanup surfaced during the community-health audit — a repo-wide sweep for outdated "8 languages" / non-existent-file references. Current-state docs only (historical CHANGELOG/ROADMAP mentions of "8 languages" are left untouched — they correctly describe the state at that time).

- **`CONTRIBUTING.md`** — the Translations note claimed *"all 8 language files `{de,en,cs,es,fr,nl,pl,sv}`"*, but 12 ship. Corrected to `{cs,da,de,en,es,fi,fr,it,nb,nl,pl,sv}`. The *Adding a new brand* step said *"mirror in all 8 languages"* → now *"mirror across all 11 translated READMEs"*.
- **`.github/CODEOWNERS`** — removed `README.en.md` (no such file exists) and listed all 12 actual READMEs (English source + 11 translations); the section comment now matches.
- **`RELEASE_PROCESS.md`** — the changelog guide's *Don't* list said *"don't quote reporter usernames in the changelog body"*, but every release actually credits reporters inline with *"Thanks @handle"* (matching the credit-every-reporter rule). Reconciled to reality: crediting moved to *Do*, the native-language ack-comment note preserved.
- **`custom_components/vag_connect/quality_scale.yaml`** — the same stale *"8 languages"* in two quality-scale comments → 12. Because this touches `custom_components/`, a short `[Unreleased]` CHANGELOG note is included (no functional change).

All internal links/anchors still resolve. No integration behaviour changes.