### PR TITLE
feat(skoda): opt-in official Škoda public API — groundwork + v8.16 watch

### DIFF
--- a/.github/workflows/skoda-official-api-watch.yml
+++ b/.github/workflows/skoda-official-api-watch.yml
@@ -1,0 +1,60 @@
+name: Škoda official-API app watch
+
+# Polls the MyŠkoda app version every 4 hours. The official Škoda public API
+# (public.api.connect.skoda-auto.cz) is live, but the X-API-Key can only be
+# minted from Settings → Smart Home → API Keys, which ships with app v8.16
+# (absent from 8.15.0). When the mirrors reach v8.16 this opens a tracking issue
+# so we can pull the APK first, androguard the key-creation endpoint, and
+# evaluate automatic key-minting for the opt-in Škoda-official channel.
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"   # every 4 hours
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check MyŠkoda app version
+        id: check
+        run: |
+          out="$(python scripts/skoda_official_watch.py)"
+          echo "$out"
+          ver="$(echo "$out" | sed -n 's/^FOUND //p')"
+          state="$(echo "$out" | grep -E '^(TRIGGER|NO-TRIGGER)$' | head -1)"
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "state=$state"  >> "$GITHUB_OUTPUT"
+
+      - name: Open tracking issue when v8.16 is out
+        if: steps.check.outputs.state == 'TRIGGER'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          title="[Škoda] Official API app reached ${VERSION} — evaluate key-minting"
+          # de-dup: skip if an open issue with this marker already exists
+          existing="$(gh issue list --state open --search 'in:title Official API app reached' --json number --jq 'length')"
+          if [ "$existing" != "0" ]; then
+            echo "Tracking issue already open — nothing to do."
+            exit 0
+          fi
+          gh issue create --title "$title" --label "enhancement" --body "$(cat <<EOF
+          The MyŠkoda app has reached **${VERSION}** on the mirrors — this is the version that ships the official-API key-management screen (Settings → Smart Home → API Keys).
+
+          **Next steps (for a maintainer):**
+          1. Pull the new APK and decompile it.
+          2. Analyse the key-creation flow (Settings → Smart Home → API Keys): find the backend endpoint the "Create key" action calls.
+          3. Decide **auto-mint feasibility**: is that endpoint reachable off-device with an existing session, or attestation-walled? If reachable → wire automatic key-minting into the opt-in Škoda-official channel; if walled → manual key entry stays.
+          4. The opt-in channel client + grounded spec already exist (\`custom_components/vag_connect/cariad/api/skoda_official.py\`, \`docs/research/skoda-official-api.md\`).
+
+          _Auto-filed by the Škoda official-API app watch (\`scripts/skoda_official_watch.py\`)._
+          EOF
+          )"
+          echo "Opened tracking issue for ${VERSION}."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added / Neu
+- **Groundwork for an opt-in official Škoda API channel** (#1286). Škoda has
+  launched a first-party, attestation-free vehicle API; this lands the client,
+  the complete grounded spec, and an automated 4-hourly watch for the app
+  version that unlocks it (the API key is minted in the Škoda app). Not yet
+  selectable and **no change for existing setups** — it needs that app update
+  before anyone can create a key.
+
 ## [4.4.0b4] - 2026-08-28 — New diagnostic sensors (drivetrain · CSID · parked-since) · Audi/VW-EU doors+trunk fix · export button on merged portals
 
 ### Added / Neu

--- a/custom_components/vag_connect/cariad/api/factory.py
+++ b/custom_components/vag_connect/cariad/api/factory.py
@@ -16,6 +16,7 @@ from .vw_na import VWNAClient
 from .audi_na import AudiNAClient
 from .bentley import BentleyClient
 from .plugandplay import PlugAndPlayCloudClient
+from .skoda_official import SkodaOfficialClient
 
 
 class CariadClientFactory:
@@ -31,7 +32,10 @@ class CariadClientFactory:
         country: str = "us",
         ola_app_version_override: str | None = None,
         ola_user_agent_override: str | None = None,
-    ) -> CariadBaseClient | PorscheClient | VWNAClient | PlugAndPlayCloudClient:
+    ) -> (
+        CariadBaseClient | PorscheClient | VWNAClient
+        | PlugAndPlayCloudClient | SkodaOfficialClient
+    ):
         """Return an authenticated-ready client for the given brand.
 
         Supported brands:
@@ -84,6 +88,12 @@ class CariadClientFactory:
             return PlugAndPlayCloudClient(
                 session, BRAND_AUDI_ACPP, email, password, spin
             )
+        if lower == "skoda_official":
+            # Škoda OFFICIAL public API (opt-in) — first-party, attestation-free,
+            # X-API-Key auth (no OAuth). No BrandConfig needed. The VIN(s) ride the
+            # ``email`` slot (comma-separated) and the API key the ``password`` slot.
+            from .skoda_official import SkodaOfficialClient
+            return SkodaOfficialClient(session, email, password, spin)
         raise ValueError(
             f"Unknown brand '{brand}'. Supported: "
             "volkswagen, audi, skoda, seat, cupra, volkswagen_na, audi_na, "

--- a/custom_components/vag_connect/cariad/api/skoda_official.py
+++ b/custom_components/vag_connect/cariad/api/skoda_official.py
@@ -1,0 +1,289 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Škoda **official** public vehicle API — opt-in, first-party, attestation-free.
+
+Distinct from :mod:`skoda` (the unofficial reverse-engineered ``mysmob`` client):
+this talks to Škoda's own public gateway ``public.api.connect.skoda-auto.cz``
+using a user-minted **API key** (``X-API-Key`` header), created in the MyŠkoda app
+(Settings → Smart Home → API Keys, app v8.16+). No OAuth, no password, no
+attestation — a durable official channel. See ``docs/research/skoda-official-api.md``
+for the full grounded surface (generated from the live OpenAPI spec).
+
+Two hard properties shape the design:
+
+* **No list endpoint** — the key is bound to specific vehicles at creation time,
+  and the only read is ``GET /vehicles/{vin}``. So the VIN(s) the key covers must
+  be supplied by the user; :meth:`get_vehicles` just returns them.
+* **20 requests / hour / key** rate limit (server states it is "not final"). Every
+  response carries ``RateLimit-Remaining``; :attr:`rate_limit_remaining` tracks it
+  so the coordinator can poll conservatively and leave headroom for commands. This
+  is a low-frequency official channel, **not** a mysmob replacement.
+
+Factory plumbing: to reuse the existing ``create(session, brand, email, password,
+spin)`` signature without a new arg, the VIN(s) ride the ``email`` slot
+(comma-separated) and the API key rides the ``password`` slot.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from aiohttp import ClientSession, ClientTimeout
+
+from ..exceptions import APIError, AuthenticationError
+from ..models import VehicleData
+
+_BASE = "https://public.api.connect.skoda-auto.cz/api/v1"
+_TIMEOUT = ClientTimeout(total=30)
+_USER_AGENT = "vwgroup-connect-ha (Home Assistant)"
+
+
+def _to_bool_open(value: Any) -> bool | None:
+    """Map an overall-status string to open=True / closed=False."""
+    if not isinstance(value, str):
+        return None
+    v = value.strip().upper()
+    if v in ("OPEN", "UNLOCKED", "YES", "ON"):
+        return True
+    if v in ("CLOSED", "LOCKED", "NO", "OFF", "UNSUPPORTED"):
+        return False
+    return None
+
+
+class SkodaOfficialClient:
+    """Read + command client for the official Škoda public API (opt-in)."""
+
+    def __init__(
+        self,
+        session: ClientSession,
+        email: str,          # factory ``email`` slot = comma-separated VIN(s)
+        password: str,       # factory ``password`` slot = the X-API-Key
+        spin: str = "",
+    ) -> None:
+        self._session = session
+        self._api_key = (password or "").strip()
+        self._vins = [v.strip().upper() for v in (email or "").split(",") if v.strip()]
+        self._spin = (spin or "").strip()
+        # Populated from every response's RateLimit-Remaining header; None until
+        # the first call. The coordinator reads this to pace itself (20/hour/key).
+        self.rate_limit_remaining: int | None = None
+        self.rate_limit_reset_s: int | None = None
+
+    async def authenticate(self, mfa_code: str | None = None) -> None:
+        """No OAuth — the ``X-API-Key`` is itself the credential. Validate it with
+        a single read of the first configured VIN so a wrong / wrong-vehicle /
+        expired key fails at setup instead of silently returning nothing (costs
+        one of the 20 requests/hour budget). Interface parity with the other
+        clients the factory returns."""
+        if not self._vins:
+            return
+        # get_status raises AuthenticationError on 401 and APIError on 404/others
+        await self.get_status(self._vins[0])
+
+    # -- transport ------------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        if not self._api_key:
+            raise AuthenticationError("Škoda official API: no API key configured")
+        return {
+            "X-API-Key": self._api_key,
+            "Accept": "application/json",
+            "User-Agent": _USER_AGENT,
+        }
+
+    def _note_rate_limit(self, resp: Any) -> None:
+        rem = resp.headers.get("RateLimit-Remaining")
+        rst = resp.headers.get("RateLimit-Reset")
+        if rem is not None and str(rem).lstrip("-").isdigit():
+            self.rate_limit_remaining = int(rem)
+        if rst is not None and str(rst).lstrip("-").isdigit():
+            self.rate_limit_reset_s = int(rst)
+
+    async def _request(self, method: str, path: str, json_body: Any = None) -> tuple[int, Any]:
+        async with self._session.request(
+            method, f"{_BASE}/{path}", headers=self._headers(),
+            json=json_body, timeout=_TIMEOUT,
+        ) as resp:
+            self._note_rate_limit(resp)
+            try:
+                body = await resp.json(content_type=None)
+            except Exception:  # noqa: BLE001 — problem+json / text on errors
+                body = await resp.text()
+            return resp.status, body
+
+    async def _get(self, path: str) -> tuple[int, Any]:
+        return await self._request("GET", path)
+
+    async def _post(self, path: str, json_body: Any = None) -> tuple[int, Any]:
+        return await self._request("POST", path, json_body)
+
+    # -- reads ----------------------------------------------------------------
+
+    async def get_vehicles(self) -> list[str]:
+        """The API has no list endpoint — the key is vehicle-bound, so return the
+        VIN(s) the user configured for this key."""
+        return list(self._vins)
+
+    async def get_status(self, vin: str) -> VehicleData:
+        status, body = await self._get(f"vehicles/{vin}")
+        if status == 401:
+            raise AuthenticationError(
+                "Škoda official API: key rejected (401) — expired or wrong vehicle"
+            )
+        if status != 200 or not isinstance(body, dict):
+            raise APIError(status, f"{_BASE}/vehicles/{vin}", str(body)[:200])
+        return self._parse_vehicle(vin, body.get("vehicle") or body)
+
+    # -- parse ----------------------------------------------------------------
+
+    @staticmethod
+    def _parse_vehicle(vin: str, v: dict[str, Any]) -> VehicleData:
+        d = VehicleData(vin=vin)
+        d.model = v.get("name") or d.model
+        if isinstance(v.get("licensePlate"), str):
+            d.license_plate = v["licensePlate"]
+
+        # -- opening / lock status (overall + detail) -------------------------
+        status = v.get("status") or {}
+        overall = status.get("overall") or {}
+        _dl = overall.get("doorsLocked") or overall.get("locked")
+        if isinstance(_dl, str):
+            d.doors_locked = _dl.strip().upper() == "LOCKED"
+        _do = _to_bool_open(overall.get("doors"))
+        if _do is not None:
+            d.doors_open = _do
+        _wo = _to_bool_open(overall.get("windows"))
+        if _wo is not None:
+            d.windows_open = _wo
+        if isinstance(status.get("carCapturedTimestamp"), str):
+            d.last_seen_at = status["carCapturedTimestamp"]
+
+        # -- odometer ---------------------------------------------------------
+        odo = v.get("odometer") or {}
+        if isinstance(odo.get("mileageInKm"), (int, float)):
+            d.odometer_km = int(odo["mileageInKm"])
+
+        # -- fuel / engine ----------------------------------------------------
+        fuel = v.get("fuelStatus") or {}
+        if isinstance(fuel.get("carType"), str):
+            d.car_type = fuel["carType"]
+        if isinstance(fuel.get("totalRangeInKm"), (int, float)):
+            d.total_range_km = int(fuel["totalRangeInKm"])
+        prim = fuel.get("primaryEngineRange") or {}
+        sec = fuel.get("secondaryEngineRange") or {}
+        etype = prim.get("engineType")
+        if isinstance(etype, str):
+            d.primary_engine_type = etype
+        if isinstance(prim.get("currentFuelLevelInPercent"), (int, float)):
+            d.primary_engine_fuel_level_pct = int(prim["currentFuelLevelInPercent"])
+            d.fuel_level = int(prim["currentFuelLevelInPercent"])
+        if isinstance(prim.get("currentSoCInPercent"), (int, float)):
+            d.primary_engine_soc_pct = int(prim["currentSoCInPercent"])
+        if isinstance(prim.get("remainingRangeInKm"), (int, float)):
+            if isinstance(etype, str) and etype.upper() == "ELECTRIC":
+                d.electric_range_km = int(prim["remainingRangeInKm"])
+            else:
+                d.combustion_range_km = int(prim["remainingRangeInKm"])
+        # electric / hybrid classification from the engine mix
+        types = {str(t.get("engineType", "")).upper() for t in (prim, sec) if t}
+        types.discard("")
+        if types == {"ELECTRIC"}:
+            d.is_electric = True
+        elif "ELECTRIC" in types and len(types) > 1:
+            d.is_hybrid = True
+
+        # -- charging ---------------------------------------------------------
+        charging = v.get("charging") or {}
+        cstat = charging.get("status") or {}
+        cset = charging.get("settings") or {}
+        cstate = cstat.get("state")
+        if isinstance(cstate, str):
+            d.charging_state = cstate
+            d.is_charging = cstate.strip().upper() in ("CHARGING", "CONSERVING")
+        if isinstance(cstat.get("chargePowerInKw"), (int, float)):
+            d.charging_power_kw = float(cstat["chargePowerInKw"])
+        batt = cstat.get("battery") or {}
+        if isinstance(batt.get("stateOfChargeInPercent"), (int, float)):
+            d.battery_soc = int(batt["stateOfChargeInPercent"])
+        if isinstance(batt.get("remainingCruisingRangeInMeters"), (int, float)):
+            d.electric_range_km = int(batt["remainingCruisingRangeInMeters"] // 1000)
+        if isinstance(cset.get("targetStateOfChargeInPercent"), (int, float)):
+            d.target_soc = int(cset["targetStateOfChargeInPercent"])
+        if isinstance(cset.get("batteryCareModeTargetValueInPercent"), (int, float)):
+            d.battery_care_target_soc_pct = int(cset["batteryCareModeTargetValueInPercent"])
+        if isinstance(cset.get("preferredChargeMode"), str):
+            d.preferred_charge_mode = cset["preferredChargeMode"]
+        if isinstance(cset.get("maxChargeCurrentAcAmpere"), (int, float)):
+            d.max_charge_current = float(cset["maxChargeCurrentAcAmpere"])
+
+        # -- air conditioning / climate --------------------------------------
+        ac = v.get("airConditioning") or {}
+        if isinstance(ac.get("state"), str):
+            d.climatisation_state = ac["state"]
+            d.climatisation_active = ac["state"].strip().upper() in (
+                "ON", "HEATING", "COOLING", "VENTILATION", "ON_HEATING", "ON_COOLING",
+            )
+        tt = ac.get("targetTemperature") or {}
+        if isinstance(tt.get("value"), (int, float)):
+            d.target_temperature = float(tt["value"])
+        wh = ac.get("windowHeating") or {}
+        _whf = _to_bool_open(wh.get("front"))
+        if _whf is not None:
+            d.window_heating_front = _whf
+        _whr = _to_bool_open(wh.get("rear"))
+        if _whr is not None:
+            d.window_heating_back = _whr
+
+        # -- parking position (the GPS the EU-DA channel can't get) ----------
+        pos = v.get("parkingPosition") or {}
+        gps = pos.get("gpsCoordinates") or {}
+        if isinstance(gps.get("latitude"), (int, float)) and isinstance(
+            gps.get("longitude"), (int, float)
+        ):
+            d.latitude = float(gps["latitude"])
+            d.longitude = float(gps["longitude"])
+        return d
+
+    # -- commands -------------------------------------------------------------
+
+    async def _command(self, vin: str, path: str, body: Any = None) -> bool:
+        status, resp = await self._post(f"vehicles/{vin}/{path}", body)
+        if status in (200, 201, 202, 204):
+            return True
+        if status == 401:
+            raise AuthenticationError("Škoda official API: key rejected (401)")
+        raise APIError(status, f"{_BASE}/vehicles/{vin}/{path}", str(resp)[:200])
+
+    async def command_start_charging(self, vin: str) -> bool:
+        return await self._command(vin, "charging/start")
+
+    async def command_stop_charging(self, vin: str) -> bool:
+        return await self._command(vin, "charging/stop")
+
+    async def command_start_climate(self, vin: str, target_c: float | None = None) -> bool:
+        body: dict[str, Any] = {}
+        if target_c is not None:
+            body["targetTemperature"] = {"value": target_c, "unit": "CELSIUS"}
+        return await self._command(vin, "air-conditioning/start", body or None)
+
+    async def command_stop_climate(self, vin: str) -> bool:
+        return await self._command(vin, "air-conditioning/stop")
+
+    async def command_start_aux_heating(self, vin: str, target_c: float | None = None) -> bool:
+        # Privileged: the S-PIN is required in the body.
+        if not self._spin:
+            raise AuthenticationError(
+                "Škoda official API: auxiliary heating requires the vehicle S-PIN"
+            )
+        body: dict[str, Any] = {"spin": self._spin}
+        if target_c is not None:
+            body["targetTemperature"] = {"value": target_c, "unit": "CELSIUS"}
+        return await self._command(vin, "auxiliary-heating/start", body)
+
+    async def command_stop_aux_heating(self, vin: str) -> bool:
+        return await self._command(vin, "auxiliary-heating/stop")
+
+    async def command_start_active_ventilation(self, vin: str) -> bool:
+        return await self._command(vin, "active-ventilation/start")
+
+    async def command_stop_active_ventilation(self, vin: str) -> bool:
+        return await self._command(vin, "active-ventilation/stop")

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -333,6 +333,7 @@ BRANDS = {
     "audi_na":        "Audi US/CA",
     "porsche":        "Porsche (My Porsche)",
     "audi_acpp":      "Audi plug&play (OBD dongle)",
+    "skoda_official": "Škoda (official API)",
 }
 
 # v2.8.0 quick-win B — native-app deeplink schemes per brand. Used by
@@ -365,6 +366,7 @@ DEEPLINK_SCHEMES: dict[str, str] = {
     "volkswagen_na": "myvw://",            # DEX: myVW 2026.5.27 (was vwapp://)
     "audi_na":       "myaudi://",          # US Audi = same global myAudi app
     "audi_acpp":     "acpp://",            # Audi connect plug&play (de.audi.connectplugandplay)
+    "skoda_official": "myskoda://",        # official API keys are managed in the MyŠkoda app
 }
 
 # Polling interval limits

--- a/docs/research/skoda-official-api.md
+++ b/docs/research/skoda-official-api.md
@@ -1,0 +1,304 @@
+# Škoda official public vehicle API — grounded reference
+
+> Source of truth: the live OpenAPI spec at `https://public.api.connect.skoda-auto.cz/v3/api-docs` (fetched raw, 66993 bytes, openapi 3.1.0), cross-checked against the evcc write-up (https://docs.evcc.io/de/blog/2026/08/27/skoda-vehicle-api/) and the MyŠkoda 8.15.0 APK. This file is the complete surface, generated from the spec.
+
+## What this is (and is NOT)
+
+- **Official, first-party** end-customer API on Škoda's own zone `public.api.connect.skoda-auto.cz` (base `/api/v1`).
+- **NOT** the pan-VW EU Data Act endpoint (`cardata.apps.emea.vwapps.io`, still pre-launch) — a separate, brand-native gateway.
+- **NOT** our current channel: we read Škoda via the unofficial reverse-engineered `mysmob.api.connect.skoda-auto.cz` (51 routes). This official API is a smaller (9 routes) but durable, attestation-free alternative.
+- **Availability:** the API keys are minted inside the MyŠkoda app **v8.16+** (not yet released — latest on the mirrors is 8.15.0, which contains **no** reference to this host). So the docs are live but no key can be created yet (~early Sept 2026).
+
+## Auth
+
+- **`X-API-Key: <key>` header** (OpenAPI `apiKeyAuth`, type apiKey in header). NOT OAuth/Bearer.
+- The key is created/managed in the MyŠkoda app (v8.16+, key-management screen / QR), **bound to the vehicles selected at creation time**, and **expires** (`X-API-Key-Expires-At` response header).
+- Privileged commands (auxiliary heating) additionally require the vehicle **S-PIN** in the JSON body (`spin`).
+- Requests target a vehicle by **VIN in the path**. There is **no list-vehicles endpoint** — the VIN must be known/entered (the key is vehicle-bound).
+
+## Rate limit (HARD constraint)
+
+- **20 requests / hour / key** (spec/evcc note it is 'not final'). Response headers: `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`.
+- 429 problem type `api-key-rate-limit-exceeded`; expired key → problem type `api-key-expired`.
+- **Implication:** far too tight for a 15-min feed. A conservative poll (e.g. every 5–10 min = 6–12/h) leaves little headroom for commands. Any channel we build must budget against `RateLimit-Remaining` and back off — this is a low-frequency official channel, not a replacement for mysmob.
+
+## Endpoints
+
+### `POST /api/v1/vehicles/{vin}/charging/stop` — stopCharging
+
+Stop charging for a given vehicle.
+
+- param `vin` in path (required)
+
+### `POST /api/v1/vehicles/{vin}/charging/start` — startCharging
+
+Start charging for a given vehicle.
+
+- param `vin` in path (required)
+
+### `POST /api/v1/vehicles/{vin}/auxiliary-heating/stop` — stopAuxiliaryHeating
+
+Stop auxiliary heating inside the desired vehicle.
+
+- param `vin` in path (required)
+
+### `POST /api/v1/vehicles/{vin}/auxiliary-heating/start` — startAuxiliaryHeating
+
+Start auxiliary heating inside the desired vehicle.
+
+- request body (application/json): `StartAuxiliaryHeatingConfiguration`
+- param `vin` in path (required)
+
+### `POST /api/v1/vehicles/{vin}/air-conditioning/stop` — stopAirConditioning
+
+Stops an air-conditioning process inside a vehicle.
+
+- param `vin` in path (required)
+
+### `POST /api/v1/vehicles/{vin}/air-conditioning/start` — startAirConditioning
+
+Starts an air-conditioning process inside a vehicle to reach the target temperature.
+
+- request body (application/json): `StartAirConditioningConfiguration`
+- param `vin` in path (required)
+
+### `POST /api/v1/vehicles/{vin}/active-ventilation/stop` — stopActiveVentilation
+
+Stop active ventilation inside the desired vehicle.
+
+- param `vin` in path (required)
+
+### `POST /api/v1/vehicles/{vin}/active-ventilation/start` — startActiveVentilation
+
+Start active ventilation inside the desired vehicle.
+
+- param `vin` in path (required)
+
+### `GET /api/v1/vehicles/{vin}` — getVehicle
+
+Returns the vehicle and its current state.
+
+- param `vin` in path (required)
+- param `include` in query
+
+## Schemas (complete)
+
+### ActiveVentilation
+
+- `state`: string  _(**required**)_ — State of the active ventilation. Possible values are:   * OFF   * PREHEATING   * VENTILATION   * UNKNOWN - system cannot recognise correct value   * UNSUPPORTED - the vehicle does not report this state 
+- `durationInSeconds`: integer  _(fmt=int32)_ — Duration in seconds the active ventilation runs for when started.
+- `carCapturedTimestamp`: string  _(fmt=date-time)_ — Timestamp when the data was last captured and sent by the vehicle. Standard ISO 8601 format.
+
+### AirConditioning
+
+- `state`: string  _(**required**)_ — State of the air conditioning. Possible values are:   * OFF   * COOLING   * HEATING   * HEATING_AUXILIARY - the auxiliary heater is assisting with heating the cabin   * VENTILATION   * COMPLETED   * UNKNOWN - system cannot recognise correct value   * UNSUPPORTED - the vehicle does not report this state 
+- `targetTemperature`: TargetTemperature
+- `estimatedReachOfTargetTemperatureAt`: string  _(fmt=date-time)_ — Timestamp when the cabin is expected to reach the target temperature. Standard ISO 8601 format.
+- `airConditioningWithoutExternalPower`: boolean — Setting indicating whether the air conditioning may run without the vehicle being connected to an external power source.
+- `airConditioningAtUnlock`: boolean — Setting indicating whether the air conditioning starts automatically when the vehicle is unlocked.
+- `windowHeating`: WindowHeating
+- `carCapturedTimestamp`: string  _(fmt=date-time)_ — Timestamp when the data was last captured and sent by the vehicle. Standard ISO 8601 format.
+
+### AuxiliaryHeating
+
+- `state`: string  _(**required**)_ — State of the auxiliary heating. Possible values are:   * OFF   * PREHEATING   * HEATING_AUXILIARY   * VENTILATION   * UNKNOWN - system cannot recognise correct value   * UNSUPPORTED - the vehicle does not report this state 
+- `startMode`: string — Mode the auxiliary heating starts in. Possible values are:   * HEATING   * VENTILATION 
+- `durationInSeconds`: integer  _(fmt=int32)_ — Duration in seconds the auxiliary heating runs for when started.
+- `targetTemperature`: TargetTemperature
+- `estimatedReachOfTargetTemperatureAt`: string  _(fmt=date-time)_ — Timestamp when the cabin is expected to reach the target temperature. Standard ISO 8601 format.
+- `carCapturedTimestamp`: string  _(fmt=date-time)_ — Timestamp when the data was last captured and sent by the vehicle. Standard ISO 8601 format.
+
+### BatteryStatus
+
+- `remainingCruisingRangeInMeters`: integer  _(fmt=int32)_ — Remaining cruising range with HV battery power in meters.
+- `stateOfChargeInPercent`: integer  _(fmt=int32)_ — State of charge in percent.
+
+### Charging
+
+- `tings`: Charging
+- `isVehicleInSavedLocation`: boolean  _(**required**)_ — Indicates whether the vehicle is in a saved location (a specific location with defined charging settings).
+- `status`: ChargingStatus
+- `settings`: ChargingSettings
+- `carCapturedTimestamp`: string  _(fmt=date-time)_ — Timestamp when the data was last captured and sent by the vehicle. Standard ISO 8601 format.
+
+### ChargingProfile
+
+- `tings`: ChargingProfile
+- `id`: integer  _(fmt=int64, **required**)_ — Identifier of this profile.
+- `name`: string  _(**required**)_ — The name of the charging profile as specified by the user.
+- `settings`: ChargingProfileSettings  _(**required**)_
+- `preferredChargingTimes`: array<ChargingTime>  _(**required**)_
+- `timers`: array<Timer>  _(**required**)_
+
+### ChargingProfileSettings
+
+- `maxChargingCurrent`: string — Value that should be used when start charging. Possible values are:   * REDUCED   * MAXIMUM 
+- `minBatteryStateOfCharge`: MinBatteryStateOfCharge
+- `targetStateOfChargeInPercent`: integer  _(fmt=int32)_ — Target charging level in percent set by user.
+- `autoUnlockPlugWhenCharged`: string — Value for auto unlock plug, when charging is finished. Possible values are:   * PERMANENT   * OFF 
+
+### ChargingProfiles
+
+- `profiles`: array<ChargingProfile>  _(**required**)_
+- `currentVehiclePositionProfile`: CurrentVehiclePositionProfile
+- `carCapturedTimestamp`: string  _(fmt=date-time)_ — Timestamp when the data was last captured and sent by the vehicle. Standard ISO 8601 format.
+
+### ChargingSettings
+
+- `targetStateOfChargeInPercent`: integer  _(fmt=int32)_ — Target state of charge in percent.
+- `batteryCareModeTargetValueInPercent`: integer  _(fmt=int32)_ — Recommended target state of charge in percent when battery care mode is enabled.
+- `preferredChargeMode`: string — Preferred charging mode. Possible values are:   * MANUAL   * TIMER   * TIMER_CHARGING_WITH_CLIMATISATION   * PREFERRED_CHARGING_TIMES   * ONLY_OWN_CURRENT   * IMMEDIATE_DISCHARGING   * HOME_STORAGE_CHARGING New values may be added over time, so clients must tolerate values they do not recognize. 
+- `availableChargeModes`: array<string> — List of available charging modes. Possible values are:   * MANUAL   * TIMER   * TIMER_CHARGING_WITH_CLIMATISATION   * PREFERRED_CHARGING_TIMES   * ONLY_OWN_CURRENT   * IMMEDIATE_DISCHARGING   * HOME_STORAGE_CHARGING New values may be added over time, so clients must tolerate values they do not recognize. 
+- `chargingCareMode`: string — Indicates whether is charging care mode activated. Possible values are:   * ACTIVATED   * DEACTIVATED New values may be added over time, so clients must tolerate values they do not recognize. 
+- `autoUnlockPlugWhenCharged`: string — Value for auto unlock plug, when charging is finished. Possible values are:   * PERMANENT   * OFF New values may be added over time, so clients must tolerate values they do not recognize. 
+- `maxChargeCurrentAc`: string — Value that should be used when start charging. Possible values are:   * REDUCED   * MAXIMUM New values may be added over time, so clients must tolerate values they do not recognize. 
+- `maxChargeCurrentAcAmpere`: integer  _(fmt=int32)_ — Maximum charging current limit in ampere. Can acquire values 5, 10, 13 or 32.
+
+### ChargingStatus
+
+- `chargingRateInKilometersPerHour`: number  _(fmt=double)_ — Rate of charging in kilometers per hour.
+- `chargePowerInKw`: number  _(fmt=double)_ — Charge power in kilowatts.
+- `remainingTimeToFullyChargedInMinutes`: integer  _(fmt=int32)_ — Remaining charging time to complete in minutes.
+- `fullyChargedAt`: string  _(fmt=date-time)_ — Timestamp when the vehicle is expected to be fully charged
+- `state`: string — Charging state. Possible values are:   * CONNECT_CABLE   * CHARGING   * CONSERVING   * READY_FOR_CHARGING   * DISCHARGING   * CHARGING_INTERRUPTED 
+- `chargeType`: string — Type of charging. Possible values are:   * AC   * DC   * OFF New values may be added over time, so clients must tolerate values they do not recognize. 
+- `battery`: BatteryStatus
+
+### ChargingTime
+
+- `id`: integer  _(fmt=int64, **required**)_ — Identifier of this charging time.
+- `enabled`: boolean  _(**required**)_ — Indicates if this preferred charging time is enabled.
+- `startTime`: string  _(**required**)_ — Specifies when the preferred charging time should start. Local time in vehicle in ISO 8601 format (HH:mm).
+- `endTime`: string  _(**required**)_ — Specifies when the preferred charging time should stop. Local time in vehicle in ISO 8601 format (HH:mm).
+
+### CurrentVehiclePositionProfile
+
+- `id`: integer  _(fmt=int64, **required**)_ — Identifier of profile.
+- `name`: string  _(**required**)_ — The name of the charging profile as specified by the user.
+- `targetStateOfChargeInPercent`: integer  _(fmt=int32)_ — Target charging level in percent set by user for this profile.
+- `nextChargingTime`: string — Specifies next charging time which will be triggered at current profile. Time is in vehicle local in ISO 8601 format (HH:mm).
+
+### EngineRange
+
+- `engineType`: string — Vehicle's engine type. Possible values are `ELECTRIC`, `GASOLINE`, `DIESEL`, `CNG`, `LPG` and `UNKNOWN`. New values may be added over time, so clients must tolerate values they do not recognize. 
+- `currentSoCInPercent`: number — Vehicle's State of Charge in percent.
+- `currentFuelLevelInPercent`: number — Vehicle's fuel level in percent.
+- `remainingRangeInKm`: number — Vehicle's remaining range in kilometers.
+
+### FuelStatus
+
+- `carType`: string — Vehicle's type. Possible values are `HYBRID`, `GASOLINE`, `DIESEL`, `CNG`, `LPG` and `UNKNOWN`. New values may be added over time, so clients must tolerate values they do not recognize. 
+- `adBlueRange`: number — Vehicle's adBlue range in kilometers. Available only for vehicles with diesel engine.
+- `totalRangeInKm`: number — Vehicle's total range in kilometers.
+- `primaryEngineRange`: EngineRange
+- `secondaryEngineRange`: EngineRange
+- `carCapturedTimestamp`: string  _(fmt=date-time)_ — Timestamp when the data was last captured and sent by the vehicle. Standard ISO 8601 format.
+
+### MinBatteryStateOfCharge
+
+- `enabled`: boolean — True if this feature is enabled.
+- `minimumBatteryStateOfChargeInPercent`: integer  _(fmt=int32)_ — If battery drop below this value, then start immediate charging.
+
+### Odometer
+
+- `mileageInKm`: integer  _(fmt=int64, **required**)_ — Current mileage of the vehicle in kilometers.
+- `carCapturedTimestamp`: string  _(fmt=date-time)_ — Timestamp when the data was last captured and sent by the vehicle. Standard ISO 8601 format.
+
+### OverallVehicleStatusDto
+
+- `doorsLocked`: string  _(**required**)_ — Overall doors and trunk lock state. Possible values are:   * YES - all supported doors AND trunk are LOCKED+CLOSED.   * NO - at least one supported door OR trunk is UNLOCKED but CLOSED.   * OPENED - at least one supported door OR bonnet is OPEN.   * TRUNK_OPENED - trunk is OPEN but all supported doors AND trunk are CLOSED.   * UNKNOWN - system cannot recognise correct value. 
+- `locked`: string  _(**required**)_ — Possible values are:   * YES - at least one door is supported AND all supported doors and trunk are LOCKED+CLOSED.   * NO - any supported door is UNLOCKED/OPEN and no door is UNKNOWN.   * UNKNOWN - system cannot recognise correct value. 
+- `doors`: string  _(**required**)_ — Possible values are:   * OPEN - any supported door is OPEN.   * CLOSED - at least one door is supported AND all supported doors are CLOSED.   * UNKNOWN - system cannot recognise correct value. 
+- `windows`: string  _(**required**)_ — Aggregated over the side windows; the sunroof is excluded and reported separately in `detail`. Possible values are:   * OPEN - any supported side window is OPEN.   * CLOSED - at least one window is supported AND all supported windows are CLOSED.   * UNKNOWN - system cannot recognise correct value.   * UNSUPPORTED - vehicle does not have all electric windows. 
+- `lights`: string  _(**required**)_ — Possible values are:   * ON - at least one supported light is ON.   * OFF - all supported lights are OFF.   * UNKNOWN - system cannot recognise correct value. 
+- `reliableLockStatus`: string — Provides information if vehicle is locked. Unlocked value is returned only for MOD4 vehicles. Possible values are:   * LOCKED - all supported doors AND trunk are LOCKED+CLOSED.   * UNLOCKED - any supported door is UNLOCKED/OPEN and no door is UNKNOWN.   * UNKNOWN - system cannot recognise correct value. 
+
+### ParkingPosition
+
+- `state`: string  _(**required**)_ — State of the vehicle from parking position point of view. Possible values are: [IN_MOTION, PARKED]
+- `gpsCoordinates`: ParkingPosition_gpsCoordinates
+- `formattedAddress`: string — Formatted address of the vehicle parking position: Street, House Number, Zip Code, City, Country. Only present when `state` is `PARKED`, and omitted when the address could not be resolved.
+
+### ParkingPosition_gpsCoordinates
+
+- `latitude`: number  _(fmt=double, **required**)_ — Latitude coordinate.
+- `longitude`: number  _(fmt=double, **required**)_ — Longitude coordinate.
+
+### ProblemDetail
+
+- `type`: string — URI reference identifying the problem type. Generic problems that carry no semantics beyond their HTTP status code use `about:blank`. More specific problem types are:   * https://public.api.connect.skoda-auto.cz/problems/api-key-expired - the API key used to authenticate has expired and must be rotated.   * https://public.api.connect.skoda-auto.cz/problems/api-key-not-authorized - the API key is not authorized to execute the operation.   * https://public.api.connect.skoda-auto.cz/problems/operation-not-authorized - the vehicle refused the operation for the user the API key belongs to.   * https://public.api.connect.skoda-auto.cz/problems/operation-not-supported - the vehicle lacks the capability the operation needs.   * https://public.api.connect.skoda-auto.cz/problems/operation-disabled - the capability the operation needs is currently disabled for the vehicle.   * https://public.api.connect.skoda-auto.cz/problems/rate-limit-exceeded - the rate limit for the API key has been exceeded.   * https://public.api.connect.skoda-auto.cz/problems/vehicle-not-accepting-requests - the vehicle declined the operation and it can be retried later. 
+- `title`: string — Short, human-readable summary of the problem type.
+- `status`: integer  _(fmt=int32)_ — HTTP status code of this occurrence of the problem.
+- `detail`: string — Human-readable explanation specific to this occurrence of the problem.
+- `instance`: string — URI reference identifying this specific occurrence of the problem.
+
+### StartAirConditioningConfiguration
+
+- `targetTemperature`: TargetTemperature
+- `airConditioningWithoutExternalPower`: boolean — Allow or forbid air conditioning when no external power connection is available.
+
+### StartAuxiliaryHeatingConfiguration
+
+- `targetTemperature`: TargetTemperature
+- `spin`: string  _(**required**)_ — Security PIN code.
+- `durationInSeconds`: integer  _(fmt=int32)_ — Duration in seconds the auxiliary heating runs for.
+- `startMode`: string — Start mode of the auxiliary heating device. Possible values are:   * HEATING   * VENTILATION 
+
+### TargetTemperature
+
+- `value`: number  _(fmt=double, **required**)_ — Target temperature value, in the unit given by `unit`.
+- `unit`: string  _(**required**)_ — Temperature unit. Possible values are:   * CELSIUS   * FAHRENHEIT 
+
+### Timer
+
+- `id`: integer  _(fmt=int64, **required**)_ — Timer identifier.
+- `enabled`: boolean  _(**required**)_ — Is timer enabled.
+- `time`: string — Time of start this timer in ISO 8601 format (HH:mm).
+- `type`: string  _(**required**)_ — Type of timer. Possible values are:   * ONE_OFF - one time timer   * RECURRING - timer repeating on days you choose 
+- `oneOffDay`: string  _(enum: MONDAY | TUESDAY | WEDNESDAY | THURSDAY | FRIDAY | SATURDAY | SUNDAY)_ — Day in week when ONE_OFF timer is required. ONE_OFF timer only.
+- `recurringOn`: array<string>
+
+### Vehicle
+
+- `vin`: string — Vehicle Identification Number.
+- `name`: string — User-defined vehicle name. When the user has not named the vehicle, the model name (e.g. `Enyaq`) is returned instead.
+- `licensePlate`: string
+- `renderUrl`: string  _(fmt=uri)_
+- `status`: VehicleStatus
+- `fuelStatus`: FuelStatus
+- `odometer`: Odometer
+- `parkingPosition`: ParkingPosition
+- `airConditioning`: AirConditioning
+- `auxiliaryHeating`: AuxiliaryHeating
+- `activeVentilation`: ActiveVentilation
+- `charging`: Charging
+- `chargingProfiles`: ChargingProfiles
+
+### VehicleError
+
+- `type`: string  _(**required**)_ — Machine-readable error type identifying the part of the response that is affected. Possible values are:   * RENDER_UNAVAILABLE - the vehicle render image URL could not be retrieved; name and licensePlate are unaffected   * VEHICLE_STATUS_UNSUPPORTED - vehicle status (doors, windows, lights, ...) is not supported   * VEHICLE_STATUS_DISABLED - vehicle status (doors, windows, lights, ...) is supported, but currently disabled   * VEHICLE_STATUS_UNAVAILABLE - vehicle status (doors, windows, lights, ...) could not be retrieved   * FUEL_STATUS_UNSUPPORTED - fuel status is not supported (for example a battery-electric vehicle)   * FUEL_STATUS_DISABLED - fuel status is supported, but currently disabled   * FUEL_STATUS_UNAVAILABLE - fuel status could not be retrieved   * ODOMETER_UNSUPPORTED - odometer reading is not supported   * ODOMETER_DISABLED - odometer reading is supported, but currently disabled   * ODOMETER_UNAVAILABLE - odometer reading could not be retrieved   * PARKING_POSITION_UNSUPPORTED - parking position is not supported   * PARKING_POSITION_DISABLED - parking position is supported, but currently disabled   * PARKING_POSITION_UNAVAILABLE - parking position could not be retrieved   * AIR_CONDITIONING_UNSUPPORTED - air conditioning information is not supported   * AIR_CONDITIONING_DISABLED - air conditioning information is supported, but currently disabled   * AIR_CONDITIONING_UNAVAILABLE - air conditioning information could not be retrieved   * AUXILIARY_HEATING_UNSUPPORTED - auxiliary heating information is not supported   * AUXILIARY_HEATING_DISABLED - auxiliary heating information is supported, but currently disabled   * AUXILIARY_HEATING_UNAVAILABLE - auxiliary heating information could not be retrieved   * ACTIVE_VENTILATION_UNSUPPORTED - active ventilation information is not supported   * ACTIVE_VENTILATION_DISABLED - active ventilation information is supported, but currently disabled   * ACTIVE_VENTILATION_UNAVAILABLE - active ventilation information could not be retrieved   * CHARGING_UNSUPPORTED - charging status is not supported   * CHARGING_DISABLED - charging status is supported, but currently disabled   * CHARGING_UNAVAILABLE - charging status could not be retrieved   * CHARGING_PROFILES_UNSUPPORTED - charging profiles are not supported   * CHARGING_PROFILES_DISABLED - charging profiles are supported, but currently disabled   * CHARGING_PROFILES_UNAVAILABLE - charging profiles could not be retrieved 
+- `description`: string — Detail information about what and why happened.
+
+### VehicleResponse
+
+- `vehicle`: Vehicle  _(**required**)_
+- `errors`: array<VehicleError> — Errors encountered while gathering the vehicle data. The response combines data from multiple sources; if some of them fail, the response contains partial data and the affected parts are omitted, each described by an error in this list. Parts that the vehicle does not support, or that it supports but are currently disabled, are reported the same way.
+
+### VehicleStatus
+
+- `overall`: OverallVehicleStatusDto  _(**required**)_
+- `detail`: VehicleStatusDetailDto  _(**required**)_
+- `carCapturedTimestamp`: string  _(fmt=date-time)_ — Timestamp when the data was last captured and sent by the vehicle. Standard ISO 8601 format.
+
+### VehicleStatusDetailDto
+
+- `sunroof`: string  _(**required**)_ — Possible value is OPEN, CLOSED, UNKNOWN or UNSUPPORTED.
+- `trunk`: string  _(**required**)_ — Possible value is OPEN, CLOSED, UNKNOWN.
+- `bonnet`: string  _(**required**)_ — Possible value is OPEN, CLOSED, UNKNOWN.
+
+### WindowHeating
+
+- `enabled`: boolean — True if window heating is enabled for the vehicle. Absent when the vehicle did not report its climatisation settings. 
+- `front`: string — State of the front window heating. Possible values are:   * ON   * OFF   * UNKNOWN - system cannot recognise correct value   * UNSUPPORTED - vehicle does not support front window heating 
+- `rear`: string — State of the rear window heating. Possible values are:   * ON   * OFF   * UNKNOWN - system cannot recognise correct value   * UNSUPPORTED - vehicle does not support rear window heating 
+

--- a/scripts/skoda_official_watch.py
+++ b/scripts/skoda_official_watch.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Watch for the MyŠkoda app version that ships the official-API key flow.
+
+The official Škoda public API (``public.api.connect.skoda-auto.cz``) is live, but
+a user can only mint an ``X-API-Key`` from **Settings → Smart Home → API Keys**,
+which arrives with app **v8.16** (verified absent from 8.15.0). This script polls
+the mirrors listed in ``scripts/app_atlas/config.json`` for the current MyŠkoda
+version and flags when it reaches the trigger version, so we can be first to pull
+it, androguard the key-creation endpoint, and evaluate auto-mint.
+
+Fail-soft: any mirror that errors is skipped; if no version is found at all it
+prints ``FOUND none`` and does NOT trigger (no false alarms). Output is
+machine-readable for the workflow:
+
+    FOUND <version-or-none>
+    TRIGGER  |  NO-TRIGGER
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+TRIGGER_VERSION = (8, 16, 0)
+_PKG = "cz.skodaauto.myskoda"
+_VER_RE = re.compile(r"\b(8\.\d{1,2}\.\d{1,2})\b")
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/128.0 Safari/537.36"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+def _cfg_sources() -> dict[str, str]:
+    here = os.path.dirname(os.path.abspath(__file__))
+    cfg = os.path.join(here, "app_atlas", "config.json")
+    try:
+        with open(cfg, encoding="utf-8") as fh:
+            src = json.load(fh)["apps"]["skoda"]["sources"]
+    except Exception:  # noqa: BLE001 — fall back to hardcoded slugs
+        src = {
+            "apkcombo_slug": "myskoda/cz.skodaauto.myskoda",
+            "uptodown_subdomain": "cz-skodaauto-myskoda",
+            "apkmirror_slug": "skoda-auto-as/myskoda",
+        }
+    return src
+
+
+def _urls(src: dict[str, str]) -> list[str]:
+    urls: list[str] = []
+    if src.get("apkcombo_slug"):
+        urls.append(f"https://apkcombo.com/{src['apkcombo_slug']}/")
+        urls.append(f"https://apkcombo.com/{src['apkcombo_slug']}/download/apk")
+    if src.get("uptodown_subdomain"):
+        urls.append(f"https://{src['uptodown_subdomain']}.en.uptodown.com/android")
+    if src.get("apkmirror_slug"):
+        urls.append(f"https://www.apkmirror.com/apk/{src['apkmirror_slug']}/")
+    return urls
+
+
+def _fetch_versions(url: str) -> list[tuple[int, int, int]]:
+    try:
+        req = urllib.request.Request(url, headers=_HEADERS)
+        with urllib.request.urlopen(req, timeout=25) as resp:  # noqa: S310 — fixed https hosts
+            html = resp.read(600_000).decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError, ValueError):
+        return []
+    out = []
+    for m in _VER_RE.findall(html):
+        parts = tuple(int(x) for x in m.split("."))
+        if len(parts) == 3:
+            out.append(parts)  # type: ignore[arg-type]
+    return out
+
+
+def main() -> int:
+    src = _cfg_sources()
+    found: list[tuple[int, int, int]] = []
+    for url in _urls(src):
+        found.extend(_fetch_versions(url))
+    if not found:
+        print("FOUND none")
+        print("NO-TRIGGER")
+        return 0
+    latest = max(found)
+    print("FOUND " + ".".join(map(str, latest)))
+    print("TRIGGER" if latest >= TRIGGER_VERSION else "NO-TRIGGER")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_skoda_official_api.py
+++ b/tests/test_skoda_official_api.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Škoda official public API client (opt-in) — parse, commands, rate-limit.
+
+Grounded against the live OpenAPI spec (docs/research/skoda-official-api.md). The
+backend can't be reached until app v8.16 mints a key, so these tests pin the
+client against the documented response + request schemas — the contract we build
+to. A real key confirms it end-to-end at launch.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.skoda_official import SkodaOfficialClient
+
+# A GET /api/v1/vehicles/{vin} body shaped exactly per the OpenAPI VehicleResponse.
+_RESPONSE: dict[str, Any] = {
+    "vehicle": {
+        "vin": "TMBUNParkedEV000001",
+        "name": "Enyaq",
+        "licensePlate": "PR-SK 123",
+        "status": {
+            "overall": {
+                "doorsLocked": "LOCKED", "locked": "LOCKED",
+                "doors": "CLOSED", "windows": "OPEN", "lights": "OFF",
+            },
+            "detail": {"sunroof": "CLOSED", "trunk": "CLOSED", "bonnet": "OPEN"},
+            "carCapturedTimestamp": "2026-08-28T09:15:00Z",
+        },
+        "fuelStatus": {
+            "carType": "ELECTRIC",
+            "totalRangeInKm": 305,
+            "primaryEngineRange": {
+                "engineType": "ELECTRIC",
+                "currentSoCInPercent": 62,
+                "remainingRangeInKm": 305,
+            },
+        },
+        "odometer": {"mileageInKm": 41230, "carCapturedTimestamp": "2026-08-28T09:15:00Z"},
+        "parkingPosition": {
+            "state": "PARKED",
+            "gpsCoordinates": {"latitude": 50.0755, "longitude": 14.4378},
+            "formattedAddress": "Praha",
+        },
+        "airConditioning": {
+            "state": "ON",
+            "targetTemperature": {"value": 21.5, "unit": "CELSIUS"},
+            "windowHeating": {"enabled": True, "front": "ON", "rear": "OFF"},
+        },
+        "charging": {
+            "isVehicleInSavedLocation": True,
+            "status": {
+                "chargePowerInKw": 11.0,
+                "remainingTimeToFullyChargedInMinutes": 90,
+                "state": "CHARGING",
+                "chargeType": "AC",
+                "battery": {"remainingCruisingRangeInMeters": 305000, "stateOfChargeInPercent": 62},
+            },
+            "settings": {
+                "targetStateOfChargeInPercent": 80,
+                "batteryCareModeTargetValueInPercent": 80,
+                "preferredChargeMode": "MANUAL",
+                "maxChargeCurrentAcAmpere": 16,
+            },
+        },
+    }
+}
+
+
+def test_parse_maps_the_full_vehicle():
+    d = SkodaOfficialClient._parse_vehicle("TMBUNParkedEV000001", _RESPONSE["vehicle"])
+    # identity
+    assert d.model == "Enyaq"
+    assert d.license_plate == "PR-SK 123"
+    # opening / lock
+    assert d.doors_locked is True
+    assert d.doors_open is False
+    assert d.windows_open is True
+    assert d.last_seen_at == "2026-08-28T09:15:00Z"
+    # odometer
+    assert d.odometer_km == 41230
+    # charging + battery
+    assert d.is_charging is True
+    assert d.charging_state == "CHARGING"
+    assert d.charging_power_kw == 11.0
+    assert d.battery_soc == 62
+    assert d.electric_range_km == 305          # remainingCruisingRangeInMeters // 1000
+    assert d.target_soc == 80
+    assert d.battery_care_target_soc_pct == 80
+    assert d.preferred_charge_mode == "MANUAL"
+    assert d.max_charge_current == 16.0
+    # climate
+    assert d.climatisation_state == "ON"
+    assert d.climatisation_active is True
+    assert d.target_temperature == 21.5
+    assert d.window_heating_front is True
+    assert d.window_heating_back is False
+    # GPS (the win over EU-DA)
+    assert d.latitude == pytest.approx(50.0755)
+    assert d.longitude == pytest.approx(14.4378)
+    # electric classification
+    assert d.is_electric is True
+    assert d.is_hybrid is False
+
+
+def test_parse_hybrid_classification():
+    v = {"fuelStatus": {
+        "primaryEngineRange": {"engineType": "GASOLINE", "currentFuelLevelInPercent": 55,
+                               "remainingRangeInKm": 420},
+        "secondaryEngineRange": {"engineType": "ELECTRIC", "currentSoCInPercent": 40,
+                                 "remainingRangeInKm": 60},
+    }}
+    d = SkodaOfficialClient._parse_vehicle("V", v)
+    assert d.is_hybrid is True
+    assert d.is_electric is False
+    assert d.primary_engine_type == "GASOLINE"
+    assert d.fuel_level == 55
+    assert d.combustion_range_km == 420
+
+
+def test_parse_tolerates_sparse_body():
+    d = SkodaOfficialClient._parse_vehicle("V", {})
+    assert d.vin == "V"
+    assert d.battery_soc is None
+    assert d.latitude is None
+
+
+# --- transport: a minimal fake aiohttp session ------------------------------
+
+class _FakeResp:
+    def __init__(self, status: int, body: Any, headers: dict[str, str]):
+        self.status = status
+        self._body = body
+        self.headers = headers
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): return False
+    async def json(self, content_type=None): return self._body
+    async def text(self): return str(self._body)
+
+
+class _FakeSession:
+    def __init__(self, status=200, body=None, headers=None):
+        self._status = status
+        self._body = body if body is not None else _RESPONSE
+        self._headers = headers or {"RateLimit-Remaining": "17", "RateLimit-Reset": "3600"}
+        self.calls: list[dict] = []
+    def request(self, method, url, headers=None, json=None, timeout=None):
+        self.calls.append({"method": method, "url": url, "json": json, "headers": headers})
+        return _FakeResp(self._status, self._body, self._headers)
+
+
+def _client(session, api_key="key-abc", vins="VIN1", spin="1234"):
+    return SkodaOfficialClient(session, email=vins, password=api_key, spin=spin)
+
+
+@pytest.mark.asyncio
+async def test_get_status_sends_x_api_key_and_tracks_rate_limit():
+    s = _FakeSession()
+    c = _client(s)
+    d = await c.get_status("VIN1")
+    assert d.battery_soc == 62
+    call = s.calls[0]
+    assert call["method"] == "GET"
+    assert call["url"].endswith("/api/v1/vehicles/VIN1")
+    assert call["headers"]["X-API-Key"] == "key-abc"
+    # rate-limit budget picked up from the response headers
+    assert c.rate_limit_remaining == 17
+    assert c.rate_limit_reset_s == 3600
+
+
+@pytest.mark.asyncio
+async def test_get_vehicles_returns_configured_vins():
+    c = _client(_FakeSession(), vins="vin1 , VIN2")
+    assert await c.get_vehicles() == ["VIN1", "VIN2"]
+
+
+@pytest.mark.asyncio
+async def test_charge_and_climate_commands_hit_the_right_paths():
+    s = _FakeSession(status=202, body={})
+    c = _client(s)
+    assert await c.command_start_charging("VIN1") is True
+    assert s.calls[-1]["url"].endswith("/vehicles/VIN1/charging/start")
+    assert s.calls[-1]["method"] == "POST"
+
+    assert await c.command_start_climate("VIN1", target_c=20.0) is True
+    assert s.calls[-1]["url"].endswith("/vehicles/VIN1/air-conditioning/start")
+    assert s.calls[-1]["json"] == {"targetTemperature": {"value": 20.0, "unit": "CELSIUS"}}
+
+    assert await c.command_stop_active_ventilation("VIN1") is True
+    assert s.calls[-1]["url"].endswith("/vehicles/VIN1/active-ventilation/stop")
+
+
+@pytest.mark.asyncio
+async def test_aux_heating_requires_spin_and_sends_it():
+    from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+
+    # with a S-PIN → sent in the body
+    s = _FakeSession(status=202, body={})
+    c = _client(s, spin="4321")
+    assert await c.command_start_aux_heating("VIN1", target_c=22.0) is True
+    body = s.calls[-1]["json"]
+    assert body["spin"] == "4321"
+    assert body["targetTemperature"] == {"value": 22.0, "unit": "CELSIUS"}
+
+    # without a S-PIN → refuses locally, never calls out
+    c2 = _client(_FakeSession(), spin="")
+    with pytest.raises(AuthenticationError):
+        await c2.command_start_aux_heating("VIN1")
+
+
+@pytest.mark.asyncio
+async def test_key_rejected_raises_auth_error():
+    from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+
+    c = _client(_FakeSession(status=401, body={"type": "api-key-expired"}))
+    with pytest.raises(AuthenticationError):
+        await c.get_status("VIN1")


