### PR TITLE
feat(skoda): official public API as an automatic failover for the mysmob channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   before anyone can create a key. The client's state parsing is grounded on the
   API's documented values (e.g. `doorsLocked` = `YES`/`NO`/`OPENED`, not
   `LOCKED`).
+- **Škoda: the official API can act as an automatic failover** for the existing
+  channel. On a Škoda entry you can add an official API key (Options → once the
+  app update lets you mint one); if the primary channel ever hard-fails, the
+  read is served from the official API instead of freezing on last-known data.
+  It's a **failover-only** source — read only on a primary failure, never
+  polled continuously — because the official API is rate-limited to 20
+  requests/hour/key. Off by default; no change unless you add a key.
 
 ## [4.4.0b4] - 2026-08-28 — New diagnostic sensors (drivetrain · CSID · parked-since) · Audi/VW-EU doors+trunk fix · export button on merged portals
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -123,6 +123,36 @@ class SkodaClient(CariadBaseClient):
         # stops 403-hammering that endpoint. Empty on a fresh restart → charging is
         # attempted once, carType is learned, then skipped from poll 2 on.
         self._powertrain: dict[str, str] = {}
+        # Škoda OFFICIAL public-API client, armed opt-in as a FAILOVER-ONLY read
+        # source (see arm_supplementary_official). None unless the user configured
+        # an API key. Never consulted on a healthy poll — only when the primary
+        # mysmob read hard-fails — because the official API is rate-limited to
+        # 20 req/hour/key.
+        self._supplementary_official: Any = None
+
+    def arm_supplementary_official(self, api_key: str) -> None:
+        """Arm the official Škoda public API as a failover source (opt-in). The
+        key is vehicle-bound server-side, so ``get_status(vin)`` is called per-VIN
+        on failover; no VIN list is needed here."""
+        if not api_key:
+            self._supplementary_official = None
+            return
+        from .skoda_official import SkodaOfficialClient  # noqa: PLC0415
+        self._supplementary_official = SkodaOfficialClient(
+            self._session, email="", password=api_key, spin=self._spin,
+        )
+
+    async def official_failover_read(self, vin: str) -> "VehicleData | None":
+        """Read one VIN via the official public API — the FAILOVER path, invoked
+        only when the primary channel raised. Fail-soft: any error returns None so
+        the failover can never itself sink the poll."""
+        off = self._supplementary_official
+        if off is None:
+            return None
+        try:
+            return await off.get_status(vin)  # type: ignore[no-any-return]
+        except Exception:  # noqa: BLE001
+            return None
 
     @staticmethod
     def _sub_from_id_token(id_token: str | None) -> str | None:

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -2301,6 +2301,20 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                 schema[vol.Optional(
                     CONF_VWEU_DEVICE_GRANT, default=False,
                 )] = _BOOL_SELECTOR
+        # Škoda official public API — opt-in FAILOVER key. A Škoda entry may add
+        # an API key it minted in the app (Settings → Smart Home → API Keys,
+        # v8.16+); the official API is then read ONLY when the primary channel
+        # hard-fails (it is rate-limited to 20 req/hour/key, so never polled
+        # continuously). Pre-filled so re-opening options never blanks it.
+        if current_data.get(CONF_BRAND) == "skoda":
+            from .const import CONF_SKODA_OFFICIAL_API_KEY  # noqa: PLC0415
+            schema[vol.Optional(
+                CONF_SKODA_OFFICIAL_API_KEY,
+                default=str(current_options.get(
+                    CONF_SKODA_OFFICIAL_API_KEY,
+                    current_data.get(CONF_SKODA_OFFICIAL_API_KEY, ""),
+                )),
+            )] = _PASSWORD_SELECTOR
         # v2.17.5 (#759) — one optional S-PIN field per known VIN, shown only
         # when the account has more than one vehicle (each may carry its own
         # S-PIN). Empty leaves that vehicle on the shared CONF_SPIN above; values

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -285,6 +285,10 @@ CONF_SUPPLEMENTARY_AUTHPROXY_COOKIES = "supplementary_authproxy_cookies"
 # back here. SECURITY: the token bundle is never logged.
 CONF_SUPPLEMENTARY_TIBBER        = "supplementary_tibber"
 CONF_SUPPLEMENTARY_TIBBER_TOKENS = "supplementary_tibber_tokens"
