### PR TITLE
fix(skoda-official): ground state strings on the API's documented values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   the complete grounded spec, and an automated 4-hourly watch for the app
   version that unlocks it (the API key is minted in the Škoda app). Not yet
   selectable and **no change for existing setups** — it needs that app update
-  before anyone can create a key.
+  before anyone can create a key. The client's state parsing is grounded on the
+  API's documented values (e.g. `doorsLocked` = `YES`/`NO`/`OPENED`, not
+  `LOCKED`).
 
 ## [4.4.0b4] - 2026-08-28 — New diagnostic sensors (drivetrain · CSID · parked-since) · Audi/VW-EU doors+trunk fix · export button on merged portals
 

--- a/custom_components/vag_connect/cariad/api/skoda_official.py
+++ b/custom_components/vag_connect/cariad/api/skoda_official.py
@@ -145,15 +145,24 @@ class SkodaOfficialClient:
         # -- opening / lock status (overall + detail) -------------------------
         status = v.get("status") or {}
         overall = status.get("overall") or {}
+        detail = status.get("detail") or {}
+        # Grounded on the spec's documented values (the fields are plain strings
+        # with no enum type, but each field's description enumerates them):
+        #   doorsLocked / locked = YES | NO | OPENED | UNKNOWN  (YES == all
+        #     supported doors AND trunk LOCKED+CLOSED) — NOT "LOCKED".
+        #   doors / windows / detail.trunk = OPEN | CLOSED | UNKNOWN.
         _dl = overall.get("doorsLocked") or overall.get("locked")
         if isinstance(_dl, str):
-            d.doors_locked = _dl.strip().upper() == "LOCKED"
+            d.doors_locked = _dl.strip().upper() == "YES"
         _do = _to_bool_open(overall.get("doors"))
         if _do is not None:
             d.doors_open = _do
         _wo = _to_bool_open(overall.get("windows"))
         if _wo is not None:
             d.windows_open = _wo
+        _trunk = _to_bool_open(detail.get("trunk"))
+        if _trunk is not None:
+            d.trunk_open = _trunk
         if isinstance(status.get("carCapturedTimestamp"), str):
             d.last_seen_at = status["carCapturedTimestamp"]
 
@@ -219,8 +228,10 @@ class SkodaOfficialClient:
         ac = v.get("airConditioning") or {}
         if isinstance(ac.get("state"), str):
             d.climatisation_state = ac["state"]
+            # spec: OFF | COOLING | HEATING | HEATING_AUXILIARY | VENTILATION |
+            # COMPLETED | UNKNOWN — active only while it's actually conditioning.
             d.climatisation_active = ac["state"].strip().upper() in (
-                "ON", "HEATING", "COOLING", "VENTILATION", "ON_HEATING", "ON_COOLING",
+                "COOLING", "HEATING", "HEATING_AUXILIARY", "VENTILATION",
             )
         tt = ac.get("targetTemperature") or {}
         if isinstance(tt.get("value"), (int, float)):

--- a/docs/research/skoda-official-api.md
+++ b/docs/research/skoda-official-api.md
@@ -22,6 +22,27 @@
 - 429 problem type `api-key-rate-limit-exceeded`; expired key → problem type `api-key-expired`.
 - **Implication:** far too tight for a 15-min feed. A conservative poll (e.g. every 5–10 min = 6–12/h) leaves little headroom for commands. Any channel we build must budget against `RateLimit-Remaining` and back off — this is a low-frequency official channel, not a replacement for mysmob.
 
+## State values + gotchas (⚠️ not formal enums — read the field descriptions)
+
+The state fields are plain `string` with **no `enum` type** in the schema; the
+real values live only in each field's `description`. Guessing them wrong
+silently mis-reports state, so they are pinned here (and in the client tests):
+
+- **`charging.status.state`**: `CONNECT_CABLE` · `CHARGING` · `CONSERVING` · `READY_FOR_CHARGING` · `DISCHARGING` · `CHARGING_INTERRUPTED`. (We treat CHARGING + CONSERVING as "charging".)
+- **`charging.status.chargeType`**: `AC` · `DC` · `OFF`.
+- **`airConditioning.state`**: `OFF` · `COOLING` · `HEATING` · `HEATING_AUXILIARY` · `VENTILATION` · `COMPLETED` · `UNKNOWN`. **There is no `ON`.** (Active only while COOLING/HEATING/HEATING_AUXILIARY/VENTILATION.)
+- **`status.overall.doorsLocked` / `locked`**: `YES` · `NO` · `OPENED` · `UNKNOWN`. **`YES` = locked** (not `"LOCKED"`).
+- **`status.overall.doors` / `windows`, `detail.trunk` / `bonnet` / `sunroof`**: `OPEN` · `CLOSED` · `UNKNOWN` (sunroof also `UNSUPPORTED`).
+- **`windowHeating.front` / `rear`**: `ON` · `OFF` · `UNKNOWN` · `UNSUPPORTED`.
+- **`fuelStatus.primaryEngineRange.engineType`**: `ELECTRIC` · `GASOLINE` · `DIESEL` · `CNG` · `LPG` · `UNKNOWN`. `fuelStatus.carType`: `HYBRID` · `GASOLINE` · … . New values may appear — clients must tolerate unknowns.
+- **`chargingSettings.maxChargeCurrentAc`** is a string (`REDUCED`/`MAXIMUM`); the numeric amps live in `maxChargeCurrentAcAmpere`.
+
+## License / token facts (Škoda announcement, 2026-08-28)
+
+- **Up to 5 access tokens per VIN**, minted in the app (v8.16+). Free.
+- **Data depends on the account's active Škoda Connect services.** Notably: **without a Remote Access license the parking position (GPS) is not returned** — so the GPS read is a bonus where licensed, not universal. Our parse already treats every field as optional.
+- Škoda is building its own dedicated HA integration (HA 2026.10) with the community; our use of this API is as an opt-in **resilience/failover** source inside a multi-brand integration, which is complementary rather than competing.
+
 ## Endpoints
 
 ### `POST /api/v1/vehicles/{vin}/charging/stop` — stopCharging

