### PR TITLE
Audi battery net-capacity gap-fill + Škoda official-API hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   cars whose main status bundle didn't include it. No new entity — just an extra
   source for the existing sensor (grounded on the myAudi 5.7.0 data model).
 
+### Fixed
+- **Škoda official-API channel: correctness + rate-limit hardening** (validated
+  against the live public API spec). Climate start now sends an empty body where
+  the API requires one (a missing body was rejected); the channel honours its
+  20-requests/hour budget by self-blocking when the server reports the quota is
+  spent (RateLimit-Remaining 0 or a Retry-After on 429/503), so the failover read
+  never breaches the limit. Off unless you add an official API key.
+
 ## [4.4.0] - 2026-08-31 — iOS Live Activities · durable Audi + VW two-way (MBB) · EU-Data-Act multi-channel merge · friendly channel names
 
 _Consolidates the 4.4.0b1–b5 betas into one stable release._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Changed
+- **Audi battery net-capacity now also comes from the health read.** The battery
+  State-of-Health response we already fetch on Audi device-grant cars carries the
+  usable net capacity in kWh; we now use it to fill the battery-capacity sensor on
+  cars whose main status bundle didn't include it. No new entity — just an extra
+  source for the existing sensor (grounded on the myAudi 5.7.0 data model).
+
 ## [4.4.0] - 2026-08-31 — iOS Live Activities · durable Audi + VW two-way (MBB) · EU-Data-Act multi-channel merge · friendly channel names
 
 _Consolidates the 4.4.0b1–b5 betas into one stable release._

--- a/custom_components/vag_connect/cariad/_authproxy.py
+++ b/custom_components/vag_connect/cariad/_authproxy.py
@@ -236,6 +236,47 @@ def parse_battery_health(body: object) -> float | None:
     return None
 
 
+def parse_usable_battery_capacity(body: object) -> float | None:
+    """Extract usable (net) battery capacity in kWh from a batteryHealthState body.
+
+    myAudi 5.7.0's ``connectedvehicle/batteryhealthstate`` model exposes
+    ``StateOfHealth.usableBatteryCapacity`` (a Double, kWh) next to the SoH %
+    (``ubeIndicator_pct``, parsed by :func:`parse_battery_health`). We already
+    fetch the ``selectivestatus?jobs=batteryHealthState`` response for the SoH
+    read, so this walks the SAME body for the capacity field — best-effort:
+    returns None unless a plausible pack capacity is present, so a car whose
+    envelope doesn't carry it simply leaves the sensor unavailable. Defensive on
+    unit: a value that looks like Wh (> 300) is scaled to kWh.
+    """
+    def _walk(node: object) -> float | None:
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if (
+                    k == "usableBatteryCapacity"
+                    and isinstance(v, (int, float))
+                    and not isinstance(v, bool)
+                ):
+                    return float(v)
+                found = _walk(v)
+                if found is not None:
+                    return found
+        elif isinstance(node, list):
+            for item in node:
+                found = _walk(item)
+                if found is not None:
+                    return found
+        return None
+
+    val = _walk(body)
+    if val is None:
+        return None
+    if val > 300:  # looks like Wh, not kWh — scale down
+        val /= 1000.0
+    if 1 < val <= 300:
+        return round(val, 1)
+    return None
+
+
 def build_transactionhistory_url(vin: str, gdc: str | None = None) -> str:
     """Remote-command history (lock/unlock lives here). Realm ``vw-de``.
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -149,6 +149,11 @@ class SkodaClient(CariadBaseClient):
         off = self._supplementary_official
         if off is None:
             return None
+        # Honour the official channel's 20/hour/key budget: if the server has told
+        # us we're out (RateLimit-Remaining 0, or a 429/503 Retry-After), skip the
+        # failover read until the window resets rather than breaching the quota.
+        if getattr(off, "over_rate_limit", False) is True:
+            return None
         try:
             return await off.get_status(vin)  # type: ignore[no-any-return]
         except Exception:  # noqa: BLE001

--- a/custom_components/vag_connect/cariad/api/skoda_official.py
+++ b/custom_components/vag_connect/cariad/api/skoda_official.py
@@ -25,6 +25,7 @@ spin)`` signature without a new arg, the VIN(s) ride the ``email`` slot
 """
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from aiohttp import ClientSession, ClientTimeout
@@ -67,6 +68,12 @@ class SkodaOfficialClient:
         # the first call. The coordinator reads this to pace itself (20/hour/key).
         self.rate_limit_remaining: int | None = None
         self.rate_limit_reset_s: int | None = None
