### PR TITLE
fix: live channel beats stale portal door/window/lock state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.4.0b5] - 2026-08-30 — Audi durable two-way (MBB) · garage-list resilience · acpp token recovery · trunk-open · Škoda official-API groundwork
+
+### Added / Neu
+- **Audi: durable two-way commands (MBB) are now available.** Car-Net Audis (most
+  PHEV / combustion, pre-ID/MEB) can enable the durable MBB command channel — the
+  toggle already existed but was blocked; a live validation confirmed an Audi
+  account mints the durable MBB bearer, so lock/unlock, climate and charge can
+  route through the resilient legacy Car-Net path (survives restarts and the
+  Play-Integrity wall). Off by default; newer ID / MEB Audis aren't eligible and
+  simply won't offer it.
+
+### Fixed / Behoben
+- **The garage list survives a backend path change.** myAudi 5.7.0 moved the
+  vehicle-list endpoint; if VW ever retires the old path, the integration now falls
+  back to the alternate (vgql) garage enumeration instead of losing every Audi.
+  Purely defensive — no change today, just resilience for a future backend switch.
+
 ### Added / Neu
 - **Groundwork for an opt-in official Škoda API channel** (#1286). Škoda has
   launched a first-party, attestation-free vehicle API; this lands the client,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   uploads a snapshot after a drive, acpp now polls hourly by default (was every
   10 min) — identical data, far less token churn.
 
+### Fixed / Behoben
+- **Portal-primary cars no longer show a stale door / window / lock state.** If
+  the EU Data Act portal is your main channel and a live channel (the CARIAD BFF
+  or vw.de) is also connected, the current door / window / lock / trunk reading
+  from the live channel now wins over the portal's up-to-15-minute-old snapshot —
+  the same rule we already apply to charging and SoC. A door-open warning
+  automation was the kind of thing that could act on the stale value. Odometer,
+  GPS position and service intervals are deliberately left untouched (they have
+  their own monotonic / carry-forward handling).
+
 ## [4.4.0b4] - 2026-08-28 — New diagnostic sensors (drivetrain · CSID · parked-since) · Audi/VW-EU doors+trunk fix · export button on merged portals
 
 ### Added / Neu

--- a/custom_components/vag_connect/cariad/_channel_merge.py
+++ b/custom_components/vag_connect/cariad/_channel_merge.py
@@ -75,6 +75,34 @@ _LIVE_TELEMETRY = frozenset({
     "climatisation_state", "climatisation_active",
 })
 
+# Volatile physical closure/lock state. Same reasoning as _LIVE_TELEMETRY: when
+# the batch feed is primary it can carry a ≥15-minute-stale (and, like the charge
+# blocks, sometimes frozen-and-re-stamped) door/window/lock snapshot, while a live
+# channel's on-demand read reflects the car's current closure state. A stale
+# "locked"/"closed" reading here is worse than for telemetry — it's the kind of
+# thing an automation ("warn me if a door is open") acts on — so a live channel's
+# reading must win exactly as it does for SoC/charging.
+#
+# Deliberately EXCLUDES the fields where "highest-priority live channel wins" is
+# NOT a safe proxy for "freshest":
+#   - odometer_km: monotonic and monotonic-protected elsewhere; a lower-priority
+#     live channel could hold a staler (lower) value → regression (see the
+#     odometer test). Gap-fill / primary must stand.
+#   - position (lat/lon/position_captured_at): governed by its own carry-forward
+#     TTL in vehicle_cache.reconcile, which already reasons about capture age.
+#   - fuel_level: has a dedicated endpoint-specific merge (BFF ← MBB VSR).
+#   - service_*/master data: effectively static; a 15-min batch age is irrelevant.
+_LIVE_CLOSURE = frozenset({
+    "doors_locked", "doors_open", "windows_open",
+    "doors_individual", "windows_individual", "windows_position",
+    "trunk_open", "trunk_locked", "hood_open", "bonnet_locked",
+})
+
+# Fields a live channel supersedes when the batch feed owns them (see the loop
+# below). Telemetry + volatile closure state; never the monotonic/static/TTL-
+# managed fields excluded above.
+_LIVE_SUPERSEDE = _LIVE_TELEMETRY | _LIVE_CLOSURE
+
 
 def merge_channels(
     sources: list[tuple[str, "VehicleData"]],
@@ -134,14 +162,15 @@ def merge_channels(
                     # This channel filled the gap, so it owns the reading.
                     field_sources[f.name] = name
 
-    # Live-telemetry supersede: a stale EU-DA batch value must never outrank a
-    # live channel's reading. For every live-telemetry field the batch feed
-    # currently owns, hand it to the highest-priority live channel that actually
-    # has a reading. No-op when no live channel is present (EU-DA-only cars keep
-    # their value) or when a live channel already owns the field. Order-preserving
-    # (walks ``sources`` in priority order) and provenance-correct.
+    # Live supersede: a stale EU-DA batch value must never outrank a live
+    # channel's reading. For every superseding field (live telemetry + volatile
+    # closure state) the batch feed currently owns, hand it to the highest-
+    # priority live channel that actually has a reading. No-op when no live
+    # channel is present (EU-DA-only cars keep their value) or when a live channel
+    # already owns the field. Order-preserving (walks ``sources`` in priority
+    # order) and provenance-correct.
     if any(nm not in _BATCH_SOURCES for nm, _ in sources):
-        for f_name in _LIVE_TELEMETRY:
+        for f_name in _LIVE_SUPERSEDE:
             if field_sources.get(f_name) not in _BATCH_SOURCES:
                 continue  # a live channel already owns it, or nobody set it
             for nm, vd in sources:

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -386,7 +386,30 @@ class VWEUClient(CariadBaseClient):
         if self._tokens and self._tokens.strategy == "mbb":
             return await self._get_vehicles_via_mbb()
 
-        data = await self._get(f"{self._garage_base()}/vehicle/v1/vehicles")
+        # b15 — garage-list resilience. myAudi 5.7.0 refactored the garage list
+        # from ``/vehicle/v1/vehicles`` to ``/vehicles`` (a new garageinformation
+        # module); CARIAD may eventually deprecate the old path. If the primary
+        # BFF list fails (e.g. a future 404 on the retired path), don't die: for
+        # Audi the vgql userVehicles list lives on a DIFFERENT host
+        # (app-api.*.my.audi.com) and enumerates the whole account garage, so fall
+        # back to it instead of returning no cars. Previously a 404 here raised
+        # APIError BEFORE the vgql merge below could run, so get_vehicles() died
+        # hard for Audi the moment the legacy path went away.
+        try:
+            data = await self._get(f"{self._garage_base()}/vehicle/v1/vehicles")
+        except APIError as err:
+            _LOGGER.warning(
+                "VAG: BFF garage list failed (HTTP %s) — falling back to the vgql "
+                "userVehicles enumeration.", getattr(err, "status", "?"),
+            )
+            await self.fetch_images()  # best-effort; populates self._image_data
+            fb_vins = [v for v in (getattr(self, "_image_data", {}) or {}) if v]
+            if fb_vins:
+                _LOGGER.info(
+                    "VAG: recovered %d vehicle(s) from the vgql garage after the "
+                    "BFF list failed.", len(fb_vins),
+                )
+            return fb_vins
         vehicles: list[dict[str, Any]] = data.get("data", [])
 
         # Cache nickname/model per VIN — used in _parse_status to set device name
@@ -842,11 +865,25 @@ class VWEUClient(CariadBaseClient):
 
     async def arm_mbb_command_channel(
         self, tokens: Any, client_id: str, vins: list[str], spin: str = "",
+        fallback_only: bool = False,
     ) -> bool:
-        """b12 — arm a durable-MBB command connector ALONGSIDE this (read-only
-        primary) client: commands route through MBB while reads stay on the
-        primary. Builds a second VWEUClient on the shared session (MBB = bearer,
-        no IDP-cookie clobber). Fail-soft → False leaves the slot None and the
+        """b12 — arm a durable-MBB command connector ALONGSIDE this client.
+
+        Two modes:
+        - ``fallback_only=False`` (b12, read-only primary, e.g. EU Data Act
+          portal): MBB *is* the command channel — commands route through it
+          while reads stay on the primary. Stored as ``self._mbb_command`` so
+          ``_mbb_command_target()`` returns it.
+        - ``fallback_only=True`` (b15, TWO-WAY device-grant primary, e.g. Audi
+          Car-Net on the CARIAD BFF): the BFF stays the command primary; this
+          connector is stored as ``self._mbb_fallback`` and used ONLY by the
+          coordinator's BFF-refusal retry path. ``_mbb_command_target()`` is
+          deliberately left untouched so normal commands keep hitting the BFF —
+          no regression for a working two-way Audi; MBB only steps in when the
+          BFF refuses (401/403).
+
+        Builds a second VWEUClient on the shared session (MBB = bearer, no
+        IDP-cookie clobber). Fail-soft → False leaves the slot None and the
         primary unaffected. Skipped if THIS client is already MBB-primary."""
         if not tokens or not getattr(tokens, "access_token", ""):
             return False
@@ -864,19 +901,37 @@ class VWEUClient(CariadBaseClient):
             cmd.set_persisted_tokens(tokens)
             cmd._mbb_client_id = client_id or ""
             cmd._mbb_manual_vins = list(vins or [])
-            self._mbb_command = cmd
-            _LOGGER.info(
-                "VW Group Connect: MBB command channel armed alongside the"
-                " read-only primary (commands → MBB, reads → primary)."
-            )
+            if fallback_only:
+                self._mbb_fallback: "VWEUClient | None" = cmd
+                _LOGGER.info(
+                    "VW Group Connect: MBB command FALLBACK armed alongside the"
+                    " two-way primary (BFF commands first, MBB only on refusal)."
+                )
+            else:
+                self._mbb_command = cmd
+                _LOGGER.info(
+                    "VW Group Connect: MBB command channel armed alongside the"
+                    " read-only primary (commands → MBB, reads → primary)."
+                )
             return True
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning(
-                "VW Group Connect: could not arm MBB command channel (%s) —"
-                " primary unaffected.", type(err).__name__,
+                "VW Group Connect: could not arm MBB command %s (%s) —"
+                " primary unaffected.",
+                "fallback" if fallback_only else "channel", type(err).__name__,
             )
-            self._mbb_command = None
+            if fallback_only:
+                self._mbb_fallback = None
+            else:
+                self._mbb_command = None
             return False
+
+    def mbb_fallback_connector(self) -> "VWEUClient | None":
+        """b15 — the armed MBB *fallback* connector (two-way device-grant
+        primary), or None. Consumed by the coordinator's BFF-refusal command
+        retry. Distinct from ``_mbb_command_target()``, which stays None on a
+        device-grant primary so normal commands keep hitting the BFF."""
+        return getattr(self, "_mbb_fallback", None)
 
     async def command_lock(self, vin: str, spin: str = "") -> None:
         """Lock vehicle — separate endpoint (primary) with combined endpoint as

--- a/custom_components/vag_connect/cariad/auth/_device_grant.py
+++ b/custom_components/vag_connect/cariad/auth/_device_grant.py
@@ -563,7 +563,15 @@ MBB_DAG_CLIENT_ID = "9496332b-ea03-4091-a224-8c746b885068@apps_vw-dilab_com"
 # The ``mbb`` token is the key — without it the id_token aud is the OIDC client
 # and the exchange 400s ("Audiences don't match issuer (VWGMBB01DELIV1)").
 MBB_DAG_SCOPE = "openid profile mbb cars"
-MBB_DAG_BRANDS = frozenset({"volkswagen"})
+# b15 (2026-08-30) — "audi" added after a LIVE validation on a real Audi account:
+# the MBB device-grant (9496332b + mbb scope) minted an id_token with aud
+# ``VWGMBB01DELIV1``, ``register/v1`` returned HTTP 200, and the exchange with the
+# REGISTERED client id returned HTTP 200 + a durable refresh_token. So Car-Net
+# Audis mint the durable MBB bearer too — the exchange was never technically
+# VW-only; the ``mbb`` scope is what carries the backend audience. Unlocks MBB
+# two-way commands for portal-primary Audi (the flow already offers the toggle
+# for audi) AND the device-grant Audi command fallback (CONF_MBB_COMMAND_FALLBACK).
+MBB_DAG_BRANDS = frozenset({"volkswagen", "audi"})
 
 
 def mbb_dag_config(brand_name: str) -> tuple[str, str] | None:

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -1352,7 +1352,8 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 mbb_cfg = mbb_dag_config(self._dag_brand)
                 if mbb_cfg is None:
                     raise ValueError(
-                        f"MBB durable login is VW-only (got {self._dag_brand})"
+                        "MBB durable login needs a Car-Net brand (Volkswagen or "
+                        f"Audi); got {self._dag_brand}"
                     )
                 mbb_client_id, mbb_scope = mbb_cfg
                 self._dag_client = DeviceAuthorizationGrant(

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -91,6 +91,15 @@ CONF_MBB_COMMAND_CHANNEL      = "mbb_command_channel"      # bool: armed?
 CONF_MBB_COMMAND_TOKENS       = "mbb_command_tokens"       # dag-shaped dict (strategy=mbb)
 CONF_MBB_COMMAND_CLIENT_ID    = "mbb_command_client_id"    # registered X-Client-Id
 CONF_MEB_COMMANDS_UNAVAILABLE = "meb_commands_unavailable"  # bool: MEB/ID car, commands requested but impossible
+# b15 — MBB COMMAND FALLBACK for a TWO-WAY device-grant primary (e.g. Audi
+# Car-Net on the CARIAD BFF). Unlike CONF_MBB_COMMAND_CHANNEL (portal primary →
+# MBB *is* the command channel), here the BFF stays the command primary and the
+# MBB connector is armed ONLY as a fallback: a command runs on the BFF first and
+# re-routes to MBB *only* when the BFF refuses it (401/403 auth refusal), and
+# only for MBB-eligible (pre-MEB Car-Net) cars. Škoda pulled its device-grant in
+# 2026-08 — this keeps a two-way Audi commandable if VW ever does the same. Reuses
+# the CONF_MBB_COMMAND_TOKENS / _CLIENT_ID / _VINS storage (same durable bearer).
+CONF_MBB_COMMAND_FALLBACK     = "mbb_command_fallback"     # bool: MBB armed as BFF-refusal fallback?
 # 2026-08 — VW EU Two-Way (modern CARIAD BFF) via device-grant client 650d46ca.
 # Its 1h Bearer is BFF-whitelisted for reads+commands (the surface vw_eu.py
 # drives), unlike the DAG-dead app client / read-only portal client. Because the

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_FUEL_TANK_CAPACITY,
     CONF_KEEP_RAW_DATASETS,
     CONF_MBB_COMMAND_CHANNEL,
+    CONF_MBB_COMMAND_FALLBACK,
     CONF_MEB_COMMANDS_UNAVAILABLE,
     CONF_PASSWORD,
     CONF_READ_ONLY,
@@ -2670,6 +2671,55 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning(
                     "VW Group Connect: MBB command channel arming failed (%s)"
                     " — reads unaffected.", type(err).__name__,
+                )
+
+        # ── b15: MBB COMMAND FALLBACK (two-way device-grant primary, e.g. Audi) ─
+        # Same durable-MBB bearer + storage as the channel above, but armed as a
+        # FALLBACK (fallback_only=True → _mbb_fallback slot): the BFF stays the
+        # command primary and MBB is used ONLY by the _cariad_cmd BFF-refusal
+        # retry. Keeps a two-way Audi commandable if VW ever revokes its
+        # device-grant (Škoda precedent 2026-08). No operationList warm-up here on
+        # purpose — the fallback must NOT change command-entity visibility (that
+        # stays on the BFF capability gate); the retry gates itself.
+        if data.get(CONF_MBB_COMMAND_FALLBACK) and arm_cmd is not None:
+            from .cariad.models import TokenSet  # noqa: PLC0415
+            from .const import (  # noqa: PLC0415
+                CONF_MBB_COMMAND_CLIENT_ID,
+                CONF_MBB_COMMAND_TOKENS,
+                CONF_MBB_VINS,
+            )
+            tok = data.get(CONF_MBB_COMMAND_TOKENS) or {}
+            fb_tokens = TokenSet(
+                access_token=str(tok.get("access_token", "")),
+                refresh_token=str(tok.get("refresh_token", "")),
+                id_token=str(tok.get("id_token", "")),
+                expires_at=float(tok.get("expires_at", 0.0) or 0.0),
+                strategy="mbb",
+            )
+            vins = data.get(CONF_MBB_VINS) or []
+            if isinstance(vins, str):
+                vins = [
+                    v.strip().upper()
+                    for v in vins.replace(",", " ").split() if v.strip()
+                ]
+            try:
+                armed = bool(await arm_cmd(
+                    fb_tokens,
+                    data.get(CONF_MBB_COMMAND_CLIENT_ID, ""),
+                    list(vins),
+                    self._spin_from_entry(),
+                    fallback_only=True,
+                ))
+                if armed:
+                    # persist the rotated MBB bearer (durable refresh survives
+                    # restarts) — shares the command-token slot with the channel.
+                    fb = getattr(client, "_mbb_fallback", None)
+                    if fb is not None:
+                        fb.on_tokens_changed = self._persist_mbb_command_tokens
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "VW Group Connect: MBB command fallback arming failed (%s)"
+                    " — BFF commands unaffected.", type(err).__name__,
                 )
 
     async def _persist_mbb_command_tokens(self, tokens: Any) -> None:
@@ -7035,6 +7085,33 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 pass
             _LOGGER.error("VW Group Connect: %s(%s) failed: %s", method, mask_vin(vin), err)
+            # b15 — a two-way primary (Audi BFF) that refuses a command with an
+            # auth 401/403 (the shape a revoked device-grant takes) → try the
+            # durable MBB fallback ONCE before surfacing, iff the user opted in
+            # and the car is MBB-eligible (both settled at arm time). MBB success
+            # ends here; MBB failure falls through and surfaces the ORIGINAL BFF
+            # error, never the fallback's.
+            fb = self._mbb_command_fallback(method, err)
+            if fb is not None:
+                try:
+                    await getattr(fb, method)(vin, **kwargs)
+                    await self.async_request_refresh()
+                    try:
+                        self.record_command_success(vin, method)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    _LOGGER.info(
+                        "VW Group Connect: %s(%s) recovered via the MBB fallback"
+                        " after the BFF refused it (HTTP %s).",
+                        method, mask_vin(vin), getattr(err, "status", "?"),
+                    )
+                    return
+                except Exception as fb_err:  # noqa: BLE001
+                    _LOGGER.info(
+                        "VW Group Connect: MBB fallback for %s(%s) also failed"
+                        " (%s) — surfacing the original BFF error.",
+                        method, mask_vin(vin), type(fb_err).__name__,
+                    )
             # v2.18.0 (#659) — surface the failure instead of letting the raw
             # APIError escape. HA doesn't know our exception types, so it logged
             # "Unexpected exception" and showed the user a Python traceback for
@@ -7103,6 +7180,38 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 pass  # enrichment must never change the command outcome
             raise HomeAssistantError(msg) from err
+
+    def _mbb_command_fallback(self, method: str, err: Exception) -> Any | None:
+        """b15 — the armed MBB fallback connector to retry a command on, or None.
+
+        Non-None ONLY when: the two-way primary client has an MBB fallback armed
+        (a device-grant Audi that opted in — already MBB-eligible, settled at arm
+        time), the failure is a BFF AUTH REFUSAL (``APIError`` 401/403, the shape
+        a revoked device-grant takes), and the command method exists on the MBB
+        connector. Deliberately NARROW: our own ``HomeAssistantError`` guards, an
+        ``SpinError`` / ``VehicleCommandError`` (both non-APIError), a capability
+        / entitlement gate, and a transient 5xx / timeout / 404 all return None —
+        MBB can't fix those, and a needless second call just doubles the failure."""
+        # Gate on the explicit config flag via a REAL dict lookup first — never
+        # ``getattr(client, "_mbb_fallback")`` alone, which a MagicMock test
+        # client would auto-vivify to a truthy value (mirrors the MagicMock-safe
+        # gating in ``_mbb_command_channel_client``). Also the cheapest guard.
+        try:
+            if not self.entry.data.get(CONF_MBB_COMMAND_FALLBACK):
+                return None
+        except Exception:  # noqa: BLE001
+            return None
+        from .cariad.exceptions import APIError  # noqa: PLC0415
+        if isinstance(err, HomeAssistantError) or not isinstance(err, APIError):
+            return None
+        if getattr(err, "status", None) not in (401, 403):
+            return None
+        client = getattr(self, "_cariad_client", None)
+        getter = getattr(client, "mbb_fallback_connector", None)
+        fb = getter() if callable(getter) else None
+        if fb is None:
+            return None
+        return fb if callable(getattr(fb, method, None)) else None
 
     async def async_set_charge_mode(self, vin: str, mode: str) -> None:
         """Set charging mode (MANUAL / TIMER / PREFERRED_CHARGING_TIMES)."""

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.4.0b4"
+  "version": "4.4.0b5"
 }

--- a/tests/test_audi_mbb_fallback.py
+++ b/tests/test_audi_mbb_fallback.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Audi two-way BFF → MBB command failover (b15).
+
+A device-grant Audi normally sends commands over the CARIAD BFF. If VW ever
+revokes the device-grant (as it did for Škoda in 2026-08), the BFF starts
+refusing commands with 401/403. When the user opted in to the durable MBB
+command fallback (``CONF_MBB_COMMAND_FALLBACK``) and the car is MBB-eligible, a
+refused command is retried ONCE over MBB before the error reaches the user.
+
+Deliberately narrow: only a BFF *auth refusal* (``APIError`` 401/403) triggers a
+retry — never a transient 5xx/404, an S-PIN guard, or one of our own
+``HomeAssistantError`` guards. On MBB failure the ORIGINAL BFF error surfaces,
+never the fallback's.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from custom_components.vag_connect.cariad.exceptions import APIError, SpinError
+from custom_components.vag_connect.const import CONF_MBB_COMMAND_FALLBACK
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+
+def _coord(*, flag: bool, primary_error: Exception | None,
+           fb_error: Exception | None = None):
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    coord.hass = MagicMock()
+    coord.entry = MagicMock()
+    coord.entry.data = {"spin": "1234"}
+    if flag:
+        coord.entry.data[CONF_MBB_COMMAND_FALLBACK] = True
+    coord._vehicles_lock = threading.Lock()
+    coord._started = True
+    coord._was_available = True
+    coord.vehicles = {"VIN1": {}}
+    coord.async_request_refresh = AsyncMock()
+
+    client = MagicMock()                                   # primary BFF client
+    client.command_lock = AsyncMock(side_effect=primary_error)
+    fb = MagicMock()                                       # armed MBB fallback
+    fb.command_lock = AsyncMock(side_effect=fb_error)
+    client.mbb_fallback_connector = MagicMock(return_value=fb)
+    coord._cariad_client = client
+    coord._fb = fb                                         # test handle
+    return coord
+
+
+class TestAudiMbbFallback:
+    def test_bff_403_recovers_via_mbb(self):
+        # BFF 403 (revoked device-grant shape) + fallback succeeds → no raise.
+        coord = _coord(flag=True, primary_error=APIError(403, "https://bff/lock", ""))
+        asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._cariad_client.command_lock.assert_awaited_once_with("VIN1")
+        coord._fb.command_lock.assert_awaited_once_with("VIN1")
+        coord.async_request_refresh.assert_awaited()
+
+    def test_bff_401_recovers_via_mbb(self):
+        coord = _coord(flag=True, primary_error=APIError(401, "https://bff/lock", ""))
+        asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._fb.command_lock.assert_awaited_once_with("VIN1")
+
+    def test_mbb_also_fails_surfaces_original_bff_error(self):
+        # Both fail → surface the ORIGINAL BFF (403) error, never the MBB (500).
+        coord = _coord(
+            flag=True,
+            primary_error=APIError(403, "https://bff/lock", ""),
+            fb_error=APIError(500, "https://mbb/lock", ""),
+        )
+        with pytest.raises(HomeAssistantError) as ei:
+            asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        assert "403" in str(ei.value)
+        assert "500" not in str(ei.value)
+        coord._fb.command_lock.assert_awaited_once()
+
+    def test_bff_404_does_not_fall_over(self):
+        # 404 is not an auth refusal → no MBB retry; surfaces, fallback untouched.
+        coord = _coord(flag=True, primary_error=APIError(404, "https://bff/lock", ""))
+        with pytest.raises(HomeAssistantError):
+            asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._fb.command_lock.assert_not_awaited()
+
+    def test_no_optin_no_fallback(self):
+        # Flag off → even a 403 does NOT fall over to MBB (config-gated).
+        coord = _coord(flag=False, primary_error=APIError(403, "https://bff/lock", ""))
+        with pytest.raises(HomeAssistantError):
+            asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._fb.command_lock.assert_not_awaited()
+
+    def test_spin_error_does_not_fall_over(self):
+        # Our own S-PIN guard is a user error, not a BFF refusal → no MBB retry;
+        # surfaces cleanly as ServiceValidationError.
+        coord = _coord(flag=True, primary_error=SpinError("wrong S-PIN"))
+        with pytest.raises(ServiceValidationError):
+            asyncio.run(coord._cariad_cmd("VIN1", "command_lock"))
+        coord._fb.command_lock.assert_not_awaited()
+
+
+class TestArmMbbFallbackConnector:
+    """arm_mbb_command_channel(fallback_only=True) must NOT change the primary
+    command route — the BFF stays command-primary; the connector is only exposed
+    via mbb_fallback_connector()."""
+
+    def _tokenset(self):
+        from custom_components.vag_connect.cariad.models import TokenSet
+        return TokenSet(access_token="mbb-bearer", refresh_token="r",
+                        id_token="", expires_at=0.0, strategy="mbb")
+
+    def test_fallback_only_uses_separate_slot(self):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        c = VWEUClient(MagicMock(), "u@e.com", "pw", "1234")
+        ok = asyncio.run(
+            c.arm_mbb_command_channel(self._tokenset(), "cid", ["VIN1"],
+                                      fallback_only=True)
+        )
+        assert ok is True
+        # BFF stays command-primary — the normal target must NOT pick it up.
+        assert c._mbb_command_target() is None
+        # …but the fallback connector IS exposed for the coordinator retry.
+        assert c.mbb_fallback_connector() is not None
+
+    def test_channel_mode_uses_command_slot(self):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        c = VWEUClient(MagicMock(), "u@e.com", "pw", "1234")
+        ok = asyncio.run(
+            c.arm_mbb_command_channel(self._tokenset(), "cid", ["VIN1"])
+        )
+        assert ok is True
+        # channel mode → commands route through MBB (portal-primary behaviour).
+        assert c._mbb_command_target() is not None
+        assert c.mbb_fallback_connector() is None

--- a/tests/test_garage_list_resilience.py
+++ b/tests/test_garage_list_resilience.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Garage-list resilience (b15).
+
+myAudi 5.7.0 moved the garage list from ``/vehicle/v1/vehicles`` to ``/vehicles``
+(a new garageinformation module). CARIAD may eventually retire the old path. If
+the primary BFF list ever 404s, ``get_vehicles()`` must NOT die — for Audi the
+vgql userVehicles list on a different host enumerates the whole garage, so we
+fall back to it. Previously the 404 raised APIError before the vgql merge could
+run, so the integration lost every Audi vehicle the moment the old path went away.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+from custom_components.vag_connect.cariad.exceptions import APIError
+from custom_components.vag_connect.cariad.models import TokenSet
+
+
+def _client(strategy: str = "device_grant") -> VWEUClient:
+    c = VWEUClient(MagicMock(), "u@e.com", "pw", "1234")
+    c._tokens = TokenSet(access_token="t", refresh_token="r", id_token="",
+                         expires_at=0.0, strategy=strategy)
+    c._eu_portal = None            # not a portal entry → reach the BFF garage path
+    c._garage_base = MagicMock(return_value="https://bff")  # type: ignore[method-assign]
+    return c
+
+
+@pytest.mark.asyncio
+async def test_bff_list_404_falls_back_to_vgql():
+    c = _client()
+    c._get = AsyncMock(side_effect=APIError(404, "https://bff/vehicle/v1/vehicles", "nf"))
+    async def _fetch_images():
+        c._image_data = {"WVWZZZ00000000001": {}}
+    c.fetch_images = _fetch_images  # type: ignore[method-assign]
+    vins = await c.get_vehicles()
+    assert vins == ["WVWZZZ00000000001"]   # rescued via the vgql garage
+
+@pytest.mark.asyncio
+async def test_bff_list_401_also_recovers():
+    c = _client()
+    c._get = AsyncMock(side_effect=APIError(401, "https://bff/vehicle/v1/vehicles", "x"))
+    async def _fetch_images():
+        c._image_data = {"VIN_A": {}, "VIN_B": {}}
+    c.fetch_images = _fetch_images  # type: ignore[method-assign]
+    vins = await c.get_vehicles()
+    assert set(vins) == {"VIN_A", "VIN_B"}
+
+@pytest.mark.asyncio
+async def test_bff_list_fail_no_vgql_returns_empty_not_raise():
+    # e.g. VW-EU token entry (no vgql) — must fail SOFT, never raise.
+    c = _client()
+    c._get = AsyncMock(side_effect=APIError(404, "https://bff/vehicle/v1/vehicles", "nf"))
+    async def _fetch_images():
+        c._image_data = {}
+    c.fetch_images = _fetch_images  # type: ignore[method-assign]
+    vins = await c.get_vehicles()
+    assert vins == []
+
+@pytest.mark.asyncio
+async def test_bff_list_success_unchanged():
+    # happy path is untouched: the BFF list still drives the result.
+    c = _client()
+    c._get = AsyncMock(return_value={"data": [{"vin": "VIN1"}]})
+    c._resolve_home_regions = AsyncMock()  # type: ignore[method-assign]
+    async def _fetch_images():
+        c._image_data = {}
+    c.fetch_images = _fetch_images  # type: ignore[method-assign]
+    vins = await c.get_vehicles()
+    assert vins == ["VIN1"]

--- a/tests/test_live_telemetry_supersede.py
+++ b/tests/test_live_telemetry_supersede.py
@@ -16,6 +16,7 @@ untouched.
 from __future__ import annotations
 
 from custom_components.vag_connect.cariad._channel_merge import (
+    _LIVE_CLOSURE,
     _LIVE_TELEMETRY,
     merge_channels,
 )
@@ -92,3 +93,76 @@ class TestScopedAndSafe:
         m = merge_channels([("website_authproxy", live), ("eu_data_act", eu)])
         assert m.battery_soc == 80
         assert m.charging_state == "off"
+
+
+class TestClosureSupersede:
+    """Volatile physical closure/lock state supersedes a batch-primary too.
+
+    Same #1195-family reasoning as telemetry: a portal-primary VW with a live
+    supplementary channel (BFF / vw.de) must not show a ≥15-min-stale door /
+    lock / window snapshot from the batch when the live channel knows the current
+    state. A stale "locked"/"closed" reading is exactly what a door-open warning
+    automation would act on.
+    """
+
+    def test_stale_batch_lock_state_yields_to_live(self):
+        # EU-DA (primary) says locked + shut; live channel reads open/unlocked now.
+        eu = _v(doors_locked=True, doors_open=False, windows_open=False,
+                 trunk_open=False, trunk_locked=True, hood_open=False)
+        live = _v(doors_locked=False, doors_open=True, windows_open=True,
+                  trunk_open=True, trunk_locked=False, hood_open=True)
+        m = merge_channels([("eu_data_act", eu), ("website_authproxy", live)])
+        assert m.doors_locked is False          # live wins, not the stale locked
+        assert m.doors_open is True
+        assert m.windows_open is True
+        assert m.trunk_open is True
+        assert m.trunk_locked is False
+        assert m.hood_open is True
+        assert m.field_sources["doors_locked"] == "website_authproxy"
+
+    def test_per_door_detail_dicts_supersede_too(self):
+        # the scalar and the per-door/-window dicts must agree — both come from
+        # the live channel, never a scalar-live / dict-batch mix.
+        eu = _v(doors_individual={"front_left": True},
+                windows_position={"front_left": 0})
+        live = _v(doors_individual={"front_left": False, "rear_left": False},
+                  windows_position={"front_left": 100})
+        m = merge_channels([("eu_data_act", eu), ("website_authproxy", live)])
+        assert m.doors_individual == {"front_left": False, "rear_left": False}
+        assert m.windows_position == {"front_left": 100}
+        assert m.field_sources["doors_individual"] == "website_authproxy"
+
+    def test_bff_channel_also_supersedes_closure(self):
+        eu = _v(doors_locked=True)
+        bff = _v(doors_locked=False)
+        m = merge_channels([("eu_data_act", eu), ("audi", bff)])
+        assert m.doors_locked is False
+        assert m.field_sources["doors_locked"] == "audi"
+
+    def test_eu_da_only_car_keeps_its_closure_state(self):
+        # no live channel → batch closure survives (nothing fresher to prefer).
+        eu = _v(doors_locked=True, doors_open=False)
+        m = merge_channels([("eu_data_act", eu)])
+        assert m.doors_locked is True
+        assert m.doors_open is False
+
+    def test_live_silent_on_closure_keeps_batch(self):
+        # command-only live channel that doesn't report door state must not blank
+        # the batch's closure reading.
+        eu = _v(doors_locked=True)
+        mbb = _v(odometer_km=12000)  # no closure fields
+        m = merge_channels([("eu_data_act", eu), ("mbb", mbb)])
+        assert m.doors_locked is True
+        assert m.field_sources["doors_locked"] == "eu_data_act"
+
+    def test_monotonic_and_static_fields_still_not_superseded(self):
+        # the guardrail: odometer + service intervals are deliberately NOT in the
+        # closure set — priority order is not a freshness proxy for them.
+        assert "odometer_km" not in _LIVE_CLOSURE
+        assert "service_km" not in _LIVE_CLOSURE
+        assert "fuel_level" not in _LIVE_CLOSURE
+        eu = _v(odometer_km=1000, service_km=15000)
+        live = _v(odometer_km=1005, service_km=14000)
+        m = merge_channels([("eu_data_act", eu), ("website_authproxy", live)])
+        assert m.odometer_km == 1000            # batch primary keeps it
+        assert m.service_km == 15000

--- a/tests/test_mbb_backup_failover.py
+++ b/tests/test_mbb_backup_failover.py
@@ -38,7 +38,10 @@ def test_backup_client_is_the_verified_failover_id() -> None:
     assert MBB_DAG_CLIENT_ID_BACKUP != MBB_DAG_CLIENT_ID
 
 
-def test_backup_config_is_volkswagen_only() -> None:
-    for brand in ("audi", "skoda", "seat", "cupra", "porsche", "bentley"):
+def test_backup_config_mbb_brands_only() -> None:
+    # b15 — audi joined the MBB brands (live-validated 2026-08-30) and the backup
+    # shares MBB_DAG_BRANDS, so it fails over for audi too (same mbb scope).
+    for brand in ("skoda", "seat", "cupra", "porsche", "bentley"):
         assert mbb_dag_backup_config(brand) is None
     assert mbb_dag_backup_config("Volkswagen") is not None  # case-insensitive
+    assert mbb_dag_backup_config("audi") is not None         # b15

--- a/tests/test_v2150_mbb_wirein.py
+++ b/tests/test_v2150_mbb_wirein.py
@@ -328,12 +328,20 @@ class TestMbbDagConfig:
         assert "mbb" in scope.split()
         assert scope == MBB_DAG_SCOPE
 
-    def test_non_vw_brands_return_none(self) -> None:
-        for brand in ("audi", "skoda", "seat", "cupra", "porsche", ""):
+    def test_non_mbb_brands_return_none(self) -> None:
+        # b15 — audi joined the MBB brands (live-validated 2026-08-30); the rest stay None.
+        for brand in ("skoda", "seat", "cupra", "porsche", ""):
             assert mbb_dag_config(brand) is None
+
+    def test_audi_now_mbb_eligible(self) -> None:
+        # b15 — Car-Net Audis mint the durable MBB bearer (id_token aud
+        # VWGMBB01DELIV1, register/v1 200, exchange 200 + durable refresh),
+        # validated live on a real Audi account.
+        assert mbb_dag_config("audi") is not None
 
     def test_case_insensitive(self) -> None:
         assert mbb_dag_config("Volkswagen") is not None
+        assert mbb_dag_config("Audi") is not None  # b15
 
 
 class TestBrandSegmentUnchanged:


### PR DESCRIPTION
On a portal-primary VW (EU Data Act portal as the main channel) with a live supplementary channel (CARIAD BFF or vw.de), the merge only let a live reading override the batch for live-telemetry fields (SoC, charging, climate). Volatile closure state — doors, windows, lock, trunk, hood — kept the portal's up-to-15-min-old snapshot, so a door-open automation could act on a stale value.

This extends the existing live-beats-batch supersede to those closure fields via a new `_LIVE_CLOSURE` set. Deliberately excluded: odometer (monotonic), position (carry-forward TTL), fuel (dedicated merge), service intervals (static) — priority order is not a freshness proxy for them (guardrail test included).

Independent of the UI work in #1300; based on the b5 line. Full suite green.