### PR DESCRIPTION
Groundwork for a first-party, attestation-free Škoda channel on the **official public API** (`public.api.connect.skoda-auto.cz`), distinct from the unofficial mysmob client. Requested in #1286.

**What's here (all inert until the config-flow step + app v8.16 land):**
- `cariad/api/skoda_official.py` — `X-API-Key` client: `GET /vehicles/{vin}` → `VehicleData` (status, charging, climate, odometer, fuel, and **GPS parking position** — the read the EU Data Act channel can't give us), the eight commands (charge / air-conditioning / auxiliary-heating (S-PIN) / active-ventilation start·stop), a validating `authenticate()`, and a rate-limit budget (**20 req/hour/key**, tracked off `RateLimit-Remaining`).
- `factory` + `const` — register the `skoda_official` pseudo-brand.
- `docs/research/skoda-official-api.md` — the complete surface, generated from the live OpenAPI spec (9 endpoints, 33 schemas, auth, rate limit).
- `tests/test_skoda_official_api.py` — parse (incl. GPS + hybrid), commands, rate-limit, S-PIN guard, 401 (8 tests).
- **v8.16 watch:** `scripts/skoda_official_watch.py` + `.github/workflows/skoda-official-api-watch.yml` — a 4-hourly check for the app version that ships the key-creation screen (Settings → Smart Home → API Keys; absent from 8.15.0), which opens a tracking issue when it lands.

**Not yet user-selectable:** the config-flow opt-in step, capability gating and coordinator rate-limit pacing are the remaining wiring, and no API key can be minted until the app update ships. Merging this activates the version watch (scheduled workflows only run from the default branch) while the channel stays dormant.