### PR TITLE
fix(eu-data-act): map the dotted trunk.open dialect (#1293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   polled continuously — because the official API is rate-limited to 20
   requests/hour/key. Off by default; no change unless you add a key.
 
+### Fixed / Behoben
+- **VW trunk-open now reads the portal's dotted `trunk.open` field** (#1293,
+  thanks @MirkoKas). The EU Data Act feed can report the trunk state as a dotted
+  boolean (`trunk.open: "true"`), the same way it already does for
+  `trunk.locked`; we only read the numeric enum and the UUID form, so on that
+  dialect the trunk-open sensor stayed empty.
+
 ## [4.4.0b4] - 2026-08-28 — New diagnostic sensors (drivetrain · CSID · parked-since) · Audi/VW-EU doors+trunk fix · export button on merged portals
 
 ### Added / Neu

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -2170,6 +2170,14 @@ def map_dataset_to_vehicle_data(
     _tail_open = _to_int(first("open_state_tailgate"))
     if _tail_open in (2, 3) and d.trunk_open is None:
         d.trunk_open = _tail_open == 2
+    # #1293 (@MirkoKas, VW) — the boolean ``trunk.open`` dialect (dotted spelling,
+    # exactly like ``trunk.locked`` above): "true" = trunk open. Distinct from the
+    # numeric ``open_state_tailgate`` enum and the UUID fallback below — a VW
+    # portal was sending only this dotted string, so trunk_open stayed unset. Use
+    # the dotted key (never the bare ``open``) so it can't collide with a door.
+    _trunk_o = first("trunk.open", "trunk_open")
+    if _trunk_o is not None and d.trunk_open is None:
+        d.trunk_open = str(_trunk_o).strip().lower() in ("true", "open", "1")
     _bonnet_open = _to_int(first("open_state_front_engine_bonnet"))
     if _bonnet_open in (2, 3) and d.hood_open is None:
         d.hood_open = _bonnet_open == 2

--- a/tests/test_v2174_competitor_sweep_fixes.py
+++ b/tests/test_v2174_competitor_sweep_fixes.py
@@ -213,3 +213,15 @@ def test_v2175_trunk_locked_dotted_and_no_doors_collision() -> None:
     )
     assert d.trunk_locked is True
     assert d.doors_locked is False
+
+
+def test_1293_trunk_open_dotted() -> None:
+    # #1293 (@MirkoKas, VW) — the portal can ship the trunk-open state as the
+    # dotted boolean 'trunk.open' (like 'trunk.locked'), not just the numeric
+    # open_state_tailgate enum. "true" → trunk_open True; "false" → False.
+    assert map_dataset_to_vehicle_data(
+        {"trunk.open": "true"}, VehicleData(vin="X")
+    ).trunk_open is True
+    assert map_dataset_to_vehicle_data(
+        {"trunk.open": "false"}, VehicleData(vin="X")
+    ).trunk_open is False


### PR DESCRIPTION
Scout on a VW flagged `eu_data_act.trunk.open = "true"`. The EU Data Act feed can report the trunk state as a dotted boolean (`trunk.open`), exactly like `trunk.locked` — the parser only read the numeric `open_state_tailgate` enum and the UUID fallback, so on that dialect `trunk_open` stayed unset. Now reads the qualified dotted key (never the bare `open`, to avoid a door collision); consuming it also stops the Scout re-flagging it. Test pinned. Thanks @MirkoKas.