+# Škoda OFFICIAL public API key (opt-in) — a FAILOVER-ONLY source: read only
+# when the primary (unofficial mysmob) channel hard-fails, never polled
+# continuously, because the official API is rate-limited to 20 requests/hour/key.
+CONF_SKODA_OFFICIAL_API_KEY      = "skoda_official_api_key"
 
 # v2.15.0b3 — "hide entities without data" (default ON). When enabled, data
 # sensors / binary sensors whose value hasn't arrived are not created, so a

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2599,6 +2599,22 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     " — primary channel unaffected.", type(err).__name__,
                 )
 
+        # ── Škoda OFFICIAL public API — FAILOVER-ONLY (opt-in) ──────────────
+        # Rate-limited (20 req/hour/key), so it is NOT a continuous-merge
+        # supplementary channel: it is read ONLY when the primary mysmob channel
+        # hard-fails (see _revive_after_hard_failure). Arming just hands the
+        # client the key; get_status(vin) is called per-VIN on failover.
+        from .const import CONF_SKODA_OFFICIAL_API_KEY  # noqa: PLC0415
+        arm_official = getattr(client, "arm_supplementary_official", None)
+        if data.get(CONF_SKODA_OFFICIAL_API_KEY) and arm_official is not None:
+            try:
+                arm_official(data.get(CONF_SKODA_OFFICIAL_API_KEY))
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "VW Group Connect: Škoda official-API failover arming failed"
+                    " (%s) — primary channel unaffected.", type(err).__name__,
+                )
+
         # ── b12: MBB COMMAND channel (commands on a read-only primary) ──────
         arm_cmd = getattr(client, "arm_mbb_command_channel", None)
         if data.get(CONF_MBB_COMMAND_CHANNEL) and arm_cmd is not None:
@@ -2840,17 +2856,40 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         last-known-good exactly as before.
         """
         client = self._cariad_client
+        # 1) read-only supplementary channels (EU Data Act / vw.de), if any armed.
         readers = getattr(client, "supplementary_readers", None)
-        if readers is None or not readers(vin):
-            return None
-        try:
-            return await self._revive_from_supplementary(vin, VehicleData(vin=vin))
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "hard-failure supplementary revive failed for %s: %s",
-                mask_vin(vin), err,
-            )
-            return None
+        if readers is not None and readers(vin):
+            try:
+                revived = await self._revive_from_supplementary(
+                    vin, VehicleData(vin=vin)
+                )
+                if revived is not None:
+                    return revived
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "hard-failure supplementary revive failed for %s: %s",
+                    mask_vin(vin), err,
+                )
+        # 2) Škoda OFFICIAL public API — a FAILOVER-ONLY source (rate-limited to
+        # 20 req/hour/key, so never read on a healthy cycle; only here, on a hard
+        # primary failure). Brand-isolated: the method exists only on the Škoda
+        # client, so getattr → None for every other brand.
+        official = getattr(client, "official_failover_read", None)
+        if official is not None:
+            try:
+                off_data: VehicleData | None = await official(vin)
+                if off_data is not None:
+                    _LOGGER.info(
+                        "VW Group Connect: %s — primary read failed, served from "
+                        "the official Škoda API (failover).", mask_vin(vin),
+                    )
+                    return off_data
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "official-API failover read failed for %s: %s",
+                    mask_vin(vin), err,
+                )
+        return None
 
     async def _poll_loop(self) -> None:
         """Background polling loop — runs independently of HA scheduler.

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Remove VW EU Two-Way (revert to the previous channel)",
           "companion_read_vehicle_health": "Companion: read odometer and service from Vehicle Health (navigates the app)",
           "companion_read_climate_detail": "Companion: read target and outside temperature (navigates the app)",
-          "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)"
+          "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)",
+          "skoda_official_api_key": "Škoda official API key — failover when the main channel is down"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Odebrat VW EU Two-Way (návrat k předchozímu kanálu)",
           "companion_read_vehicle_health": "Companion: číst stav tachometru a servis ze stavu vozidla (naviguje v aplikaci)",
           "companion_read_climate_detail": "Companion: číst cílovou a venkovní teplotu (naviguje v aplikaci)",
-          "companion_read_parking_position": "Companion: číst pozici parkování z odkazu pro sdílení v aplikaci (naviguje v aplikaci)"
+          "companion_read_parking_position": "Companion: číst pozici parkování z odkazu pro sdílení v aplikaci (naviguje v aplikaci)",
+          "skoda_official_api_key": "Oficiální klíč API Škoda — záloha, když hlavní kanál nefunguje"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Fjern VW EU To-vejs (gå tilbage til den forrige kanal)",
           "companion_read_vehicle_health": "Companion: læs kilometerstand og service fra køretøjstjek (navigerer i appen)",
           "companion_read_climate_detail": "Companion: læs måltemperatur og udetemperatur (navigerer i appen)",