+        self.retry_after_s: int | None = None
+        # Local self-block window (monotonic deadline) — set when the server says
+        # the budget is exhausted (RateLimit-Remaining 0, or a 429/503 Retry-After),
+        # so the failover never breaches the 20/hour/key quota. Mirrors the openHAB
+        # MySkoda binding's client-side rate limiter.
+        self._blocked_until: float = 0.0
 
     async def authenticate(self, mfa_code: str | None = None) -> None:
         """No OAuth — the ``X-API-Key`` is itself the credential. Validate it with
@@ -93,10 +100,29 @@ class SkodaOfficialClient:
     def _note_rate_limit(self, resp: Any) -> None:
         rem = resp.headers.get("RateLimit-Remaining")
         rst = resp.headers.get("RateLimit-Reset")
+        ra = resp.headers.get("Retry-After")  # sent on 429 / 503
         if rem is not None and str(rem).lstrip("-").isdigit():
             self.rate_limit_remaining = int(rem)
         if rst is not None and str(rst).lstrip("-").isdigit():
             self.rate_limit_reset_s = int(rst)
+        if ra is not None and str(ra).isdigit():
+            self.retry_after_s = int(ra)
+        # Self-block when the server says we're out of budget. Prefer the explicit
+        # Retry-After (429/503); else block for the reset window once remaining==0.
+        wait = 0
+        if self.retry_after_s and str(resp.status).startswith(("4", "5")):
+            wait = self.retry_after_s
+        elif self.rate_limit_remaining == 0 and self.rate_limit_reset_s:
+            wait = self.rate_limit_reset_s
+        if wait > 0:
+            self._blocked_until = time.monotonic() + wait
+
+    @property
+    def over_rate_limit(self) -> bool:
+        """True while the local self-block window (from RateLimit-Remaining 0 or a
+        Retry-After) is still open — the failover read skips instead of breaching
+        the 20/hour/key quota."""
+        return time.monotonic() < self._blocked_until
 
     async def _request(self, method: str, path: str, json_body: Any = None) -> tuple[int, Any]:
         async with self._session.request(
@@ -271,10 +297,14 @@ class SkodaOfficialClient:
         return await self._command(vin, "charging/stop")
 
     async def command_start_climate(self, vin: str, target_c: float | None = None) -> bool:
+        # air-conditioning/start has requestBody required:true; StartAirConditioning
+        # Configuration has no required inner field, so an empty {} is a valid
+        # instance. Send {} unconditionally — a None body omits the JSON entirely
+        # and the server rejects it with 400.
         body: dict[str, Any] = {}
         if target_c is not None:
             body["targetTemperature"] = {"value": target_c, "unit": "CELSIUS"}
-        return await self._command(vin, "air-conditioning/start", body or None)
+        return await self._command(vin, "air-conditioning/start", body)
 
     async def command_stop_climate(self, vin: str) -> bool:
         return await self._command(vin, "air-conditioning/stop")

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -798,11 +798,24 @@ class VWEUClient(CariadBaseClient):
         # SoH from the batteryHealthState sub-job above (value lives at
         # ``stateOfHealth.ubeIndicator_pct``; parse_battery_health walks for it).
         if soh_raw:
-            from .._authproxy import parse_battery_health  # noqa: PLC0415
+            from .._authproxy import (  # noqa: PLC0415
+                parse_battery_health,
+                parse_usable_battery_capacity,
+            )
 
             _soh = parse_battery_health(soh_raw)
             if _soh is not None:
                 d.battery_soh_pct = int(round(_soh))
+            # The same batteryHealthState body also carries usable (net) capacity
+            # in kWh (myAudi 5.7.0 StateOfHealth.usableBatteryCapacity) — the same
+            # quantity as batteryCapacityNetto. Use it only as a GAP-FILL source
+            # for the existing battery_cap_kwh sensor: the main selectivestatus /
+            # EU-DA value wins when present, but a car whose main bundle omitted
+            # net capacity gets it from the health read instead of nothing.
+            if d.battery_cap_kwh is None:
+                _cap = parse_usable_battery_capacity(soh_raw)
+                if _cap is not None:
+                    d.battery_cap_kwh = _cap
 
         # v1.25.0 PR-G — MBB VSR Phase 2 read-side fallback (Golf 7 GTE
         # Tank-Level use case). Triggers when:

--- a/tests/test_battery_health_state_bff.py
+++ b/tests/test_battery_health_state_bff.py
@@ -11,7 +11,10 @@ best-effort pattern (a 403/404 never breaks the poll).
 """
 from __future__ import annotations
 
-from custom_components.vag_connect.cariad._authproxy import parse_battery_health
+from custom_components.vag_connect.cariad._authproxy import (
+    parse_battery_health,
+    parse_usable_battery_capacity,
+)
 
 
 def test_parses_soh_from_bff_envelope() -> None:
