### PR TITLE
Audi MBB command fallback — opt-in UI (stacked on #1299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   uploads a snapshot after a drive, acpp now polls hourly by default (was every
   10 min) — identical data, far less token churn.
 
+### Changed / Geändert
+- **All 12 languages tidied up.** The new Audi backup-connection setup screen,
+  the portal-feed and one-time-export sensor states, and the vehicle-image
+  entities now read in your own language instead of falling back to English —
+  and a handful of stray English labels (a couple of password fields,
+  "Stale" / "Delivered" / "Timed out") got translated too.
+
 ## [4.4.0b4] - 2026-08-28 — New diagnostic sensors (drivetrain · CSID · parked-since) · Audi/VW-EU doors+trunk fix · export button on merged portals
 
 ### Added / Neu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   10 min) — identical data, far less token churn.
 
 ### Changed / Geändert
+- **The data-source sensor now reads in plain language.** When a car is fed by
+  several logins at once, "Data source channel" showed cryptic tokens like
+  `eu_data_act+mbb`. It now reads "EU Data Act portal + Car-Net", lists each
+  source under a `channels` attribute, and shows the same friendly name as the
+  `source` attribute on every reading — so you can see at a glance which login
+  produced what, and one car is never listed twice. The raw tokens stay under a
+  `raw` attribute for support.
 - **All 12 languages tidied up.** The new Audi backup-connection setup screen,
   the portal-feed and one-time-export sensor states, and the vehicle-image
   entities now read in your own language instead of falling back to English —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   10 min) — identical data, far less token churn.
 
 ### Changed / Geändert
+- **The car-render images no longer crowd the device page.** Audi/VW cars ship
+  the same render in seven sizes and angles; enabling all seven buried the
+  device page under seven near-identical photos. Now only the recommended one
+  (the large side view) is on by default — the other six are still created but
+  switched off, so you can enable exactly the size/angle you want for a
+  dashboard in one click. Existing setups keep whatever they already have.
 - **The data-source sensor now reads in plain language.** When a car is fed by
   several logins at once, "Data source channel" showed cryptic tokens like
   `eu_data_act+mbb`. It now reads "EU Data Act portal + Car-Net", lists each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.4.0b5] - 2026-08-30 — Audi durable two-way (MBB) · garage-list resilience · acpp token recovery · trunk-open · Škoda official-API groundwork
