### PR TITLE
fix(acpp): refresh token on 401 + keep last-known-good on restart + hourly polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,17 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   become %XX). The cap is now on the final encoded URL and trimmed conservatively
   — the full report is always available under Diagnostics.
 
+### Fixed / Behoben
+- **Audi plug&play (OBD dongle): recovers from an expired token instead of
+  spamming errors, and keeps its data across a restart.** The acpp channel never
+  refreshed its ~1h token — once it expired every poll 401'd and the Error
+  Reporter filled with ~20 repeated 401s. It now refreshes and retries on a 401
+  (rotating the refresh token); a genuinely dead token raises a single re-auth
+  prompt instead of a flood. A failed first read after a restart no longer
+  discards the restored last-known-good snapshot. And since the dongle only
+  uploads a snapshot after a drive, acpp now polls hourly by default (was every
+  10 min) — identical data, far less token churn.
+
 ## [4.4.0b4] - 2026-08-28 — New diagnostic sensors (drivetrain · CSID · parked-since) · Audi/VW-EU doors+trunk fix · export button on merged portals
 
 ### Added / Neu

--- a/custom_components/vag_connect/cariad/api/plugandplay.py
+++ b/custom_components/vag_connect/cariad/api/plugandplay.py
@@ -114,7 +114,7 @@ class PlugAndPlayCloudClient:
     def tokens(self) -> TokenSet | None:
         return self._tokens
 