--- a/tests/test_skoda_official_api.py
+++ b/tests/test_skoda_official_api.py
@@ -23,7 +23,7 @@ _RESPONSE: dict[str, Any] = {
         "licensePlate": "PR-SK 123",
         "status": {
             "overall": {
-                "doorsLocked": "LOCKED", "locked": "LOCKED",
+                "doorsLocked": "YES", "locked": "YES",
                 "doors": "CLOSED", "windows": "OPEN", "lights": "OFF",
             },
             "detail": {"sunroof": "CLOSED", "trunk": "CLOSED", "bonnet": "OPEN"},
@@ -45,7 +45,7 @@ _RESPONSE: dict[str, Any] = {
             "formattedAddress": "Praha",
         },
         "airConditioning": {
-            "state": "ON",
+            "state": "HEATING",
             "targetTemperature": {"value": 21.5, "unit": "CELSIUS"},
             "windowHeating": {"enabled": True, "front": "ON", "rear": "OFF"},
         },
@@ -75,9 +75,10 @@ def test_parse_maps_the_full_vehicle():
     assert d.model == "Enyaq"
     assert d.license_plate == "PR-SK 123"
     # opening / lock
-    assert d.doors_locked is True
+    assert d.doors_locked is True          # overall doorsLocked == "YES"
     assert d.doors_open is False
     assert d.windows_open is True
+    assert d.trunk_open is False            # detail.trunk == "CLOSED"
     assert d.last_seen_at == "2026-08-28T09:15:00Z"
     # odometer
     assert d.odometer_km == 41230
@@ -92,7 +93,7 @@ def test_parse_maps_the_full_vehicle():
     assert d.preferred_charge_mode == "MANUAL"
     assert d.max_charge_current == 16.0
     # climate
-    assert d.climatisation_state == "ON"
+    assert d.climatisation_state == "HEATING"
     assert d.climatisation_active is True
     assert d.target_temperature == 21.5
     assert d.window_heating_front is True
@@ -125,6 +126,33 @@ def test_parse_tolerates_sparse_body():
     assert d.vin == "V"
     assert d.battery_soc is None
     assert d.latitude is None
+
+
+def test_grounded_enum_values_from_spec():
+    """Pin the exact state strings the OpenAPI spec documents in its field
+    descriptions (the fields are plain strings with no enum type). Getting these
+    wrong silently mis-reports state — e.g. doorsLocked is YES/NO/OPENED, never
+    'LOCKED'; AC 'ON' does not exist."""
+    for val, expect in (("YES", True), ("NO", False), ("OPENED", False), ("UNKNOWN", False)):
+        d = SkodaOfficialClient._parse_vehicle("V", {"status": {"overall": {"doorsLocked": val}}})
+        assert d.doors_locked is expect, f"doorsLocked={val}"
+    for val, expect in (
+        ("HEATING", True), ("COOLING", True), ("HEATING_AUXILIARY", True),
+        ("VENTILATION", True), ("OFF", False), ("COMPLETED", False), ("UNKNOWN", False),
+    ):
+        d = SkodaOfficialClient._parse_vehicle("V", {"airConditioning": {"state": val}})
+        assert d.climatisation_active is expect, f"ac={val}"
+    for val, expect in (
+        ("CHARGING", True), ("CONSERVING", True), ("READY_FOR_CHARGING", False),
+        ("CONNECT_CABLE", False), ("DISCHARGING", False), ("CHARGING_INTERRUPTED", False),
+    ):
+        d = SkodaOfficialClient._parse_vehicle("V", {"charging": {"status": {"state": val}}})
+        assert d.is_charging is expect, f"charging={val}"
+    for val, e_range in (("ELECTRIC", "electric_range_km"), ("GASOLINE", "combustion_range_km"),
+                         ("DIESEL", "combustion_range_km"), ("CNG", "combustion_range_km")):
+        d = SkodaOfficialClient._parse_vehicle(
+            "V", {"fuelStatus": {"primaryEngineRange": {"engineType": val, "remainingRangeInKm": 200}}})
+        assert getattr(d, e_range) == 200, f"engineType={val}"
 
 
 # --- transport: a minimal fake aiohttp session ------------------------------


### PR DESCRIPTION
Answering "is it deeply grounded / error-free?" — the **structure** (endpoints, field types, GPS, commands) was grounded on the authoritative OpenAPI spec, but the **state-string values** were not: those fields are plain `string` with **no `enum` type**, so their real values live only in each field's `description`. Two were guessed wrong, and the tests happened to validate the guesses.

Fixed against the documented values:
- `status.overall.doorsLocked` is `YES` / `NO` / `OPENED` (**`YES` = locked**), not `"LOCKED"` — so `doors_locked` was always `False`.
- `airConditioning.state` is `OFF` / `COOLING` / `HEATING` / `HEATING_AUXILIARY` / `VENTILATION` / `COMPLETED` / `UNKNOWN` — there is **no `ON`**, and `HEATING_AUXILIARY` was missing.

Also: surface `trunk` from `detail.trunk`; a regression test now pins every documented state string (charging, AC, doors-lock, engine type); and the docs record the state values + the license/token facts from Škoda's announcement (5 tokens/VIN; **GPS needs a Remote Access license**, so it's a bonus where licensed, not universal).

Still inert (not user-selectable, no key mintable until app v8.16). No change for existing setups.