+
+### Added / Neu
+- **Audi: durable two-way commands (MBB) are now available.** Car-Net Audis (most
+  PHEV / combustion, pre-ID/MEB) can enable the durable MBB command channel — the
+  toggle already existed but was blocked; a live validation confirmed an Audi
+  account mints the durable MBB bearer, so lock/unlock, climate and charge can
+  route through the resilient legacy Car-Net path (survives restarts and the
+  Play-Integrity wall). Off by default; newer ID / MEB Audis aren't eligible and
+  simply won't offer it.
+
+### Fixed / Behoben
+- **The garage list survives a backend path change.** myAudi 5.7.0 moved the
+  vehicle-list endpoint; if VW ever retires the old path, the integration now falls
+  back to the alternate (vgql) garage enumeration instead of losing every Audi.
+  Purely defensive — no change today, just resilience for a future backend switch.
+
 ### Added / Neu
 - **Groundwork for an opt-in official Škoda API channel** (#1286). Škoda has
   launched a first-party, attestation-free vehicle API; this lands the client,

--- a/custom_components/vag_connect/_channel_labels.py
+++ b/custom_components/vag_connect/_channel_labels.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Layperson-friendly names for the read channels a car is fed over.
+
+A car can be read over several channels at once (see ``cariad/_channel_merge``).
+Internally each channel is a short token — ``eu_data_act``, ``website_authproxy``,
+``mbb``, a brand slug like ``audi``. Those tokens are the right thing to store and
+to key logic on, but they read like jargon in the UI. This module maps a token to
+the same wording a user already saw when they set the login up, so the
+``data_source_channel`` sensor and each entity's ``source`` attribute say
+"Car-Net" and "vw.de website" instead of ``mbb`` and ``website_authproxy``.
+
+Pure display helper: the raw tokens in ``source_channel`` / ``field_sources`` are
+never changed, so all provenance logic and tests keep working on the tokens.
+"""
+from __future__ import annotations
+
+from .const import BRANDS
+
+# Channel tokens that are not brand slugs. Brand slugs (audi, volkswagen, …) fall
+# through to BRANDS so the name matches the setup dialog exactly.
+_CHANNEL_LABELS: dict[str, str] = {
+    "eu_data_act": "EU Data Act portal",
+    "website_authproxy": "vw.de website",
+    "tibber": "Tibber",
+    "mbb": "Car-Net",
+    "companion_adb": "Companion app (ADB)",
+    "companion_relay": "Companion app (relay)",
+    "brand_native": "Brand app",
+    "primary": "Main login",
+}
+
+
+def channel_display_name(token: str) -> str:
+    """One channel token → its friendly name. Unknown tokens are returned as-is
+    (never silently hidden), so a channel added later still shows *something*."""
+    if not token:
+        return token
+    if token in _CHANNEL_LABELS:
+        return _CHANNEL_LABELS[token]
+    return BRANDS.get(token, token)
+
+
+def channels_overview(raw: str | None) -> tuple[str | None, list[str]]:
+    """A ``"+"``-joined ``source_channel`` string → ``(display, labels)``.
+
+    Maps every contributing token to its friendly name and de-duplicates on the
+    *mapped* name (so two tokens that share a label never show twice), preserving
+    the deterministic order of the sorted raw join. Returns ``(None, [])`` for an
+    empty / single-source-with-no-data value.
+    """
+    if not raw:
+        return None, []
+    labels: list[str] = []
+    seen: set[str] = set()
+    for token in raw.split("+"):
+        label = channel_display_name(token)
+        if label and label not in seen:
+            seen.add(label)
+            labels.append(label)
+    if not labels:
+        return None, []
+    return " + ".join(labels), labels

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -386,7 +386,30 @@ class VWEUClient(CariadBaseClient):
         if self._tokens and self._tokens.strategy == "mbb":
             return await self._get_vehicles_via_mbb()
 
-        data = await self._get(f"{self._garage_base()}/vehicle/v1/vehicles")
+        # b15 — garage-list resilience. myAudi 5.7.0 refactored the garage list
+        # from ``/vehicle/v1/vehicles`` to ``/vehicles`` (a new garageinformation
+        # module); CARIAD may eventually deprecate the old path. If the primary
+        # BFF list fails (e.g. a future 404 on the retired path), don't die: for
+        # Audi the vgql userVehicles list lives on a DIFFERENT host
+        # (app-api.*.my.audi.com) and enumerates the whole account garage, so fall
+        # back to it instead of returning no cars. Previously a 404 here raised
+        # APIError BEFORE the vgql merge below could run, so get_vehicles() died
+        # hard for Audi the moment the legacy path went away.
+        try:
+            data = await self._get(f"{self._garage_base()}/vehicle/v1/vehicles")
+        except APIError as err:
+            _LOGGER.warning(
+                "VAG: BFF garage list failed (HTTP %s) — falling back to the vgql "
+                "userVehicles enumeration.", getattr(err, "status", "?"),
+            )
+            await self.fetch_images()  # best-effort; populates self._image_data
+            fb_vins = [v for v in (getattr(self, "_image_data", {}) or {}) if v]
+            if fb_vins:
+                _LOGGER.info(
+                    "VAG: recovered %d vehicle(s) from the vgql garage after the "
+                    "BFF list failed.", len(fb_vins),
+                )
+            return fb_vins
         vehicles: list[dict[str, Any]] = data.get("data", [])
 
         # Cache nickname/model per VIN — used in _parse_status to set device name
@@ -842,11 +865,25 @@ class VWEUClient(CariadBaseClient):
 
     async def arm_mbb_command_channel(
         self, tokens: Any, client_id: str, vins: list[str], spin: str = "",
+        fallback_only: bool = False,
     ) -> bool:
-        """b12 — arm a durable-MBB command connector ALONGSIDE this (read-only
-        primary) client: commands route through MBB while reads stay on the
-        primary. Builds a second VWEUClient on the shared session (MBB = bearer,
-        no IDP-cookie clobber). Fail-soft → False leaves the slot None and the
+        """b12 — arm a durable-MBB command connector ALONGSIDE this client.
+
+        Two modes:
+        - ``fallback_only=False`` (b12, read-only primary, e.g. EU Data Act
+          portal): MBB *is* the command channel — commands route through it
+          while reads stay on the primary. Stored as ``self._mbb_command`` so
+          ``_mbb_command_target()`` returns it.
+        - ``fallback_only=True`` (b15, TWO-WAY device-grant primary, e.g. Audi
+          Car-Net on the CARIAD BFF): the BFF stays the command primary; this
+          connector is stored as ``self._mbb_fallback`` and used ONLY by the
+          coordinator's BFF-refusal retry path. ``_mbb_command_target()`` is
+          deliberately left untouched so normal commands keep hitting the BFF —
+          no regression for a working two-way Audi; MBB only steps in when the
+          BFF refuses (401/403).
+
+        Builds a second VWEUClient on the shared session (MBB = bearer, no
+        IDP-cookie clobber). Fail-soft → False leaves the slot None and the
         primary unaffected. Skipped if THIS client is already MBB-primary."""
         if not tokens or not getattr(tokens, "access_token", ""):
             return False
@@ -864,19 +901,37 @@ class VWEUClient(CariadBaseClient):
             cmd.set_persisted_tokens(tokens)
             cmd._mbb_client_id = client_id or ""
             cmd._mbb_manual_vins = list(vins or [])
-            self._mbb_command = cmd
-            _LOGGER.info(
-                "VW Group Connect: MBB command channel armed alongside the"
-                " read-only primary (commands → MBB, reads → primary)."
-            )
+            if fallback_only:
+                self._mbb_fallback: "VWEUClient | None" = cmd
+                _LOGGER.info(
+                    "VW Group Connect: MBB command FALLBACK armed alongside the"
+                    " two-way primary (BFF commands first, MBB only on refusal)."
+                )
+            else:
+                self._mbb_command = cmd
+                _LOGGER.info(
+                    "VW Group Connect: MBB command channel armed alongside the"
+                    " read-only primary (commands → MBB, reads → primary)."
+                )
             return True
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning(
-                "VW Group Connect: could not arm MBB command channel (%s) —"
-                " primary unaffected.", type(err).__name__,
+                "VW Group Connect: could not arm MBB command %s (%s) —"
+                " primary unaffected.",
+                "fallback" if fallback_only else "channel", type(err).__name__,
             )
-            self._mbb_command = None
+            if fallback_only:
+                self._mbb_fallback = None
+            else:
+                self._mbb_command = None
             return False
+
+    def mbb_fallback_connector(self) -> "VWEUClient | None":
+        """b15 — the armed MBB *fallback* connector (two-way device-grant
+        primary), or None. Consumed by the coordinator's BFF-refusal command
+        retry. Distinct from ``_mbb_command_target()``, which stays None on a
+        device-grant primary so normal commands keep hitting the BFF."""
+        return getattr(self, "_mbb_fallback", None)
 
     async def command_lock(self, vin: str, spin: str = "") -> None:
         """Lock vehicle — separate endpoint (primary) with combined endpoint as

--- a/custom_components/vag_connect/cariad/auth/_device_grant.py
+++ b/custom_components/vag_connect/cariad/auth/_device_grant.py
@@ -563,7 +563,15 @@ MBB_DAG_CLIENT_ID = "9496332b-ea03-4091-a224-8c746b885068@apps_vw-dilab_com"
 # The ``mbb`` token is the key — without it the id_token aud is the OIDC client
 # and the exchange 400s ("Audiences don't match issuer (VWGMBB01DELIV1)").
 MBB_DAG_SCOPE = "openid profile mbb cars"
-MBB_DAG_BRANDS = frozenset({"volkswagen"})
+# b15 (2026-08-30) — "audi" added after a LIVE validation on a real Audi account:
+# the MBB device-grant (9496332b + mbb scope) minted an id_token with aud
+# ``VWGMBB01DELIV1``, ``register/v1`` returned HTTP 200, and the exchange with the
+# REGISTERED client id returned HTTP 200 + a durable refresh_token. So Car-Net
+# Audis mint the durable MBB bearer too — the exchange was never technically
+# VW-only; the ``mbb`` scope is what carries the backend audience. Unlocks MBB
+# two-way commands for portal-primary Audi (the flow already offers the toggle
+# for audi) AND the device-grant Audi command fallback (CONF_MBB_COMMAND_FALLBACK).
+MBB_DAG_BRANDS = frozenset({"volkswagen", "audi"})
 
 
 def mbb_dag_config(brand_name: str) -> tuple[str, str] | None:

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -47,6 +47,7 @@ from .const import (
     CONF_ENABLE_REVERSE_GEOCODING,
     CONF_FORCE_PPE_CLIMATE,
     CONF_MBB_COMMAND_CHANNEL,
+    CONF_MBB_COMMAND_FALLBACK,
     CONF_MEB_COMMANDS_UNAVAILABLE,
     CONF_MBB_COMMAND_CLIENT_ID,
     CONF_MBB_COMMAND_TOKENS,
@@ -458,6 +459,14 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 "companion_adb": (
                     "Companion-Handy (ADB) — EXPERIMENTELL, alle Marken "
                     "(zweites Handy mit eingeloggter App nötig)"
+                ),
+                # b15 — arm the durable MBB command fallback on an EXISTING
+                # device-grant Audi (Car-Net cars). One-time browser confirm; the
+                # BFF stays primary, MBB only steps in if VW ever revokes the
+                # device grant. Aborts gracefully if no eligible Audi entry exists.
+                "audi_mbb_fallback": (
+                    "MBB-Command-Fallback für bestehende Audi (Car-Net) — "
+                    "dauerhafte Zwei-Wege-Reserve, falls VW den Device-Grant sperrt"
                 ),
             },
         )
@@ -997,6 +1006,71 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             }),
         )
 
+    async def async_step_audi_mbb_fallback(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """b15 — arm the durable MBB command FALLBACK on an existing device-grant
+        Audi. A device-grant Audi stores no password, so Reconfigure / Re-auth
+        (both password-gated) can't reach it — this menu step runs a one-time MBB
+        browser confirm and attaches the durable Car-Net bearer to the chosen Audi
+        as a BFF-refusal fallback (``CONF_MBB_COMMAND_FALLBACK``), so lock / climate
+        / charge survive a future device-grant revocation. Only Car-Net (pre-MEB)
+        Audis are eligible; MEB / ID cars are rejected at the MBB exchange and the
+        flow aborts with ``mbb_not_eligible``."""
+        candidates = [
+            e for e in self.hass.config_entries.async_entries(DOMAIN)
+            if e.data.get(CONF_BRAND) == "audi"
+            and (e.data.get("dag_initial_tokens") or {}).get("strategy")
+            == "device_grant"
+            and not e.data.get(CONF_MBB_COMMAND_FALLBACK)
+        ]
+        if not candidates:
+            return self.async_abort(reason="no_devicegrant_audi")
+
+        if user_input is not None:
+            self._mbb_fallback_entry_id = (
+                user_input.get("entry_id") or candidates[0].entry_id
+            )
+            # Reset DAG state for the MBB attempt (mirrors async_step_mbb_login),
+            # tagged as a fallback so browser_login_finish attaches rather than
+            # creating a new entry.
+            self._dag_mbb = True
+            self._dag_mbb_fallback = True
+            self._dag_brand = "audi"
+            self._dag_request_task = None
+            self._dag_poll_task = None
+            self._dag_user_code = ""
+            self._dag_verification_uri = ""
+            self._dag_device_code = ""
+            self._dag_tokens = None
+            self._dag_mbb_tokens = None
+            self._dag_mbb_client_id = ""
+            self._dag_mbb_ineligible = False
+            self._dag_user_id = ""
+            self._dag_error = ""
+            self._dag_user_input = dict(user_input)
+            return await self.async_step_browser_login_pending()
+
+        schema_dict: dict[Any, Any] = {}
+        if len(candidates) > 1:
+            schema_dict[vol.Required("entry_id")] = SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        SelectOptionDict(value=e.entry_id, label=e.title)
+                        for e in candidates
+                    ],
+                    mode=SelectSelectorMode.LIST,
+                )
+            )
+        schema_dict[vol.Optional(CONF_MBB_VINS, default="")] = TextSelector(
+            TextSelectorConfig()
+        )
+        schema_dict[vol.Optional(CONF_SPIN, default="")] = _SPIN_SELECTOR
+        return self.async_show_form(
+            step_id="audi_mbb_fallback",
+            data_schema=vol.Schema(schema_dict),
+        )
+
     async def async_step_browser_login(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
@@ -1513,6 +1587,49 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         if self._dag_tokens is None:
             # Shouldn't happen if step routing is correct, but defensive.
             return self.async_abort(reason="dag_no_tokens")
+
+        # b15 — device-grant Audi command FALLBACK: the MBB QR just minted the
+        # durable Car-Net bearer; attach it to an EXISTING device-grant Audi entry
+        # as a BFF-refusal fallback (CONF_MBB_COMMAND_FALLBACK). Reached from
+        # ``async_step_audi_mbb_fallback`` (menu) or the setup checkbox, both of
+        # which set ``_dag_mbb_fallback`` + ``_mbb_fallback_entry_id``. The BFF
+        # stays the command primary; MBB only steps in when the BFF refuses (401/
+        # 403) — see coordinator ``_cariad_cmd``. If the MBB bearer never minted
+        # (MEB/ID car), abort with the eligibility reason.
+        if getattr(self, "_dag_mbb_fallback", False):
+            if self._dag_mbb_tokens is None:
+                return self.async_abort(reason="mbb_not_eligible")
+            entry = self.hass.config_entries.async_get_entry(
+                getattr(self, "_mbb_fallback_entry_id", "") or ""
+            )
+            if entry is None:
+                return self.async_abort(reason="reconfigure_failed")
+            new_data = {
+                **entry.data,
+                CONF_MBB_COMMAND_FALLBACK: True,
+                CONF_MBB_COMMAND_TOKENS: {
+                    "access_token": self._dag_mbb_tokens.access_token,
+                    "refresh_token": self._dag_mbb_tokens.refresh_token,
+                    "id_token": self._dag_tokens.id_token,
+                    "expires_at": self._dag_mbb_tokens.expires_at,
+                    "strategy": "mbb",
+                },
+                CONF_MBB_COMMAND_CLIENT_ID: self._dag_mbb_client_id,
+            }
+            raw_vins = str(self._dag_user_input.get(CONF_MBB_VINS, "") or "")
+            vins = [
+                v.strip().upper()
+                for v in raw_vins.replace(",", " ").split()
+                if 11 <= len(v.strip()) <= 17
+            ]
+            if vins:
+                new_data[CONF_MBB_VINS] = vins
+            _spin = str(self._dag_user_input.get(CONF_SPIN, "") or "").strip()
+            if _spin:
+                new_data[CONF_SPIN] = _spin
+            self.hass.config_entries.async_update_entry(entry, data=new_data)
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            return self.async_abort(reason="mbb_fallback_armed")
 
         # b12 — Portal-primary entry WITH an MBB command channel: the QR just
         # minted the durable-MBB bearer; attach it to the pending portal entry

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -465,8 +465,9 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 # BFF stays primary, MBB only steps in if VW ever revokes the
                 # device grant. Aborts gracefully if no eligible Audi entry exists.
                 "audi_mbb_fallback": (
-                    "MBB-Command-Fallback für bestehende Audi (Car-Net) — "
-                    "dauerhafte Zwei-Wege-Reserve, falls VW den Device-Grant sperrt"
+                    "Fernbefehle für einen bestehenden Audi absichern — "
+                    "Reserve-Verbindung, damit Ver-/Entriegeln, Klima & Laden "
+                    "weiterlaufen, falls sich die Audi-Anbindung ändert"
                 ),
             },
         )
@@ -1185,7 +1186,11 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             # can retry. The error message lives in self._dag_error
             # (surfaced via debug log; future: repair-issue / notification).
             return self.async_show_progress_done(
-                next_step_id="mbb_login" if self._dag_mbb else "browser_login"
+                next_step_id=(
+                    "audi_mbb_fallback"
+                    if getattr(self, "_dag_mbb_fallback", False)
+                    else "mbb_login" if self._dag_mbb else "browser_login"
+                )
             )
 
         # Phase 1 done — hand off to Phase 2 (separate step_id so HA
@@ -1229,6 +1234,8 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         """
         # Defensive — should only be reached with Phase 1 state populated.
         if not self._dag_device_code:
+            if getattr(self, "_dag_mbb_fallback", False):
+                return await self.async_step_audi_mbb_fallback()
             return await self.async_step_browser_login()
 
         # Kick off poll_for_tokens() on first entry (idempotent)
@@ -1290,6 +1297,8 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 # back to the right brand/MBB picker so user can retry.
                 self._dag_poll_task = None
                 self._dag_device_code = ""
+                if getattr(self, "_dag_mbb_fallback", False):
+                    return await self.async_step_audi_mbb_fallback()
                 if self._dag_mbb:
                     return await self.async_step_mbb_login()
                 return await self.async_step_browser_login()

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -1352,7 +1352,8 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 mbb_cfg = mbb_dag_config(self._dag_brand)
                 if mbb_cfg is None:
                     raise ValueError(
-                        f"MBB durable login is VW-only (got {self._dag_brand})"
+                        "MBB durable login needs a Car-Net brand (Volkswagen or "
+                        f"Audi); got {self._dag_brand}"
                     )
                 mbb_client_id, mbb_scope = mbb_cfg
                 self._dag_client = DeviceAuthorizationGrant(

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -400,6 +400,12 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         # EXISTING entry via Reconfigure. The QR finish/approve steps then UPDATE
         # this entry in place instead of creating a new one.
         self._mbb_reconfigure_entry_id: str | None = None
+        # b15 — device-grant Audi MBB command-fallback opt-in
+        # (async_step_audi_mbb_fallback). ``_dag_mbb_fallback`` tags the QR run so
+        # browser_login_finish ATTACHES the durable bearer to an existing Audi
+        # (``_mbb_fallback_entry_id``) instead of creating a new entry.
+        self._dag_mbb_fallback: bool = False
+        self._mbb_fallback_entry_id: str | None = None
         # v2.14.0 — website-authproxy (opt-in beta) pending state between the
         # credentials step and the email-OTP step. The connector + its session
         # are held open across the two-step OTP exchange so the cookie jar
@@ -975,6 +981,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         if user_input is not None:
             # Reset DAG state for this MBB attempt.
             self._dag_mbb = True
+            self._dag_mbb_fallback = False  # b15 — this is the VW MBB flow, not the Audi fallback
             self._dag_brand = "volkswagen"
             self._dag_user_input = dict(user_input)
             self._dag_request_task = None
@@ -1101,6 +1108,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             else:
                 # Reset state for this attempt.
                 self._dag_mbb = False
+                self._dag_mbb_fallback = False  # b15 — normal device grant, not the Audi MBB fallback
                 self._dag_brand = brand
                 self._dag_user_input = dict(user_input)
                 self._dag_request_task = None
@@ -1188,7 +1196,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             return self.async_show_progress_done(
                 next_step_id=(
                     "audi_mbb_fallback"
-                    if getattr(self, "_dag_mbb_fallback", False)
+                    if self._dag_mbb_fallback
                     else "mbb_login" if self._dag_mbb else "browser_login"
                 )
             )
@@ -1234,7 +1242,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         """
         # Defensive — should only be reached with Phase 1 state populated.
         if not self._dag_device_code:
-            if getattr(self, "_dag_mbb_fallback", False):
+            if self._dag_mbb_fallback:
                 return await self.async_step_audi_mbb_fallback()
             return await self.async_step_browser_login()
 
@@ -1297,7 +1305,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 # back to the right brand/MBB picker so user can retry.
                 self._dag_poll_task = None
                 self._dag_device_code = ""
-                if getattr(self, "_dag_mbb_fallback", False):
+                if self._dag_mbb_fallback:
                     return await self.async_step_audi_mbb_fallback()
                 if self._dag_mbb:
                     return await self.async_step_mbb_login()
@@ -1605,11 +1613,11 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         # stays the command primary; MBB only steps in when the BFF refuses (401/
         # 403) — see coordinator ``_cariad_cmd``. If the MBB bearer never minted
         # (MEB/ID car), abort with the eligibility reason.
-        if getattr(self, "_dag_mbb_fallback", False):
+        if self._dag_mbb_fallback:
             if self._dag_mbb_tokens is None:
                 return self.async_abort(reason="mbb_not_eligible")
             entry = self.hass.config_entries.async_get_entry(
-                getattr(self, "_mbb_fallback_entry_id", "") or ""
+                self._mbb_fallback_entry_id or ""
             )
             if entry is None:
                 return self.async_abort(reason="reconfigure_failed")

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -91,6 +91,15 @@ CONF_MBB_COMMAND_CHANNEL      = "mbb_command_channel"      # bool: armed?
 CONF_MBB_COMMAND_TOKENS       = "mbb_command_tokens"       # dag-shaped dict (strategy=mbb)
 CONF_MBB_COMMAND_CLIENT_ID    = "mbb_command_client_id"    # registered X-Client-Id
 CONF_MEB_COMMANDS_UNAVAILABLE = "meb_commands_unavailable"  # bool: MEB/ID car, commands requested but impossible
+# b15 — MBB COMMAND FALLBACK for a TWO-WAY device-grant primary (e.g. Audi
+# Car-Net on the CARIAD BFF). Unlike CONF_MBB_COMMAND_CHANNEL (portal primary →
+# MBB *is* the command channel), here the BFF stays the command primary and the
+# MBB connector is armed ONLY as a fallback: a command runs on the BFF first and
+# re-routes to MBB *only* when the BFF refuses it (401/403 auth refusal), and
+# only for MBB-eligible (pre-MEB Car-Net) cars. Škoda pulled its device-grant in
+# 2026-08 — this keeps a two-way Audi commandable if VW ever does the same. Reuses
+# the CONF_MBB_COMMAND_TOKENS / _CLIENT_ID / _VINS storage (same durable bearer).
+CONF_MBB_COMMAND_FALLBACK     = "mbb_command_fallback"     # bool: MBB armed as BFF-refusal fallback?
 # 2026-08 — VW EU Two-Way (modern CARIAD BFF) via device-grant client 650d46ca.
 # Its 1h Bearer is BFF-whitelisted for reads+commands (the surface vw_eu.py
 # drives), unlike the DAG-dead app client / read-only portal client. Because the

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_FUEL_TANK_CAPACITY,
     CONF_KEEP_RAW_DATASETS,
     CONF_MBB_COMMAND_CHANNEL,
+    CONF_MBB_COMMAND_FALLBACK,
     CONF_MEB_COMMANDS_UNAVAILABLE,
     CONF_PASSWORD,
     CONF_READ_ONLY,
@@ -2670,6 +2671,55 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning(
                     "VW Group Connect: MBB command channel arming failed (%s)"
                     " — reads unaffected.", type(err).__name__,
+                )
+
+        # ── b15: MBB COMMAND FALLBACK (two-way device-grant primary, e.g. Audi) ─
+        # Same durable-MBB bearer + storage as the channel above, but armed as a
+        # FALLBACK (fallback_only=True → _mbb_fallback slot): the BFF stays the
+        # command primary and MBB is used ONLY by the _cariad_cmd BFF-refusal
+        # retry. Keeps a two-way Audi commandable if VW ever revokes its
+        # device-grant (Škoda precedent 2026-08). No operationList warm-up here on
+        # purpose — the fallback must NOT change command-entity visibility (that
+        # stays on the BFF capability gate); the retry gates itself.
+        if data.get(CONF_MBB_COMMAND_FALLBACK) and arm_cmd is not None:
+            from .cariad.models import TokenSet  # noqa: PLC0415
+            from .const import (  # noqa: PLC0415
+                CONF_MBB_COMMAND_CLIENT_ID,
+                CONF_MBB_COMMAND_TOKENS,
+                CONF_MBB_VINS,
+            )
+            tok = data.get(CONF_MBB_COMMAND_TOKENS) or {}
+            fb_tokens = TokenSet(
+                access_token=str(tok.get("access_token", "")),
+                refresh_token=str(tok.get("refresh_token", "")),
+                id_token=str(tok.get("id_token", "")),
+                expires_at=float(tok.get("expires_at", 0.0) or 0.0),
+                strategy="mbb",
+            )
+            vins = data.get(CONF_MBB_VINS) or []
+            if isinstance(vins, str):
+                vins = [
+                    v.strip().upper()
+                    for v in vins.replace(",", " ").split() if v.strip()
+                ]
+            try:
+                armed = bool(await arm_cmd(
+                    fb_tokens,
+                    data.get(CONF_MBB_COMMAND_CLIENT_ID, ""),
+                    list(vins),
+                    self._spin_from_entry(),
+                    fallback_only=True,
+                ))
+                if armed:
+                    # persist the rotated MBB bearer (durable refresh survives
+                    # restarts) — shares the command-token slot with the channel.
+                    fb = getattr(client, "_mbb_fallback", None)
+                    if fb is not None:
+                        fb.on_tokens_changed = self._persist_mbb_command_tokens
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "VW Group Connect: MBB command fallback arming failed (%s)"
+                    " — BFF commands unaffected.", type(err).__name__,
                 )
 
     async def _persist_mbb_command_tokens(self, tokens: Any) -> None:
@@ -7035,6 +7085,33 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 pass
             _LOGGER.error("VW Group Connect: %s(%s) failed: %s", method, mask_vin(vin), err)
+            # b15 — a two-way primary (Audi BFF) that refuses a command with an
+            # auth 401/403 (the shape a revoked device-grant takes) → try the
+            # durable MBB fallback ONCE before surfacing, iff the user opted in
+            # and the car is MBB-eligible (both settled at arm time). MBB success
+            # ends here; MBB failure falls through and surfaces the ORIGINAL BFF
+            # error, never the fallback's.
+            fb = self._mbb_command_fallback(method, err)
+            if fb is not None:
+                try:
+                    await getattr(fb, method)(vin, **kwargs)
+                    await self.async_request_refresh()
+                    try:
+                        self.record_command_success(vin, method)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    _LOGGER.info(
+                        "VW Group Connect: %s(%s) recovered via the MBB fallback"
+                        " after the BFF refused it (HTTP %s).",
+                        method, mask_vin(vin), getattr(err, "status", "?"),
+                    )
+                    return
+                except Exception as fb_err:  # noqa: BLE001
+                    _LOGGER.info(
+                        "VW Group Connect: MBB fallback for %s(%s) also failed"
+                        " (%s) — surfacing the original BFF error.",
+                        method, mask_vin(vin), type(fb_err).__name__,
+                    )
             # v2.18.0 (#659) — surface the failure instead of letting the raw
             # APIError escape. HA doesn't know our exception types, so it logged
             # "Unexpected exception" and showed the user a Python traceback for
@@ -7103,6 +7180,38 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 pass  # enrichment must never change the command outcome
             raise HomeAssistantError(msg) from err
+
+    def _mbb_command_fallback(self, method: str, err: Exception) -> Any | None:
+        """b15 — the armed MBB fallback connector to retry a command on, or None.
+
+        Non-None ONLY when: the two-way primary client has an MBB fallback armed
+        (a device-grant Audi that opted in — already MBB-eligible, settled at arm
+        time), the failure is a BFF AUTH REFUSAL (``APIError`` 401/403, the shape
+        a revoked device-grant takes), and the command method exists on the MBB
+        connector. Deliberately NARROW: our own ``HomeAssistantError`` guards, an
+        ``SpinError`` / ``VehicleCommandError`` (both non-APIError), a capability
+        / entitlement gate, and a transient 5xx / timeout / 404 all return None —
+        MBB can't fix those, and a needless second call just doubles the failure."""
+        # Gate on the explicit config flag via a REAL dict lookup first — never
+        # ``getattr(client, "_mbb_fallback")`` alone, which a MagicMock test
+        # client would auto-vivify to a truthy value (mirrors the MagicMock-safe
+        # gating in ``_mbb_command_channel_client``). Also the cheapest guard.
+        try:
+            if not self.entry.data.get(CONF_MBB_COMMAND_FALLBACK):
+                return None
+        except Exception:  # noqa: BLE001
+            return None
+        from .cariad.exceptions import APIError  # noqa: PLC0415
+        if isinstance(err, HomeAssistantError) or not isinstance(err, APIError):
+            return None
+        if getattr(err, "status", None) not in (401, 403):
+            return None
+        client = getattr(self, "_cariad_client", None)
+        getter = getattr(client, "mbb_fallback_connector", None)
+        fb = getter() if callable(getter) else None
+        if fb is None:
+            return None
+        return fb if callable(getattr(fb, method, None)) else None
 
     async def async_set_charge_mode(self, vin: str, mode: str) -> None:
         """Set charging mode (MANUAL / TIMER / PREFERRED_CHARGING_TIMES)."""

--- a/custom_components/vag_connect/entity_base.py
+++ b/custom_components/vag_connect/entity_base.py
@@ -285,7 +285,10 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
 
         source = self._field_source
         if source:
-            attrs["source"] = source
+            # friendly channel name ("Car-Net"), not the raw token ("mbb").
+            # _field_source stays the raw token for internal keying.
+            from ._channel_labels import channel_display_name  # noqa: PLC0415
+            attrs["source"] = channel_display_name(source)
 
         own = self._platform_attributes()
         if own:

--- a/custom_components/vag_connect/image.py
+++ b/custom_components/vag_connect/image.py
@@ -350,6 +350,17 @@ _RENDER_TKEYS = frozenset({
     "render_side_sm", "render_small", "render_icon", "render_angle_hd",
 })
 
+# The Audi/VW MediaService ships the SAME car render in 7 sizes/angles. Enabling
+# all 7 buried the device page under seven near-identical car photos. Keep only
+# the ⭐-recommended one (the large side profile, best for Lovelace) enabled by
+# default; the other six are still created but disabled — a user who wants a
+# specific size/angle for a dashboard enables it in one click. Existing setups
+# keep whatever they already have (the registry enabled-state is sticky); this
+# only tidies NEW vehicles. Brand-native viewpoints (CUPRA/SEAT OLA, Škoda) and
+# the single Škoda widget render are the only render(s) those brands have, so
+# they stay enabled.
+_DEFAULT_ENABLED_RENDERS = frozenset({"render_side_lg"})
+
 
 class VagRenderImageEntity(VagConnectEntity, ImageEntity):
     """One render image entity for a single MediaType + vehicle combination.
@@ -377,6 +388,12 @@ class VagRenderImageEntity(VagConnectEntity, ImageEntity):
         _suffix = meta["entity_suffix"]
         if _suffix in _RENDER_TKEYS:
             self._attr_translation_key = _suffix
+            # Only the ⭐-recommended catalog render is on by default; the other
+            # six sizes/angles are created but disabled to keep the device page
+            # clean (see _DEFAULT_ENABLED_RENDERS).
+            self._attr_entity_registry_enabled_default = (
+                _suffix in _DEFAULT_ENABLED_RENDERS
+            )
         else:
             # Open-ended OLA/mysmob viewpoint — keep the backend label.
             self._attr_name = self._label_for(meta)

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.4.0b4"
+  "version": "4.4.0b5"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -4143,9 +4143,19 @@ class VagConnectSensor(VagConnectEntity, SensorEntity):
         # Only present when a genuine tie occurred, so it never bloats the
         # recorder on a clean poll.
         if self.entity_description.key == "data_source_channel":
+            from ._channel_labels import channels_overview  # noqa: PLC0415
+            src_attrs: dict[str, Any] = {}
+            raw = self._vehicle.get("source_channel")
+            _display, labels = channels_overview(
+                raw if isinstance(raw, str) else None)
+            if labels:
+                # friendly per-channel list + the raw token join for support
+                src_attrs["channels"] = labels
+                src_attrs["raw"] = raw
             contested = self._vehicle.get("contested_fields")
             if isinstance(contested, dict) and contested:
-                return json_safe_dict({"contested_fields": contested})
+                src_attrs["contested_fields"] = contested
+            return json_safe_dict(src_attrs) if src_attrs else None
         # v2.15.3 — Skoda trip-cost sensors carry the (dynamic) ISO currency
         # code as an attribute, since device_class=MONETARY would force a fixed
         # native currency unit we don't know ahead of time.
@@ -4169,6 +4179,15 @@ class VagConnectSensor(VagConnectEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         val = self._vehicle.get(self.entity_description.data_key)
+        # data_source_channel — show the friendly, de-duplicated channel list
+        # ("Car-Net + EU Data Act portal") instead of the raw token join
+        # ("eu_data_act+mbb"). The raw value stays in the ``raw`` attribute and
+        # in ``source_channel`` itself, so nothing that keys on tokens changes.
+        if self.entity_description.key == "data_source_channel":
+            from ._channel_labels import channels_overview  # noqa: PLC0415
+            display, _labels = channels_overview(
+                val if isinstance(val, str) else None)
+            return display
         # v2.10.0 (charging_statistics) - power-curve sample list. Native
         # value is the COUNT to keep state HA-recorder friendly; the full
         # list lives in extra_state_attributes (see above). Returns None

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -134,6 +134,19 @@
           "approved_in_browser": "Leave checked. Click Submit only after you have signed in and confirmed the code in the browser."
         }
       },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
+      },
       "companion_adb": {
         "title": "Companion phone (ADB) — experimental",
         "description": "Read and control your car by driving the official app on a spare Android phone over ADB. This is EXPERIMENTAL and opt-in. You need a second phone that stays signed into the brand app, with ADB over Wi-Fi enabled. An older phone (Android 10 or earlier) connects here directly; a modern phone (Android 11+, wireless debugging) needs the 'VW Group App ADB Bridge' add-on, which you then point this at. Volkswagen is verified; the other brands are read-only for now until a screen map from a real device is confirmed. Nothing is rooted and no app tokens are read — the integration only reads the screen and taps buttons.",
@@ -185,7 +198,9 @@
       "already_configured": "This account is already configured.",
       "reauth_successful": "Re-authentication successful.",
       "reconfigure_successful": "Configuration updated successfully.",
-      "mbb_not_eligible": "Your vehicle isn't eligible for the MBB durable login — the backend returned \"Unknown user\". This means it's a newer ID / MEB model (ID.3/4/5, e-up, etc.) that was never enrolled in the legacy Car-Net/MBB system, so the durable login + remote commands can't reach it. Use the EU Data Act portal channel (or the Email + Password login) for these vehicles instead. The MBB login is for older Car-Net cars (most PHEV / combustion models)."
+      "mbb_not_eligible": "Your vehicle isn't eligible for the MBB durable login — the backend returned \"Unknown user\". This means it's a newer ID / MEB model (ID.3/4/5, e-up, etc.) that was never enrolled in the legacy Car-Net/MBB system, so the durable login + remote commands can't reach it. Use the EU Data Act portal channel (or the Email + Password login) for these vehicles instead. The MBB login is for older Car-Net cars (most PHEV / combustion models).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -135,16 +135,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       },
       "companion_adb": {
@@ -199,8 +199,8 @@
       "reauth_successful": "Re-authentication successful.",
       "reconfigure_successful": "Configuration updated successfully.",
       "mbb_not_eligible": "Your vehicle isn't eligible for the MBB durable login — the backend returned \"Unknown user\". This means it's a newer ID / MEB model (ID.3/4/5, e-up, etc.) that was never enrolled in the legacy Car-Net/MBB system, so the durable login + remote commands can't reach it. Use the EU Data Act portal channel (or the Email + Password login) for these vehicles instead. The MBB login is for older Car-Net cars (most PHEV / combustion models).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — udržte dálkové příkazy v provozu (záložní připojení)",
+        "description": "Přidá záložní připojení, aby dálkové příkazy vašeho Audi — zamknout/odemknout, klimatizace a nabíjení — fungovaly dál, i kdyby Audi někdy změnilo způsob, jakým se aplikace přihlašuje. V běžném provozu se nic nemění: vaše Audi používá své normální připojení a záloha se zapojí jen tehdy, když normální připojení přestane přijímat příkazy. Nastavení vyžaduje jen jedno rychlé potvrzení v prohlížeči (žádné heslo se neukládá). Vyberte Audi, které jste už přidali pomocí přihlášení přes QR / aplikaci. Funguje u většiny benzinových, naftových a plug-in hybridních Audi; některé nejnovější plně elektrické modely nejsou podporovány a jsou automaticky odmítnuty.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Které Audi",
+          "mbb_vins": "ID vozidla (VIN) — obvykle nechte prázdné",
+          "spin": "S-PIN (potřebný jen pro zamknutí/odemknutí)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Nechte prázdné, pokud si to nastavení nevyžádá.",
+          "spin": "Vaše S-PIN k Audi — kód, který používáte pro dálkové zamykání/odemykání."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Opětovné ověření bylo úspěšné.",
       "reconfigure_successful": "Konfigurace byla úspěšně aktualizována.",
       "mbb_not_eligible": "Vaše vozidlo není způsobilé pro trvalé přihlášení MBB — backend vrátil „Unknown user“. Jde o novější model ID / MEB (ID.3/4/5, e-up apod.), který nikdy nebyl registrován ve starém systému Car-Net/MBB, takže trvalé přihlášení a vzdálené příkazy se k němu nedostanou. Pro taková vozidla použijte kanál portálu EU Data Act (nebo přihlášení e-mailem a heslem). Přihlášení MBB je pro starší vozy Car-Net (většina plug-in hybridních / spalovacích modelů).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Záložní připojení je nastaveno. Pokud normální připojení vašeho Audi někdy přestane přijímat dálkové příkazy, zamykání/odemykání, klimatizace a nabíjení se automaticky přepnou na zálohu. V běžném provozu se nic nemění.",
+      "no_devicegrant_audi": "Nebylo nalezeno žádné odpovídající Audi. Tato záloha platí jen pro Audi přidané přihlášením přes QR / aplikaci, které ji ještě nemá. Nejprve takto přidejte své Audi a pak se sem vraťte."
     },
     "progress": {
       "awaiting_browser_login": "Otevřete {verification_uri} v libovolném prohlížeči, přihlaste se pomocí účtu Brand ID a potvrďte kód {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU Two-Way (příkazy + živé čtení dat, BETA)",
         "description": "**Experimentální, dobrovolné — pouze Volkswagen.** Přidává obousměrné ovládání (zamknout/odemknout, klimatizace, nabíjení) a živé čtení dat z CARIAD po přihlášení pomocí vašeho Volkswagen ID. Protože Volkswagen na této cestě vydává pouze hodinový token, vaše heslo se **uloží**, aby jej integrace mohla automaticky obnovovat. Odesílá se výhradně na přihlašovací server samotného Volkswagenu a nikdy se nezapisuje do logů ani diagnostiky. Nechcete heslo ukládat? Použijte místo toho kanály jen pro čtení. **Předpoklad:** vaše Volkswagen ID musí být hlavním uživatelem vozidla.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "E-mailová adresa",
+          "password": "Heslo"
         },
         "data_description": {
           "username": "E-mail vašeho účtu Volkswagen ID / myVolkswagen.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Stav kanálu portálu",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "Čekání na data z portálu",
+          "empty_snapshots": "Prázdné snímky",
+          "delivery_not_ready": "Doručení není připraveno",
+          "stale": "Zastaralé"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minuty od posledního snímku"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Historický export",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Vyžádáno — připravuje se",
+          "done": "Doručeno",
+          "timed_out": "Vypršel časový limit"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Vytvořit žádost o data EU Data Act"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Vyžádat historický export"
       },
       "companion_reset_button": {
         "name": "Resetovat spojení companion"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "Pohled 3/4 (ikona)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "Pohled 3/4 (malý)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "Pohled 3/4 (střední)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Boční pohled (malý)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Boční pohled (velký)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "Pohled 3/4 (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "Pohled 3/4 (velký)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Vyobrazení vozidla"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "Poslední data, která vaše auto nahlásilo, byla zaznamenána zhruba **před {age} hodinami**, přestože samotné dotazování stále probíhá úspěšně. Můžou za tím být dvě věci: auto je nejspíš jen zaparkované a spí (normální stav — není třeba nic dělat), nebo jeho přísun dat podle EU Data Act vypršel a přestal dodávat čerstvé hodnoty.\n\nHodnoty, které teď vidíte, jsou poslední známé, ne aktuální. Pokud jste od té doby s autem jeli nebo ho připojili k nabíjení a toto upozornění nezmizí, nejspíš vypršel přísun dat: otevřete volkswagen.de → nastavení dat vašeho vozu a obnovte/znovu vyžádejte sdílení dat, nebo kanál přidejte znovu.\n\nToto upozornění zmizí samo ve chvíli, kdy dorazí čerstvější údaj."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: jednorázový historický export nebyl dokončen",
+      "description": "Jednorázový historický export vyžádaný pro toto auto nevytvořil soubor ve stanovené lhůtě. Portál VW pro tento požadavek nevrací žádný konečný stav, takže mohl být tiše zahozen. Požadavek byl vymazán — můžete jej vyžádat znovu nebo se podívat přímo do portálu."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "Portál EU Data Act ještě není připraven. Počkejte, až integrace po nastavení jednou provede dotaz, a poté zkuste historický export znovu."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "Jednorázový historický export je momentálně vypnutý."
     },
     "historical_wedge_blocked": {
       "message": "Pro toto auto už probíhá jednorázový export historie. Portál zpracovává vždy jen jeden takový požadavek, takže než si vyžádáte další, počkejte, až se ten aktuální dokončí (nebo vyprší)."

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Opětovné ověření bylo úspěšné.",
       "reconfigure_successful": "Konfigurace byla úspěšně aktualizována.",
       "mbb_not_eligible": "Vaše vozidlo není způsobilé pro trvalé přihlášení MBB — backend vrátil „Unknown user“. Jde o novější model ID / MEB (ID.3/4/5, e-up apod.), který nikdy nebyl registrován ve starém systému Car-Net/MBB, takže trvalé přihlášení a vzdálené příkazy se k němu nedostanou. Pro taková vozidla použijte kanál portálu EU Data Act (nebo přihlášení e-mailem a heslem). Přihlášení MBB je pro starší vozy Car-Net (většina plug-in hybridních / spalovacích modelů).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Otevřete {verification_uri} v libovolném prohlížeči, přihlaste se pomocí účtu Brand ID a potvrďte kód {user_code}.",

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Zaškrtněte, pokud na telefonu běží aplikace agenta. Telefon pak volá Home Assistant: není potřeba ADB, bezdrátové ladění ani pevná IP adresa — pole s adresou nechte prázdné.",
           "companion_agent_token": "Náhodný token vygenerovaný aplikací agenta. Nejméně 32 znaků a pro každé vozidlo jiný."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Tento účet je již nastaven.",
       "reauth_successful": "Opětovné ověření bylo úspěšné.",
       "reconfigure_successful": "Konfigurace byla úspěšně aktualizována.",
-      "mbb_not_eligible": "Vaše vozidlo není způsobilé pro trvalé přihlášení MBB — backend vrátil „Unknown user“. Jde o novější model ID / MEB (ID.3/4/5, e-up apod.), který nikdy nebyl registrován ve starém systému Car-Net/MBB, takže trvalé přihlášení a vzdálené příkazy se k němu nedostanou. Pro taková vozidla použijte kanál portálu EU Data Act (nebo přihlášení e-mailem a heslem). Přihlášení MBB je pro starší vozy Car-Net (většina plug-in hybridních / spalovacích modelů)."
+      "mbb_not_eligible": "Vaše vozidlo není způsobilé pro trvalé přihlášení MBB — backend vrátil „Unknown user“. Jde o novější model ID / MEB (ID.3/4/5, e-up apod.), který nikdy nebyl registrován ve starém systému Car-Net/MBB, takže trvalé přihlášení a vzdálené příkazy se k němu nedostanou. Pro taková vozidla použijte kanál portálu EU Data Act (nebo přihlášení e-mailem a heslem). Přihlášení MBB je pro starší vozy Car-Net (většina plug-in hybridních / spalovacích modelů).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Otevřete {verification_uri} v libovolném prohlížeči, přihlaste se pomocí účtu Brand ID a potvrďte kód {user_code}.",

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — hold fjernkommandoer kørende (reserveforbindelse)",
+        "description": "Dette tilføjer en reserveforbindelse, så din Audis fjernkommandoer — lås/lås op, klima og opladning — bliver ved med at virke, også hvis Audi en dag ændrer måden, appen logger ind på. I hverdagen ændrer der sig ingenting: din Audi bruger sin normale forbindelse, og reserven træder kun til, hvis den normale holder op med at tage imod kommandoer. Opsætningen kræver én hurtig bekræftelse i browseren (der gemmes ingen adgangskode). Vælg den Audi, du allerede har tilføjet med QR-/app-login. Det virker på de fleste benzin-, diesel- og plug-in-hybrid-Audier; enkelte af de nyeste helelektriske modeller understøttes ikke og afvises automatisk.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Hvilken Audi",
+          "mbb_vins": "Køretøjs-ID (VIN) — lad normalt feltet stå tomt",
+          "spin": "S-PIN (kun nødvendig til lås/lås op)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Lad feltet stå tomt, medmindre opsætningen beder om det.",
+          "spin": "Din Audi-S-PIN — koden, du bruger til at låse og låse op på afstand."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Fornyet login lykkedes.",
       "reconfigure_successful": "Konfigurationen blev opdateret.",
       "mbb_not_eligible": "Dit køretøj er ikke egnet til det vedvarende MBB-login — backendet returnerede \"Unknown user\". Det betyder, at det er en nyere ID/MEB-model (ID.3/4/5, e-up osv.), der aldrig blev registreret i det ældre Car-Net/MBB-system, så det vedvarende login + fjernkommandoerne kan ikke nå det. Brug EU Data Act-portalkanalen (eller login med e-mail + adgangskode) til disse køretøjer i stedet. MBB-loginet er til ældre Car-Net-biler (de fleste PHEV-/forbrændingsmodeller).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Reserveforbindelse oprettet. Hvis din Audis normale forbindelse en dag holder op med at tage imod fjernkommandoer, skifter lås/lås op, klima og opladning automatisk til reserven. I hverdagen ændrer der sig ingenting.",
+      "no_devicegrant_audi": "Ingen passende Audi fundet. Denne reserve gælder kun for en Audi, du har tilføjet med QR-/app-login, og som ikke allerede har den. Tilføj din Audi på den måde først, og kom så tilbage hertil."
     },
     "progress": {
       "awaiting_browser_login": "Åbn {verification_uri} i en hvilken som helst browser, log ind med din Brand ID-konto, og bekræft koden {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU To-vejs (kommandoer + live-aflæsninger, BETA)",
         "description": "**Eksperimentel, tilvalg — kun Volkswagen.** Tilføjer to-vejs-styring (lås/lås op, klima, opladning) og live CARIAD-aflæsninger ved at logge ind med dit Volkswagen ID. Da Volkswagen kun udsteder et token på 1 time ad denne vej, **gemmes** din adgangskode, så integrationen kan forny det automatisk. Den sendes kun til Volkswagens egen loginserver og skrives aldrig til logfiler eller diagnostik. Vil du hellere ikke gemme en adgangskode? Brug de skrivebeskyttede kanaler i stedet. **Forudsætning:** din Volkswagen ID skal være køretøjets primære bruger.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "E-mailadresse",
+          "password": "Adgangskode"
         },
         "data_description": {
           "username": "E-mailen til din Volkswagen ID- / myVolkswagen-konto.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Portal-feedets tilstand",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "Venter på portaldata",
+          "empty_snapshots": "Tomme snapshots",
+          "delivery_not_ready": "Levering ikke klar",
+          "stale": "Forældet"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minutter siden seneste snapshot"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Historisk eksport",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Anmodet — gøres klar",
+          "done": "Leveret",
+          "timed_out": "Fik timeout"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Opret EU Data Act-dataanmodning"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Anmod om historisk eksport"
       },
       "companion_reset_button": {
         "name": "Nulstil companion-forbindelse"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "Skråt forfra (ikon)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "Skråt forfra (lille)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "Skråt forfra (mellem)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Set fra siden (lille)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Set fra siden (stor)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "Skråt forfra (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "Skråt forfra (stor)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Billede af køretøjet"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "De seneste data, din bil har rapporteret, blev registreret for omkring **{age} timer siden** — selvom integrationen stadig henter data uden problemer. Det kan skyldes to ting: bilen er måske bare parkeret og i dvale (helt normalt — der er ikke noget at gøre), eller dens dataforsyning under EU Data Act kan være udløbet og holdt op med at levere friske aflæsninger.\n\nDe værdier, du ser lige nu, er de senest kendte — ikke live-data. Hvis bilen er blevet kørt eller sat til opladning siden da, og denne advarsel bliver hængende, er dataforsyningen højst sandsynligt udløbet: åbn volkswagen.de → din bils dataindstillinger og forny/anmod om datadelingen igen, eller tilføj kanalen på ny.\n\nDenne advarsel forsvinder automatisk, i det øjeblik en nyere aflæsning kommer ind."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: engangseksport af historik blev ikke fuldført",
+      "description": "Den engangseksport af historik, du anmodede om for denne bil, nåede ikke at lave en fil inden for tidsfristen. VW-portalen giver ikke denne anmodning nogen endelig status, så den kan være blevet droppet i stilhed. Anmodningen er nulstillet — du kan anmode igen eller kigge direkte i portalen."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "EU Data Act-portalen er ikke klar endnu. Vent, til integrationen har hentet data én gang efter opsætning, og prøv derefter det historiske eksport igen."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "Engangseksport af historik er slået fra i øjeblikket."
     },
     "historical_wedge_blocked": {
       "message": "Der er allerede en engangseksport af historikken i gang for denne bil. Portalen håndterer kun én sådan anmodning ad gangen, så vent, til den nuværende er færdig (eller får timeout), før du beder om en ny."

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Sæt flueben her, hvis telefonen kører companion-agent-appen. Telefonen ringer så til Home Assistant, så hverken ADB, trådløs fejlfinding eller fast IP er nødvendig — lad adressefeltet stå tomt.",
           "companion_agent_token": "Det tilfældige token, som agent-appen har genereret. Mindst 32 tegn, og et forskelligt for hvert køretøj."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Denne konto er allerede konfigureret.",
       "reauth_successful": "Fornyet login lykkedes.",
       "reconfigure_successful": "Konfigurationen blev opdateret.",
-      "mbb_not_eligible": "Dit køretøj er ikke egnet til det vedvarende MBB-login — backendet returnerede \"Unknown user\". Det betyder, at det er en nyere ID/MEB-model (ID.3/4/5, e-up osv.), der aldrig blev registreret i det ældre Car-Net/MBB-system, så det vedvarende login + fjernkommandoerne kan ikke nå det. Brug EU Data Act-portalkanalen (eller login med e-mail + adgangskode) til disse køretøjer i stedet. MBB-loginet er til ældre Car-Net-biler (de fleste PHEV-/forbrændingsmodeller)."
+      "mbb_not_eligible": "Dit køretøj er ikke egnet til det vedvarende MBB-login — backendet returnerede \"Unknown user\". Det betyder, at det er en nyere ID/MEB-model (ID.3/4/5, e-up osv.), der aldrig blev registreret i det ældre Car-Net/MBB-system, så det vedvarende login + fjernkommandoerne kan ikke nå det. Brug EU Data Act-portalkanalen (eller login med e-mail + adgangskode) til disse køretøjer i stedet. MBB-loginet er til ældre Car-Net-biler (de fleste PHEV-/forbrændingsmodeller).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Åbn {verification_uri} i en hvilken som helst browser, log ind med din Brand ID-konto, og bekræft koden {user_code}.",

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Fornyet login lykkedes.",
       "reconfigure_successful": "Konfigurationen blev opdateret.",
       "mbb_not_eligible": "Dit køretøj er ikke egnet til det vedvarende MBB-login — backendet returnerede \"Unknown user\". Det betyder, at det er en nyere ID/MEB-model (ID.3/4/5, e-up osv.), der aldrig blev registreret i det ældre Car-Net/MBB-system, så det vedvarende login + fjernkommandoerne kan ikke nå det. Brug EU Data Act-portalkanalen (eller login med e-mail + adgangskode) til disse køretøjer i stedet. MBB-loginet er til ældre Car-Net-biler (de fleste PHEV-/forbrændingsmodeller).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Åbn {verification_uri} i en hvilken som helst browser, log ind med din Brand ID-konto, og bekræft koden {user_code}.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Aktivieren, wenn auf dem Handy die Companion-Agent-App läuft. Das Handy ruft dann Home Assistant an: kein ADB, kein Wireless Debugging und keine feste Handy-IP nötig — Adressfeld leer lassen.",
           "companion_agent_token": "Das Zufalls-Token aus der Agent-App. Mindestens 32 Zeichen, und für jedes Fahrzeug ein eigenes."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB-Command-Fallback (dauerhafte Zwei-Wege-Reserve)",
+        "description": "Aktiviere den dauerhaften Car-Net-(MBB-)Befehlskanal als Fallback auf einer per QR-/Browser-Login eingerichteten Audi. Eine einmalige Browser-Bestätigung (kein Passwort gespeichert) mintet einen dauerhaften Bearer; der normale CARIAD-Befehlspfad bleibt primär, MBB springt nur ein, falls Volkswagen den Device-Grant je sperrt. Für Car-Net-Audis (die meisten PHEV/Verbrenner, vor ID/MEB) — neuere ID-/MEB-Modelle sind nicht berechtigt und werden beim Exchange abgelehnt.",
+        "data": {
+          "entry_id": "Zu aktivierende Audi",
+          "mbb_vins": "VIN(s) (kommagetrennt, optional)",
+          "spin": "S-PIN (optional — für Ver-/Entriegeln nötig)"
+        },
+        "data_description": {
+          "mbb_vins": "Nur nötig, wenn der Fallback die Garage nicht selbst auflisten kann — normalerweise leer lassen.",
+          "spin": "Deine S-PIN, für Fern-Ver-/Entriegeln über den Car-Net-Kanal nötig."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Dieses Konto ist bereits eingerichtet.",
       "reauth_successful": "Erneute Anmeldung erfolgreich.",
       "reconfigure_successful": "Konfiguration erfolgreich aktualisiert.",
-      "mbb_not_eligible": "Dein Fahrzeug ist für den dauerhaften MBB-Login nicht geeignet — das Backend meldet „Unknown user\". Das heisst, es ist ein neueres ID-/MEB-Modell (ID.3/4/5, e-up usw.), das nie im alten Car-Net/MBB-System registriert war — der dauerhafte Login + die Fernbefehle erreichen es daher nicht. Nutze für solche Fahrzeuge den EU-Data-Act-Kanal (oder den E-Mail-+-Passwort-Login). Der MBB-Login ist für ältere Car-Net-Autos (die meisten PHEV-/Verbrenner-Modelle)."
+      "mbb_not_eligible": "Dein Fahrzeug ist für den dauerhaften MBB-Login nicht geeignet — das Backend meldet „Unknown user\". Das heisst, es ist ein neueres ID-/MEB-Modell (ID.3/4/5, e-up usw.), das nie im alten Car-Net/MBB-System registriert war — der dauerhafte Login + die Fernbefehle erreichen es daher nicht. Nutze für solche Fahrzeuge den EU-Data-Act-Kanal (oder den E-Mail-+-Passwort-Login). Der MBB-Login ist für ältere Car-Net-Autos (die meisten PHEV-/Verbrenner-Modelle).",
+      "mbb_fallback_armed": "MBB-Command-Fallback aktiviert. Falls Volkswagen den Device-Grant dieser Audi je sperrt, fallen Ver-/Entriegeln, Klima und Laden automatisch auf den dauerhaften Car-Net-(MBB-)Kanal zurück. Im Alltag ändert sich nichts — der BFF bleibt der primäre Befehlspfad.",
+      "no_devicegrant_audi": "Keine passende Audi gefunden. Diese Option aktiviert den MBB-Command-Fallback auf einer Audi, die per QR-/Browser-Login (Device-Grant) eingerichtet wurde und ihn noch nicht hat. Richte deine Audi zuerst so ein, dann führe dies aus."
     },
     "progress": {
       "awaiting_browser_login": "Öffne {verification_uri} in einem Browser, melde dich mit deinem Brand-ID-Konto an und bestätige den Code {user_code}.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB-Command-Fallback (dauerhafte Zwei-Wege-Reserve)",
-        "description": "Aktiviere den dauerhaften Car-Net-(MBB-)Befehlskanal als Fallback auf einer per QR-/Browser-Login eingerichteten Audi. Eine einmalige Browser-Bestätigung (kein Passwort gespeichert) mintet einen dauerhaften Bearer; der normale CARIAD-Befehlspfad bleibt primär, MBB springt nur ein, falls Volkswagen den Device-Grant je sperrt. Für Car-Net-Audis (die meisten PHEV/Verbrenner, vor ID/MEB) — neuere ID-/MEB-Modelle sind nicht berechtigt und werden beim Exchange abgelehnt.",
+        "title": "Audi — Fernbefehle absichern (Reserve-Verbindung)",
+        "description": "Das richtet eine Reserve-Verbindung ein, damit die Fernbefehle deines Audi — Ver-/Entriegeln, Klima und Laden — weiterlaufen, falls Audi je ändert, wie sich die App anmeldet. Im Alltag ändert sich nichts: dein Audi nutzt seine normale Verbindung, die Reserve springt nur ein, wenn die normale keine Befehle mehr annimmt. Die Einrichtung braucht eine kurze Browser-Bestätigung (kein Passwort wird gespeichert). Wähle den Audi, den du schon per QR-/App-Login hinzugefügt hast. Funktioniert bei den meisten Benzin-, Diesel- und Plug-in-Hybrid-Audis; einige der neuesten reinen Elektromodelle werden nicht unterstützt und automatisch abgelehnt.",
         "data": {
-          "entry_id": "Zu aktivierende Audi",
-          "mbb_vins": "VIN(s) (kommagetrennt, optional)",
-          "spin": "S-PIN (optional — für Ver-/Entriegeln nötig)"
+          "entry_id": "Welcher Audi",
+          "mbb_vins": "Fahrzeug-ID (VIN) — meist leer lassen",
+          "spin": "S-PIN (nur für Ver-/Entriegeln nötig)"
         },
         "data_description": {
-          "mbb_vins": "Nur nötig, wenn der Fallback die Garage nicht selbst auflisten kann — normalerweise leer lassen.",
-          "spin": "Deine S-PIN, für Fern-Ver-/Entriegeln über den Car-Net-Kanal nötig."
+          "mbb_vins": "Leer lassen, außer die Einrichtung fragt danach.",
+          "spin": "Deine Audi-S-PIN — der Code fürs Fern-Ver-/Entriegeln."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Erneute Anmeldung erfolgreich.",
       "reconfigure_successful": "Konfiguration erfolgreich aktualisiert.",
       "mbb_not_eligible": "Dein Fahrzeug ist für den dauerhaften MBB-Login nicht geeignet — das Backend meldet „Unknown user\". Das heisst, es ist ein neueres ID-/MEB-Modell (ID.3/4/5, e-up usw.), das nie im alten Car-Net/MBB-System registriert war — der dauerhafte Login + die Fernbefehle erreichen es daher nicht. Nutze für solche Fahrzeuge den EU-Data-Act-Kanal (oder den E-Mail-+-Passwort-Login). Der MBB-Login ist für ältere Car-Net-Autos (die meisten PHEV-/Verbrenner-Modelle).",
-      "mbb_fallback_armed": "MBB-Command-Fallback aktiviert. Falls Volkswagen den Device-Grant dieser Audi je sperrt, fallen Ver-/Entriegeln, Klima und Laden automatisch auf den dauerhaften Car-Net-(MBB-)Kanal zurück. Im Alltag ändert sich nichts — der BFF bleibt der primäre Befehlspfad.",
-      "no_devicegrant_audi": "Keine passende Audi gefunden. Diese Option aktiviert den MBB-Command-Fallback auf einer Audi, die per QR-/Browser-Login (Device-Grant) eingerichtet wurde und ihn noch nicht hat. Richte deine Audi zuerst so ein, dann führe dies aus."
+      "mbb_fallback_armed": "Reserve-Verbindung eingerichtet. Falls die normale Verbindung deines Audi je keine Fernbefehle mehr annimmt, wechseln Ver-/Entriegeln, Klima und Laden automatisch auf die Reserve. Im Alltag ändert sich nichts.",
+      "no_devicegrant_audi": "Kein passender Audi gefunden. Diese Reserve gilt nur für einen Audi, den du per QR-/App-Login hinzugefügt hast und der sie noch nicht hat. Füge deinen Audi zuerst so hinzu, dann komm hierher zurück."
     },
     "progress": {
       "awaiting_browser_login": "Öffne {verification_uri} in einem Browser, melde dich mit deinem Brand-ID-Konto an und bestätige den Code {user_code}.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -317,8 +317,8 @@
         "title": "VW EU Two-Way (Befehle + Live-Daten, BETA)",
         "description": "**Experimentell, freiwillig — nur Volkswagen.** Fügt Zwei-Wege-Steuerung (Ver-/Entriegeln, Klima, Laden) und Live-CARIAD-Daten hinzu, indem du dich mit deiner Volkswagen ID anmeldest. Da Volkswagen auf diesem Weg nur ein 1-Stunden-Token ausstellt, wird dein Passwort **gespeichert**, damit die Integration es automatisch erneuern kann. Es wird nur an Volkswagens eigenen Login-Server gesendet und nie in Logs oder Diagnose geschrieben. Du möchtest kein Passwort speichern? Nutze stattdessen die nur-lesenden Kanäle. **Voraussetzung:** Deine Volkswagen ID muss Hauptnutzer des Fahrzeugs sein.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "E-Mail-Adresse",
+          "password": "Passwort"
         },
         "data_description": {
           "username": "Die E-Mail deines Volkswagen-ID- / myVolkswagen-Kontos.",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Re-authentication successful.",
       "reconfigure_successful": "Configuration updated successfully.",
       "mbb_not_eligible": "Your vehicle isn't eligible for the MBB durable login — the backend returned \"Unknown user\". This means it's a newer ID / MEB model (ID.3/4/5, e-up, etc.) that was never enrolled in the legacy Car-Net/MBB system, so the durable login + remote commands can't reach it. Use the EU Data Act portal channel (or the Email + Password login) for these vehicles instead. The MBB login is for older Car-Net cars (most PHEV / combustion models).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Tick this when the phone runs the companion agent app. The phone then calls Home Assistant, so no ADB, no wireless debugging and no fixed phone IP are needed — leave the address field empty.",
           "companion_agent_token": "The random token the agent app generated. At least 32 characters, and a different one for every vehicle."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "This account is already configured.",
       "reauth_successful": "Re-authentication successful.",
       "reconfigure_successful": "Configuration updated successfully.",
-      "mbb_not_eligible": "Your vehicle isn't eligible for the MBB durable login — the backend returned \"Unknown user\". This means it's a newer ID / MEB model (ID.3/4/5, e-up, etc.) that was never enrolled in the legacy Car-Net/MBB system, so the durable login + remote commands can't reach it. Use the EU Data Act portal channel (or the Email + Password login) for these vehicles instead. The MBB login is for older Car-Net cars (most PHEV / combustion models)."
+      "mbb_not_eligible": "Your vehicle isn't eligible for the MBB durable login — the backend returned \"Unknown user\". This means it's a newer ID / MEB model (ID.3/4/5, e-up, etc.) that was never enrolled in the legacy Car-Net/MBB system, so the durable login + remote commands can't reach it. Use the EU Data Act portal channel (or the Email + Password login) for these vehicles instead. The MBB login is for older Car-Net cars (most PHEV / combustion models).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Marque esta casilla si el teléfono ejecuta la app de agente. Entonces es el teléfono el que llama a Home Assistant: no hacen falta ADB, depuración inalámbrica ni IP fija — deje la dirección vacía.",
           "companion_agent_token": "El token aleatorio que generó la app de agente. Al menos 32 caracteres, y uno distinto por vehículo."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Esta cuenta ya está configurada.",
       "reauth_successful": "Reautenticación exitosa.",
       "reconfigure_successful": "Configuración actualizada con éxito.",
-      "mbb_not_eligible": "Tu vehículo no es apto para el inicio de sesión duradero MBB — el backend devolvió «Unknown user». Es un modelo ID / MEB más reciente (ID.3/4/5, e-up, etc.) que nunca se registró en el antiguo sistema Car-Net/MBB, por lo que el inicio de sesión duradero y los comandos remotos no pueden alcanzarlo. Usa el canal del portal EU Data Act (o el inicio de sesión con correo + contraseña) para estos vehículos. El inicio de sesión MBB es para coches Car-Net antiguos (la mayoría de modelos híbridos enchufables / de combustión)."
+      "mbb_not_eligible": "Tu vehículo no es apto para el inicio de sesión duradero MBB — el backend devolvió «Unknown user». Es un modelo ID / MEB más reciente (ID.3/4/5, e-up, etc.) que nunca se registró en el antiguo sistema Car-Net/MBB, por lo que el inicio de sesión duradero y los comandos remotos no pueden alcanzarlo. Usa el canal del portal EU Data Act (o el inicio de sesión con correo + contraseña) para estos vehículos. El inicio de sesión MBB es para coches Car-Net antiguos (la mayoría de modelos híbridos enchufables / de combustión).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Abre {verification_uri} en cualquier navegador, inicia sesión con tu cuenta Brand ID y confirma el código {user_code}.",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — mantén los comandos remotos funcionando (conexión de reserva)",
+        "description": "Esto añade una conexión de reserva para que los comandos remotos de tu Audi — bloqueo/desbloqueo, climatización y carga — sigan funcionando aunque Audi cambie alguna vez la forma en que la app inicia sesión. En el día a día no cambia nada: tu Audi usa su conexión normal, y la de reserva solo entra en acción si la normal deja de aceptar comandos. Configurarla solo requiere una rápida confirmación en el navegador (no se guarda ninguna contraseña). Elige el Audi que ya añadiste con el inicio de sesión por QR / app. Funciona en la mayoría de los Audi de gasolina, diésel e híbridos enchufables; algunos de los modelos totalmente eléctricos más nuevos no son compatibles y se rechazan automáticamente.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Qué Audi",
+          "mbb_vins": "ID del vehículo (VIN) — normalmente déjalo en blanco",
+          "spin": "S-PIN (solo necesario para bloqueo/desbloqueo)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Déjalo en blanco a menos que la configuración te lo pida.",
+          "spin": "Tu S-PIN de Audi — el código que usas para el bloqueo/desbloqueo remoto."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Reautenticación exitosa.",
       "reconfigure_successful": "Configuración actualizada con éxito.",
       "mbb_not_eligible": "Tu vehículo no es apto para el inicio de sesión duradero MBB — el backend devolvió «Unknown user». Es un modelo ID / MEB más reciente (ID.3/4/5, e-up, etc.) que nunca se registró en el antiguo sistema Car-Net/MBB, por lo que el inicio de sesión duradero y los comandos remotos no pueden alcanzarlo. Usa el canal del portal EU Data Act (o el inicio de sesión con correo + contraseña) para estos vehículos. El inicio de sesión MBB es para coches Car-Net antiguos (la mayoría de modelos híbridos enchufables / de combustión).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Conexión de reserva configurada. Si la conexión normal de tu Audi deja alguna vez de aceptar comandos remotos, el bloqueo/desbloqueo, la climatización y la carga pasan a la de reserva automáticamente. En el día a día no cambia nada.",
+      "no_devicegrant_audi": "No se encontró ningún Audi compatible. Esta reserva solo se aplica a un Audi que hayas añadido con el inicio de sesión por QR / app y que aún no la tenga. Añade primero tu Audi de esa forma y luego vuelve aquí."
     },
     "progress": {
       "awaiting_browser_login": "Abre {verification_uri} en cualquier navegador, inicia sesión con tu cuenta Brand ID y confirma el código {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU bidireccional (comandos + lecturas en vivo, BETA)",
         "description": "**Experimental, opcional — solo Volkswagen.** Añade control bidireccional (bloqueo/desbloqueo, climatización, carga) y lecturas CARIAD en vivo iniciando sesión con tu Volkswagen ID. Como Volkswagen solo emite un token de 1 hora por esta vía, tu contraseña se **almacena** para que la integración pueda renovarlo automáticamente. Solo se envía al propio servidor de inicio de sesión de Volkswagen y nunca se escribe en los registros ni en los diagnósticos. ¿Prefieres no almacenar una contraseña? Usa los canales de solo lectura en su lugar. **Requisito:** tu Volkswagen ID debe ser el usuario principal del vehículo.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "Dirección de correo electrónico",
+          "password": "Contraseña"
         },
         "data_description": {
           "username": "El correo electrónico de tu cuenta Volkswagen ID / myVolkswagen.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Estado del feed del portal",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "Esperando datos del portal",
+          "empty_snapshots": "Instantáneas vacías",
+          "delivery_not_ready": "Entrega no lista",
+          "stale": "Desactualizado"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minutos desde la última instantánea"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Exportación histórica",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Solicitada — preparando",
+          "done": "Entregado",
+          "timed_out": "Tiempo agotado"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Crear solicitud de datos EU Data Act"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Solicitar exportación histórica"
       },
       "companion_reset_button": {
         "name": "Restablecer conexión companion"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "Vista 3/4 (icono)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "Vista 3/4 (pequeña)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "Vista 3/4 (mediana)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Vista lateral (pequeña)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Vista lateral (grande)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "Vista 3/4 (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "Vista 3/4 (grande)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Render del vehículo"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "Los últimos datos que comunicó tu coche se registraron hace unas **{age} horas**, aunque la integración sigue consultando sin problemas. Esto puede deberse a dos motivos: puede que el coche esté simplemente aparcado y en reposo (algo normal, no hay nada que hacer) o que su fuente de datos del EU Data Act haya caducado y haya dejado de enviar lecturas nuevas.\n\nLos valores que ves ahora son los últimos conocidos, no datos en tiempo real. Si has conducido o enchufado el coche desde entonces y este aviso sigue apareciendo, lo más probable es que la fuente de datos haya caducado: abre volkswagen.de → los ajustes de datos de tu coche y renueva o vuelve a solicitar el uso compartido de datos, o vuelve a añadir el canal.\n\nEste aviso desaparece automáticamente en cuanto llega una lectura más reciente."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: la exportación histórica única no se completó",
+      "description": "La exportación histórica única solicitada para este coche no generó ningún archivo dentro del plazo del cliente. El portal de VW no asigna a esta solicitud ningún estado final, así que puede haberse descartado de forma silenciosa. La solicitud se ha restablecido — puedes volver a solicitarla o consultar directamente el portal."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "El portal de la Ley de Datos de la UE aún no está listo. Espera a que la integración haya consultado una vez tras la configuración e inténtalo de nuevo."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "La exportación histórica única está desactivada actualmente."
     },
     "historical_wedge_blocked": {
       "message": "Ya hay una exportación puntual del historial en curso para este vehículo. El portal solo procesa una solicitud de este tipo a la vez, así que espera a que la actual termine (o se agote el tiempo de espera) antes de solicitar otra."

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Reautenticación exitosa.",
       "reconfigure_successful": "Configuración actualizada con éxito.",
       "mbb_not_eligible": "Tu vehículo no es apto para el inicio de sesión duradero MBB — el backend devolvió «Unknown user». Es un modelo ID / MEB más reciente (ID.3/4/5, e-up, etc.) que nunca se registró en el antiguo sistema Car-Net/MBB, por lo que el inicio de sesión duradero y los comandos remotos no pueden alcanzarlo. Usa el canal del portal EU Data Act (o el inicio de sesión con correo + contraseña) para estos vehículos. El inicio de sesión MBB es para coches Car-Net antiguos (la mayoría de modelos híbridos enchufables / de combustión).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Abre {verification_uri} en cualquier navegador, inicia sesión con tu cuenta Brand ID y confirma el código {user_code}.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Valitse tämä, jos puhelimessa on companion-agenttisovellus. Silloin puhelin soittaa Home Assistantille: ADB:tä, langatonta vianjäljitystä tai kiinteää IP-osoitetta ei tarvita — jätä osoitekenttä tyhjäksi.",
           "companion_agent_token": "Agenttisovelluksen luoma satunnainen tunnus. Vähintään 32 merkkiä ja jokaiselle ajoneuvolle oma."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Tämä tili on jo määritetty.",
       "reauth_successful": "Uudelleenkirjautuminen onnistui.",
       "reconfigure_successful": "Määritys päivitetty onnistuneesti.",
-      "mbb_not_eligible": "Ajoneuvosi ei sovellu pysyvään MBB-kirjautumiseen — taustajärjestelmä palautti ”Unknown user”. Tämä tarkoittaa, että se on uudempi ID- / MEB-malli (ID.3/4/5, e-up jne.), jota ei koskaan liitetty vanhaan Car-Net/MBB-järjestelmään, joten pysyvä kirjautuminen + etäkomennot eivät tavoita sitä. Käytä näille ajoneuvoille EU Data Act -portaalikanavaa (tai sähköposti + salasana -kirjautumista) sen sijaan. MBB-kirjautuminen on tarkoitettu vanhemmille Car-Net-autoille (useimmat PHEV- / polttomoottorimallit)."
+      "mbb_not_eligible": "Ajoneuvosi ei sovellu pysyvään MBB-kirjautumiseen — taustajärjestelmä palautti ”Unknown user”. Tämä tarkoittaa, että se on uudempi ID- / MEB-malli (ID.3/4/5, e-up jne.), jota ei koskaan liitetty vanhaan Car-Net/MBB-järjestelmään, joten pysyvä kirjautuminen + etäkomennot eivät tavoita sitä. Käytä näille ajoneuvoille EU Data Act -portaalikanavaa (tai sähköposti + salasana -kirjautumista) sen sijaan. MBB-kirjautuminen on tarkoitettu vanhemmille Car-Net-autoille (useimmat PHEV- / polttomoottorimallit).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Avaa {verification_uri} millä tahansa selaimella, kirjaudu Brand ID -tiliisi ja vahvista koodi {user_code}.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Uudelleenkirjautuminen onnistui.",
       "reconfigure_successful": "Määritys päivitetty onnistuneesti.",
       "mbb_not_eligible": "Ajoneuvosi ei sovellu pysyvään MBB-kirjautumiseen — taustajärjestelmä palautti ”Unknown user”. Tämä tarkoittaa, että se on uudempi ID- / MEB-malli (ID.3/4/5, e-up jne.), jota ei koskaan liitetty vanhaan Car-Net/MBB-järjestelmään, joten pysyvä kirjautuminen + etäkomennot eivät tavoita sitä. Käytä näille ajoneuvoille EU Data Act -portaalikanavaa (tai sähköposti + salasana -kirjautumista) sen sijaan. MBB-kirjautuminen on tarkoitettu vanhemmille Car-Net-autoille (useimmat PHEV- / polttomoottorimallit).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Avaa {verification_uri} millä tahansa selaimella, kirjaudu Brand ID -tiliisi ja vahvista koodi {user_code}.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — pidä etäkomennot toiminnassa (varayhteys)",
+        "description": "Tämä lisää varayhteyden, jotta Audisi etäkomennot — lukitus/avaus, ilmastointi ja lataus — pysyvät toiminnassa, vaikka Audi joskus muuttaisi tapaa, jolla sovellus kirjautuu sisään. Arjessa mikään ei muutu: Audisi käyttää tavallista yhteyttään, ja varayhteys astuu kuvaan vain, jos tavallinen lakkaa hyväksymästä komentoja. Käyttöönotto vaatii yhden nopean selainvahvistuksen (salasanaa ei tallenneta). Valitse Audi, jonka lisäsit jo QR-/sovelluskirjautumisella. Toimii useimmissa bensiini-, diesel- ja lataushybridi-Audeissa; joitakin uusimpia täyssähkömalleja ei tueta, ja ne hylätään automaattisesti.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Mikä Audi",
+          "mbb_vins": "Ajoneuvon tunnus (VIN) — jätä yleensä tyhjäksi",
+          "spin": "S-PIN (tarvitaan vain lukitukseen/avaukseen)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Jätä tämä tyhjäksi, ellei käyttöönotto pyydä sitä.",
+          "spin": "Audi-S-PINisi — koodi, jota käytät etälukitukseen/-avaukseen."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Uudelleenkirjautuminen onnistui.",
       "reconfigure_successful": "Määritys päivitetty onnistuneesti.",
       "mbb_not_eligible": "Ajoneuvosi ei sovellu pysyvään MBB-kirjautumiseen — taustajärjestelmä palautti ”Unknown user”. Tämä tarkoittaa, että se on uudempi ID- / MEB-malli (ID.3/4/5, e-up jne.), jota ei koskaan liitetty vanhaan Car-Net/MBB-järjestelmään, joten pysyvä kirjautuminen + etäkomennot eivät tavoita sitä. Käytä näille ajoneuvoille EU Data Act -portaalikanavaa (tai sähköposti + salasana -kirjautumista) sen sijaan. MBB-kirjautuminen on tarkoitettu vanhemmille Car-Net-autoille (useimmat PHEV- / polttomoottorimallit).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Varayhteys otettu käyttöön. Jos Audisi tavallinen yhteys joskus lakkaa hyväksymästä etäkomentoja, lukitus/avaus, ilmastointi ja lataus siirtyvät automaattisesti varayhteyteen. Arjessa mikään ei muutu.",
+      "no_devicegrant_audi": "Sopivaa Audia ei löytynyt. Tämä varayhteys koskee vain Audia, jonka lisäsit QR-/sovelluskirjautumisella ja jolla sitä ei vielä ole. Lisää Audisi ensin siten ja palaa sitten tänne."
     },
     "progress": {
       "awaiting_browser_login": "Avaa {verification_uri} millä tahansa selaimella, kirjaudu Brand ID -tiliisi ja vahvista koodi {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU Two-Way (komennot + live-lukemat, BETA)",
         "description": "**Kokeellinen, valinnainen — vain Volkswagen.** Lisää kaksisuuntaisen ohjauksen (lukitus/avaus, ilmastointi, lataus) ja live-CARIAD-lukemat kirjautumalla Volkswagen ID -tunnuksellasi. Koska Volkswagen myöntää tätä kautta vain 1 tunnin tunnisteen, salasanasi **tallennetaan**, jotta integraatio voi uusia sen automaattisesti. Se lähetetään vain Volkswagenin omalle kirjautumispalvelimelle eikä sitä koskaan kirjata lokeihin tai diagnostiikkaan. Etkö halua tallentaa salasanaa? Käytä sen sijaan vain luku -kanavia. **Edellytys:** Volkswagen ID:si on oltava ajoneuvon ensisijainen käyttäjä.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "Sähköpostiosoite",
+          "password": "Salasana"
         },
         "data_description": {
           "username": "Volkswagen ID- / myVolkswagen-tilisi sähköposti.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Portaalisyötteen tila",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "Odotetaan portaalin tietoja",
+          "empty_snapshots": "Tyhjät tilannevedokset",
+          "delivery_not_ready": "Toimitus ei valmis",
+          "stale": "Vanhentunut"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minuutteja viime tilannevedoksesta"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Historiatietojen vienti",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Pyydetty — valmistellaan",
+          "done": "Toimitettu",
+          "timed_out": "Aikakatkaisu"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Luo EU Data Act -datapyyntö"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Pyydä historiatietojen vienti"
       },
       "companion_reset_button": {
         "name": "Nollaa companion-yhteys"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "3/4-näkymä (ikoni)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "3/4-näkymä (pieni)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "3/4-näkymä (keskikoko)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Sivunäkymä (pieni)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Sivunäkymä (suuri)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "3/4-näkymä (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "3/4-näkymä (suuri)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Ajoneuvon kuva"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "Auton viimeksi raportoimat tiedot kerättiin noin **{age} tuntia sitten**, vaikka integraatio hakee tietoja edelleen onnistuneesti. Tähän voi olla kaksi syytä: auto voi yksinkertaisesti olla pysäköitynä ja lepotilassa (normaalia — ei tarvitse tehdä mitään), tai sen EU Data Act -tietosyöte on saattanut vanhentua eikä toimita enää tuoreita lukemia.\n\nNäkemäsi arvot ovat viimeisimmät tunnetut, eivät reaaliaikaiset. Jos autoa on ajettu tai se on kytketty lataukseen tämän jälkeen eikä varoitus poistu, tietosyöte on mitä todennäköisimmin vanhentunut: avaa volkswagen.de → auton tietoasetukset ja uusi tai pyydä tietojen jakaminen uudelleen, tai lisää kanava uudelleen.\n\nTämä varoitus poistuu automaattisesti heti, kun tuoreempi lukema saapuu."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: kertaluonteinen historiatietojen vienti ei valmistunut",
+      "description": "Tälle autolle pyydetty kertaluonteinen historiatietojen vienti ei tuottanut tiedostoa määräaikaan mennessä. VW-portaali ei anna tälle pyynnölle lopputilaa, joten se on voitu hylätä hiljaisesti. Pyyntö on nollattu — voit pyytää sen uudelleen tai tarkistaa asian suoraan portaalista."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "EU:n datasäädösportaali ei ole vielä valmis. Odota, kunnes integraatio on hakenut tiedot kerran käyttöönoton jälkeen, ja yritä sitten uudelleen."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "Kertaluonteinen historiatietojen vienti on tällä hetkellä poistettu käytöstä."
     },
     "historical_wedge_blocked": {
       "message": "Tälle autolle on jo käynnissä kertaluonteinen historiatietojen vienti. Portaali käsittelee vain yhtä tällaista pyyntöä kerrallaan, joten odota, että nykyinen valmistuu (tai aikakatkaistaan), ennen kuin pyydät uutta."

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Cochez si le téléphone exécute l'application agent. C'est alors le téléphone qui appelle Home Assistant : ni ADB, ni débogage sans fil, ni IP fixe ne sont nécessaires — laissez l'adresse vide.",
           "companion_agent_token": "Le jeton aléatoire généré par l'application agent. Au moins 32 caractères, et un jeton différent par véhicule."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Ce compte est déjà configuré.",
       "reauth_successful": "Ré-authentification réussie.",
       "reconfigure_successful": "Configuration mise à jour avec succès.",
-      "mbb_not_eligible": "Votre véhicule n'est pas éligible à la connexion durable MBB — le backend a renvoyé « Unknown user ». Il s'agit d'un modèle ID / MEB récent (ID.3/4/5, e-up, etc.) jamais enregistré dans l'ancien système Car-Net/MBB ; la connexion durable et les commandes à distance ne peuvent donc pas l'atteindre. Utilisez le canal du portail EU Data Act (ou la connexion E-mail + mot de passe) pour ces véhicules. La connexion MBB est destinée aux anciennes voitures Car-Net (la plupart des modèles hybrides rechargeables / thermiques)."
+      "mbb_not_eligible": "Votre véhicule n'est pas éligible à la connexion durable MBB — le backend a renvoyé « Unknown user ». Il s'agit d'un modèle ID / MEB récent (ID.3/4/5, e-up, etc.) jamais enregistré dans l'ancien système Car-Net/MBB ; la connexion durable et les commandes à distance ne peuvent donc pas l'atteindre. Utilisez le canal du portail EU Data Act (ou la connexion E-mail + mot de passe) pour ces véhicules. La connexion MBB est destinée aux anciennes voitures Car-Net (la plupart des modèles hybrides rechargeables / thermiques).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Ouvrez {verification_uri} dans n'importe quel navigateur, connectez-vous avec votre compte Brand ID et confirmez le code {user_code}.",

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — garder les commandes à distance opérationnelles (connexion de secours)",
+        "description": "Cela ajoute une connexion de secours pour que les commandes à distance de votre Audi — verrouillage/déverrouillage, climatisation et charge — continuent de fonctionner même si Audi venait à changer la façon dont l'application se connecte. Au quotidien, rien ne change : votre Audi utilise sa connexion habituelle, et la connexion de secours ne prend le relais que si la connexion habituelle cesse d'accepter les commandes. La configuration ne demande qu'une brève confirmation dans le navigateur (aucun mot de passe n'est stocké). Choisissez l'Audi que vous avez déjà ajoutée via la connexion QR / application. Cela fonctionne sur la plupart des Audi essence, diesel et hybrides rechargeables ; certains des tout derniers modèles 100 % électriques ne sont pas pris en charge et sont refusés automatiquement.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Quelle Audi",
+          "mbb_vins": "Identifiant du véhicule (VIN) — à laisser vide en général",
+          "spin": "S-PIN (nécessaire uniquement pour le verrouillage/déverrouillage)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Laissez ce champ vide, sauf si la configuration vous le demande.",
+          "spin": "Votre S-PIN Audi — le code que vous utilisez pour le verrouillage/déverrouillage à distance."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Ré-authentification réussie.",
       "reconfigure_successful": "Configuration mise à jour avec succès.",
       "mbb_not_eligible": "Votre véhicule n'est pas éligible à la connexion durable MBB — le backend a renvoyé « Unknown user ». Il s'agit d'un modèle ID / MEB récent (ID.3/4/5, e-up, etc.) jamais enregistré dans l'ancien système Car-Net/MBB ; la connexion durable et les commandes à distance ne peuvent donc pas l'atteindre. Utilisez le canal du portail EU Data Act (ou la connexion E-mail + mot de passe) pour ces véhicules. La connexion MBB est destinée aux anciennes voitures Car-Net (la plupart des modèles hybrides rechargeables / thermiques).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Connexion de secours configurée. Si la connexion habituelle de votre Audi cesse un jour d'accepter les commandes à distance, le verrouillage/déverrouillage, la climatisation et la charge basculent automatiquement sur la connexion de secours. Rien ne change au quotidien.",
+      "no_devicegrant_audi": "Aucune Audi correspondante trouvée. Cette connexion de secours s'applique uniquement à une Audi que vous avez ajoutée via la connexion QR / application et qui n'en dispose pas encore. Ajoutez d'abord votre Audi de cette façon, puis revenez ici."
     },
     "progress": {
       "awaiting_browser_login": "Ouvrez {verification_uri} dans n'importe quel navigateur, connectez-vous avec votre compte Brand ID et confirmez le code {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU bidirectionnel (commandes + lectures en direct, BÊTA)",
         "description": "**Expérimental, sur option — Volkswagen uniquement.** Ajoute le contrôle bidirectionnel (verrouillage/déverrouillage, climatisation, charge) et les lectures CARIAD en direct en vous connectant avec votre Volkswagen ID. Comme Volkswagen n'émet qu'un jeton d'une heure sur ce canal, votre mot de passe est **stocké** afin que l'intégration puisse le renouveler automatiquement. Il est envoyé uniquement au serveur de connexion de Volkswagen et n'est jamais écrit dans les journaux ni les diagnostics. Vous préférez ne pas stocker de mot de passe ? Utilisez plutôt les canaux en lecture seule. **Prérequis :** votre Volkswagen ID doit être l'utilisateur principal du véhicule.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "Adresse e-mail",
+          "password": "Mot de passe"
         },
         "data_description": {
           "username": "L'e-mail de votre compte Volkswagen ID / myVolkswagen.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "État du flux du portail",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "En attente des données du portail",
+          "empty_snapshots": "Instantanés vides",
+          "delivery_not_ready": "Livraison pas encore prête",
+          "stale": "Obsolète"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minutes depuis le dernier instantané"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Export historique",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Demandé — en préparation",
+          "done": "Livré",
+          "timed_out": "Délai dépassé"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Créer une demande de données EU Data Act"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Demander l'export historique"
       },
       "companion_reset_button": {
         "name": "Réinitialiser la connexion companion"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "Vue 3/4 (icône)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "Vue 3/4 (petite)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "Vue 3/4 (moyenne)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Vue latérale (petite)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Vue latérale (grande)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "Vue 3/4 (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "Vue 3/4 (grande)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Rendu du véhicule"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "Les dernières données transmises par votre voiture datent d'environ **{age} heures**, alors que l'intégration continue pourtant d'interroger le véhicule avec succès. Deux causes sont possibles : soit la voiture est tout simplement garée et en veille (c'est normal — rien à faire), soit son flux de données EU Data Act s'est interrompu et ne fournit plus de relevés récents.\n\nLes valeurs que vous voyez actuellement sont les dernières connues, pas des données en direct. Si la voiture a roulé ou a été branchée depuis et que cet avertissement persiste, c'est très probablement que le flux de données a expiré : ouvrez volkswagen.de → les paramètres de données de votre voiture et renouvelez/redemandez le partage de données, ou rajoutez le canal.\n\nCet avertissement disparaît automatiquement dès qu'un relevé plus récent arrive."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin} : l'export historique ponctuel n'a pas abouti",
+      "description": "L'export historique ponctuel demandé pour cette voiture n'a pas produit de fichier dans le délai imparti. Le portail VW ne fournit aucun état final pour cette demande, elle a donc peut-être été abandonnée silencieusement. La demande a été réinitialisée — vous pouvez la relancer ou vérifier directement dans le portail."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "Le portail EU Data Act n'est pas encore prêt. Attendez que l'intégration ait interrogé une fois après la configuration, puis réessayez l'export historique."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "L'export historique ponctuel est actuellement désactivé."
     },
     "historical_wedge_blocked": {
       "message": "Un export ponctuel de l'historique est déjà en cours pour ce véhicule. Le portail ne traite qu'une seule demande de ce type à la fois : attendez donc que celle en cours se termine (ou expire) avant d'en demander une autre."

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Ré-authentification réussie.",
       "reconfigure_successful": "Configuration mise à jour avec succès.",
       "mbb_not_eligible": "Votre véhicule n'est pas éligible à la connexion durable MBB — le backend a renvoyé « Unknown user ». Il s'agit d'un modèle ID / MEB récent (ID.3/4/5, e-up, etc.) jamais enregistré dans l'ancien système Car-Net/MBB ; la connexion durable et les commandes à distance ne peuvent donc pas l'atteindre. Utilisez le canal du portail EU Data Act (ou la connexion E-mail + mot de passe) pour ces véhicules. La connexion MBB est destinée aux anciennes voitures Car-Net (la plupart des modèles hybrides rechargeables / thermiques).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Ouvrez {verification_uri} dans n'importe quel navigateur, connectez-vous avec votre compte Brand ID et confirmez le code {user_code}.",

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Nuova autenticazione riuscita.",
       "reconfigure_successful": "Configurazione aggiornata correttamente.",
       "mbb_not_eligible": "Il tuo veicolo non è idoneo al login duraturo MBB — il backend ha risposto \"Unknown user\". Questo significa che è un modello ID / MEB più recente (ID.3/4/5, e-up, ecc.) che non è mai stato registrato nel vecchio sistema Car-Net/MBB, quindi il login duraturo + i comandi remoti non lo possono raggiungere. Per questi veicoli usa invece il canale del portale EU Data Act (o il login con email + password). Il login MBB è per le auto Car-Net più vecchie (la maggior parte dei modelli PHEV / a combustione).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Apri {verification_uri} in un browser qualsiasi, accedi con il tuo account Brand ID e conferma il codice {user_code}.",

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — mantieni attivi i comandi a distanza (connessione di riserva)",
+        "description": "Aggiunge una connessione di riserva così i comandi a distanza del tuo Audi — blocca/sblocca, clima e ricarica — continuano a funzionare anche se un giorno Audi cambia il modo in cui l'app effettua l'accesso. Nel quotidiano non cambia nulla: il tuo Audi usa la sua connessione normale, e la riserva interviene solo se quella normale smette di accettare i comandi. Per configurarla basta una rapida conferma nel browser (nessuna password viene memorizzata). Scegli l'Audi che hai già aggiunto con il login QR / app. Funziona sulla maggior parte degli Audi a benzina, diesel e ibridi plug-in; alcuni dei modelli completamente elettrici più recenti non sono supportati e vengono rifiutati automaticamente.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Quale Audi",
+          "mbb_vins": "ID del veicolo (VIN) — di solito lascia vuoto",
+          "spin": "S-PIN (necessaria solo per blocca/sblocca)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Lascialo vuoto, a meno che la configurazione non lo richieda.",
+          "spin": "La S-PIN del tuo Audi — il codice che usi per bloccare e sbloccare a distanza."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Nuova autenticazione riuscita.",
       "reconfigure_successful": "Configurazione aggiornata correttamente.",
       "mbb_not_eligible": "Il tuo veicolo non è idoneo al login duraturo MBB — il backend ha risposto \"Unknown user\". Questo significa che è un modello ID / MEB più recente (ID.3/4/5, e-up, ecc.) che non è mai stato registrato nel vecchio sistema Car-Net/MBB, quindi il login duraturo + i comandi remoti non lo possono raggiungere. Per questi veicoli usa invece il canale del portale EU Data Act (o il login con email + password). Il login MBB è per le auto Car-Net più vecchie (la maggior parte dei modelli PHEV / a combustione).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Connessione di riserva configurata. Se la connessione normale del tuo Audi dovesse mai smettere di accettare i comandi a distanza, blocca/sblocca, clima e ricarica passano automaticamente alla riserva. Nel quotidiano non cambia nulla.",
+      "no_devicegrant_audi": "Nessun Audi corrispondente trovato. Questa riserva vale solo per un Audi che hai aggiunto con il login QR / app e che non ce l'ha già. Aggiungi prima il tuo Audi in quel modo, poi torna qui."
     },
     "progress": {
       "awaiting_browser_login": "Apri {verification_uri} in un browser qualsiasi, accedi con il tuo account Brand ID e conferma il codice {user_code}.",
@@ -317,7 +317,7 @@
         "title": "VW EU Two-Way (comandi + letture in tempo reale, BETA)",
         "description": "**Sperimentale, opt-in — solo Volkswagen.** Aggiunge il controllo bidirezionale (blocca/sblocca, clima, ricarica) e le letture CARIAD in tempo reale accedendo con il tuo Volkswagen ID. Poiché su questo percorso Volkswagen rilascia solo un token di 1 ora, la tua password viene **memorizzata** così che l'integrazione possa rinnovarlo automaticamente. È inviata solo al server di login di Volkswagen e non viene mai scritta nei log o nella diagnostica. Preferisci non memorizzare una password? Usa invece i canali in sola lettura. **Requisito:** il tuo Volkswagen ID deve essere l'utente principale del veicolo.",
         "data": {
-          "username": "Email Address",
+          "username": "Indirizzo email",
           "password": "Password"
         },
         "data_description": {
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Stato del feed del portale",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "In attesa dei dati del portale",
+          "empty_snapshots": "Snapshot vuoti",
+          "delivery_not_ready": "Consegna non pronta",
+          "stale": "Obsoleto"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minuti dall'ultimo snapshot"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Esportazione storica",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Richiesta — in preparazione",
+          "done": "Consegnato",
+          "timed_out": "Tempo scaduto"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Crea richiesta dati EU Data Act"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Richiedi esportazione storica"
       },
       "companion_reset_button": {
         "name": "Reimposta connessione companion"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "Vista 3/4 (icona)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "Vista 3/4 (piccola)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "Vista 3/4 (media)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Vista laterale (piccola)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Vista laterale (grande)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "Vista 3/4 (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "Vista 3/4 (grande)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Render del veicolo"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "Gli ultimi dati trasmessi dalla tua auto risalgono a circa **{age} ore fa**, anche se l'integrazione continua a interrogarla correttamente. Le cause possono essere due: l'auto potrebbe semplicemente essere parcheggiata e in stand-by (è normale, non devi fare nulla), oppure il suo flusso dati EU Data Act potrebbe essersi interrotto e aver smesso di fornire letture aggiornate.\n\nI valori che vedi ora sono gli ultimi noti, non in tempo reale. Se da allora hai guidato o messo in carica l'auto e questo avviso resta, con ogni probabilità il flusso dati è scaduto: apri volkswagen.de → le impostazioni dati della tua auto e rinnova/richiedi di nuovo la condivisione dei dati, oppure aggiungi di nuovo il canale.\n\nQuesto avviso scompare automaticamente non appena arriva una lettura più recente."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: l'esportazione storica una tantum non è stata completata",
+      "description": "L'esportazione storica una tantum richiesta per quest'auto non ha prodotto alcun file entro il termine previsto dal client. Il portale VW non fornisce uno stato finale per questa richiesta, quindi potrebbe essere stata scartata silenziosamente. La richiesta è stata azzerata — puoi richiederla di nuovo oppure controllare direttamente nel portale."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "Il portale EU Data Act non è ancora pronto. Attendi che l'integrazione abbia effettuato un'interrogazione dopo la configurazione, poi riprova l'esportazione storica."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "L'esportazione storica una tantum è attualmente disattivata."
     },
     "historical_wedge_blocked": {
       "message": "È già in corso un'esportazione una tantum dello storico per questo veicolo. Il portale gestisce una sola richiesta di questo tipo alla volta, quindi attendi che quella in corso si concluda (o vada in timeout) prima di richiederne un'altra."

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Seleziona questa opzione se sul telefono gira l'app agent. Sarà il telefono a chiamare Home Assistant: niente ADB, niente debug wireless e nessun IP fisso — lascia vuoto il campo indirizzo.",
           "companion_agent_token": "Il token casuale generato dall'app agent. Almeno 32 caratteri, e uno diverso per ogni veicolo."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Questo account è già configurato.",
       "reauth_successful": "Nuova autenticazione riuscita.",
       "reconfigure_successful": "Configurazione aggiornata correttamente.",
-      "mbb_not_eligible": "Il tuo veicolo non è idoneo al login duraturo MBB — il backend ha risposto \"Unknown user\". Questo significa che è un modello ID / MEB più recente (ID.3/4/5, e-up, ecc.) che non è mai stato registrato nel vecchio sistema Car-Net/MBB, quindi il login duraturo + i comandi remoti non lo possono raggiungere. Per questi veicoli usa invece il canale del portale EU Data Act (o il login con email + password). Il login MBB è per le auto Car-Net più vecchie (la maggior parte dei modelli PHEV / a combustione)."
+      "mbb_not_eligible": "Il tuo veicolo non è idoneo al login duraturo MBB — il backend ha risposto \"Unknown user\". Questo significa che è un modello ID / MEB più recente (ID.3/4/5, e-up, ecc.) che non è mai stato registrato nel vecchio sistema Car-Net/MBB, quindi il login duraturo + i comandi remoti non lo possono raggiungere. Per questi veicoli usa invece il canale del portale EU Data Act (o il login con email + password). Il login MBB è per le auto Car-Net più vecchie (la maggior parte dei modelli PHEV / a combustione).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Apri {verification_uri} in un browser qualsiasi, accedi con il tuo account Brand ID e conferma il codice {user_code}.",

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — hold fjernkommandoene i gang (reserveforbindelse)",
+        "description": "Dette legger til en reserveforbindelse slik at fjernkommandoene til Audi-en din — lås/lås opp, klima og lading — fortsetter å virke selv om Audi en gang skulle endre måten appen logger inn på. Til daglig endres ingenting: Audi-en din bruker den vanlige forbindelsen sin, og reserven trer bare inn hvis den vanlige slutter å ta imot kommandoer. Oppsettet krever bare én rask bekreftelse i nettleseren (ingen passord lagres). Velg Audi-en du allerede har lagt til med QR-/app-pålogging. Det fungerer på de fleste bensin-, diesel- og ladbare hybrid-Audier; enkelte av de aller nyeste helelektriske modellene støttes ikke og avvises automatisk.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Hvilken Audi",
+          "mbb_vins": "Kjøretøy-ID (VIN) — la vanligvis stå tomt",
+          "spin": "S-PIN (trengs kun for lås/lås opp)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "La dette stå tomt med mindre oppsettet ber om det.",
+          "spin": "Audi-S-PIN-en din — koden du bruker til å låse/låse opp på avstand."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Ny pålogging vellykket.",
       "reconfigure_successful": "Konfigurasjonen ble oppdatert.",
       "mbb_not_eligible": "Kjøretøyet ditt kvalifiserer ikke for den varige MBB-påloggingen — baksystemet svarte «Unknown user». Det betyr at det er en nyere ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldri ble registrert i det eldre Car-Net/MBB-systemet, så den varige påloggingen + fjernkommandoene når ikke frem til det. Bruk EU Data Act-portalkanalen (eller e-post + passord-påloggingen) for disse kjøretøyene i stedet. MBB-påloggingen er for eldre Car-Net-biler (de fleste PHEV-/forbrenningsmodeller).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Reserveforbindelsen er satt opp. Hvis den vanlige forbindelsen til Audi-en din en gang slutter å ta imot fjernkommandoer, bytter lås/lås opp, klima og lading automatisk over til reserven. Ingenting endres til daglig.",
+      "no_devicegrant_audi": "Fant ingen passende Audi. Denne reserven gjelder bare en Audi du la til med QR-/app-pålogging og som ikke allerede har den. Legg til Audi-en din på den måten først, og kom deretter tilbake hit."
     },
     "progress": {
       "awaiting_browser_login": "Åpne {verification_uri} i hvilken som helst nettleser, logg inn med Brand ID-kontoen din, og bekreft koden {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU Two-Way (kommandoer + sanntidsavlesninger, BETA)",
         "description": "**Eksperimentell, valgfri — kun Volkswagen.** Legger til toveisstyring (lås/lås opp, klima, lading) og sanntidsavlesninger fra CARIAD ved at du logger inn med Volkswagen ID-en din. Fordi Volkswagen bare utsteder et token som er gyldig i én time på denne måten, **lagres** passordet ditt slik at integrasjonen kan fornye det automatisk. Det sendes kun til Volkswagens egen påloggingsserver og skrives aldri til logger eller diagnostikk. Vil du helst ikke lagre et passord? Bruk de skrivebeskyttede kanalene i stedet. **Forutsetning:** Volkswagen ID-en din må være kjøretøyets primærbruker.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "E-postadresse",
+          "password": "Passord"
         },
         "data_description": {
           "username": "E-posten til Volkswagen ID- / myVolkswagen-kontoen din.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Portalfeed-tilstand",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "Venter på portaldata",
+          "empty_snapshots": "Tomme øyeblikksbilder",
+          "delivery_not_ready": "Levering ikke klar",
+          "stale": "Foreldet"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minutter siden siste øyeblikksbilde"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Historisk eksport",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Forespurt — forberedes",
+          "done": "Levert",
+          "timed_out": "Tidsavbrudd"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Opprett EU Data Act-dataforespørsel"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Be om historisk eksport"
       },
       "companion_reset_button": {
         "name": "Tilbakestill companion-tilkobling"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "3/4-visning (ikon)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "3/4-visning (liten)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "3/4-visning (middels)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Sidevisning (liten)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Sidevisning (stor)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "3/4-visning (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "3/4-visning (stor)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Kjøretøybilde"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "De siste dataene bilen din rapporterte inn, ble registrert for omtrent **{age} timer siden** – selv om integrasjonen fortsatt henter inn data uten problemer. To ting kan være årsaken: bilen står kanskje bare parkert og i dvale (helt normalt – ingenting å gjøre), eller EU Data Act-datastrømmen kan ha løpt ut og sluttet å levere ferske avlesninger.\n\nVerdiene du ser nå, er de sist kjente – ikke sanntidsverdier. Hvis bilen har blitt kjørt eller satt til lading siden da, og denne advarselen fortsatt vises, har datastrømmen mest sannsynlig utløpt: åpne volkswagen.de → datainnstillingene for bilen din, og forny / be om datadelingen på nytt, eller legg til kanalen på nytt.\n\nDenne advarselen forsvinner av seg selv så snart en ferskere avlesning kommer inn."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: engangs historisk eksport ble ikke fullført",
+      "description": "Den engangs historiske eksporten som ble bestilt for denne bilen, produserte ingen fil innen tidsfristen. VW-portalen gir ikke denne forespørselen noen slutt-status, så den kan ha blitt forkastet uten beskjed. Forespørselen er nullstilt — du kan be om den på nytt, eller sjekke portalen direkte."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "EU Data Act-portalen er ikke klar ennå. Vent til integrasjonen har hentet data én gang etter oppsett, og prøv deretter det historiske eksporten på nytt."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "Engangs historisk eksport er for øyeblikket deaktivert."
     },
     "historical_wedge_blocked": {
       "message": "Det pågår allerede en engangseksport av historikken for denne bilen. Portalen håndterer bare én slik forespørsel om gangen, så vent til den pågående er ferdig (eller får tidsavbrudd) før du ber om en ny."

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Kryss av her hvis telefonen kjører companion-agent-appen. Telefonen ringer da Home Assistant, så verken ADB, trådløs feilsøking eller fast IP trengs — la adressefeltet stå tomt.",
           "companion_agent_token": "Det tilfeldige tokenet agent-appen genererte. Minst 32 tegn, og et eget for hvert kjøretøy."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Denne kontoen er allerede konfigurert.",
       "reauth_successful": "Ny pålogging vellykket.",
       "reconfigure_successful": "Konfigurasjonen ble oppdatert.",
-      "mbb_not_eligible": "Kjøretøyet ditt kvalifiserer ikke for den varige MBB-påloggingen — baksystemet svarte «Unknown user». Det betyr at det er en nyere ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldri ble registrert i det eldre Car-Net/MBB-systemet, så den varige påloggingen + fjernkommandoene når ikke frem til det. Bruk EU Data Act-portalkanalen (eller e-post + passord-påloggingen) for disse kjøretøyene i stedet. MBB-påloggingen er for eldre Car-Net-biler (de fleste PHEV-/forbrenningsmodeller)."
+      "mbb_not_eligible": "Kjøretøyet ditt kvalifiserer ikke for den varige MBB-påloggingen — baksystemet svarte «Unknown user». Det betyr at det er en nyere ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldri ble registrert i det eldre Car-Net/MBB-systemet, så den varige påloggingen + fjernkommandoene når ikke frem til det. Bruk EU Data Act-portalkanalen (eller e-post + passord-påloggingen) for disse kjøretøyene i stedet. MBB-påloggingen er for eldre Car-Net-biler (de fleste PHEV-/forbrenningsmodeller).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Åpne {verification_uri} i hvilken som helst nettleser, logg inn med Brand ID-kontoen din, og bekreft koden {user_code}.",

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Ny pålogging vellykket.",
       "reconfigure_successful": "Konfigurasjonen ble oppdatert.",
       "mbb_not_eligible": "Kjøretøyet ditt kvalifiserer ikke for den varige MBB-påloggingen — baksystemet svarte «Unknown user». Det betyr at det er en nyere ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldri ble registrert i det eldre Car-Net/MBB-systemet, så den varige påloggingen + fjernkommandoene når ikke frem til det. Bruk EU Data Act-portalkanalen (eller e-post + passord-påloggingen) for disse kjøretøyene i stedet. MBB-påloggingen er for eldre Car-Net-biler (de fleste PHEV-/forbrenningsmodeller).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Åpne {verification_uri} i hvilken som helst nettleser, logg inn med Brand ID-kontoen din, og bekreft koden {user_code}.",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — commando's op afstand blijven werken (reserveverbinding)",
+        "description": "Dit voegt een reserveverbinding toe zodat de commando's op afstand van je Audi — vergrendelen/ontgrendelen, klimaat en laden — blijven werken, zelfs als Audi ooit verandert hoe de app zich aanmeldt. In het dagelijks gebruik verandert er niets: je Audi gebruikt zijn normale verbinding, en de reserve springt alleen bij als de normale geen commando's meer accepteert. Instellen kost één snelle bevestiging in de browser (er wordt geen wachtwoord opgeslagen). Kies de Audi die je al hebt toegevoegd met de QR-/app-login. Het werkt op de meeste benzine-, diesel- en plug-in-hybride Audi's; enkele van de nieuwste volledig elektrische modellen worden niet ondersteund en worden automatisch afgewezen.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Welke Audi",
+          "mbb_vins": "Voertuig-ID (VIN) — meestal leeg laten",
+          "spin": "S-PIN (alleen nodig voor vergrendelen/ontgrendelen)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Laat dit leeg, tenzij de installatie erom vraagt.",
+          "spin": "Je Audi S-PIN — de code die je gebruikt voor vergrendelen/ontgrendelen op afstand."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Herauthenticatie geslaagd.",
       "reconfigure_successful": "Configuratie succesvol bijgewerkt.",
       "mbb_not_eligible": "Je voertuig komt niet in aanmerking voor de duurzame MBB-login — de backend gaf \"Unknown user\" terug. Het is een nieuwer ID-/MEB-model (ID.3/4/5, e-up enz.) dat nooit in het oude Car-Net/MBB-systeem was geregistreerd, dus de duurzame login en de commando's op afstand kunnen het niet bereiken. Gebruik voor zulke voertuigen het EU Data Act-portaalkanaal (of de e-mail-+-wachtwoordlogin). De MBB-login is voor oudere Car-Net-auto's (de meeste plug-inhybride / verbrandingsmodellen).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Reserveverbinding ingesteld. Als de normale verbinding van je Audi ooit geen commando's op afstand meer accepteert, schakelen vergrendelen/ontgrendelen, klimaat en laden automatisch over naar de reserve. In het dagelijks gebruik verandert er niets.",
+      "no_devicegrant_audi": "Geen passende Audi gevonden. Deze reserve geldt alleen voor een Audi die je met de QR-/app-login hebt toegevoegd en die de reserve nog niet heeft. Voeg je Audi eerst op die manier toe en kom dan hier terug."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in een willekeurige browser, meld je aan met je Brand ID-account en bevestig de code {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU Two-Way (commando's + live uitlezingen, BÈTA)",
         "description": "**Experimenteel, opt-in — alleen Volkswagen.** Voegt tweerichtingsbediening (vergrendelen/ontgrendelen, klimaat, laden) en live CARIAD-uitlezingen toe door je aan te melden met je Volkswagen ID. Omdat Volkswagen via deze weg maar een token van 1 uur afgeeft, wordt je wachtwoord **opgeslagen** zodat de integratie het automatisch kan vernieuwen. Het wordt alleen naar de eigen loginserver van Volkswagen verzonden en nooit vastgelegd in logboeken of diagnose. Liever geen wachtwoord opslaan? Gebruik dan de alleen-lezen kanalen. **Vereiste:** je Volkswagen ID moet de hoofdgebruiker van het voertuig zijn.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "E-mailadres",
+          "password": "Wachtwoord"
         },
         "data_description": {
           "username": "Het e-mailadres van je Volkswagen ID / myVolkswagen-account.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Status portaalfeed",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "Wachten op portaalgegevens",
+          "empty_snapshots": "Lege snapshots",
+          "delivery_not_ready": "Levering niet gereed",
+          "stale": "Verouderd"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minuten sinds laatste snapshot"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Historische export",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Aangevraagd — wordt voorbereid",
+          "done": "Geleverd",
+          "timed_out": "Time-out"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "EU Data Act-gegevensverzoek aanmaken"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Historische export aanvragen"
       },
       "companion_reset_button": {
         "name": "Companion-verbinding resetten"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "3/4-aanzicht (icoon)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "3/4-aanzicht (klein)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "3/4-aanzicht (middel)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Zijaanzicht (klein)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Zijaanzicht (groot)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "3/4-aanzicht (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "3/4-aanzicht (groot)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Voertuigrender"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "De laatste gegevens die je auto doorgaf, zijn ongeveer **{age} uur geleden** vastgelegd, ook al blijft de integratie succesvol opvragen. Dat kan twee oorzaken hebben: misschien staat de auto gewoon geparkeerd en in slaapstand (normaal — je hoeft niets te doen), of de gegevensstroom via de EU Data Act is verlopen en levert geen verse metingen meer.\n\nDe waarden die je nu ziet, zijn de laatst bekende — niet live. Is er sindsdien gereden of opgeladen en blijft deze waarschuwing staan, dan is de gegevensstroom hoogstwaarschijnlijk verlopen: ga naar volkswagen.de → de gegevensinstellingen van je auto en vernieuw of vraag het delen van gegevens opnieuw aan, of voeg het kanaal opnieuw toe.\n\nDeze waarschuwing verdwijnt vanzelf zodra er een verse meting binnenkomt."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: eenmalige historische export niet voltooid",
+      "description": "De eenmalige historische export die voor deze auto is aangevraagd, heeft binnen de deadline van de client geen bestand opgeleverd. Het VW-portaal geeft deze aanvraag geen eindstatus, dus mogelijk is hij stilletjes verworpen. De aanvraag is gewist — je kunt hem opnieuw aanvragen of rechtstreeks in het portaal kijken."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "Het EU Data Act-portaal is nog niet gereed. Wacht tot de integratie na de installatie één keer heeft opgehaald en probeer de historische export dan opnieuw."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "De eenmalige historische export is momenteel uitgeschakeld."
     },
     "historical_wedge_blocked": {
       "message": "Er loopt al een eenmalige export van de geschiedenis voor deze auto. Het portaal verwerkt maar één zo'n verzoek tegelijk, dus wacht tot het huidige klaar is (of een time-out krijgt) voordat je een nieuwe aanvraagt."

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Vink dit aan als de telefoon de companion-agent-app draait. De telefoon belt dan Home Assistant, dus ADB, draadloos debuggen en een vast IP zijn niet nodig — laat het adresveld leeg.",
           "companion_agent_token": "Het willekeurige token uit de agent-app. Minstens 32 tekens, en voor elk voertuig een ander."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Dit account is al geconfigureerd.",
       "reauth_successful": "Herauthenticatie geslaagd.",
       "reconfigure_successful": "Configuratie succesvol bijgewerkt.",
-      "mbb_not_eligible": "Je voertuig komt niet in aanmerking voor de duurzame MBB-login — de backend gaf \"Unknown user\" terug. Het is een nieuwer ID-/MEB-model (ID.3/4/5, e-up enz.) dat nooit in het oude Car-Net/MBB-systeem was geregistreerd, dus de duurzame login en de commando's op afstand kunnen het niet bereiken. Gebruik voor zulke voertuigen het EU Data Act-portaalkanaal (of de e-mail-+-wachtwoordlogin). De MBB-login is voor oudere Car-Net-auto's (de meeste plug-inhybride / verbrandingsmodellen)."
+      "mbb_not_eligible": "Je voertuig komt niet in aanmerking voor de duurzame MBB-login — de backend gaf \"Unknown user\" terug. Het is een nieuwer ID-/MEB-model (ID.3/4/5, e-up enz.) dat nooit in het oude Car-Net/MBB-systeem was geregistreerd, dus de duurzame login en de commando's op afstand kunnen het niet bereiken. Gebruik voor zulke voertuigen het EU Data Act-portaalkanaal (of de e-mail-+-wachtwoordlogin). De MBB-login is voor oudere Car-Net-auto's (de meeste plug-inhybride / verbrandingsmodellen).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in een willekeurige browser, meld je aan met je Brand ID-account en bevestig de code {user_code}.",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Herauthenticatie geslaagd.",
       "reconfigure_successful": "Configuratie succesvol bijgewerkt.",
       "mbb_not_eligible": "Je voertuig komt niet in aanmerking voor de duurzame MBB-login — de backend gaf \"Unknown user\" terug. Het is een nieuwer ID-/MEB-model (ID.3/4/5, e-up enz.) dat nooit in het oude Car-Net/MBB-systeem was geregistreerd, dus de duurzame login en de commando's op afstand kunnen het niet bereiken. Gebruik voor zulke voertuigen het EU Data Act-portaalkanaal (of de e-mail-+-wachtwoordlogin). De MBB-login is voor oudere Car-Net-auto's (de meeste plug-inhybride / verbrandingsmodellen).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in een willekeurige browser, meld je aan met je Brand ID-account en bevestig de code {user_code}.",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — utrzymaj działanie poleceń zdalnych (połączenie zapasowe)",
+        "description": "To dodaje połączenie zapasowe, dzięki któremu polecenia zdalne Twojego Audi — ryglowanie/odryglowanie, klimatyzacja i ładowanie — działają nadal, nawet jeśli Audi kiedyś zmieni sposób logowania aplikacji. Na co dzień nic się nie zmienia: Twoje Audi korzysta ze zwykłego połączenia, a zapasowe włącza się tylko wtedy, gdy zwykłe przestanie przyjmować polecenia. Konfiguracja wymaga jednego szybkiego potwierdzenia w przeglądarce (żadne hasło nie jest przechowywane). Wybierz Audi, które już dodałeś przez logowanie QR / aplikacją. Działa z większością Audi benzynowych, wysokoprężnych i hybryd plug-in; niektóre najnowsze modele w pełni elektryczne nie są obsługiwane i zostają automatycznie odrzucone.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Które Audi",
+          "mbb_vins": "Identyfikator pojazdu (VIN) — zwykle zostaw puste",
+          "spin": "S-PIN (potrzebny tylko do ryglowania/odryglowania)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Zostaw to pole puste, chyba że konfiguracja o nie poprosi.",
+          "spin": "Twój S-PIN do Audi — kod, którego używasz do zdalnego ryglowania/odryglowania."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Ponowne uwierzytelnianie zakończone sukcesem.",
       "reconfigure_successful": "Konfiguracja zaktualizowana pomyślnie.",
       "mbb_not_eligible": "Twój pojazd nie kwalifikuje się do trwałego logowania MBB — backend zwrócił „Unknown user”. To nowszy model ID / MEB (ID.3/4/5, e-up itp.), który nigdy nie był zarejestrowany w starym systemie Car-Net/MBB, więc trwałe logowanie i polecenia zdalne nie mogą go osiągnąć. Dla takich pojazdów użyj kanału portalu EU Data Act (lub logowania e-mail + hasło). Logowanie MBB jest przeznaczone dla starszych aut Car-Net (większość modeli hybryd plug-in / spalinowych).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Połączenie zapasowe skonfigurowane. Jeśli zwykłe połączenie Twojego Audi kiedyś przestanie przyjmować polecenia zdalne, ryglowanie/odryglowanie, klimatyzacja i ładowanie automatycznie przełączą się na zapasowe. Na co dzień nic się nie zmienia.",
+      "no_devicegrant_audi": "Nie znaleziono pasującego Audi. To połączenie zapasowe dotyczy tylko Audi dodanego przez logowanie QR / aplikacją, które jeszcze go nie ma. Najpierw dodaj w ten sposób swoje Audi, a potem wróć tutaj."
     },
     "progress": {
       "awaiting_browser_login": "Otwórz {verification_uri} w dowolnej przeglądarce, zaloguj się na konto Brand ID i potwierdź kod {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU Two-Way (polecenia + odczyty na żywo, BETA)",
         "description": "**Eksperymentalne, opcjonalne — tylko Volkswagen.** Dodaje sterowanie dwukierunkowe (ryglowanie/odryglowanie, klimatyzacja, ładowanie) oraz odczyty na żywo z CARIAD po zalogowaniu się przy użyciu Volkswagen ID. Ponieważ Volkswagen wydaje na tej ścieżce token ważny tylko 1 godzinę, Twoje hasło jest **przechowywane**, aby integracja mogła odnawiać go automatycznie. Jest wysyłane wyłącznie do własnego serwera logowania Volkswagena i nigdy nie trafia do logów ani diagnostyki. Wolisz nie przechowywać hasła? Użyj zamiast tego kanałów tylko do odczytu. **Wymóg:** Twoje Volkswagen ID musi być głównym użytkownikiem pojazdu.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "Adres e-mail",
+          "password": "Hasło"
         },
         "data_description": {
           "username": "Adres e-mail Twojego konta Volkswagen ID / myVolkswagen.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Stan kanału portalu",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "Oczekiwanie na dane portalu",
+          "empty_snapshots": "Puste migawki",
+          "delivery_not_ready": "Dostawa niegotowa",
+          "stale": "Nieaktualne"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minuty od ostatniej migawki"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Eksport historyczny",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Zażądano — przygotowywanie",
+          "done": "Dostarczono",
+          "timed_out": "Przekroczono limit czasu"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Utwórz żądanie danych EU Data Act"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Zażądaj eksportu historycznego"
       },
       "companion_reset_button": {
         "name": "Resetuj połączenie companion"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "Ujęcie 3/4 (ikona)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "Ujęcie 3/4 (małe)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "Ujęcie 3/4 (średnie)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Ujęcie z boku (małe)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Ujęcie z boku (duże)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "Ujęcie 3/4 (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "Ujęcie 3/4 (duże)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Render pojazdu"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "Ostatnie dane przesłane przez Twój samochód zostały zarejestrowane około **{age} godz. temu**, mimo że integracja nadal poprawnie odpytuje serwer. Mogą być tego dwie przyczyny: samochód może być po prostu zaparkowany i uśpiony (to normalne — nie musisz nic robić) albo jego kanał danych w ramach EU Data Act wygasł i przestał dostarczać świeże odczyty.\n\nWartości, które teraz widzisz, to ostatnie znane, a nie dane na żywo. Jeśli od tego czasu samochód był używany lub podłączony do ładowania, a to ostrzeżenie wciąż się wyświetla, kanał danych najprawdopodobniej wygasł: otwórz volkswagen.de → ustawienia danych swojego samochodu i odnów/ponownie zażądaj udostępniania danych albo dodaj kanał od nowa.\n\nTo ostrzeżenie zniknie automatycznie w chwili, gdy nadejdzie świeższy odczyt."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: jednorazowy eksport historyczny nie został ukończony",
+      "description": "Jednorazowy eksport historyczny zażądany dla tego auta nie utworzył pliku w wyznaczonym czasie. Portal VW nie zwraca dla tego żądania żadnego stanu końcowego, więc mogło ono zostać po cichu odrzucone. Żądanie zostało wyczyszczone — możesz je ponowić lub sprawdzić bezpośrednio w portalu."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "Portal EU Data Act nie jest jeszcze gotowy. Poczekaj, aż integracja wykona jedno odpytanie po konfiguracji, a następnie ponów eksport historyczny."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "Jednorazowy eksport historyczny jest obecnie wyłączony."
     },
     "historical_wedge_blocked": {
       "message": "Dla tego samochodu trwa już jednorazowy eksport danych historycznych. Portal obsługuje tylko jedno takie żądanie naraz, więc zaczekaj, aż bieżące się zakończy (lub wygaśnie), zanim poprosisz o kolejne."

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Zaznacz, jeśli na telefonie działa aplikacja agenta. To telefon łączy się wtedy z Home Assistant: nie potrzeba ADB, debugowania bezprzewodowego ani stałego IP — pozostaw pole adresu puste.",
           "companion_agent_token": "Losowy token wygenerowany przez aplikację agenta. Co najmniej 32 znaki i inny dla każdego pojazdu."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "To konto jest już skonfigurowane.",
       "reauth_successful": "Ponowne uwierzytelnianie zakończone sukcesem.",
       "reconfigure_successful": "Konfiguracja zaktualizowana pomyślnie.",
-      "mbb_not_eligible": "Twój pojazd nie kwalifikuje się do trwałego logowania MBB — backend zwrócił „Unknown user”. To nowszy model ID / MEB (ID.3/4/5, e-up itp.), który nigdy nie był zarejestrowany w starym systemie Car-Net/MBB, więc trwałe logowanie i polecenia zdalne nie mogą go osiągnąć. Dla takich pojazdów użyj kanału portalu EU Data Act (lub logowania e-mail + hasło). Logowanie MBB jest przeznaczone dla starszych aut Car-Net (większość modeli hybryd plug-in / spalinowych)."
+      "mbb_not_eligible": "Twój pojazd nie kwalifikuje się do trwałego logowania MBB — backend zwrócił „Unknown user”. To nowszy model ID / MEB (ID.3/4/5, e-up itp.), który nigdy nie był zarejestrowany w starym systemie Car-Net/MBB, więc trwałe logowanie i polecenia zdalne nie mogą go osiągnąć. Dla takich pojazdów użyj kanału portalu EU Data Act (lub logowania e-mail + hasło). Logowanie MBB jest przeznaczone dla starszych aut Car-Net (większość modeli hybryd plug-in / spalinowych).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Otwórz {verification_uri} w dowolnej przeglądarce, zaloguj się na konto Brand ID i potwierdź kod {user_code}.",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Ponowne uwierzytelnianie zakończone sukcesem.",
       "reconfigure_successful": "Konfiguracja zaktualizowana pomyślnie.",
       "mbb_not_eligible": "Twój pojazd nie kwalifikuje się do trwałego logowania MBB — backend zwrócił „Unknown user”. To nowszy model ID / MEB (ID.3/4/5, e-up itp.), który nigdy nie był zarejestrowany w starym systemie Car-Net/MBB, więc trwałe logowanie i polecenia zdalne nie mogą go osiągnąć. Dla takich pojazdów użyj kanału portalu EU Data Act (lub logowania e-mail + hasło). Logowanie MBB jest przeznaczone dla starszych aut Car-Net (większość modeli hybryd plug-in / spalinowych).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Otwórz {verification_uri} w dowolnej przeglądarce, zaloguj się na konto Brand ID i potwierdź kod {user_code}.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — MBB command fallback (durable two-way)",
-        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "title": "Audi — keep remote commands working (backup connection)",
+        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
         "data": {
-          "entry_id": "Audi to arm",
-          "mbb_vins": "VIN(s) (comma-separated, optional)",
-          "spin": "S-PIN (optional — needed for lock/unlock)"
+          "entry_id": "Which Audi",
+          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
+          "spin": "S-PIN (only needed for lock/unlock)"
         },
         "data_description": {
-          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
-          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+          "mbb_vins": "Leave this blank unless the setup asks for it.",
+          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Omautentisering lyckades.",
       "reconfigure_successful": "Konfigurationen uppdaterades.",
       "mbb_not_eligible": "Ditt fordon är inte behörigt för den varaktiga MBB-inloggningen — backend returnerade \"Unknown user\". Det är en nyare ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldrig registrerades i det gamla Car-Net/MBB-systemet, så den varaktiga inloggningen och fjärrkommandona når den inte. Använd EU Data Act-portalkanalen (eller e-post + lösenord-inloggningen) för sådana fordon. MBB-inloggningen är för äldre Car-Net-bilar (de flesta laddhybrid-/förbränningsmodeller).",
-      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
-      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
+      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
+      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
     },
     "progress": {
       "awaiting_browser_login": "Öppna {verification_uri} i valfri webbläsare, logga in med ditt Brand ID-konto och bekräfta koden {user_code}.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -157,6 +157,19 @@
           "companion_use_relay": "Kryssa i detta om telefonen kör companion-agentappen. Telefonen ringer då upp Home Assistant, så varken ADB, trådlös felsökning eller fast IP behövs — lämna adressfältet tomt.",
           "companion_agent_token": "Den slumpmässiga token som agentappen skapade. Minst 32 tecken, och en egen för varje fordon."
         }
+      },
+      "audi_mbb_fallback": {
+        "title": "Audi — MBB command fallback (durable two-way)",
+        "description": "Arm the durable Car-Net (MBB) command channel as a fallback on an Audi you set up via the QR / browser login. A one-time browser confirmation (no password stored) mints a durable bearer; the normal CARIAD command path stays primary, and MBB only steps in if Volkswagen ever revokes the device grant. For Car-Net Audis (most PHEV / combustion, pre-ID/MEB) — newer ID / MEB models aren't eligible and will be declined at the exchange.",
+        "data": {
+          "entry_id": "Audi to arm",
+          "mbb_vins": "VIN(s) (comma-separated, optional)",
+          "spin": "S-PIN (optional — needed for lock/unlock)"
+        },
+        "data_description": {
+          "mbb_vins": "Only needed if the fallback can't list your garage on its own — usually leave blank.",
+          "spin": "Your S-PIN, required for remote lock/unlock over the Car-Net channel."
+        }
       }
     },
     "error": {
@@ -185,7 +198,9 @@
       "already_configured": "Det här kontot är redan konfigurerat.",
       "reauth_successful": "Omautentisering lyckades.",
       "reconfigure_successful": "Konfigurationen uppdaterades.",
-      "mbb_not_eligible": "Ditt fordon är inte behörigt för den varaktiga MBB-inloggningen — backend returnerade \"Unknown user\". Det är en nyare ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldrig registrerades i det gamla Car-Net/MBB-systemet, så den varaktiga inloggningen och fjärrkommandona når den inte. Använd EU Data Act-portalkanalen (eller e-post + lösenord-inloggningen) för sådana fordon. MBB-inloggningen är för äldre Car-Net-bilar (de flesta laddhybrid-/förbränningsmodeller)."
+      "mbb_not_eligible": "Ditt fordon är inte behörigt för den varaktiga MBB-inloggningen — backend returnerade \"Unknown user\". Det är en nyare ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldrig registrerades i det gamla Car-Net/MBB-systemet, så den varaktiga inloggningen och fjärrkommandona når den inte. Använd EU Data Act-portalkanalen (eller e-post + lösenord-inloggningen) för sådana fordon. MBB-inloggningen är för äldre Car-Net-bilar (de flesta laddhybrid-/förbränningsmodeller).",
+      "mbb_fallback_armed": "MBB command fallback armed. If Volkswagen ever revokes this Audi's device grant, lock/unlock, climate and charge fall back to the durable Car-Net (MBB) channel automatically. Nothing changes day-to-day — the BFF stays the primary command path.",
+      "no_devicegrant_audi": "No eligible Audi found. This option arms the MBB command fallback on an Audi that was set up via the QR / browser login (device grant) and doesn't have it yet. Set your Audi up that way first, then run this."
     },
     "progress": {
       "awaiting_browser_login": "Öppna {verification_uri} i valfri webbläsare, logga in med ditt Brand ID-konto och bekräfta koden {user_code}.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -159,16 +159,16 @@
         }
       },
       "audi_mbb_fallback": {
-        "title": "Audi — keep remote commands working (backup connection)",
-        "description": "This adds a backup connection so your Audi's remote commands — lock/unlock, climate and charging — keep working even if Audi ever changes how the app signs in. Day to day nothing changes: your Audi uses its normal connection, and the backup only steps in if the normal one stops accepting commands. Setting it up takes one quick browser confirmation (no password is stored). Choose the Audi you already added with the QR / app login. It works on most petrol, diesel and plug-in-hybrid Audis; some of the newest fully-electric models aren't supported and are turned down automatically.",
+        "title": "Audi — se till att fjärrkommandon fortsätter fungera (reservanslutning)",
+        "description": "Det här lägger till en reservanslutning så att din Audis fjärrkommandon — lås/lås upp, klimat och laddning — fortsätter fungera även om Audi någon gång ändrar hur appen loggar in. I vardagen ändras ingenting: din Audi använder sin vanliga anslutning, och reserven träder bara in om den vanliga slutar ta emot kommandon. Att ställa in det tar en snabb bekräftelse i webbläsaren (inget lösenord lagras). Välj den Audi du redan lagt till med QR-/app-inloggningen. Det fungerar på de flesta bensin-, diesel- och laddhybrid-Audi; några av de allra nyaste helelektriska modellerna stöds inte och avvisas automatiskt.",
         "data": {
-          "entry_id": "Which Audi",
-          "mbb_vins": "Vehicle ID (VIN) — usually leave blank",
-          "spin": "S-PIN (only needed for lock/unlock)"
+          "entry_id": "Vilken Audi",
+          "mbb_vins": "Fordons-ID (VIN) — lämna oftast tomt",
+          "spin": "S-PIN (behövs bara för lås/lås upp)"
         },
         "data_description": {
-          "mbb_vins": "Leave this blank unless the setup asks for it.",
-          "spin": "Your Audi S-PIN — the code you use for remote lock/unlock."
+          "mbb_vins": "Lämna det här tomt om inte inställningen ber om det.",
+          "spin": "Din Audi-S-PIN — koden du använder för att låsa/låsa upp på distans."
         }
       }
     },
@@ -199,8 +199,8 @@
       "reauth_successful": "Omautentisering lyckades.",
       "reconfigure_successful": "Konfigurationen uppdaterades.",
       "mbb_not_eligible": "Ditt fordon är inte behörigt för den varaktiga MBB-inloggningen — backend returnerade \"Unknown user\". Det är en nyare ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldrig registrerades i det gamla Car-Net/MBB-systemet, så den varaktiga inloggningen och fjärrkommandona når den inte. Använd EU Data Act-portalkanalen (eller e-post + lösenord-inloggningen) för sådana fordon. MBB-inloggningen är för äldre Car-Net-bilar (de flesta laddhybrid-/förbränningsmodeller).",
-      "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
-      "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here."
+      "mbb_fallback_armed": "Reservanslutningen är inställd. Om din Audis vanliga anslutning någon gång slutar ta emot fjärrkommandon växlar lås/lås upp, klimat och laddning automatiskt till reserven. Ingenting ändras i vardagen.",
+      "no_devicegrant_audi": "Ingen matchande Audi hittades. Den här reserven gäller bara en Audi som du lagt till med QR-/app-inloggningen och som inte redan har den. Lägg till din Audi på det sättet först och kom sedan tillbaka hit."
     },
     "progress": {
       "awaiting_browser_login": "Öppna {verification_uri} i valfri webbläsare, logga in med ditt Brand ID-konto och bekräfta koden {user_code}.",
@@ -317,8 +317,8 @@
         "title": "VW EU Two-Way (kommandon + live-avläsningar, BETA)",
         "description": "**Experimentell, frivillig — endast Volkswagen.** Lägger till tvåvägsstyrning (lås/lås upp, klimat, laddning) och live-CARIAD-avläsningar genom att du loggar in med ditt Volkswagen ID. Eftersom Volkswagen bara utfärdar en 1-timmestoken på den här vägen **lagras** ditt lösenord så att integrationen kan förnya den automatiskt. Det skickas endast till Volkswagens egen inloggningsserver och skrivs aldrig till loggar eller diagnostik. Vill du hellre inte lagra ett lösenord? Använd de skrivskyddade kanalerna istället. **Krav:** ditt Volkswagen ID måste vara fordonets huvudanvändare.",
         "data": {
-          "username": "Email Address",
-          "password": "Password"
+          "username": "E-postadress",
+          "password": "Lösenord"
         },
         "data_description": {
           "username": "E-postadressen för ditt Volkswagen ID-/myVolkswagen-konto.",
@@ -372,24 +372,24 @@
         }
       },
       "portal_health": {
-        "name": "Portal feed health",
+        "name": "Portalflödets status",
         "state": {
           "ok": "OK",
-          "waiting_for_portal_data": "Waiting for portal data",
-          "empty_snapshots": "Empty snapshots",
-          "delivery_not_ready": "Delivery not ready",
-          "stale": "Stale"
+          "waiting_for_portal_data": "Väntar på portaldata",
+          "empty_snapshots": "Tomma ögonblicksbilder",
+          "delivery_not_ready": "Leverans inte klar",
+          "stale": "Föråldrad"
         }
       },
       "minutes_since_last_snapshot": {
-        "name": "Minutes since last snapshot"
+        "name": "Minuter sedan senaste ögonblicksbild"
       },
       "historical_export_state": {
-        "name": "Historical export",
+        "name": "Historisk export",
         "state": {
-          "pending": "Requested — preparing",
-          "done": "Delivered",
-          "timed_out": "Timed out"
+          "pending": "Begärd — förbereds",
+          "done": "Levererad",
+          "timed_out": "Tidsgräns överskreds"
         }
       },
       "target_soc": {
@@ -1772,7 +1772,7 @@
         "name": "Skapa EU Data Act-databegäran"
       },
       "historical_export_button": {
-        "name": "Request historical export"
+        "name": "Begär historisk export"
       },
       "companion_reset_button": {
         "name": "Återställ companion-anslutning"
@@ -1821,28 +1821,28 @@
     },
     "image": {
       "render_icon": {
-        "name": "3/4 view (icon)"
+        "name": "3/4-vy (ikon)"
       },
       "render_small": {
-        "name": "3/4 view (small)"
+        "name": "3/4-vy (liten)"
       },
       "render_medium": {
-        "name": "3/4 view (medium)"
+        "name": "3/4-vy (mellan)"
       },
       "render_side_sm": {
-        "name": "Side view (small)"
+        "name": "Sidovy (liten)"
       },
       "render_side_lg": {
-        "name": "Side view (large)"
+        "name": "Sidovy (stor)"
       },
       "render_angle_hd": {
-        "name": "3/4 view (HD)"
+        "name": "3/4-vy (HD)"
       },
       "render_angle_lg": {
-        "name": "3/4 view (large)"
+        "name": "3/4-vy (stor)"
       },
       "vehicle_render": {
-        "name": "Vehicle render"
+        "name": "Fordonsbild"
       }
     },
     "lock": {
@@ -1982,8 +1982,8 @@
       "description": "De senaste uppgifterna som din bil rapporterade samlades in för **ungefär {age} timmar sedan**, trots att integrationen fortfarande hämtar data utan problem. Det kan bero på två saker: bilen kan helt enkelt stå parkerad i viloläge (helt normalt — inget att göra), eller så kan dess dataflöde enligt EU Data Act ha upphört och slutat leverera färska värden.\n\nVärdena du ser just nu är de senast kända, inte realtidsvärden. Om bilen har körts eller laddats sedan dess och den här varningen ändå står kvar, har dataflödet med största sannolikhet gått ut: öppna volkswagen.de → bilens datainställningar och förnya/begär datadelningen på nytt, eller lägg till kanalen igen.\n\nVarningen försvinner automatiskt så snart ett färskare värde kommer in."
     },
     "historical_timeout": {
-      "title": "{vin}: one-time historical export didn't complete",
-      "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+      "title": "{vin}: engångsexporten av historik slutfördes inte",
+      "description": "Engångsexporten av historik som begärdes för den här bilen skapade ingen fil inom tidsgränsen. VW-portalen ger den här begäran inget slutläge, så den kan ha försvunnit tyst. Begäran har rensats — du kan begära den igen eller titta direkt i portalen."
     }
   },
   "services": {
@@ -2202,7 +2202,7 @@
       "message": "EU Data Act-portalen är inte redo ännu. Vänta tills integrationen har hämtat data en gång efter installationen och försök sedan med den historiska exporten igen."
     },
     "historical_disabled": {
-      "message": "The one-time historical export is currently disabled."
+      "message": "Engångsexporten av historik är för närvarande avstängd."
     },
     "historical_wedge_blocked": {
       "message": "En engångsexport av historiken pågår redan för den här bilen. Portalen hanterar bara en sådan begäran i taget, så vänta tills den pågående är klar (eller når tidsgränsen) innan du begär en ny."

--- a/tests/test_audi_mbb_fallback.py
+++ b/tests/test_audi_mbb_fallback.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Audi two-way BFF → MBB command failover (b15).
+
+A device-grant Audi normally sends commands over the CARIAD BFF. If VW ever
+revokes the device-grant (as it did for Škoda in 2026-08), the BFF starts
+refusing commands with 401/403. When the user opted in to the durable MBB
+command fallback (``CONF_MBB_COMMAND_FALLBACK``) and the car is MBB-eligible, a
+refused command is retried ONCE over MBB before the error reaches the user.
+
+Deliberately narrow: only a BFF *auth refusal* (``APIError`` 401/403) triggers a
+retry — never a transient 5xx/404, an S-PIN guard, or one of our own
+``HomeAssistantError`` guards. On MBB failure the ORIGINAL BFF error surfaces,
+never the fallback's.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from custom_components.vag_connect.cariad.exceptions import APIError, SpinError
+from custom_components.vag_connect.const import CONF_MBB_COMMAND_FALLBACK
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+
+def _coord(*, flag: bool, primary_error: Exception | None,
+           fb_error: Exception | None = None):
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    coord.hass = MagicMock()
+    coord.entry = MagicMock()
+    coord.entry.data = {"spin": "1234"}
+    if flag:
+        coord.entry.data[CONF_MBB_COMMAND_FALLBACK] = True
+    coord._vehicles_lock = threading.Lock()
+    coord._started = True
+    coord._was_available = True
+    coord.vehicles = {"VIN1": {}}
+    coord.async_request_refresh = AsyncMock()
+
+    client = MagicMock()                                   # primary BFF client
+    client.command_lock = AsyncMock(side_effect=primary_error)
+    fb = MagicMock()                                       # armed MBB fallback
+    fb.command_lock = AsyncMock(side_effect=fb_error)
+    client.mbb_fallback_connector = MagicMock(return_value=fb)
+    coord._cariad_client = client
+    coord._fb = fb                                         # test handle
+    return coord
+
+
+class TestAudiMbbFallback:
+    def test_bff_403_recovers_via_mbb(self):
+        # BFF 403 (revoked device-grant shape) + fallback succeeds → no raise.
+        coord = _coord(flag=True, primary_error=APIError(403, "https://bff/lock", ""))
+        asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._cariad_client.command_lock.assert_awaited_once_with("VIN1")
+        coord._fb.command_lock.assert_awaited_once_with("VIN1")
+        coord.async_request_refresh.assert_awaited()
+
+    def test_bff_401_recovers_via_mbb(self):
+        coord = _coord(flag=True, primary_error=APIError(401, "https://bff/lock", ""))
+        asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._fb.command_lock.assert_awaited_once_with("VIN1")
+
+    def test_mbb_also_fails_surfaces_original_bff_error(self):
+        # Both fail → surface the ORIGINAL BFF (403) error, never the MBB (500).
+        coord = _coord(
+            flag=True,
+            primary_error=APIError(403, "https://bff/lock", ""),
+            fb_error=APIError(500, "https://mbb/lock", ""),
+        )
+        with pytest.raises(HomeAssistantError) as ei:
+            asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        assert "403" in str(ei.value)
+        assert "500" not in str(ei.value)
+        coord._fb.command_lock.assert_awaited_once()
+
+    def test_bff_404_does_not_fall_over(self):
+        # 404 is not an auth refusal → no MBB retry; surfaces, fallback untouched.
+        coord = _coord(flag=True, primary_error=APIError(404, "https://bff/lock", ""))
+        with pytest.raises(HomeAssistantError):
+            asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._fb.command_lock.assert_not_awaited()
+
+    def test_no_optin_no_fallback(self):
+        # Flag off → even a 403 does NOT fall over to MBB (config-gated).
+        coord = _coord(flag=False, primary_error=APIError(403, "https://bff/lock", ""))
+        with pytest.raises(HomeAssistantError):
+            asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._fb.command_lock.assert_not_awaited()
+
+    def test_spin_error_does_not_fall_over(self):
+        # Our own S-PIN guard is a user error, not a BFF refusal → no MBB retry;
+        # surfaces cleanly as ServiceValidationError.
+        coord = _coord(flag=True, primary_error=SpinError("wrong S-PIN"))
+        with pytest.raises(ServiceValidationError):
+            asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._fb.command_lock.assert_not_awaited()
+
+
+class TestArmMbbFallbackConnector:
+    """arm_mbb_command_channel(fallback_only=True) must NOT change the primary
+    command route — the BFF stays command-primary; the connector is only exposed
+    via mbb_fallback_connector()."""
+
+    def _tokenset(self):
+        from custom_components.vag_connect.cariad.models import TokenSet
+        return TokenSet(access_token="mbb-bearer", refresh_token="r",
+                        id_token="", expires_at=0.0, strategy="mbb")
+
+    def test_fallback_only_uses_separate_slot(self):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        c = VWEUClient(MagicMock(), "u@e.com", "pw", "1234")
+        ok = asyncio.run(
+            c.arm_mbb_command_channel(self._tokenset(), "cid", ["VIN1"],
+                                      fallback_only=True)
+        )
+        assert ok is True
+        # BFF stays command-primary — the normal target must NOT pick it up.
+        assert c._mbb_command_target() is None
+        # …but the fallback connector IS exposed for the coordinator retry.
+        assert c.mbb_fallback_connector() is not None
+
+    def test_channel_mode_uses_command_slot(self):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        c = VWEUClient(MagicMock(), "u@e.com", "pw", "1234")
+        ok = asyncio.run(
+            c.arm_mbb_command_channel(self._tokenset(), "cid", ["VIN1"])
+        )
+        assert ok is True
+        # channel mode → commands route through MBB (portal-primary behaviour).
+        assert c._mbb_command_target() is not None
+        assert c.mbb_fallback_connector() is None

--- a/tests/test_audi_mbb_fallback_ui.py
+++ b/tests/test_audi_mbb_fallback_ui.py
@@ -84,3 +84,13 @@ def test_fallback_finish_stores_optional_spin_and_vins():
     new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
     assert new_data[CONF_MBB_VINS] == ["WVWZZZ0000000001", "WVWZZZ0000000002"]
     assert new_data[CONF_SPIN] == "1234"
+
+
+def test_fresh_flow_has_clean_fallback_state():
+    # b15 structural — the opt-in state is declared in __init__ (matching the
+    # other _dag_* flow state), so a fresh flow never leaks a stale fallback
+    # target into another login path, and no getattr guards are needed.
+    from custom_components.vag_connect.config_flow import VagConnectConfigFlow
+    flow = VagConnectConfigFlow()
+    assert flow._dag_mbb_fallback is False
+    assert flow._mbb_fallback_entry_id is None

--- a/tests/test_audi_mbb_fallback_ui.py
+++ b/tests/test_audi_mbb_fallback_ui.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Config-flow opt-in for the device-grant Audi MBB command fallback (b15).
+
+A device-grant Audi stores no password, so Reconfigure / Re-auth (both password
+gated) can't reach it. The ``audi_mbb_fallback`` menu step runs a one-time MBB
+browser confirm and ``browser_login_finish`` attaches the durable Car-Net bearer
+to the chosen Audi as ``CONF_MBB_COMMAND_FALLBACK`` (armed as a BFF-refusal
+fallback by the coordinator). MEB/ID cars mint no MBB bearer → the flow aborts
+with ``mbb_not_eligible``.
+
+This covers the finish-branch STORAGE logic (unit-testable). The interactive QR
+itself needs a live smoke test on a real Audi.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.vag_connect.const import (
+    CONF_MBB_COMMAND_CLIENT_ID,
+    CONF_MBB_COMMAND_FALLBACK,
+    CONF_MBB_COMMAND_TOKENS,
+)
+
+
+def _armed_flow(entry_data: dict):
+    from custom_components.vag_connect.config_flow import VagConnectConfigFlow
+    flow = VagConnectConfigFlow()
+    flow._dag_mbb_fallback = True
+    flow._dag_tokens = SimpleNamespace(
+        id_token="ID", access_token="A", refresh_token="R", expires_at=0.0)
+    flow._dag_mbb_tokens = SimpleNamespace(
+        access_token="MBB_A", refresh_token="MBB_R", expires_at=123.0)
+    flow._dag_mbb_client_id = "REGISTERED_CID"
+    flow._dag_user_input = {}
+    flow._mbb_fallback_entry_id = "eid"
+    entry = MagicMock()
+    entry.entry_id = "eid"
+    entry.data = dict(entry_data)
+    flow.hass = MagicMock()
+    flow.hass.config_entries.async_get_entry = MagicMock(return_value=entry)
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+    flow.async_abort = MagicMock(
+        side_effect=lambda reason: {"type": "abort", "reason": reason})
+    return flow, entry
+
+
+def test_fallback_finish_arms_and_merges():
+    flow, entry = _armed_flow(
+        {"brand": "audi", "dag_initial_tokens": {"strategy": "device_grant"}})
+    res = asyncio.run(flow.async_step_browser_login_finish())
+    assert res["reason"] == "mbb_fallback_armed"
+    flow.hass.config_entries.async_update_entry.assert_called_once()
+    new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+    assert new_data[CONF_MBB_COMMAND_FALLBACK] is True
+    assert new_data[CONF_MBB_COMMAND_CLIENT_ID] == "REGISTERED_CID"
+    assert new_data[CONF_MBB_COMMAND_TOKENS]["access_token"] == "MBB_A"
+    assert new_data[CONF_MBB_COMMAND_TOKENS]["refresh_token"] == "MBB_R"
+    assert new_data[CONF_MBB_COMMAND_TOKENS]["strategy"] == "mbb"
+    # existing entry data is preserved (merge, not replace)
+    assert new_data["brand"] == "audi"
+    assert new_data["dag_initial_tokens"]["strategy"] == "device_grant"
+    flow.hass.config_entries.async_reload.assert_awaited_once()
+
+
+def test_fallback_finish_meb_ineligible_aborts():
+    # MEB/ID Audi: the MBB exchange never mints a bearer → _dag_mbb_tokens None.
+    flow, entry = _armed_flow({"brand": "audi"})
+    flow._dag_mbb_tokens = None
+    res = asyncio.run(flow.async_step_browser_login_finish())
+    assert res["reason"] == "mbb_not_eligible"
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_fallback_finish_stores_optional_spin_and_vins():
+    flow, entry = _armed_flow({"brand": "audi"})
+    flow._dag_user_input = {"mbb_vins": "WVWZZZ0000000001, WVWZZZ0000000002",
+                            "spin": "1234"}
+    asyncio.run(flow.async_step_browser_login_finish())
+    from custom_components.vag_connect.const import CONF_MBB_VINS, CONF_SPIN
+    new_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+    assert new_data[CONF_MBB_VINS] == ["WVWZZZ0000000001", "WVWZZZ0000000002"]
+    assert new_data[CONF_SPIN] == "1234"

--- a/tests/test_channel_labels.py
+++ b/tests/test_channel_labels.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Friendly channel-name mapping for the data-source provenance UI.
+
+The raw ``source_channel`` / ``field_sources`` tokens stay jargon internally;
+these helpers turn them into the wording a user saw at setup, and de-duplicate
+so a combined car never shows the same source twice.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect._channel_labels import (
+    channel_display_name,
+    channels_overview,
+)
+from custom_components.vag_connect.const import BRANDS
+
+
+class TestDisplayName:
+    def test_channel_tokens_are_friendly(self) -> None:
+        assert channel_display_name("eu_data_act") == "EU Data Act portal"
+        assert channel_display_name("website_authproxy") == "vw.de website"
+        assert channel_display_name("mbb") == "Car-Net"
+
+    def test_brand_tokens_reuse_setup_labels(self) -> None:
+        # a brand slug shows exactly the name from the setup dialog
+        assert channel_display_name("audi") == BRANDS["audi"]
+        assert channel_display_name("skoda") == BRANDS["skoda"]
+
+    def test_unknown_token_is_returned_as_is(self) -> None:
+        # a channel added later must still show *something*, never vanish
+        assert channel_display_name("some_new_channel") == "some_new_channel"
+
+    def test_empty_is_safe(self) -> None:
+        assert channel_display_name("") == ""
+
+
+class TestOverview:
+    def test_multi_channel_join_is_friendly(self) -> None:
+        display, labels = channels_overview("eu_data_act+mbb")
+        assert display == "EU Data Act portal + Car-Net"
+        assert labels == ["EU Data Act portal", "Car-Net"]
+
+    def test_dedup_on_mapped_label(self) -> None:
+        # two tokens that map to the same friendly label collapse to one entry
+        display, labels = channels_overview("companion_adb+companion_adb")
+        assert labels == ["Companion app (ADB)"]
+        assert display == "Companion app (ADB)"
+
+    def test_single_channel(self) -> None:
+        assert channels_overview("audi") == (BRANDS["audi"], [BRANDS["audi"]])
+
+    def test_empty_and_none(self) -> None:
+        assert channels_overview(None) == (None, [])
+        assert channels_overview("") == (None, [])
+
+    def test_order_follows_sorted_raw_join(self) -> None:
+        # merge_channels emits a sorted token join; the display preserves it
+        display, _ = channels_overview("audi+eu_data_act+website_authproxy")
+        assert display == f"{BRANDS['audi']} + EU Data Act portal + vw.de website"

--- a/tests/test_garage_list_resilience.py
+++ b/tests/test_garage_list_resilience.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Garage-list resilience (b15).
+
+myAudi 5.7.0 moved the garage list from ``/vehicle/v1/vehicles`` to ``/vehicles``
+(a new garageinformation module). CARIAD may eventually retire the old path. If
+the primary BFF list ever 404s, ``get_vehicles()`` must NOT die — for Audi the
+vgql userVehicles list on a different host enumerates the whole garage, so we
+fall back to it. Previously the 404 raised APIError before the vgql merge could
+run, so the integration lost every Audi vehicle the moment the old path went away.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+from custom_components.vag_connect.cariad.exceptions import APIError
+from custom_components.vag_connect.cariad.models import TokenSet
+
+
+def _client(strategy: str = "device_grant") -> VWEUClient:
+    c = VWEUClient(MagicMock(), "u@e.com", "pw", "1234")
+    c._tokens = TokenSet(access_token="t", refresh_token="r", id_token="",
+                         expires_at=0.0, strategy=strategy)
+    c._eu_portal = None            # not a portal entry → reach the BFF garage path
+    c._garage_base = MagicMock(return_value="https://bff")  # type: ignore[method-assign]
+    return c
+
+
+@pytest.mark.asyncio
+async def test_bff_list_404_falls_back_to_vgql():
+    c = _client()
+    c._get = AsyncMock(side_effect=APIError(404, "https://bff/vehicle/v1/vehicles", "nf"))
+    async def _fetch_images():
+        c._image_data = {"WVWZZZ00000000001": {}}
+    c.fetch_images = _fetch_images  # type: ignore[method-assign]
+    vins = await c.get_vehicles()
+    assert vins == ["WVWZZZ00000000001"]   # rescued via the vgql garage
+
+@pytest.mark.asyncio
+async def test_bff_list_401_also_recovers():
+    c = _client()
+    c._get = AsyncMock(side_effect=APIError(401, "https://bff/vehicle/v1/vehicles", "x"))
+    async def _fetch_images():
+        c._image_data = {"VIN_A": {}, "VIN_B": {}}
+    c.fetch_images = _fetch_images  # type: ignore[method-assign]
+    vins = await c.get_vehicles()
+    assert set(vins) == {"VIN_A", "VIN_B"}
+
+@pytest.mark.asyncio
+async def test_bff_list_fail_no_vgql_returns_empty_not_raise():
+    # e.g. VW-EU token entry (no vgql) — must fail SOFT, never raise.
+    c = _client()
+    c._get = AsyncMock(side_effect=APIError(404, "https://bff/vehicle/v1/vehicles", "nf"))
+    async def _fetch_images():
+        c._image_data = {}
+    c.fetch_images = _fetch_images  # type: ignore[method-assign]
+    vins = await c.get_vehicles()
+    assert vins == []
+
+@pytest.mark.asyncio
+async def test_bff_list_success_unchanged():
+    # happy path is untouched: the BFF list still drives the result.
+    c = _client()
+    c._get = AsyncMock(return_value={"data": [{"vin": "VIN1"}]})
+    c._resolve_home_regions = AsyncMock()  # type: ignore[method-assign]
+    async def _fetch_images():
+        c._image_data = {}
+    c.fetch_images = _fetch_images  # type: ignore[method-assign]
+    vins = await c.get_vehicles()
+    assert vins == ["VIN1"]

--- a/tests/test_m1_contested_surfaced.py
+++ b/tests/test_m1_contested_surfaced.py
@@ -29,12 +29,24 @@ def _sensor(vehicle: dict) -> VagConnectSensor:
 
 
 def test_contested_fields_surfaced() -> None:
+    # contested tie is surfaced alongside the friendly channel overview
     s = _sensor({"contested_fields": {"battery_soc": ["50", "71"]}})
     assert s.extra_state_attributes == {
-        "contested_fields": {"battery_soc": ["50", "71"]}
+        "channels": ["EU Data Act portal"],
+        "raw": "eu_data_act",
+        "contested_fields": {"battery_soc": ["50", "71"]},
     }
 
 
-def test_no_attribute_when_nothing_contested() -> None:
-    assert _sensor({"contested_fields": {}}).extra_state_attributes is None
-    assert _sensor({}).extra_state_attributes is None
+def test_channel_overview_without_contested() -> None:
+    # a clean poll still names its source(s); no contested_fields key
+    attrs = _sensor({"contested_fields": {}}).extra_state_attributes
+    assert attrs == {"channels": ["EU Data Act portal"], "raw": "eu_data_act"}
+    assert "contested_fields" not in attrs
+
+
+def test_no_attributes_when_no_source_and_no_contested() -> None:
+    coord = _coord({})
+    coord.data["X"]["source_channel"] = None
+    desc = VagSensorDescription(key="data_source_channel", data_key="source_channel")
+    assert VagConnectSensor(coord, "X", desc).extra_state_attributes is None

--- a/tests/test_mbb_backup_failover.py
+++ b/tests/test_mbb_backup_failover.py
@@ -38,7 +38,10 @@ def test_backup_client_is_the_verified_failover_id() -> None:
     assert MBB_DAG_CLIENT_ID_BACKUP != MBB_DAG_CLIENT_ID
 
 
-def test_backup_config_is_volkswagen_only() -> None:
-    for brand in ("audi", "skoda", "seat", "cupra", "porsche", "bentley"):
+def test_backup_config_mbb_brands_only() -> None:
+    # b15 — audi joined the MBB brands (live-validated 2026-08-30) and the backup
+    # shares MBB_DAG_BRANDS, so it fails over for audi too (same mbb scope).
+    for brand in ("skoda", "seat", "cupra", "porsche", "bentley"):
         assert mbb_dag_backup_config(brand) is None
     assert mbb_dag_backup_config("Volkswagen") is not None  # case-insensitive
+    assert mbb_dag_backup_config("audi") is not None         # b15

--- a/tests/test_v1240_image_cross_brand.py
+++ b/tests/test_v1240_image_cross_brand.py
@@ -199,6 +199,48 @@ class TestEntityCreationByBrand:
         assert len(catalog) == 7
         assert len(synth) == 0
 
+
+class TestDefaultEnabled:
+    """Only the ⭐-recommended catalog render is on by default; the other six
+    sizes/angles are created but disabled so the device page stays clean. The
+    seven entities are still all CREATED (see test above) — this is purely the
+    registry enabled-state."""
+
+    def _entity(self, suffix: str):
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.image import VagRenderImageEntity
+        from custom_components.vag_connect.cariad.api.graphql import (
+            RENDER_IMAGE_TYPES,
+        )
+        meta = next(
+            m for m in RENDER_IMAGE_TYPES if m["entity_suffix"] == suffix)
+        return VagRenderImageEntity(
+            MagicMock(), MagicMock(), "V", meta, "https://x/a.png")
+
+    def test_recommended_render_enabled_by_default(self):
+        assert self._entity("render_side_lg").entity_registry_enabled_default
+
+    def test_other_catalog_renders_disabled_by_default(self):
+        for suffix in (
+            "render_angle_lg", "render_medium", "render_side_sm",
+            "render_small", "render_icon", "render_angle_hd",
+        ):
+            assert (
+                self._entity(suffix).entity_registry_enabled_default is False
+            ), suffix
+
+    def test_dynamic_viewpoint_stays_enabled(self):
+        # a CUPRA/SEAT/Skoda viewpoint is the only render that brand has, so it
+        # must not be hidden behind the disabled-by-default rule.
+        from unittest.mock import MagicMock
+        from custom_components.vag_connect.image import (
+            VagRenderImageEntity, _synthesize_meta,
+        )
+        e = VagRenderImageEntity(
+            MagicMock(), MagicMock(), "V", _synthesize_meta("side"),
+            "https://x/side.png")
+        assert e.entity_registry_enabled_default is True
+
     def test_cupra_seat_ola_viewpoints_now_spawn(self):
         """Pre-v1.24.0 BUG: 0 entities. Post-fix: 4 synth entities."""
         urls = {

--- a/tests/test_v2150_mbb_wirein.py
+++ b/tests/test_v2150_mbb_wirein.py
@@ -328,12 +328,20 @@ class TestMbbDagConfig:
         assert "mbb" in scope.split()
         assert scope == MBB_DAG_SCOPE
 
-    def test_non_vw_brands_return_none(self) -> None:
-        for brand in ("audi", "skoda", "seat", "cupra", "porsche", ""):
+    def test_non_mbb_brands_return_none(self) -> None:
+        # b15 — audi joined the MBB brands (live-validated 2026-08-30); the rest stay None.
+        for brand in ("skoda", "seat", "cupra", "porsche", ""):
             assert mbb_dag_config(brand) is None
+
+    def test_audi_now_mbb_eligible(self) -> None:
+        # b15 — Car-Net Audis mint the durable MBB bearer (id_token aud
+        # VWGMBB01DELIV1, register/v1 200, exchange 200 + durable refresh),
+        # validated live on a real Audi account.
+        assert mbb_dag_config("audi") is not None
 
     def test_case_insensitive(self) -> None:
         assert mbb_dag_config("Volkswagen") is not None
+        assert mbb_dag_config("Audi") is not None  # b15
 
 
 class TestBrandSegmentUnchanged:

--- a/tests/test_v2150b12_setup_menu_mbb_toggle.py
+++ b/tests/test_v2150b12_setup_menu_mbb_toggle.py
@@ -43,12 +43,15 @@ def _flow() -> VagConnectConfigFlow:
 
 def test_menu_has_the_expected_sources() -> None:
     # b12 collapsed the old standalone mbb_login / website_authproxy entries into
-    # the Portal toggle. v3.0.0a1 added the experimental companion (ADB) source
-    # as a third entry. The two removed ones must stay gone.
+    # the Portal toggle. v3.0.0a1 added the experimental companion (ADB) source.
+    # b15 added the "audi_mbb_fallback" entry (arm the MBB fallback on an existing
+    # device-grant Audi). The two removed ones must stay gone.
     result = asyncio.run(_flow().async_step_user(None))
     assert result["type"] == "menu"
     opts = set(result["menu_options"])
-    assert opts == {"browser_login", "email_password", "companion_adb"}
+    assert opts == {
+        "browser_login", "email_password", "companion_adb", "audi_mbb_fallback",
+    }
     assert "mbb_login" not in opts
     assert "website_authproxy" not in opts
 

--- a/tests/test_v2150c1_channel_merge.py
+++ b/tests/test_v2150c1_channel_merge.py
@@ -48,8 +48,13 @@ class TestSourceChannelSensor:
         )
         return VagConnectSensor(coord, "X", desc)
 
-    def test_value_passthrough(self) -> None:
-        assert self._sensor("eu_data_act+mbb").native_value == "eu_data_act+mbb"
+    def test_value_shows_friendly_deduped_names(self) -> None:
+        # raw token join -> friendly, de-duplicated display; raw kept on attr.
+        s = self._sensor("eu_data_act+mbb")
+        assert s.native_value == "EU Data Act portal + Car-Net"
+        attrs = s.extra_state_attributes or {}
+        assert attrs["channels"] == ["EU Data Act portal", "Car-Net"]
+        assert attrs["raw"] == "eu_data_act+mbb"
 
     def test_none_value(self) -> None:
         assert self._sensor(None).native_value is None

--- a/tests/test_v2180_entity_attrs_mro.py
+++ b/tests/test_v2180_entity_attrs_mro.py
@@ -120,7 +120,7 @@ def test_shared_and_platform_attributes_both_survive() -> None:
     }
     attrs = _Probe(veh).extra_state_attributes
     assert attrs is not None
-    assert attrs["source"] == "eu_data_act"  # would be missing pre-fix
+    assert attrs["source"] == "EU Data Act portal"  # friendly; would be missing pre-fix
     assert attrs["mine"] == 1  # the platform's own must not be lost
     assert "image_url" in attrs
 

--- a/tests/test_v2180_entity_source_attribute.py
+++ b/tests/test_v2180_entity_source_attribute.py
@@ -58,7 +58,7 @@ def test_source_lands_in_extra_state_attributes() -> None:
     coord = _coord({"battery_soc": "eu_data_act"})
     attrs = _entity(coord, "battery_soc").extra_state_attributes
     assert attrs is not None
-    assert attrs["source"] == "eu_data_act"
+    assert attrs["source"] == "EU Data Act portal"  # friendly (raw token via _field_source)
 
 
 def test_unknown_field_has_no_source() -> None:
@@ -87,4 +87,4 @@ def test_image_url_attribute_still_works() -> None:
     )
     attrs = _entity(coord, "battery_soc").extra_state_attributes or {}
     assert "image_url" in attrs
-    assert attrs["source"] == "eu_data_act"
+    assert attrs["source"] == "EU Data Act portal"  # friendly (raw token via _field_source)


### PR DESCRIPTION
## Audi MBB command fallback — opt-in UI

Adds the config-flow UI to arm the durable Car-Net (MBB) command fallback on an **existing device-grant Audi** — the last piece of the Audi command-failover work (engine + live validation shipped in #1299 / 4.4.0b5).

**Why a new step (not Reconfigure / Re-auth):** a device-grant Audi stores no password, and both Reconfigure and Re-auth are password-gated — so neither can reach it. This adds a menu step `audi_mbb_fallback` that runs a one-time MBB browser confirm and attaches the durable bearer to a chosen Audi as `CONF_MBB_COMMAND_FALLBACK`.

**Behaviour:** the CARIAD BFF stays the command primary; MBB only steps in when the BFF refuses a command with 401/403 (the shape a revoked device grant takes) — see the coordinator retry from #1299. MEB / ID Audis mint no MBB bearer → the flow aborts with `mbb_not_eligible`.

**Grounded:** the MBB token mint for Audi was live-validated on a real Audi account (durable bearer, `register/v1` 200, exchange 200) before this was built.

### Contents
- `audi_mbb_fallback` menu step (enumerates eligible device-grant Audi entries; picker if >1; optional S-PIN / VIN)
- `browser_login_finish` fallback branch (merges the MBB tokens into the target entry)
- Strings + all 12 translations (de translated, others English fallback)
- Unit tests for the finish-branch storage

### Notes
- **Stacked on #1299 (4.4.0b5)** — depends on the fallback engine + `CONF_MBB_COMMAND_FALLBACK` + `audi` in `MBB_DAG_BRANDS` from that PR. Merge #1299 first; this diff reduces to just the UI once b5 lands.
- The interactive QR flow can't be exercised headless — **needs a live smoke test on a real Car-Net Audi before merge** (suits a b6 beta).
- Full suite: 5525 passed.