@@ -33,6 +36,23 @@ def test_parses_soh_from_bff_envelope() -> None:
 
 def test_parses_soh_when_flatter() -> None:
     assert parse_battery_health({"stateOfHealth": {"ubeIndicator_pct": 91.4}}) == 91.4
+
+
+def test_parses_usable_capacity_from_bff_envelope() -> None:
+    # myAudi 5.7.0's connectedvehicle batteryHealthState model confirmed
+    # StateOfHealth.usableBatteryCapacity (kWh) rides in the same body we already
+    # fetch for SoH; we gap-fill battery_cap_kwh from it. (52.0 is a real Audi net
+    # capacity sample from the RE'd envelope above.)
+    body = {"batteryHealthState": {"stateOfHealth": {"value": {
+        "ubeIndicator_pct": 87, "usableBatteryCapacity": 52.0}}}}
+    assert parse_usable_battery_capacity(body) == 52.0
+
+
+def test_usable_capacity_wh_fallback_and_sanity() -> None:
+    assert parse_usable_battery_capacity({"usableBatteryCapacity": 77000}) == 77.0  # Wh→kWh
+    assert parse_usable_battery_capacity({"usableBatteryCapacity": 0.5}) is None     # too small
+    assert parse_usable_battery_capacity({}) is None
+    assert parse_usable_battery_capacity({"usableBatteryCapacity": True}) is None    # bool guard
 
 
 def test_rejects_missing_or_implausible() -> None:

--- a/tests/test_skoda_official_api.py
+++ b/tests/test_skoda_official_api.py
@@ -245,3 +245,43 @@ async def test_key_rejected_raises_auth_error():
     c = _client(_FakeSession(status=401, body={"type": "api-key-expired"}))
     with pytest.raises(AuthenticationError):
         await c.get_status("VIN1")
+
+
+@pytest.mark.asyncio
+async def test_climate_start_without_temp_sends_empty_body_not_none():
+    # air-conditioning/start has requestBody required:true — an empty {} is a
+    # valid instance but a None body omits the JSON and the server 400s.
+    s = _FakeSession(status=202, body={})
+    c = _client(s)
+    assert await c.command_start_climate("VIN1") is True
+    assert s.calls[-1]["url"].endswith("/vehicles/VIN1/air-conditioning/start")
+    assert s.calls[-1]["json"] == {}          # NOT None
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_budget_self_blocks_when_exhausted():
+    # RateLimit-Remaining 0 → self-block for the reset window; over_rate_limit True.
+    s = _FakeSession(headers={"RateLimit-Remaining": "0", "RateLimit-Reset": "1800"})
+    c = _client(s)
+    await c.get_status("VIN1")
+    assert c.rate_limit_remaining == 0
+    assert c.over_rate_limit is True
+    # a healthy budget does not block
+    s2 = _FakeSession(headers={"RateLimit-Remaining": "12", "RateLimit-Reset": "1800"})
+    c2 = _client(s2)
+    await c2.get_status("VIN1")
+    assert c2.over_rate_limit is False
+
+
+@pytest.mark.asyncio
+async def test_retry_after_on_429_sets_block():
+    from custom_components.vag_connect.cariad.exceptions import APIError
+
+    s = _FakeSession(status=429, body={"type": "too-many-requests"},
+                     headers={"Retry-After": "600"})
+    c = _client(s)
+    with pytest.raises(APIError):
+        await c.get_status("VIN1")
+    # Retry-After was still captured (from the response, before the raise)
+    assert c.retry_after_s == 600
+    assert c.over_rate_limit is True


### PR DESCRIPTION
## Two grounded fixes, both validated against the live data models

### Audi — battery net-capacity from the health read (`cabdd62`)
The State-of-Health response we already fetch on Audi device-grant cars carries the
usable net capacity in kWh. We now use it to fill the battery-capacity sensor on cars
whose main status bundle didn't include it. **No new entity** — just an extra source
for the existing sensor, and only when the primary value is missing. Grounded on the
myAudi 5.7.0 data model.

### Škoda official-API channel — correctness + rate-limit hardening (`1209bf5`)
Validated against the live public-API spec:
- **Climate start now sends an empty body** where the API requires one — a missing
  body was rejected with 400.
- **The channel honours its 20-requests/hour budget** by self-blocking when the server
  reports the quota is spent (`RateLimit-Remaining: 0`, or a `Retry-After` on 429/503),
  so the failover read can never breach the limit.

Off unless an official API key is present; failover-only (never in the continuous merge).

## Verification
- Full suite green (5574 passed, 15 skipped)
- ruff clean, mypy strict clean
- `[Unreleased]` CHANGELOG entries for both

Stacked below: auto-enrolment builds on the hardened official-API client here.
