### PR TITLE
fix: Audi/VW-EU doors+trunk parsing (#1281) and EU-Data-Act export button on merged setups (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   the lock state was right. The trunk's own "open" and "locked" sensors are
   populated now too. (Bonnet and windows already worked — they ship a single
   word.)
+- **The one-time historical-export button now appears on merged setups too**
+  (#923, thanks @naked-head and @dazzzl). It was only created when the EU Data
+  Act portal was your *primary* (read-only) channel — so if you'd added the
+  portal as a supplementary channel on top of a command account
+  (`eu_data_act+website_authproxy`), the button never showed even though the
+  export works exactly the same there. It now appears whenever a portal channel
+  is present, and a merged setup can import the result too.
 
 ## [4.4.0b3] - 2026-08-28 — Reporter fixes: PPE windows/doors · portal-health honesty · companion 4.3.2 · reachable historical export
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   Danish, Finnish, Italian and Norwegian were added a while back — only the
   counts lagged behind. No functional change.
 
+### Fixed / Behoben
+- **Audi/VW-EU doors and trunk now report open/closed correctly** (#1281,
+  thanks @peterbauer1709). A door entry carries both its lock word and its
+  open word in one list (`["unlocked", "open"]`); we read only the first, so
+  every physically open side door — and the trunk — showed closed even though
+  the lock state was right. The trunk's own "open" and "locked" sensors are
+  populated now too. (Bonnet and windows already worked — they ship a single
+  word.)
+
 ## [4.4.0b3] - 2026-08-28 — Reporter fixes: PPE windows/doors · portal-health honesty · companion 4.3.2 · reachable historical export
 
 > [!NOTE]

--- a/custom_components/vag_connect/button.py
+++ b/custom_components/vag_connect/button.py
@@ -48,17 +48,25 @@ async def async_setup_entry(
         if coordinator.is_companion():
             entities.append(VagCompanionResetButton(coordinator, vin))
             return entities
-        if read_only:
-            # v2.17.1 — portal (read-only) entries expose a button to create or
-            # refresh the EU-Data-Act continuous data request on demand, so a
-            # user whose portal has no active request can fix "no data" from
-            # inside Home Assistant instead of the portal UI.
+        # v2.17.1 / #923 — EU-Data-Act portal buttons appear whenever this entry
+        # reads the portal: as its PRIMARY (read-only) channel OR as a
+        # SUPPLEMENTARY channel merged onto a command primary. They used to be
+        # gated on read-only-portal mode only, so a merged
+        # ``eu_data_act+website_authproxy`` setup (@naked-head, @dazzzl) never
+        # got the one-time export button even though the export works identically
+        # there — the kickoff scraper is authed on the shared session either way.
+        if coordinator.has_data_act_portal_channel():
+            # Create/refresh the continuous data request on demand, so a user
+            # whose portal has no active request can fix "no data" from inside
+            # Home Assistant instead of the portal UI.
             entities.append(VagDataActRequestButton(coordinator, vin))
             # Stage-1 — a one-time historical-export trigger, unless the whole
             # lifecycle is disabled by the kill-switch.
             from .const import ONETIME_EXPORT_DISABLED  # noqa: PLC0415
             if not ONETIME_EXPORT_DISABLED:
                 entities.append(VagHistoricalExportButton(coordinator, vin))
+        if read_only:
+            # A read-only entry has no vehicle commands to add below.
             return entities
         # v3.0.0a1 — also require the client to implement the command, else the
         # button raises AttributeError on press (companion/ADB has neither).

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -4091,37 +4091,62 @@ class VWEUClient(CariadBaseClient):
         # ``status[0].value``, so a PPE car reporting the string form parsed to
         # empty windows *and* doors (windows_open False, windows_individual {})
         # even though the raw clearly said "open". Read either shape.
-        def _acc_status(entry: dict[str, Any]) -> str | None:
-            s0 = safe_get(entry, "status[0]")
-            if isinstance(s0, dict):
-                s0 = s0.get("value") or s0.get("status")
-            return s0.lower() if isinstance(s0, str) else None
+        # #1281 (@peterbauer1709, Audi S6 e-tron / PPE) — a *door* entry ships
+        # BOTH its lock token and its open token in the SAME ``status`` list
+        # (``["unlocked", "open"]``), so the earlier ``status[0]``-only read
+        # returned the lock word ("unlocked") and every side door + the trunk
+        # read as closed even when physically open. A bonnet/window carries a
+        # single token (``["open"]``), which is why those already worked.
+        # Collect the whole token set (string OR ``[{"value": ...}]`` object
+        # form, #1279) and look for the specific token we want.
+        def _acc_tokens(entry: dict[str, Any]) -> set[str]:
+            out: set[str] = set()
+            for s in (entry.get("status") or []):
+                if isinstance(s, dict):
+                    s = s.get("value") or s.get("status")
+                if isinstance(s, str):
+                    out.add(s.lower())
+            return out
 
         if doors:
-            d.doors_open = any(_acc_status(door) == "open" for door in doors)
-            d.doors_individual = {
-                str(name): _acc_status(door) == "open"
+            door_tokens = {
+                str(name): _acc_tokens(door)
                 for door in doors
                 if (name := door.get("name")) is not None
             }
-            # Trunk lock state lives in the doors array under the
-            # entry whose name is "trunk". Backends ship either a
-            # top-level ``locked`` boolean or a status entry with
-            # value=="locked" — accept both.
-            trunk = next(
-                (door for door in doors if door.get("name") == "trunk"),
-                None,
-            )
-            if trunk is not None:
-                trunk_locked_raw = (
-                    trunk.get("locked")
-                    if "locked" in trunk
-                    else safe_get(trunk, "lockState[0].value")
+            d.doors_individual = {
+                name: "open" in tk for name, tk in door_tokens.items()
+            }
+            d.doors_open = any("open" in tk for tk in door_tokens.values())
+            # The trunk rides in the doors array under name "trunk". Surface its
+            # dedicated open + lock state — both were previously left null on the
+            # two-token ``["unlocked", "closed"]`` shape (open never set at all,
+            # lock only read from a top-level ``locked`` key that PPE omits).
+            trunk_tk = door_tokens.get("trunk")
+            if trunk_tk is not None:
+                if "open" in trunk_tk or "closed" in trunk_tk:
+                    d.trunk_open = "open" in trunk_tk
+                if "locked" in trunk_tk:
+                    d.trunk_locked = True
+                elif "unlocked" in trunk_tk:
+                    d.trunk_locked = False
+            # Legacy shapes: other backends carry the trunk lock as a top-level
+            # ``locked`` boolean or a ``lockState[0].value`` string instead.
+            if d.trunk_locked is None:
+                trunk = next(
+                    (door for door in doors if door.get("name") == "trunk"),
+                    None,
                 )
-                if isinstance(trunk_locked_raw, bool):
-                    d.trunk_locked = trunk_locked_raw
-                elif isinstance(trunk_locked_raw, str):
-                    d.trunk_locked = trunk_locked_raw.lower() == "locked"
+                if trunk is not None:
+                    trunk_locked_raw = (
+                        trunk.get("locked")
+                        if "locked" in trunk
+                        else safe_get(trunk, "lockState[0].value")
+                    )
+                    if isinstance(trunk_locked_raw, bool):
+                        d.trunk_locked = trunk_locked_raw
+                    elif isinstance(trunk_locked_raw, str):
+                        d.trunk_locked = trunk_locked_raw.lower() == "locked"
         elif overall == "SAFE":
             # Backend reported SAFE but didn't enumerate the doors
             # array. Honour the aggregate signal so the entity shows
@@ -4129,25 +4154,26 @@ class VWEUClient(CariadBaseClient):
             d.doors_open = False
 
         if windows:
-            d.windows_open = any(_acc_status(w) == "open" for w in windows)
+            d.windows_open = any("open" in _acc_tokens(w) for w in windows)
             # v2.18.1 (#810, @lucson) — windows_individual follows the documented
             # ``True == closed`` convention: the same one VagWindowSensor (which
             # inverts for the HA WINDOW device_class) and the EU-Data-Act portal
-            # parser already use. Storing ``== "open"`` here (True == open) was the
-            # lone outlier and rendered every *closed* window as *open* on Audi /
-            # VW-EU cars. Only entries with a real open/closed status are stored; a
-            # non-open/closed sentinel (an option-dependent roof on a car without
-            # one) is skipped so it can't surface as a phantom window.
+            # parser already use. Only entries with a real open/closed status are
+            # stored; a non-open/closed sentinel (an option-dependent roof on a
+            # car without one) is skipped so it can't surface as a phantom window.
             windows_individual: dict[str, bool] = {}
             windows_position: dict[str, int] = {}
             for w in windows:
                 name = w.get("name")
                 if name is None:
                     continue
-                st = _acc_status(w)
-                if st not in ("open", "closed"):
+                tk = _acc_tokens(w)
+                if "open" in tk:
+                    windows_individual[str(name)] = False  # True == closed
+                elif "closed" in tk:
+                    windows_individual[str(name)] = True
+                else:
                     continue
-                windows_individual[str(name)] = st == "closed"
                 # #1279 — PPE cars ship an opening percentage (``windowOpen_pct``)
                 # per window, so surface it instead of leaving windows_position {}.
                 pct = w.get("windowOpen_pct")

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2021,7 +2021,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         live PHEV to electric. Returns True if anything merged, False if the ZIP
         isn't ready yet (the portal generates it asynchronously).
         """
-        portal = getattr(self._cariad_client, "_eu_portal", None)
+        # #923 — a supplementary portal (merged onto a command primary) exposes
+        # the same ``get_vehicle_data``; without this a merged setup could
+        # request the export but never import it (``_eu_portal`` is None there).
+        portal = (
+            getattr(self._cariad_client, "_eu_portal", None)
+            or getattr(self._cariad_client, "_supplementary_eu_portal", None)
+        )
         if portal is None or not hasattr(portal, "get_vehicle_data"):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -6494,6 +6500,24 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 "VW Group Connect: could not persist supplementary vw.de cookies "
                 "(%s) — will retry next poll.", type(err).__name__,
             )
+
+    def has_data_act_portal_channel(self) -> bool:
+        """True when this entry reads the EU Data Act portal — as its primary
+        (read-only) channel OR as a supplementary channel merged onto a command
+        primary.
+
+        Both can use the portal's one-time historical export and the continuous
+        data-request button; the kickoff scraper is authed on the shared session
+        where the (primary or supplementary) portal logged in — see
+        ``async_create_data_act_request`` and its b12 note. #923
+        (@naked-head/@dazzzl): the export button was gated on read-only-portal
+        mode only, so a merged ``eu_data_act+website_authproxy`` setup never got
+        it even though the export works exactly the same there.
+        """
+        from .const import CONF_SUPPLEMENTARY_EU_PORTAL  # noqa: PLC0415
+        return self.is_read_only() or bool(
+            self.entry.data.get(CONF_SUPPLEMENTARY_EU_PORTAL)
+        )
 
     def is_read_only(self) -> bool:
         """v1.12.0 (#63) — return True if user enabled Read-only Mode.

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -4298,6 +4298,10 @@ class TestButtonCapabilityGating:
         # v2.26.0 — likewise pin is_companion False so button setup doesn't take
         # the companion (reset-only) branch on a bare-MagicMock truthy value.
         coord.is_companion = MagicMock(return_value=False)
+        # #923 — pin the portal-channel predicate False so this capability-gating
+        # suite doesn't also spawn the EU-Data-Act portal buttons on a truthy
+        # bare MagicMock (those are exercised in TestDataActPortalButtonGating).
+        coord.has_data_act_portal_channel = MagicMock(return_value=False)
         coord.vehicles = {"VIN1": {"vin": "VIN1", "model": "Born"}}
         coord.vehicle_capabilities = {"VIN1": caps} if caps else {}
         # v1.13.0 (#56 Phase 3) — entry.data["brand"] is what
@@ -4400,6 +4404,86 @@ class TestButtonCapabilityGating:
         added = self._setup(self._coord(caps={"capabilities": []}))
         names = [type(e).__name__ for e in added]
         assert "VagRefreshButton" in names
+
+
+class TestDataActPortalButtonGating:
+    """#923 (@naked-head, @dazzzl) — the EU-Data-Act portal buttons (data-act
+    request + one-time historical export) must appear whenever the entry reads
+    the portal: as its primary read-only channel OR as a supplementary channel
+    merged onto a command primary. Previously they were gated on read-only only,
+    so a merged ``eu_data_act+website_authproxy`` setup never got them."""
+
+    def _coord(self, *, read_only, portal, brand="volkswagen"):
+        from unittest.mock import MagicMock
+        coord = MagicMock()
+        coord.is_read_only = MagicMock(return_value=read_only)
+        coord.is_companion = MagicMock(return_value=False)
+        coord.has_data_act_portal_channel = MagicMock(return_value=portal)
+        # No command capabilities → flash/wake gated off, so the assertions
+        # isolate the portal buttons.
+        coord.command_capability_supported = MagicMock(return_value=False)
+        coord.command_method_available = MagicMock(return_value=False)
+        coord.vehicles = {"VIN1": {"vin": "VIN1", "model": "ID.4"}}
+        coord.entry = MagicMock()
+        coord.entry.data = {"brand": brand}
+        return coord
+
+    def _setup(self, coord, brand="volkswagen"):
+        import asyncio
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.button import async_setup_entry
+        entry = MagicMock()
+        entry.runtime_data = coord
+        entry.data = {"brand": brand}
+        added: list = []
+        asyncio.run(async_setup_entry(MagicMock(), entry, added.extend))
+        return [type(e).__name__ for e in added]
+
+    def test_supplementary_portal_gets_export_buttons(self):
+        """Merged command-primary + supplementary portal (not read-only): the
+        request + historical-export buttons now spawn — the #923 fix."""
+        names = self._setup(self._coord(read_only=False, portal=True))
+        assert "VagDataActRequestButton" in names
+        assert "VagHistoricalExportButton" in names
+        assert "VagRefreshButton" in names
+
+    def test_read_only_portal_still_gets_export_buttons(self):
+        """Regression: a primary read-only portal keeps its export buttons."""
+        names = self._setup(self._coord(read_only=True, portal=True))
+        assert "VagDataActRequestButton" in names
+        assert "VagHistoricalExportButton" in names
+        # read-only entries have no vehicle commands
+        assert "VagFlashButton" not in names
+        assert "VagWakeButton" not in names
+
+    def test_no_portal_channel_gets_no_export_buttons(self):
+        """A plain command primary without any portal channel must NOT spawn
+        the portal buttons (no regression for command-only users)."""
+        names = self._setup(self._coord(read_only=False, portal=False))
+        assert "VagDataActRequestButton" not in names
+        assert "VagHistoricalExportButton" not in names
+        assert "VagRefreshButton" in names
+
+    def test_predicate_true_for_read_only_or_supplementary(self):
+        """The coordinator predicate itself: read-only OR a supplementary portal
+        flag → True; neither → False."""
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        from custom_components.vag_connect.const import CONF_SUPPLEMENTARY_EU_PORTAL
+
+        def _p(read_only, supp):
+            coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+            coord.is_read_only = MagicMock(return_value=read_only)
+            coord.entry = MagicMock()
+            coord.entry.data = (
+                {CONF_SUPPLEMENTARY_EU_PORTAL: True} if supp else {}
+            )
+            return VagConnectCoordinator.has_data_act_portal_channel(coord)
+
+        assert _p(read_only=True, supp=False) is True
+        assert _p(read_only=False, supp=True) is True
+        assert _p(read_only=True, supp=True) is True
+        assert _p(read_only=False, supp=False) is False
 
 
 # ── Session 2C: SEAT/CUPRA SecToken flow + capabilities for other brands ──────

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -22,6 +22,10 @@ def _make_coordinator(vehicles=None):
     # v2.26.0 — same reason: a bare MagicMock's is_companion() is truthy, which
     # would send button setup down the companion (reset-only) branch.
     coord.is_companion = MagicMock(return_value=False)
+    # #923 — pin the portal-channel predicate False so a command-primary
+    # coordinator doesn't also spawn the EU-Data-Act portal buttons on a truthy
+    # bare MagicMock (portal buttons have their own gating test).
+    coord.has_data_act_portal_channel = MagicMock(return_value=False)
     coord.data = vehicles or {
         "WVGZZZ1KZAW123456": {
             "vin": "WVGZZZ1KZAW123456",

--- a/tests/test_vw_eu_window_invert.py
+++ b/tests/test_vw_eu_window_invert.py
@@ -124,3 +124,61 @@ def test_object_shape_status_still_works_and_reads_position():
     data = client._parse_status("VINX", raw, parking={})
     assert data.windows_individual["frontRight"] is False  # open
     assert data.windows_position["frontRight"] == 42
+
+
+def test_1281_two_token_door_status_open():
+    """#1281 (@peterbauer1709, Audi S6 e-tron MY2026) — a door entry carries
+    BOTH its lock token and its open token in one status list
+    (``["unlocked", "open"]``). The old ``status[0]``-only read returned
+    "unlocked", so every physically open side door + the trunk read as closed."""
+    client = _vw_client()
+    raw = _doors_raw(
+        {"name": "frontLeft", "status": ["unlocked", "open"]},
+        {"name": "frontRight", "status": ["unlocked", "open"]},
+        {"name": "rearLeft", "status": ["unlocked", "open"]},
+        {"name": "rearRight", "status": ["unlocked", "open"]},
+        {"name": "trunk", "status": ["unlocked", "closed"]},
+    )
+    data = client._parse_status("VINX", raw, parking={})
+    assert data.doors_open is True
+    assert data.doors_individual["frontLeft"] is True     # doors_individual: True == open
+    assert data.doors_individual["frontRight"] is True
+    assert data.doors_individual["rearLeft"] is True
+    assert data.doors_individual["rearRight"] is True
+    assert data.doors_individual["trunk"] is False         # trunk closed
+
+
+def test_1281_trunk_open_and_lock_surfaced():
+    """#1281 — the trunk's dedicated ``trunk_open`` / ``trunk_locked`` fields
+    were left null on the two-token shape (open was never set at all; lock was
+    only read from a top-level ``locked`` key that PPE omits)."""
+    client = _vw_client()
+    data = client._parse_status(
+        "VINX", _doors_raw({"name": "trunk", "status": ["unlocked", "open"]}),
+        parking={})
+    assert data.trunk_open is True
+    assert data.trunk_locked is False
+
+    data = client._parse_status(
+        "VINX", _doors_raw({"name": "trunk", "status": ["locked", "closed"]}),
+        parking={})
+    assert data.trunk_open is False
+    assert data.trunk_locked is True
+
+
+def test_1281_mixed_bonnet_single_doors_double():
+    """#1281 second scenario: bonnet single-token ``["open"]`` (always worked),
+    side doors closed two-token, trunk open two-token — all correct at once."""
+    client = _vw_client()
+    raw = _doors_raw(
+        {"name": "bonnet", "status": ["open"]},
+        {"name": "frontLeft", "status": ["unlocked", "closed"]},
+        {"name": "frontRight", "status": ["unlocked", "closed"]},
+        {"name": "trunk", "status": ["unlocked", "open"]},
+    )
+    data = client._parse_status("VINX", raw, parking={})
+    assert data.doors_individual["bonnet"] is True      # open
+    assert data.doors_individual["frontLeft"] is False   # closed
+    assert data.doors_individual["trunk"] is True        # open
+    assert data.trunk_open is True
+    assert data.doors_open is True                        # bonnet + trunk open

--- a/tests/test_vw_eu_window_invert.py
+++ b/tests/test_vw_eu_window_invert.py
@@ -182,3 +182,33 @@ def test_1281_mixed_bonnet_single_doors_double():
     assert data.doors_individual["trunk"] is True        # open
     assert data.trunk_open is True
     assert data.doors_open is True                        # bonnet + trunk open
+
+
+def test_1281_real_mixed_door_trace_from_reporter():
+    """#1279/#1281 — @peterbauer1709's real Audi S6 e-tron accessStatus trace
+    with a mixed door state (only the two right doors open). Every entry is the
+    two-token ``[lock, open]`` shape; before the fix all six read closed."""
+    client = _vw_client()
+    raw = {"access": {"accessStatus": {"value": {
+        "overallStatus": "unsafe",
+        "doors": [
+            {"name": "bonnet", "status": ["closed"]},
+            {"name": "frontLeft", "status": ["unlocked", "closed"]},
+            {"name": "frontRight", "status": ["unlocked", "open"]},
+            {"name": "rearLeft", "status": ["unlocked", "closed"]},
+            {"name": "rearRight", "status": ["unlocked", "open"]},
+            {"name": "trunk", "status": ["unlocked", "closed"]},
+        ],
+    }}}}
+    data = client._parse_status("VINX", raw, parking={})
+    assert data.doors_individual == {
+        "bonnet": False,
+        "frontLeft": False,
+        "frontRight": True,    # physically open
+        "rearLeft": False,
+        "rearRight": True,     # physically open
+        "trunk": False,
+    }
+    assert data.doors_open is True
+    assert data.trunk_open is False
+    assert data.trunk_locked is False   # trunk "unlocked"


### PR DESCRIPTION
Two reporter fixes from the feedback sweep.

## #1281 — doors and trunk read as closed on Audi/VW-EU (PPE)
Thanks @peterbauer1709. A door entry carries **both** its lock word and its open word in one `status` list — `["unlocked", "open"]` — while a bonnet or window ships a single word (`["open"]`). We read only the first element, so every physically open side door and the trunk showed closed even though the lock state parsed fine. Now reads the whole token set and looks for "open" specifically. The trunk's own `trunk_open` / `trunk_locked` sensors are populated too (they were never set on this shape). Bonnet and windows already worked. Tests cover two-token doors, trunk open/lock, and the mixed bonnet+trunk case.

## #923 — one-time historical-export button missing on merged portal setups
Thanks @naked-head and @dazzzl, who both independently found it and diagnosed the cause. The button (and the data-act request button) were only created when the EU Data Act portal was the **primary** read-only channel. A user who added the portal as a **supplementary** channel on a command primary (`source_channel: eu_data_act+website_authproxy`) never got the button — even though the export works identically there: the kickoff scraper is already authed on the shared session where the supplementary portal logged in (the continuous-request kickoff has used that path since b12).

- `coordinator.has_data_act_portal_channel()` (read-only **or** supplementary) now gates the two portal buttons instead of `read_only`.
- `async_import_historical_export` now also honours `_supplementary_eu_portal`, so a merged setup can import the result, not just request it.
- Tests: portal-button gating (merged / read-only / none) + the predicate.

Full suite green. No behaviour change for command-only or companion entries.