-    async def _get(self, path: str) -> tuple[int, Any]:
+    async def _get(self, path: str, _retry: bool = True) -> tuple[int, Any]:
         if not self._tokens or not self._tokens.access_token:
             raise AuthenticationError("plug&play client is not authenticated")
         headers = {
@@ -132,11 +132,26 @@ class PlugAndPlayCloudClient:
         async with self._session.get(
             f"{self.API_BASE}/{path}", headers=headers, timeout=_TIMEOUT
         ) as resp:
+            status = resp.status
             try:
                 body = await resp.json(content_type=None)
             except Exception:  # noqa: BLE001 — error bodies may be text
                 body = await resp.text()
-            return resp.status, body
+        # acpp is a STANDALONE client (not a BaseClient), so it does NOT inherit
+        # the base 401→refresh path. The access token is short-lived (~1h) and the
+        # refresh token rotates — on a 401, refresh once and retry (mirroring
+        # BaseClient._request), and keep the rotated token so the next poll doesn't
+        # replay a dead one. A persistent 401 falls through unchanged.
+        if (
+            status == 401 and _retry
+            and self._tokens is not None and self._tokens.refresh_token
+        ):
+            try:
+                self._tokens = await self._auth.refresh(self._tokens.refresh_token)
+            except Exception:  # noqa: BLE001 — refresh failed → surface the 401
+                return status, body
+            return await self._get(path, _retry=False)
+        return status, body
 
     async def get_raw_snapshot(self, vin: str) -> dict[str, Any]:
         """Return the full acpp snapshot for a VIN.
@@ -156,6 +171,14 @@ class PlugAndPlayCloudClient:
              "last_parking_position": {"gpsLocation": {...}}, "app_services": {...}}
         """
         status, body = await self._get(f"vehicle/{vin}")
+        if status == 401:
+            # After _get's refresh+retry, a persistent 401 means the stored token
+            # is truly dead. Raise AuthenticationError (not APIError) so the
+            # coordinator suppresses the per-poll Error-Reporter flood and fires a
+            # single re-auth Repair instead of ~20 buffered 401s (acpp, Prash).
+            raise AuthenticationError(
+                f"plug&play token rejected (401): {self.API_BASE}/vehicle/{vin}"
+            )
         if status != 200 or not isinstance(body, dict):
             # 404 here specifically means the VIN is not enrolled in THIS account
             # ("Vehicle with vin: '...' does not exist").

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -396,6 +396,11 @@ MAX_SCAN_INTERVAL     = 60   # minutes — the config-flow selectable ceiling (#
 # every other brand keeps the 10-min default.
 RECOMMENDED_SCAN_INTERVAL: dict[str, int] = {
     "skoda": 30,
+    # acpp (Audi plug&play OBD dongle) uploads a snapshot only when the dongle
+    # syncs after a drive — polling faster than the car is driven returns
+    # identical data and just churns the ~1h rotating token. Hourly reliably
+    # catches the post-drive snapshot.
+    "audi_acpp": 60,
 }
 
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1511,6 +1511,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     vins = await self._enumerate_via_eu_data_act_fallback()
                     if not vins:
                         raise
+            # Restart resilience: enumeration still empty (e.g. an acpp / read-only
+            # silo whose first post-restart read 401'd, or a transient enumeration
+            # failure) — fall back to the VINs already restored from the
+            # last-known-good cache instead of tearing the entry down. get_status
+            # then decides per-VIN (a raise keeps the restored snapshot via the
+            # keep-loop), so entities show last-known-good rather than unavailable.
+            if not vins:
+                vins = [v for v in self.vehicles if not str(v).startswith("_")]
             if not vins:
                 return False
 

--- a/tests/test_acpp_resilience.py
+++ b/tests/test_acpp_resilience.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""acpp (Audi plug&play dongle) resilience — 401 self-heal + poll cadence.
+
+The acpp client is a standalone class (not a BaseClient), so it never inherited
+the base 401→refresh path: a stale ~1h token 401'd every poll, raised APIError,
+and flooded the Error Reporter (~20 repeated 401s, reported by Prash). Now it
+refreshes-and-retries on 401 (rotating the refresh token), and a *persistent* 401
+raises AuthenticationError so the coordinator fires one re-auth Repair instead of
+spamming. It also polls hourly (the dongle only uploads after a drive).
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.plugandplay import PlugAndPlayCloudClient
+from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+from custom_components.vag_connect.cariad.models import BRAND_AUDI_ACPP, TokenSet
+
+
+class _Resp:
+    def __init__(self, status: int, body: Any):
+        self.status = status
+        self._b = body
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): return False
+    async def json(self, content_type: Any = None): return self._b
+    async def text(self): return str(self._b)
+
+
+class _Session:
+    """Returns the queued (status, body) responses in order, one per GET."""
+    def __init__(self, *responses: tuple[int, Any]):
+        self._responses = list(responses)
+        self.calls = 0
+    def get(self, url: str, headers: Any = None, timeout: Any = None):
+        i = min(self.calls, len(self._responses) - 1)
+        self.calls += 1
+        status, body = self._responses[i]
+        return _Resp(status, body)
+
+
+def _client(session: _Session) -> PlugAndPlayCloudClient:
+    c = PlugAndPlayCloudClient(session, BRAND_AUDI_ACPP, "user@example.com", "pw")
+    c._tokens = TokenSet(
+        access_token="dead", refresh_token="refresh-1", id_token="", expires_at=0.0,
+    )
+    return c
+
+
+@pytest.mark.asyncio
+async def test_get_refreshes_and_retries_on_401():
+    s = _Session((401, {"e": "unauth"}), (200, {"ok": True}))
+    c = _client(s)
+    c._auth.refresh = AsyncMock(return_value=TokenSet(  # type: ignore[method-assign]
+        access_token="fresh", refresh_token="refresh-2", id_token="", expires_at=0.0,
+    ))
+    status, body = await c._get("vehicle/VIN1")
+    assert status == 200 and body == {"ok": True}
+    c._auth.refresh.assert_awaited_once_with("refresh-1")
+    # the rotated token is kept for the next poll
+    assert c._tokens.access_token == "fresh"
+    assert c._tokens.refresh_token == "refresh-2"
+    assert s.calls == 2   # exactly one retry, no loop
+
+
+@pytest.mark.asyncio
+async def test_get_surfaces_401_when_refresh_fails():
+    s = _Session((401, {"e": "unauth"}))
+    c = _client(s)
+    c._auth.refresh = AsyncMock(side_effect=RuntimeError("refresh boom"))  # type: ignore[method-assign]
+    status, _ = await c._get("vehicle/VIN1")
+    assert status == 401           # surfaced, not retried into a loop
+    assert s.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_does_not_refresh_without_a_refresh_token():
+    s = _Session((401, {"e": "unauth"}))
+    c = _client(s)
+    c._tokens = TokenSet(access_token="dead", refresh_token="", id_token="", expires_at=0.0)
+    c._auth.refresh = AsyncMock()  # type: ignore[method-assign]
+    status, _ = await c._get("vehicle/VIN1")
+    assert status == 401
+    c._auth.refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_persistent_401_raises_auth_error_not_apierror():
+    # get_raw_snapshot must raise AuthenticationError on a persistent 401 so the
+    # coordinator suppresses the per-poll Error-Reporter flood + fires one reauth.
+    c = PlugAndPlayCloudClient(MagicMock(), BRAND_AUDI_ACPP, "u", "p")
+    c._tokens = MagicMock(access_token="x")
+
+    async def _fake_get(path: str, _retry: bool = True):
+        return 401, {"e": "unauth"}
+    c._get = _fake_get  # type: ignore[assignment]
+    with pytest.raises(AuthenticationError):
+        await c.get_raw_snapshot("VIN1")
+
+
+def test_acpp_polls_hourly_by_default():
+    from custom_components.vag_connect.const import recommended_scan_interval
+    assert recommended_scan_interval("audi_acpp") == 60      # dongle syncs on-drive
+    assert recommended_scan_interval("skoda") == 30          # unchanged


### PR DESCRIPTION
The Audi plug&play (acpp) client is a standalone class (not a `BaseClient`), so it never inherited the base 401→refresh path or token persistence: a stale ~1h token 401'd on every poll, raised `APIError`, and flooded the Error Reporter with ~20 repeated 401s.

- **`plugandplay._get`** — on 401, refresh once and retry (rotating the refresh token, keeping the new one), mirroring `BaseClient._request`.
- **`plugandplay.get_raw_snapshot`** — a *persistent* 401 now raises `AuthenticationError`, not `APIError(401)`, so the coordinator suppresses the per-poll reporter flood and fires a single re-auth Repair.
- **`coordinator.async_setup`** — if enumeration comes back empty (an acpp read that 401'd, or a transient failure), fall back to the VINs already restored from the last-known-good cache instead of tearing the entry down — so acpp entities keep showing last-known-good across a restart.
- **`const`** — acpp defaults to hourly polling. The dongle only uploads on-drive, so faster polling returns identical data and just churns the rotating token. (No per-day server limit is known; the constraint is the on-drive sync cadence.)

Tests: 401 refresh+retry, refresh-fail surfaces the 401, no-refresh-token path, persistent-401→AuthenticationError, hourly default. Full suite green.