### PR TITLE
fix(reporter): cap the error-report URL on encoded length, not raw body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   `trunk.locked`; we only read the numeric enum and the UUID form, so on that
   dialect the trunk-open sensor stayed empty.
 
+### Fixed / Behoben
+- **Error-reporter links stay submittable even on long reports.** A report with
+  many errors (e.g. a burst of 20 repeated 401s) could build a pre-filled GitHub
+  URL too long to actually send: the cap was on the raw body, but url-encoding a
+  traceback-heavy body inflates it 2-3x (paths, carets, newlines, brackets all
+  become %XX). The cap is now on the final encoded URL and trimmed conservatively
+  — the full report is always available under Diagnostics.
+
 ## [4.4.0b4] - 2026-08-28 — New diagnostic sensors (drivetrain · CSID · parked-since) · Audi/VW-EU doors+trunk fix · export button on merged portals
 
 ### Added / Neu

--- a/custom_components/vag_connect/cariad/_reporter_pipeline.py
+++ b/custom_components/vag_connect/cariad/_reporter_pipeline.py
@@ -54,6 +54,12 @@ from ._unexpected_keys import UnexpectedField, _VIN_RE
 # empty-body issues we saw in #409 and #412. 4000 raw → ~6000 encoded
 # leaves comfortable headroom.
 _GITHUB_BODY_MAX = 4000
+# Hard ceiling on the FINAL encoded issue URL. GitHub's backend 414s past ~8 KB,
+# but in practice a pre-filled link stopped being submittable well below that
+# (a 20-error acpp 401 report at ~7.7 KB couldn't be sent — browser/UI limits
+# bite lower than the server's). Cap conservatively: the full report is always
+# in Diagnostics, so trimming the pre-filled URL harder costs nothing.
+_GITHUB_URL_MAX = 6500
 
 # Repo where users land for crowd-sourced bug reports. Keeping this
 # constant means we can swap to a discussions URL later without touching
@@ -320,17 +326,39 @@ def github_issue_url(
 
     The URL is safe to feed straight into ``learn_more_url`` on a HA
     repair issue, or to print and copy to clipboard.
+
+    The cap is on the FINAL ENCODED url, not the raw body: url-encoding a
+    traceback-heavy body inflates it far more than the ~1.5x a prose body
+    costs (paths, ``^^^^`` carets, newlines, brackets and spaces all become
+    ``%XX``), so a raw-length cap alone could still produce an un-submittable
+    URL — a 20-error acpp 401 report did exactly that. We truncate on the raw
+    length first (cheap), then shrink until the encoded URL is safely under
+    GitHub's ~8 KB ceiling.
     """
-    if len(body) > body_max:
-        body = body[: body_max - 80] + (
-            "\n\n_… truncated — full report available via "
-            "Settings → Devices → VW Group Connect → Diagnostics._"
-        )
-    params: list[tuple[str, str]] = [("title", title), ("body", body)]
-    if labels:
-        params.append(("labels", ",".join(labels)))
-    qs = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
-    return f"{repo_url.rstrip('/')}/issues/new?{qs}"
+    marker = (
+        "\n\n_… truncated — full report available via "
+        "Settings → Devices → VW Group Connect → Diagnostics._"
+    )
+
+    def _build(text: str) -> str:
+        params: list[tuple[str, str]] = [("title", title), ("body", text)]
+        if labels:
+            params.append(("labels", ",".join(labels)))
+        qs = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+        return f"{repo_url.rstrip('/')}/issues/new?{qs}"
+
+    truncated = len(body) > body_max
+    if truncated:
+        body = body[: body_max - len(marker)]
+    url = _build(body + (marker if truncated else ""))
+    # Encoded-length backstop: shrink the body geometrically until the whole
+    # URL fits under _GITHUB_URL_MAX. Converges in a few passes; the floor guard
+    # stops it if even a minimal body + a long title would overflow.
+    while len(url) > _GITHUB_URL_MAX and len(body) > 200:
+        body = body[: int(len(body) * 0.85)]
+        truncated = True
+        url = _build(body + marker)
+    return url
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -330,6 +330,28 @@ class TestReporterPipeline:
         # Total query length is bounded
         assert len(url) < 1500
 
+    def test_github_issue_url_caps_the_ENCODED_length_on_dense_bodies(self):
+        # A raw-length cap alone doesn't bound the encoded URL — a
+        # traceback-heavy body inflates 2-3x under url-encoding (paths, carets,
+        # newlines, brackets, spaces all → %XX). A 20-error acpp 401 report was
+        # un-submittable this way. The encoded-length backstop must keep the
+        # final URL under the ceiling regardless of content, at the default
+        # body_max (no caller override).
+        from custom_components.vag_connect.cariad._reporter_pipeline import (
+            _GITHUB_URL_MAX,
+            github_issue_url,
+        )
+
+        # maximally-inflating content: nearly every char becomes %XX
+        dense = "\n^^^^ /config/custom_components/vag_connect/ ()[]{}<> " * 400
+        url = github_issue_url(
+            "[Error Reporter] 20 recent error(s) on audi_acpp A5 Coupé TDI CR",
+            dense,
+            labels=("error-reporter", "audi_acpp"),
+        )
+        assert len(url) <= _GITHUB_URL_MAX
+        assert "truncated" in urllib.parse.unquote(url)
+
     def test_ensure_unexpected_keys_issue_creates_when_findings_present(self):
         from custom_components.vag_connect.cariad._reporter_pipeline import (
             ensure_unexpected_keys_issue,


### PR DESCRIPTION
A report with many errors could build a pre-filled GitHub issue URL too long to submit: truncation was on the raw body (4000 chars), but url-encoding a traceback-heavy body inflates it 2-3x (paths, carets, newlines, brackets → %XX), so the encoded URL still overflowed the practical browser/GitHub limit — a 20-error acpp 401 report hit this at ~7.7 KB. Now caps the FINAL encoded URL, shrinking the body geometrically until it fits under a conservative 6500-char ceiling (the full report is always in Diagnostics). Test pins it against a dense body.