-          "companion_read_parking_position": "Companion: læs parkeringsposition fra appens delingslink (navigerer i appen)"
+          "companion_read_parking_position": "Companion: læs parkeringsposition fra appens delingslink (navigerer i appen)",
+          "skoda_official_api_key": "Officiel Škoda API-nøgle — failover når hovedkanalen er nede"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "VW EU Two-Way entfernen (zurück zum vorherigen Kanal)",
           "companion_read_vehicle_health": "Companion: Kilometerstand und Service aus dem Fahrzeugcheck lesen (navigiert in der App)",
           "companion_read_climate_detail": "Companion: Solltemperatur und Außentemperatur lesen (navigiert in der App)",
-          "companion_read_parking_position": "Companion: Parkposition aus dem Teilen-Link der App lesen (navigiert in der App)"
+          "companion_read_parking_position": "Companion: Parkposition aus dem Teilen-Link der App lesen (navigiert in der App)",
+          "skoda_official_api_key": "Offizieller Škoda-API-Schlüssel — Failover, wenn der Hauptkanal ausfällt"
         },
         "data_description": {
           "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Remove VW EU Two-Way (revert to the previous channel)",
           "companion_read_vehicle_health": "Companion: read odometer and service from Vehicle Health (navigates the app)",
           "companion_read_climate_detail": "Companion: read target and outside temperature (navigates the app)",
-          "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)"
+          "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)",
+          "skoda_official_api_key": "Škoda official API key — failover when the main channel is down"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Eliminar VW EU bidireccional (volver al canal anterior)",
           "companion_read_vehicle_health": "Companion: leer cuentakilómetros y servicio desde el estado del vehículo (navega por la app)",
           "companion_read_climate_detail": "Companion: leer temperatura objetivo y exterior (navega por la app)",
-          "companion_read_parking_position": "Companion: leer la posición de aparcamiento desde el enlace para compartir de la app (navega por la app)"
+          "companion_read_parking_position": "Companion: leer la posición de aparcamiento desde el enlace para compartir de la app (navega por la app)",
+          "skoda_official_api_key": "Clave API oficial de Škoda — conmutación por error si falla el canal principal"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Poista VW EU Two-Way (palaa edelliseen kanavaan)",
           "companion_read_vehicle_health": "Companion: lue mittarilukema ja huolto ajoneuvon kunnosta (navigoi sovelluksessa)",
           "companion_read_climate_detail": "Companion: lue tavoite- ja ulkolämpötila (navigoi sovelluksessa)",
-          "companion_read_parking_position": "Companion: lue pysäköintipaikka sovelluksen jakolinkistä (navigoi sovelluksessa)"
+          "companion_read_parking_position": "Companion: lue pysäköintipaikka sovelluksen jakolinkistä (navigoi sovelluksessa)",
+          "skoda_official_api_key": "Virallinen Škoda-API-avain — vikasieto, kun pääkanava on poissa käytöstä"
         },
         "data_description": {
           "scan_interval": "Kuinka usein tietoja haetaan (minuutteja). Vähintään: 3.",

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Supprimer VW EU bidirectionnel (revenir au canal précédent)",
           "companion_read_vehicle_health": "Companion : lire le kilométrage et l'entretien dans l'état du véhicule (navigue dans l'app)",
           "companion_read_climate_detail": "Companion : lire la température de consigne et extérieure (navigue dans l'app)",
-          "companion_read_parking_position": "Companion : lire la position de stationnement depuis le lien de partage de l'app (navigue dans l'app)"
+          "companion_read_parking_position": "Companion : lire la position de stationnement depuis le lien de partage de l'app (navigue dans l'app)",
+          "skoda_official_api_key": "Clé API officielle Škoda — bascule si le canal principal tombe"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Rimuovi VW EU Two-Way (torna al canale precedente)",
           "companion_read_vehicle_health": "Companion: leggi contachilometri e tagliando da Vehicle Health (naviga nell'app)",
           "companion_read_climate_detail": "Companion: leggi temperatura impostata ed esterna (naviga nell'app)",
-          "companion_read_parking_position": "Companion: leggi la posizione di parcheggio dal link di condivisione dell'app (naviga nell'app)"
+          "companion_read_parking_position": "Companion: leggi la posizione di parcheggio dal link di condivisione dell'app (naviga nell'app)",
+          "skoda_official_api_key": "Chiave API ufficiale Škoda — failover se il canale principale non è disponibile"
         },
         "data_description": {
           "scan_interval": "Con quale frequenza vengono recuperati i dati (minuti). Minimo: 3.",

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Fjern VW EU Two-Way (gå tilbake til forrige kanal)",
           "companion_read_vehicle_health": "Companion: les kilometerstand og service fra kjøretøysjekk (navigerer i appen)",
           "companion_read_climate_detail": "Companion: les måltemperatur og utetemperatur (navigerer i appen)",
-          "companion_read_parking_position": "Companion: les parkeringsposisjon fra appens delingslenke (navigerer i appen)"
+          "companion_read_parking_position": "Companion: les parkeringsposisjon fra appens delingslenke (navigerer i appen)",
+          "skoda_official_api_key": "Offisiell Škoda API-nøkkel — failover når hovedkanalen er nede"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "VW EU Two-Way verwijderen (terug naar het vorige kanaal)",
           "companion_read_vehicle_health": "Companion: kilometerstand en onderhoud uit de voertuigcheck lezen (navigeert in de app)",
           "companion_read_climate_detail": "Companion: streef- en buitentemperatuur lezen (navigeert in de app)",
-          "companion_read_parking_position": "Companion: parkeerpositie uit de deellink van de app lezen (navigeert in de app)"
+          "companion_read_parking_position": "Companion: parkeerpositie uit de deellink van de app lezen (navigeert in de app)",
+          "skoda_official_api_key": "Officiële Škoda API-sleutel — failover als het hoofdkanaal uitvalt"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Usuń VW EU Two-Way (przywróć poprzedni kanał)",
           "companion_read_vehicle_health": "Companion: odczyt przebiegu i serwisu ze stanu pojazdu (nawiguje po aplikacji)",
           "companion_read_climate_detail": "Companion: odczyt temperatury zadanej i zewnętrznej (nawiguje po aplikacji)",
-          "companion_read_parking_position": "Companion: odczyt pozycji parkowania z linku udostępniania w aplikacji (nawiguje po aplikacji)"
+          "companion_read_parking_position": "Companion: odczyt pozycji parkowania z linku udostępniania w aplikacji (nawiguje po aplikacji)",
+          "skoda_official_api_key": "Oficjalny klucz API Škoda — przełączanie awaryjne, gdy główny kanał nie działa"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -227,7 +227,8 @@
           "remove_vweu_twoway": "Ta bort VW EU Two-Way (återgå till föregående kanal)",
           "companion_read_vehicle_health": "Companion: läs mätarställning och service från fordonsstatus (navigerar i appen)",
           "companion_read_climate_detail": "Companion: läs börtemperatur och utetemperatur (navigerar i appen)",
-          "companion_read_parking_position": "Companion: läs parkeringsposition från appens delningslänk (navigerar i appen)"
+          "companion_read_parking_position": "Companion: läs parkeringsposition från appens delningslänk (navigerar i appen)",
+          "skoda_official_api_key": "Officiell Škoda API-nyckel — failover när huvudkanalen är nere"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",

--- a/tests/test_skoda_official_failover.py
+++ b/tests/test_skoda_official_failover.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Škoda official public API as a FAILOVER-ONLY source.
+
+When the primary (unofficial mysmob) Škoda channel HARD-fails, the coordinator's
+``_revive_after_hard_failure`` falls back to the official public API — but only
+there, never on a healthy poll, because the official API is rate-limited to
+20 requests/hour/key. These tests pin both the delegation and, crucially, that
+the official channel is NOT wired into the continuous supplementary merge.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.skoda import SkodaClient
+from custom_components.vag_connect.cariad.api.skoda_official import SkodaOfficialClient
+from custom_components.vag_connect.cariad.models import VehicleData
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+
+def _skoda_client() -> SkodaClient:
+    c = SkodaClient.__new__(SkodaClient)
+    c._session = object()
+    c._spin = "1234"
+    c._supplementary_authproxy = None
+    c._supplementary_eu_portal = None
+    c._supplementary_tibber = None
+    c._supplementary_official = None
+    return c
+
+
+def test_arm_supplementary_official_creates_and_disarms():
+    c = _skoda_client()
+    c.arm_supplementary_official("key-abc")
+    assert isinstance(c._supplementary_official, SkodaOfficialClient)
+    # an empty key disarms it
+    c.arm_supplementary_official("")
+    assert c._supplementary_official is None
+
+
+@pytest.mark.asyncio
+async def test_official_failover_read_delegates_and_failsoft():
+    c = _skoda_client()
+    # not armed → None
+    assert await c.official_failover_read("V") is None
+    # armed → delegates to the official client's get_status
+    c._supplementary_official = MagicMock()
+    c._supplementary_official.get_status = AsyncMock(
+        return_value=VehicleData(vin="V", battery_soc=55)
+    )
+    d = await c.official_failover_read("V")
+    assert d is not None and d.battery_soc == 55
+    # any error → None (a failover must never itself sink the poll)
+    c._supplementary_official.get_status = AsyncMock(side_effect=RuntimeError("boom"))
+    assert await c.official_failover_read("V") is None
+
+
+def test_official_is_failover_only_never_continuous_merge():
+    """The 20/h/key rate limit means the official API must NEVER be a
+    continuous-merge supplementary — only a failover. Even when armed, it must
+    not appear in supplementary_readers (which is consulted every poll)."""
+    c = _skoda_client()
+    c.arm_supplementary_official("key")
+    names = [name for name, _ in c.supplementary_readers("V")]
+    assert "skoda_official" not in names
+    assert names == []   # nothing else armed → readers empty (failover stays out)
+
+
+@pytest.mark.asyncio
+async def test_revive_after_hard_failure_falls_over_to_official():
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    client = MagicMock()
+    client.supplementary_readers = MagicMock(return_value=[])   # no continuous suppliers
+    client.official_failover_read = AsyncMock(
+        return_value=VehicleData(vin="V", battery_soc=42)
+    )
+    coord._cariad_client = client
+    d = await coord._revive_after_hard_failure("V")
+    assert d is not None and d.battery_soc == 42
+    client.official_failover_read.assert_awaited_once_with("V")
+
+
+@pytest.mark.asyncio
+async def test_revive_prefers_supplementary_over_official():
+    """A normal read-only supplementary (EU-DA / vw.de) still wins; the official
+    API is the last resort, so its budget is only spent when nothing else has
+    the car."""
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    client = MagicMock()
+    client.supplementary_readers = MagicMock(return_value=[("eu_data_act", None)])
+    client.official_failover_read = AsyncMock(return_value=VehicleData(vin="V", battery_soc=42))
+    coord._cariad_client = client
+    coord._revive_from_supplementary = AsyncMock(
+        return_value=VehicleData(vin="V", battery_soc=90)
+    )
+    d = await coord._revive_after_hard_failure("V")
+    assert d is not None and d.battery_soc == 90        # supplementary won
+    client.official_failover_read.assert_not_called()   # official budget untouched
+
+
+@pytest.mark.asyncio
+async def test_no_official_on_other_brands_is_a_noop():
+    """A non-Škoda client has no official_failover_read → getattr None → no-op."""
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    client = MagicMock(spec=[])           # no attributes at all
+    coord._cariad_client = client
+    assert await coord._revive_after_hard_failure("V") is None


### PR DESCRIPTION
Requested: when the reverse-engineered (mysmob) Škoda channel crashes, the official public API steps in as the read source — instead of freezing on last-known data.

**How it works**
- On a Škoda entry you can add an official API key (Options). It arms a failover client at setup.
- When the primary `get_status()` **hard-fails**, `coordinator._revive_after_hard_failure` — after the existing read-only supplementary channels (EU Data Act / vw.de) — reads that VIN from the official API and serves it.
- **Failover-only by design:** it is deliberately **not** added to `supplementary_readers` (the continuous every-poll merge), because the official API is rate-limited to **20 requests/hour/key**. So its budget is spent only during an actual outage, never on a healthy cycle.

**Isolation & safety**
- Brand-isolated: `official_failover_read` exists only on the Škoda client, so every other brand is a `getattr → None` no-op.
- Off by default; a normal read-only supplementary still wins, so the official budget is the last resort.
- Fail-soft throughout: any error in the failover returns `None` and the entry keeps last-known-good, exactly as before.

**Tests:** arming/disarming, fail-soft delegation, the rate-limit guard (official absent from the continuous merge), the coordinator fail-over, supplementary-preferred-over-official, other-brand no-op. Full suite green; field label in all 12 languages.

No key can be minted until the Škoda app v8.16 ships, so this is inert for every existing setup until then.