### PR TITLE
Škoda official API — automatic enrolment for logged-in owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **Škoda official public API — automatic enrolment, zero setup.** Škoda opened a
+  public data API (app v8.16+). Already-logged-in Škoda owners are now enrolled
+  automatically: we mint a per-car API key from the existing login, wire it up as a
+  durable failover read channel, and drop a one-time notification that it's live —
+  nothing to paste, nothing to configure. New users get it the same painless way.
+  The key is minted once and remembered, honours the 5-keys-per-car limit, and the
+  channel stays rate-limited (20 requests/hour per car) so it's only read when the
+  primary channel is down. A manual key field stays in the options as a fallback.
+
 ### Changed
 - **Audi battery net-capacity now also comes from the health read.** The battery
   State-of-Health response we already fetch on Audi device-grant cars carries the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   The key is minted once and remembered, honours the 5-keys-per-car limit, and the
   channel stays rate-limited (20 requests/hour per car) so it's only read when the
   primary channel is down. A manual key field stays in the options as a fallback.
+  The key-mint step also writes a privacy-safe outcome line into the integration
+  diagnostics (HTTP status + response field names only — no VIN, body, or secret),
+  so if the mint ever misbehaves on a real car the download tells us exactly what
+  happened.
 
 ### Changed
 - **Audi battery net-capacity now also comes from the health read.** The battery

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -35,10 +35,11 @@ _LOGGER = logging.getLogger(__name__)
 _BASE = "https://mysmob.api.connect.skoda-auto.cz"
 
 # Official public-API key management (mysmob BFF, RE'd from MyŠkoda 8.16 —
-# cz.myskoda.api.bff_public_api_keys.v2). Rides the same mysmob Bearer this client
-# already holds. POST creates a key (returns the secret once), GET lists remaining
-# quota per VIN, DELETE removes one by id. Keys are VIN-bound; max 5 per VIN.
-_KEYGEN_PATH = "/api/v2/public-api-keys"
+# cz.myskoda.api.bff_public_api_keys.v2), path /api/v2/public-api-keys. Rides the
+# same mysmob Bearer this client already holds. POST creates a key (returns the
+# secret once), GET lists remaining quota per VIN, DELETE removes one by id. Keys
+# are VIN-bound; max 5 per VIN. Path inlined at each call site (literal, so the
+# Bruno drift-check resolves it) — kept here for documentation.
 _OFFICIAL_KEY_NAME = "Home Assistant (vag_connect)"
 # The key-management route is only exercised by the MyŠkoda app (v8.16+); spoof the
 # real app User-Agent on these calls so a possible min-app-version gate is satisfied
@@ -205,7 +206,7 @@ class SkodaClient(CariadBaseClient):
             return None
         try:
             body = await self._post(
-                f"{_BASE}{_KEYGEN_PATH}",
+                f"{_BASE}/api/v2/public-api-keys",
                 json={"name": name, "vin": vin.strip().upper()},
                 headers={"User-Agent": _KEYGEN_USER_AGENT},
             )
@@ -224,7 +225,7 @@ class SkodaClient(CariadBaseClient):
             return None
         try:
             body = await self._get(
-                f"{_BASE}{_KEYGEN_PATH}",
+                f"{_BASE}/api/v2/public-api-keys",
                 headers={"User-Agent": _KEYGEN_USER_AGENT},
             )
         except Exception as err:  # noqa: BLE001
@@ -240,7 +241,7 @@ class SkodaClient(CariadBaseClient):
             return False
         try:
             await self._request(
-                "DELETE", f"{_BASE}{_KEYGEN_PATH}/{key_id}",
+                "DELETE", f"{_BASE}/api/v2/public-api-keys/{key_id}",
                 headers={"User-Agent": _KEYGEN_USER_AGENT},
             )
             return True

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -34,6 +34,17 @@ from .base import CariadBaseClient
 _LOGGER = logging.getLogger(__name__)
 _BASE = "https://mysmob.api.connect.skoda-auto.cz"
 
+# Official public-API key management (mysmob BFF, RE'd from MyŠkoda 8.16 —
+# cz.myskoda.api.bff_public_api_keys.v2). Rides the same mysmob Bearer this client
+# already holds. POST creates a key (returns the secret once), GET lists remaining
+# quota per VIN, DELETE removes one by id. Keys are VIN-bound; max 5 per VIN.
+_KEYGEN_PATH = "/api/v2/public-api-keys"
+_OFFICIAL_KEY_NAME = "Home Assistant (vag_connect)"
+# The key-management route is only exercised by the MyŠkoda app (v8.16+); spoof the
+# real app User-Agent on these calls so a possible min-app-version gate is satisfied
+# (verbatim from the 8.16 APK; MySkoda/Android/{versionName}/{versionCode}).
+_KEYGEN_USER_AGENT = "MySkoda/Android/8.16.0/260821007"
+
 # driving-range.carType enum values that are pure-combustion (no HV battery, no
 # plug). EVs report "electric", PHEVs "hybrid" — deliberately absent, so a plug-in
 # car is NEVER matched. Used to skip the battery-only /charging read on a confirmed
@@ -130,16 +141,20 @@ class SkodaClient(CariadBaseClient):
         # 20 req/hour/key.
         self._supplementary_official: Any = None
 
-    def arm_supplementary_official(self, api_key: str) -> None:
-        """Arm the official Škoda public API as a failover source (opt-in). The
-        key is vehicle-bound server-side, so ``get_status(vin)`` is called per-VIN
-        on failover; no VIN list is needed here."""
-        if not api_key:
+    def arm_supplementary_official(
+        self, api_key: str = "", keys_by_vin: dict[str, str] | None = None,
+    ) -> None:
+        """Arm the official Škoda public API as a failover source (opt-in). Keys are
+        vehicle-bound server-side, so ``get_status(vin)`` is called per-VIN on
+        failover. ``keys_by_vin`` carries the auto-enrolled per-VIN keys; ``api_key``
+        is the single manual-fallback key (applied to any VIN without its own)."""
+        if not api_key and not keys_by_vin:
             self._supplementary_official = None
             return
         from .skoda_official import SkodaOfficialClient  # noqa: PLC0415
         self._supplementary_official = SkodaOfficialClient(
             self._session, email="", password=api_key, spin=self._spin,
+            keys_by_vin=keys_by_vin,
         )
 
     async def official_failover_read(self, vin: str) -> "VehicleData | None":
@@ -158,6 +173,80 @@ class SkodaClient(CariadBaseClient):
             return await off.get_status(vin)  # type: ignore[no-any-return]
         except Exception:  # noqa: BLE001
             return None
+
+    # -- official public-API key minting (mysmob BFF) -------------------------
+    # Auto-enrollment: mint the official X-API-Key from the user's existing mysmob
+    # login so an already-logged-in Škoda owner gets the durable official channel
+    # with zero effort. RE'd from MyŠkoda 8.16 (bff_public_api_keys.v2).
+
+    @property
+    def can_mint_official_key(self) -> bool:
+        """True only on a NATIVE mysmob login. The keygen POST needs a real mysmob
+        Bearer (a JWT); a portal-fallback entry holds the cookie-session sentinel
+        (strategy ``data_act_portal``, ``_eu_portal`` set), so minting there would
+        401. Gate on: no portal connector, empty token strategy, JWT access token."""
+        if getattr(self, "_eu_portal", None) is not None:
+            return False
+        tok = self._tokens
+        if tok is None or getattr(tok, "strategy", "") != "":
+            return False
+        at = getattr(tok, "access_token", "") or ""
+        return isinstance(at, str) and at.startswith("ey")
+
+    async def mint_api_key(
+        self, vin: str, name: str = _OFFICIAL_KEY_NAME
+    ) -> dict[str, Any] | None:
+        """Create an official public-API key for one VIN via the mysmob BFF, using
+        the existing login. Returns ``{id, key, name, validUntil}`` — the ``key``
+        secret is returned ONLY here, never on a later list — or None on any
+        failure (fail-soft: auto-enroll must never sink the poll). Spoofs the real
+        app User-Agent in case the route is app-version-gated."""
+        if not self.can_mint_official_key or not vin:
+            return None
+        try:
+            body = await self._post(
+                f"{_BASE}{_KEYGEN_PATH}",
+                json={"name": name, "vin": vin.strip().upper()},
+                headers={"User-Agent": _KEYGEN_USER_AGENT},
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "official-API key mint failed for %s: %s", vin[-6:], type(err).__name__
+            )
+            return None
+        return body if isinstance(body, dict) and body.get("key") else None
+
+    async def list_api_keys(self) -> dict[str, Any] | None:
+        """List official-API keys + remaining per-VIN quota (``maxKeys`` 5). Returns
+        the response dict (``{maxKeys, vehicleKeys:[{vin, keysRemaining}]}``) or
+        None. Returns no key secrets. Used to check quota before minting."""
+        if not self.can_mint_official_key:
+            return None
+        try:
+            body = await self._get(
+                f"{_BASE}{_KEYGEN_PATH}",
+                headers={"User-Agent": _KEYGEN_USER_AGENT},
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("official-API key list failed: %s", type(err).__name__)
+            return None
+        return body if isinstance(body, dict) else None
+
+    async def delete_api_key(self, key_id: str) -> bool:
+        """Delete one official-API key by id (to free a slot before re-minting an
+        expired one). True on success. Only keys we minted are deletable — the list
+        endpoint returns no foreign ids."""
+        if not self.can_mint_official_key or not key_id:
+            return False
+        try:
+            await self._request(
+                "DELETE", f"{_BASE}{_KEYGEN_PATH}/{key_id}",
+                headers={"User-Agent": _KEYGEN_USER_AGENT},
+            )
+            return True
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("official-API key delete failed: %s", type(err).__name__)
+            return False
 
     @staticmethod
     def _sub_from_id_token(id_token: str | None) -> str | None:

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -27,7 +27,7 @@ from .._util import (
     safe_int,
     workshop_phone_from_contact,
 )
-from ..exceptions import AuthenticationError
+from ..exceptions import APIError, AuthenticationError
 from ..models import BRAND_SKODA, VehicleData
 from .base import CariadBaseClient
 
@@ -201,7 +201,14 @@ class SkodaClient(CariadBaseClient):
         the existing login. Returns ``{id, key, name, validUntil}`` — the ``key``
         secret is returned ONLY here, never on a later list — or None on any
         failure (fail-soft: auto-enroll must never sink the poll). Spoofs the real
-        app User-Agent in case the route is app-version-gated."""
+        app User-Agent in case the route is app-version-gated.
+
+        Records a PII-free outcome label under ``probe_outcomes`` on every path
+        (``skoda_official_keygen``) so the integration diagnostics tell us what the
+        live mysmob key-mint route actually did — we RE'd it from the 8.16 app but
+        never ran it against the backend, so real-world outcomes come back as
+        probes. Only the HTTP status and the response's top-level KEY names are
+        recorded — never a body, VIN, or the key secret."""
         if not self.can_mint_official_key or not vin:
             return None
         try:
@@ -210,17 +217,34 @@ class SkodaClient(CariadBaseClient):
                 json={"name": name, "vin": vin.strip().upper()},
                 headers={"User-Agent": _KEYGEN_USER_AGENT},
             )
+        except APIError as err:
+            self.probe_outcomes["skoda_official_keygen"] = f"POST {err.status}"
+            _LOGGER.debug(
+                "official-API key mint failed for %s: HTTP %s", vin[-6:], err.status
+            )
+            return None
         except Exception as err:  # noqa: BLE001
+            self.probe_outcomes["skoda_official_keygen"] = f"POST err:{type(err).__name__}"
             _LOGGER.debug(
                 "official-API key mint failed for %s: %s", vin[-6:], type(err).__name__
             )
             return None
-        return body if isinstance(body, dict) and body.get("key") else None
+        if isinstance(body, dict) and body.get("key"):
+            self.probe_outcomes["skoda_official_keygen"] = (
+                "POST 2xx key+validUntil" if body.get("validUntil") else "POST 2xx key"
+            )
+            return body
+        # 2xx but no key secret — record the shape (key NAMES only, no values).
+        shape = ",".join(sorted(body.keys())) if isinstance(body, dict) else "non-dict"
+        self.probe_outcomes["skoda_official_keygen"] = f"POST 2xx no-key [{shape}]"
+        return None
 
     async def list_api_keys(self) -> dict[str, Any] | None:
         """List official-API keys + remaining per-VIN quota (``maxKeys`` 5). Returns
         the response dict (``{maxKeys, vehicleKeys:[{vin, keysRemaining}]}``) or
-        None. Returns no key secrets. Used to check quota before minting."""
+        None. Returns no key secrets. Used to check quota before minting. Records a
+        PII-free ``skoda_official_keygen_list`` probe outcome (HTTP status + counts
+        only) so diagnostics show whether the live list route answers."""
         if not self.can_mint_official_key:
             return None
         try:
@@ -228,10 +252,25 @@ class SkodaClient(CariadBaseClient):
                 f"{_BASE}/api/v2/public-api-keys",
                 headers={"User-Agent": _KEYGEN_USER_AGENT},
             )
+        except APIError as err:
+            self.probe_outcomes["skoda_official_keygen_list"] = f"GET {err.status}"
+            _LOGGER.debug("official-API key list failed: HTTP %s", err.status)
+            return None
         except Exception as err:  # noqa: BLE001
+            self.probe_outcomes["skoda_official_keygen_list"] = (
+                f"GET err:{type(err).__name__}"
+            )
             _LOGGER.debug("official-API key list failed: %s", type(err).__name__)
             return None
-        return body if isinstance(body, dict) else None
+        if isinstance(body, dict):
+            vk = body.get("vehicleKeys")
+            self.probe_outcomes["skoda_official_keygen_list"] = (
+                f"GET 2xx maxKeys={body.get('maxKeys')} "
+                f"vins={len(vk) if isinstance(vk, list) else '?'}"
+            )
+            return body
+        self.probe_outcomes["skoda_official_keygen_list"] = "GET 2xx non-dict"
+        return None
 
     async def delete_api_key(self, key_id: str) -> bool:
         """Delete one official-API key by id (to free a slot before re-minting an

--- a/custom_components/vag_connect/cariad/api/skoda_official.py
+++ b/custom_components/vag_connect/cariad/api/skoda_official.py
@@ -59,10 +59,23 @@ class SkodaOfficialClient:
         email: str,          # factory ``email`` slot = comma-separated VIN(s)
         password: str,       # factory ``password`` slot = the X-API-Key
         spin: str = "",
+        keys_by_vin: dict[str, str] | None = None,
     ) -> None:
         self._session = session
         self._api_key = (password or "").strip()
+        # Keys are VIN-bound (minted per VIN, max 5/VIN). ``keys_by_vin`` carries the
+        # auto-enrolled per-VIN keys; the single ``_api_key`` is the manual fallback
+        # applied to any VIN not in the map. _key_for(vin) picks the right one.
+        self._keys_by_vin = {
+            k.strip().upper(): (val or "").strip()
+            for k, val in (keys_by_vin or {}).items()
+            if k and (val or "").strip()
+        }
         self._vins = [v.strip().upper() for v in (email or "").split(",") if v.strip()]
+        # A per-VIN map is itself an authoritative VIN list (used when no explicit
+        # email/VIN slot was passed, i.e. the auto-enroll path).
+        if not self._vins and self._keys_by_vin:
+            self._vins = sorted(self._keys_by_vin)
         self._spin = (spin or "").strip()
         # Populated from every response's RateLimit-Remaining header; None until
         # the first call. The coordinator reads this to pace itself (20/hour/key).
@@ -74,6 +87,11 @@ class SkodaOfficialClient:
         # so the failover never breaches the 20/hour/key quota. Mirrors the openHAB
         # MySkoda binding's client-side rate limiter.
         self._blocked_until: float = 0.0
+
+    def _key_for(self, vin: str) -> str:
+        """The X-API-Key to use for one VIN: its own minted key, else the single
+        manual key as a fallback."""
+        return self._keys_by_vin.get((vin or "").strip().upper(), self._api_key)
 
     async def authenticate(self, mfa_code: str | None = None) -> None:
         """No OAuth — the ``X-API-Key`` is itself the credential. Validate it with
@@ -88,11 +106,12 @@ class SkodaOfficialClient:
 
     # -- transport ------------------------------------------------------------
 
-    def _headers(self) -> dict[str, str]:
-        if not self._api_key:
+    def _headers(self, api_key: str | None = None) -> dict[str, str]:
+        key = api_key or self._api_key
+        if not key:
             raise AuthenticationError("Škoda official API: no API key configured")
         return {
-            "X-API-Key": self._api_key,
+            "X-API-Key": key,
             "Accept": "application/json",
             "User-Agent": _USER_AGENT,
         }
@@ -124,9 +143,11 @@ class SkodaOfficialClient:
         the 20/hour/key quota."""
         return time.monotonic() < self._blocked_until
 
-    async def _request(self, method: str, path: str, json_body: Any = None) -> tuple[int, Any]:
+    async def _request(
+        self, method: str, path: str, json_body: Any = None, api_key: str | None = None,
+    ) -> tuple[int, Any]:
         async with self._session.request(
-            method, f"{_BASE}/{path}", headers=self._headers(),
+            method, f"{_BASE}/{path}", headers=self._headers(api_key),
             json=json_body, timeout=_TIMEOUT,
         ) as resp:
             self._note_rate_limit(resp)
@@ -136,11 +157,13 @@ class SkodaOfficialClient:
                 body = await resp.text()
             return resp.status, body
 
-    async def _get(self, path: str) -> tuple[int, Any]:
-        return await self._request("GET", path)
+    async def _get(self, path: str, api_key: str | None = None) -> tuple[int, Any]:
+        return await self._request("GET", path, api_key=api_key)
 
-    async def _post(self, path: str, json_body: Any = None) -> tuple[int, Any]:
-        return await self._request("POST", path, json_body)
+    async def _post(
+        self, path: str, json_body: Any = None, api_key: str | None = None,
+    ) -> tuple[int, Any]:
+        return await self._request("POST", path, json_body, api_key=api_key)
 
     # -- reads ----------------------------------------------------------------
 
@@ -150,7 +173,7 @@ class SkodaOfficialClient:
         return list(self._vins)
 
     async def get_status(self, vin: str) -> VehicleData:
-        status, body = await self._get(f"vehicles/{vin}")
+        status, body = await self._get(f"vehicles/{vin}", api_key=self._key_for(vin))
         if status == 401:
             raise AuthenticationError(
                 "Škoda official API: key rejected (401) — expired or wrong vehicle"
@@ -283,7 +306,8 @@ class SkodaOfficialClient:
     # -- commands -------------------------------------------------------------
 
     async def _command(self, vin: str, path: str, body: Any = None) -> bool:
-        status, resp = await self._post(f"vehicles/{vin}/{path}", body)
+        status, resp = await self._post(
+            f"vehicles/{vin}/{path}", body, api_key=self._key_for(vin))
         if status in (200, 201, 202, 204):
             return True
         if status == 401:

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -298,6 +298,11 @@ CONF_SUPPLEMENTARY_TIBBER_TOKENS = "supplementary_tibber_tokens"
 # when the primary (unofficial mysmob) channel hard-fails, never polled
 # continuously, because the official API is rate-limited to 20 requests/hour/key.
 CONF_SKODA_OFFICIAL_API_KEY      = "skoda_official_api_key"
+# Auto-enrolled per-VIN official keys, minted from the user's mysmob login:
+# {vin: {"key": str, "id": str, "validUntil": str}}. Keys are VIN-bound, so this
+# is a map, not a single key; CONF_SKODA_OFFICIAL_API_KEY stays the manual-fallback
+# single key for any VIN not auto-enrolled.
+CONF_SKODA_OFFICIAL_KEYS         = "skoda_official_keys"
 
 # v2.15.0b3 — "hide entities without data" (default ON). When enabled, data
 # sensors / binary sensors whose value hasn't arrived are not created, so a

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1536,6 +1536,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # stops consuming the daily request budget. Reassigning here means
             # both the gather and the zip below use the filtered list.
             vins = self._active_vins(vins)
+            # Škoda auto-enrollment to the official public API — mint a per-VIN
+            # X-API-Key from the user's existing mysmob login so an already-logged-in
+            # owner gets the durable official channel with zero effort, and new users
+            # get it painlessly. Idempotent + fail-soft (never sinks the poll).
+            try:
+                await self._auto_enroll_skoda_official(vins)
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Škoda official auto-enroll skipped", exc_info=True)
             # Fetch status for all vehicles
             results = await asyncio.gather(
                 *[self._cariad_client.get_status(vin) for vin in vins],
@@ -2523,6 +2531,87 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         else:
             clear_issue_test_cohort_share(self.hass, self.entry.entry_id)
 
+    def _arm_official_from_map(self, keys_map: dict[str, Any]) -> None:
+        """Arm the Škoda official failover channel from a persisted per-VIN key map
+        ({vin: {key, id, validUntil}})."""
+        arm = getattr(self._cariad_client, "arm_supplementary_official", None)
+        if arm is None:
+            return
+        by_vin = {
+            str(vin).upper(): (rec.get("key") or "")
+            for vin, rec in (keys_map or {}).items()
+            if isinstance(rec, dict) and rec.get("key")
+        }
+        if by_vin:
+            try:
+                arm(keys_by_vin=by_vin)
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Škoda official arm-from-map failed", exc_info=True)
+
+    async def _auto_enroll_skoda_official(self, vins: list[str]) -> None:
+        """Auto-enroll a logged-in Škoda user in the official public API: mint a
+        per-VIN X-API-Key from the EXISTING mysmob login, persist it, arm the
+        official failover channel, and raise a one-time HA repair informing the
+        user. Idempotent (mints only for VINs without a stored key, honours the
+        5-keys/VIN quota) and fail-soft (never sinks the poll). Gated on a native
+        mysmob login inside can_mint_official_key."""
+        from . import repairs  # noqa: PLC0415
+        from .const import CONF_BRAND, CONF_SKODA_OFFICIAL_KEYS  # noqa: PLC0415
+        client = self._cariad_client
+        if str(self.entry.data.get(CONF_BRAND, "")) != "skoda":
+            return
+        if not getattr(client, "can_mint_official_key", False):
+            return
+        mint = getattr(client, "mint_api_key", None)
+        list_keys = getattr(client, "list_api_keys", None)
+        if mint is None or list_keys is None:
+            return
+        stored: dict[str, Any] = dict(self.entry.data.get(CONF_SKODA_OFFICIAL_KEYS) or {})
+        stored_upper = {str(k).upper() for k in stored}
+        to_mint = [v for v in vins if str(v).upper() not in stored_upper]
+        if not to_mint:
+            if stored:
+                self._arm_official_from_map(stored)
+            return
+        # Quota check (maxKeys 5 per VIN) — one GET before minting.
+        remaining: dict[str, int] = {}
+        listing = await list_keys()
+        if isinstance(listing, dict):
+            for vk in listing.get("vehicleKeys") or []:
+                if isinstance(vk, dict) and vk.get("vin") is not None:
+                    try:
+                        remaining[str(vk["vin"]).upper()] = int(vk.get("keysRemaining", 0))
+                    except (TypeError, ValueError):
+                        pass
+        newly: dict[str, Any] = {}
+        quota_full = False
+        for vin in to_mint:
+            if remaining.get(str(vin).upper(), 1) <= 0:
+                quota_full = True  # user already holds 5 keys for this VIN in the app
+                continue
+            minted = await mint(vin)
+            if isinstance(minted, dict) and minted.get("key"):
+                newly[str(vin).upper()] = {
+                    "key": minted["key"],
+                    "id": minted.get("id", ""),
+                    "validUntil": minted.get("validUntil", ""),
+                }
+        if not newly:
+            # Nothing minted this run (route rejected / quota full). Keep any stored
+            # keys armed; if the only blocker was a full key quota, guide the user.
+            if stored:
+                self._arm_official_from_map(stored)
+            if quota_full:
+                repairs.raise_issue_skoda_official_quota(self.hass, self.entry.entry_id)
+            return
+        full = {**stored, **newly}
+        self._arm_official_from_map(full)
+        # Persist for the next restart so we never re-mint (idempotent: a second run
+        # sees the same data and async_update_entry is a no-op → no reload loop).
+        self.hass.config_entries.async_update_entry(
+            self.entry, data={**self.entry.data, CONF_SKODA_OFFICIAL_KEYS: full})
+        repairs.raise_issue_skoda_official_enrolled(self.hass, self.entry.entry_id)
+
     async def _arm_supplementary_channels(self) -> None:
         """v2.15.0b1 (C1) — arm configured supplementary read channels on the
         client. No-op when none configured → single-channel setup unchanged;
@@ -2613,11 +2702,21 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # supplementary channel: it is read ONLY when the primary mysmob channel
         # hard-fails (see _revive_after_hard_failure). Arming just hands the
         # client the key; get_status(vin) is called per-VIN on failover.
-        from .const import CONF_SKODA_OFFICIAL_API_KEY  # noqa: PLC0415
+        from .const import (  # noqa: PLC0415
+            CONF_SKODA_OFFICIAL_API_KEY,
+            CONF_SKODA_OFFICIAL_KEYS,
+        )
         arm_official = getattr(client, "arm_supplementary_official", None)
-        if data.get(CONF_SKODA_OFFICIAL_API_KEY) and arm_official is not None:
+        single_key = data.get(CONF_SKODA_OFFICIAL_API_KEY) or ""
+        key_map = data.get(CONF_SKODA_OFFICIAL_KEYS) or {}
+        by_vin = {
+            str(vin).upper(): (rec.get("key") or "")
+            for vin, rec in key_map.items()
+            if isinstance(rec, dict) and rec.get("key")
+        }
+        if (single_key or by_vin) and arm_official is not None:
             try:
-                arm_official(data.get(CONF_SKODA_OFFICIAL_API_KEY))
+                arm_official(api_key=single_key, keys_by_vin=by_vin or None)
             except Exception as err:  # noqa: BLE001
                 _LOGGER.warning(
                     "VW Group Connect: Škoda official-API failover arming failed"

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2548,6 +2548,15 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 _LOGGER.debug("Škoda official arm-from-map failed", exc_info=True)
 
+    def _skoda_probe(self, key: str, label: str) -> None:
+        """Write a PII-free outcome label into the client's ``probe_outcomes`` so the
+        integration diagnostics surface it. No-op if the client has no such sink.
+        Used to report what the (RE'd-but-live-untested) official key-mint route did,
+        so real-world outcomes come back as diagnostics probes."""
+        po = getattr(self._cariad_client, "probe_outcomes", None)
+        if isinstance(po, dict):
+            po[key] = label
+
     async def _auto_enroll_skoda_official(self, vins: list[str]) -> None:
         """Auto-enroll a logged-in Škoda user in the official public API: mint a
         per-VIN X-API-Key from the EXISTING mysmob login, persist it, arm the
@@ -2561,14 +2570,28 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if str(self.entry.data.get(CONF_BRAND, "")) != "skoda":
             return
         if not getattr(client, "can_mint_official_key", False):
+            # Record WHY the official channel can't auto-enrol (portal-fallback or a
+            # non-native login) so diagnostics explain its absence. PII-free.
+            self._skoda_probe("skoda_official", "gate: not a native mysmob login")
             return
         mint = getattr(client, "mint_api_key", None)
         list_keys = getattr(client, "list_api_keys", None)
         if mint is None or list_keys is None:
             return
+        # Mint each VIN at most once per HA session: a stored key means it already
+        # succeeded; a VIN we already tried this session (and that failed) must not be
+        # re-hammered every poll — its failure is captured in the keygen probe and it
+        # gets a fresh attempt on the next restart.
+        attempted = getattr(self, "_skoda_official_attempted", None)
+        if not isinstance(attempted, set):
+            attempted = set()
+            self._skoda_official_attempted = attempted
         stored: dict[str, Any] = dict(self.entry.data.get(CONF_SKODA_OFFICIAL_KEYS) or {})
         stored_upper = {str(k).upper() for k in stored}
-        to_mint = [v for v in vins if str(v).upper() not in stored_upper]
+        to_mint = [
+            v for v in vins
+            if str(v).upper() not in stored_upper and str(v).upper() not in attempted
+        ]
         if not to_mint:
             if stored:
                 self._arm_official_from_map(stored)
@@ -2586,6 +2609,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         newly: dict[str, Any] = {}
         quota_full = False
         for vin in to_mint:
+            attempted.add(str(vin).upper())  # tried this session — don't re-hammer
             if remaining.get(str(vin).upper(), 1) <= 0:
                 quota_full = True  # user already holds 5 keys for this VIN in the app
                 continue
@@ -2601,6 +2625,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # keys armed; if the only blocker was a full key quota, guide the user.
             if stored:
                 self._arm_official_from_map(stored)
+            self._skoda_probe(
+                "skoda_official",
+                "quota-full (5 keys/VIN in app)" if quota_full
+                else "no key minted (see skoda_official_keygen probe)",
+            )
             if quota_full:
                 repairs.raise_issue_skoda_official_quota(self.hass, self.entry.entry_id)
             return
@@ -2611,6 +2640,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         self.hass.config_entries.async_update_entry(
             self.entry, data={**self.entry.data, CONF_SKODA_OFFICIAL_KEYS: full})
         repairs.raise_issue_skoda_official_enrolled(self.hass, self.entry.entry_id)
+        self._skoda_probe("skoda_official", f"enrolled ({len(newly)} new key(s))")
 
     async def _arm_supplementary_channels(self) -> None:
         """v2.15.0b1 (C1) — arm configured supplementary read channels on the

--- a/custom_components/vag_connect/repairs.py
+++ b/custom_components/vag_connect/repairs.py
@@ -211,6 +211,40 @@ def clear_issue_test_cohort_share(hass: HomeAssistant, entry_id: str) -> None:
     ir.async_delete_issue(hass, DOMAIN, f"{entry_id}_test_cohort_share")
 
 
+def raise_issue_skoda_official_enrolled(hass: HomeAssistant, entry_id: str) -> None:
+    """Škoda official-API auto-enrollment — inform the user (once, dismissibly) that
+    we minted an official API key from their existing login and now have Škoda's
+    durable, official channel available as an automatic failover. Purely
+    informational: not auto-fixable, lowest severity, idempotent (HA de-dupes)."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"{entry_id}_skoda_official_enrolled",
+        is_fixable=False,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="skoda_official_enrolled",
+        learn_more_url="https://github.com/its-me-prash/vwgroup-connect-ha/issues/1286",
+    )
+
+
+def raise_issue_skoda_official_quota(hass: HomeAssistant, entry_id: str) -> None:
+    """Škoda official-API auto-enrollment blocked — the account already holds the
+    maximum 5 API keys for this vehicle, so we couldn't mint one. Tell the user
+    (once, dismissibly) how to free a slot in the MyŠkoda app. Not auto-fixable;
+    lowest severity; idempotent."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"{entry_id}_skoda_official_quota",
+        is_fixable=False,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="skoda_official_quota_full",
+        learn_more_url="https://github.com/its-me-prash/vwgroup-connect-ha/issues/1286",
+    )
+
+
 def raise_issue_requirements_conflict(hass: HomeAssistant) -> None:
     """Raise a repair issue for configuration problems."""
     ir.async_create_issue(

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: one-time historical export didn't complete",
       "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+    },
+    "skoda_official_enrolled": {
+      "title": "Škoda official API — you're now enrolled automatically",
+      "description": "Good news: we used your existing Škoda login to create an official Škoda API key for your car, so Home Assistant can now read it over Škoda's new official, durable channel — as an automatic backup if the normal connection ever struggles. Nothing to do on your side; this is just a heads-up, and you can dismiss it."
+    },
+    "skoda_official_quota_full": {
+      "title": "Škoda official API — key limit reached",
+      "description": "We tried to set up Škoda's official API for your car automatically, but your account already has the maximum of 5 API keys for this vehicle. To use it, free a slot in the MyŠkoda app (Settings → API keys → delete an unused one) and reload the integration, or paste an existing key manually in the integration's options. Everything else keeps working as before."
     }
   },
   "selector": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: jednorázový historický export nebyl dokončen",
       "description": "Jednorázový historický export vyžádaný pro toto auto nevytvořil soubor ve stanovené lhůtě. Portál VW pro tento požadavek nevrací žádný konečný stav, takže mohl být tiše zahozen. Požadavek byl vymazán — můžete jej vyžádat znovu nebo se podívat přímo do portálu."
+    },
+    "skoda_official_enrolled": {
+      "title": "Oficiální API Škoda — nyní jste automaticky zaregistrováni",
+      "description": "Dobrá zpráva: pomocí vašeho stávajícího přihlášení Škoda jsme pro vaše auto vytvořili oficiální API klíč Škoda, takže ho Home Assistant teď dokáže načítat přes nový oficiální a trvalý kanál Škoda — jako automatickou zálohu pro případ, že by běžné připojení někdy mělo potíže. Z vaší strany není potřeba nic dělat; je to jen upozornění a můžete ho zavřít."
+    },
+    "skoda_official_quota_full": {
+      "title": "Oficiální API Škoda — dosažen limit klíčů",
+      "description": "Pokusili jsme se pro vaše auto automaticky nastavit oficiální API Škoda, ale váš účet už má pro toto vozidlo maximum 5 API klíčů. Chcete-li ho používat, uvolněte v aplikaci MyŠkoda jedno místo (Nastavení → API klíče → smažte nepoužívaný) a znovu načtěte integraci, nebo v možnostech integrace ručně vložte existující klíč. Vše ostatní funguje dál jako dosud."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: engangseksport af historik blev ikke fuldført",
       "description": "Den engangseksport af historik, du anmodede om for denne bil, nåede ikke at lave en fil inden for tidsfristen. VW-portalen giver ikke denne anmodning nogen endelig status, så den kan være blevet droppet i stilhed. Anmodningen er nulstillet — du kan anmode igen eller kigge direkte i portalen."
+    },
+    "skoda_official_enrolled": {
+      "title": "Škodas officielle API — du er nu tilmeldt automatisk",
+      "description": "Godt nyt: Vi brugte dit eksisterende Škoda-login til at oprette en officiel Škoda API-nøgle til din bil, så Home Assistant nu kan læse den via Škodas nye officielle og stabile kanal — som en automatisk reserve, hvis den normale forbindelse en dag driller. Du behøver ikke gøre noget; det er bare til info, og du kan roligt lukke beskeden."
+    },
+    "skoda_official_quota_full": {
+      "title": "Škodas officielle API — grænsen for nøgler er nået",
+      "description": "Vi forsøgte at sætte Škodas officielle API op til din bil automatisk, men din konto har allerede det maksimale antal på 5 API-nøgler til denne bil. For at bruge den skal du frigøre en plads i MyŠkoda-appen (Indstillinger → API-nøgler → slet en, du ikke bruger) og genindlæse integrationen, eller indsætte en eksisterende nøgle manuelt i integrationens indstillinger. Alt andet fungerer som hidtil."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: Einmaliger historischer Export nicht abgeschlossen",
       "description": "Der angefragte einmalige historische Export für dieses Auto hat innerhalb der Client-Frist keine Datei erzeugt. Das VW-Portal liefert für diese Anfrage keinen Endzustand, sie wurde also möglicherweise still verworfen. Die Anfrage wurde zurückgesetzt — du kannst sie erneut anfragen oder direkt im Portal nachsehen."
+    },
+    "skoda_official_enrolled": {
+      "title": "Offizielle Škoda-API — du bist jetzt automatisch dabei",
+      "description": "Gute Nachricht: Wir haben mit deinem bestehenden Škoda-Login automatisch einen offiziellen Škoda-API-Schlüssel für dein Auto erstellt. Home Assistant kann es jetzt über Škodas neuen offiziellen, dauerhaften Kanal lesen — als automatische Reserve, falls die normale Verbindung mal schwächelt. Für dich gibt es nichts zu tun; das ist nur ein Hinweis, den du ausblenden kannst."
+    },
+    "skoda_official_quota_full": {
+      "title": "Offizielle Škoda-API — Schlüssel-Limit erreicht",
+      "description": "Wir wollten Škodas offizielle API für dein Auto automatisch einrichten, aber dein Konto hat für dieses Fahrzeug bereits die maximal 5 API-Schlüssel. Um sie zu nutzen, gib in der MyŠkoda-App einen Platz frei (Einstellungen → API-Schlüssel → einen ungenutzten löschen) und lade die Integration neu — oder trage einen vorhandenen Schlüssel manuell in den Optionen ein. Alles andere läuft weiter wie bisher."
     }
   },
   "selector": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: one-time historical export didn't complete",
       "description": "The one-time historical export requested for this car didn't produce a file within the client deadline. The VW portal gives this request no terminal state, so it may have been silently dropped. The request has been cleared — you can request it again, or check the portal directly."
+    },
+    "skoda_official_enrolled": {
+      "title": "Škoda official API — you're now enrolled automatically",
+      "description": "Good news: we used your existing Škoda login to create an official Škoda API key for your car, so Home Assistant can now read it over Škoda's new official, durable channel — as an automatic backup if the normal connection ever struggles. Nothing to do on your side; this is just a heads-up, and you can dismiss it."
+    },
+    "skoda_official_quota_full": {
+      "title": "Škoda official API — key limit reached",
+      "description": "We tried to set up Škoda's official API for your car automatically, but your account already has the maximum of 5 API keys for this vehicle. To use it, free a slot in the MyŠkoda app (Settings → API keys → delete an unused one) and reload the integration, or paste an existing key manually in the integration's options. Everything else keeps working as before."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: la exportación histórica única no se completó",
       "description": "La exportación histórica única solicitada para este coche no generó ningún archivo dentro del plazo del cliente. El portal de VW no asigna a esta solicitud ningún estado final, así que puede haberse descartado de forma silenciosa. La solicitud se ha restablecido — puedes volver a solicitarla o consultar directamente el portal."
+    },
+    "skoda_official_enrolled": {
+      "title": "API oficial de Škoda — ya estás inscrito automáticamente",
+      "description": "Buenas noticias: usamos el inicio de sesión de Škoda que ya tenías para crear una clave de la API oficial de Škoda para tu coche, así que ahora Home Assistant puede leerlo a través del nuevo canal oficial y duradero de Škoda, como copia de seguridad automática por si la conexión normal alguna vez falla. No tienes que hacer nada por tu parte; esto es solo un aviso y puedes descartarlo."
+    },
+    "skoda_official_quota_full": {
+      "title": "API oficial de Škoda — límite de claves alcanzado",
+      "description": "Intentamos configurar la API oficial de Škoda para tu coche automáticamente, pero tu cuenta ya tiene el máximo de 5 claves de API para este vehículo. Para usarla, libera un espacio en la app MyŠkoda (Ajustes → Claves de API → elimina una que no uses) y recarga la integración, o pega manualmente una clave existente en las opciones de la integración. Todo lo demás sigue funcionando como antes."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: kertaluonteinen historiatietojen vienti ei valmistunut",
       "description": "Tälle autolle pyydetty kertaluonteinen historiatietojen vienti ei tuottanut tiedostoa määräaikaan mennessä. VW-portaali ei anna tälle pyynnölle lopputilaa, joten se on voitu hylätä hiljaisesti. Pyyntö on nollattu — voit pyytää sen uudelleen tai tarkistaa asian suoraan portaalista."
+    },
+    "skoda_official_enrolled": {
+      "title": "Škodan virallinen API — sinut on nyt liitetty automaattisesti",
+      "description": "Hyviä uutisia: käytimme nykyisiä Škoda-kirjautumistietojasi ja loimme autollesi virallisen Škoda-API-avaimen, joten Home Assistant voi nyt lukea autosi tiedot Škodan uuden virallisen ja pysyvän kanavan kautta — automaattisena varayhteytenä siltä varalta, että tavallinen yhteys joskus takkuaa. Sinun ei tarvitse tehdä mitään; tämä on vain tiedoksi, ja voit sulkea ilmoituksen."
+    },
+    "skoda_official_quota_full": {
+      "title": "Škodan virallinen API — avainten yläraja saavutettu",
+      "description": "Yritimme ottaa Škodan virallisen API:n automaattisesti käyttöön autollesi, mutta tililläsi on jo tälle ajoneuvolle enimmäismäärä eli 5 API-avainta. Ota se käyttöön vapauttamalla paikka MyŠkoda-sovelluksessa (Asetukset → API-avaimet → poista käyttämätön) ja lataamalla integraatio uudelleen, tai liitä olemassa oleva avain käsin integraation asetuksiin. Kaikki muu toimii kuten ennenkin."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin} : l'export historique ponctuel n'a pas abouti",
       "description": "L'export historique ponctuel demandé pour cette voiture n'a pas produit de fichier dans le délai imparti. Le portail VW ne fournit aucun état final pour cette demande, elle a donc peut-être été abandonnée silencieusement. La demande a été réinitialisée — vous pouvez la relancer ou vérifier directement dans le portail."
+    },
+    "skoda_official_enrolled": {
+      "title": "API officielle Škoda — vous êtes désormais inscrit automatiquement",
+      "description": "Bonne nouvelle : nous avons utilisé votre connexion Škoda existante pour créer une clé API Škoda officielle pour votre voiture. Home Assistant peut donc maintenant la lire via le nouveau canal officiel et durable de Škoda — comme sauvegarde automatique si jamais la connexion habituelle rencontre des difficultés. Rien à faire de votre côté ; c'est juste une information, et vous pouvez la fermer."
+    },
+    "skoda_official_quota_full": {
+      "title": "API officielle Škoda — limite de clés atteinte",
+      "description": "Nous avons essayé de configurer l'API officielle de Škoda pour votre voiture automatiquement, mais votre compte a déjà atteint le maximum de 5 clés API pour ce véhicule. Pour l'utiliser, libérez un emplacement dans l'application MyŠkoda (Paramètres → Clés API → supprimez-en une inutilisée) puis rechargez l'intégration, ou collez manuellement une clé existante dans les options de l'intégration. Tout le reste continue de fonctionner comme avant."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: l'esportazione storica una tantum non è stata completata",
       "description": "L'esportazione storica una tantum richiesta per quest'auto non ha prodotto alcun file entro il termine previsto dal client. Il portale VW non fornisce uno stato finale per questa richiesta, quindi potrebbe essere stata scartata silenziosamente. La richiesta è stata azzerata — puoi richiederla di nuovo oppure controllare direttamente nel portale."
+    },
+    "skoda_official_enrolled": {
+      "title": "API ufficiale di Škoda — ora sei registrato in automatico",
+      "description": "Buone notizie: abbiamo usato il tuo accesso Škoda esistente per creare una chiave API ufficiale di Škoda per la tua auto, così Home Assistant può ora leggerla tramite il nuovo canale ufficiale e stabile di Škoda — come backup automatico nel caso la connessione normale dovesse dare problemi. Non devi fare niente: è solo un avviso, e puoi chiuderlo."
+    },
+    "skoda_official_quota_full": {
+      "title": "API ufficiale di Škoda — limite di chiavi raggiunto",
+      "description": "Abbiamo provato a configurare in automatico l'API ufficiale di Škoda per la tua auto, ma il tuo account ha già il massimo di 5 chiavi API per questo veicolo. Per usarla, libera uno slot nell'app MyŠkoda (Impostazioni → Chiavi API → eliminane una che non usi) e ricarica l'integrazione, oppure incolla a mano una chiave esistente nelle opzioni dell'integrazione. Tutto il resto continua a funzionare come prima."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: engangs historisk eksport ble ikke fullført",
       "description": "Den engangs historiske eksporten som ble bestilt for denne bilen, produserte ingen fil innen tidsfristen. VW-portalen gir ikke denne forespørselen noen slutt-status, så den kan ha blitt forkastet uten beskjed. Forespørselen er nullstilt — du kan be om den på nytt, eller sjekke portalen direkte."
+    },
+    "skoda_official_enrolled": {
+      "title": "Škoda offisielt API — du er nå automatisk påmeldt",
+      "description": "Gode nyheter: vi brukte den eksisterende Škoda-innloggingen din til å lage en offisiell Škoda API-nøkkel for bilen din, så Home Assistant nå kan lese den over Škodas nye offisielle og varige kanal — som en automatisk reserve hvis den vanlige tilkoblingen skulle få problemer. Du trenger ikke gjøre noe; dette er bare en beskjed, og du kan lukke den."
+    },
+    "skoda_official_quota_full": {
+      "title": "Škoda offisielt API — grensen for nøkler er nådd",
+      "description": "Vi prøvde å sette opp Škodas offisielle API for bilen din automatisk, men kontoen din har allerede maks 5 API-nøkler for dette kjøretøyet. For å bruke det må du frigjøre en plass i MyŠkoda-appen (Innstillinger → API-nøkler → slett en ubrukt) og laste inn integrasjonen på nytt, eller lime inn en eksisterende nøkkel manuelt i integrasjonens alternativer. Alt annet fungerer som før."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: eenmalige historische export niet voltooid",
       "description": "De eenmalige historische export die voor deze auto is aangevraagd, heeft binnen de deadline van de client geen bestand opgeleverd. Het VW-portaal geeft deze aanvraag geen eindstatus, dus mogelijk is hij stilletjes verworpen. De aanvraag is gewist — je kunt hem opnieuw aanvragen of rechtstreeks in het portaal kijken."
+    },
+    "skoda_official_enrolled": {
+      "title": "Officiële Škoda-API — je bent nu automatisch aangemeld",
+      "description": "Goed nieuws: we hebben je bestaande Škoda-login gebruikt om een officiële Škoda-API-sleutel voor je auto aan te maken, zodat Home Assistant hem nu kan uitlezen via het nieuwe, officiële en stabiele kanaal van Škoda — als automatische back-up voor als de normale verbinding het ooit laat afweten. Je hoeft zelf niets te doen; dit is gewoon een seintje, en je kunt het wegklikken."
+    },
+    "skoda_official_quota_full": {
+      "title": "Officiële Škoda-API — maximaal aantal sleutels bereikt",
+      "description": "We probeerden de officiële API van Škoda automatisch voor je auto in te stellen, maar je account heeft voor deze auto al het maximum van 5 API-sleutels. Om hem te gebruiken, maak je een plek vrij in de MyŠkoda-app (Instellingen → API-sleutels → verwijder een ongebruikte) en herlaad je de integratie, of plak je zelf een bestaande sleutel in de opties van de integratie. Al het andere blijft gewoon werken zoals eerst."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: jednorazowy eksport historyczny nie został ukończony",
       "description": "Jednorazowy eksport historyczny zażądany dla tego auta nie utworzył pliku w wyznaczonym czasie. Portal VW nie zwraca dla tego żądania żadnego stanu końcowego, więc mogło ono zostać po cichu odrzucone. Żądanie zostało wyczyszczone — możesz je ponowić lub sprawdzić bezpośrednio w portalu."
+    },
+    "skoda_official_enrolled": {
+      "title": "Oficjalne API Škoda — masz już automatyczny dostęp",
+      "description": "Dobra wiadomość: wykorzystaliśmy Twoje istniejące dane logowania Škoda, aby utworzyć oficjalny klucz API Škoda dla Twojego samochodu. Dzięki temu Home Assistant może teraz odczytywać dane przez nowy, oficjalny i trwały kanał Škoda — jako automatyczne zabezpieczenie na wypadek, gdyby zwykłe połączenie kiedyś szwankowało. Nie musisz nic robić; to tylko informacja i możesz ją zamknąć."
+    },
+    "skoda_official_quota_full": {
+      "title": "Oficjalne API Škoda — osiągnięto limit kluczy",
+      "description": "Próbowaliśmy automatycznie skonfigurować oficjalne API Škoda dla Twojego samochodu, ale na Twoim koncie jest już maksymalna liczba 5 kluczy API dla tego pojazdu. Aby z niego skorzystać, zwolnij jedno miejsce w aplikacji MyŠkoda (Ustawienia → Klucze API → usuń nieużywany) i przeładuj integrację, albo wklej istniejący klucz ręcznie w opcjach integracji. Cała reszta działa tak jak wcześniej."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1984,6 +1984,14 @@
     "historical_timeout": {
       "title": "{vin}: engångsexporten av historik slutfördes inte",
       "description": "Engångsexporten av historik som begärdes för den här bilen skapade ingen fil inom tidsgränsen. VW-portalen ger den här begäran inget slutläge, så den kan ha försvunnit tyst. Begäran har rensats — du kan begära den igen eller titta direkt i portalen."
+    },
+    "skoda_official_enrolled": {
+      "title": "Škodas officiella API – du är nu automatiskt ansluten",
+      "description": "Goda nyheter: vi använde din befintliga Škoda-inloggning för att skapa en officiell Škoda API-nyckel för din bil, så nu kan Home Assistant läsa av den via Škodas nya officiella, stabila kanal – som en automatisk reserv om den vanliga anslutningen någon gång krånglar. Du behöver inte göra något – det här är bara till info, och du kan stänga meddelandet."
+    },
+    "skoda_official_quota_full": {
+      "title": "Škodas officiella API – nyckelgränsen är nådd",
+      "description": "Vi försökte ställa in Škodas officiella API för din bil automatiskt, men ditt konto har redan det maximala antalet på 5 API-nycklar för det här fordonet. För att kunna använda det, frigör en plats i MyŠkoda-appen (Inställningar → API-nycklar → ta bort en oanvänd) och ladda om integrationen, eller klistra in en befintlig nyckel manuellt i integrationens alternativ. Allt annat fungerar som vanligt."
     }
   },
   "services": {

--- a/tests/bruno/skoda/52_POST_create_api_key.bru
+++ b/tests/bruno/skoda/52_POST_create_api_key.bru
@@ -1,0 +1,44 @@
+meta {
+  name: POST create official public-API key
+  type: http
+  seq: 52
+}
+
+post {
+  url: {{base_url}}/api/v2/public-api-keys
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+  User-Agent: MySkoda/Android/8.16.0/260821007
+}
+
+body:json {
+  {
+    "name": "Home Assistant (vag_connect)",
+    "vin": "{{vin}}"
+  }
+}
+
+docs {
+  Mints an official Skoda public-API key (X-API-Key) for one VIN, from
+  the mysmob login this client already holds — no re-scope needed. The
+  returned CreatedApiKeyDto {id, key, name, validUntil} carries the key
+  SECRET, which is returned ONLY here (never on a later list). Keys are
+  VIN-bound; the account may hold up to 5 per VIN.
+
+  The route is normally exercised only by the MySkoda app (v8.16+), so
+  the call spoofs the real app User-Agent above in case a min-app-version
+  gate applies.
+
+  Implementation: SkodaClient.mint_api_key() in
+  custom_components/vag_connect/cariad/api/skoda.py. Drives the Skoda
+  official-API auto-enrolment in coordinator._auto_enroll_skoda_official.
+}

--- a/tests/bruno/skoda/53_GET_list_api_keys.bru
+++ b/tests/bruno/skoda/53_GET_list_api_keys.bru
@@ -1,0 +1,31 @@
+meta {
+  name: GET official public-API keys + quota
+  type: http
+  seq: 53
+}
+
+get {
+  url: {{base_url}}/api/v2/public-api-keys
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+  User-Agent: MySkoda/Android/8.16.0/260821007
+}
+
+docs {
+  Lists the official public-API keys on the account and the remaining
+  quota per VIN: {maxKeys: 5, vehicleKeys: [{vin, keysRemaining}]}. No
+  key secrets are returned here — only the mint (POST) call returns a
+  secret. Used to check quota before minting so we never breach the
+  5-keys-per-VIN limit.
+
+  Implementation: SkodaClient.list_api_keys() in
+  custom_components/vag_connect/cariad/api/skoda.py.
+}

--- a/tests/bruno/skoda/54_DELETE_api_key.bru
+++ b/tests/bruno/skoda/54_DELETE_api_key.bru
@@ -1,0 +1,30 @@
+meta {
+  name: DELETE official public-API key
+  type: http
+  seq: 54
+}
+
+delete {
+  url: {{base_url}}/api/v2/public-api-keys/{{key_id}}
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+  User-Agent: MySkoda/Android/8.16.0/260821007
+}
+
+docs {
+  Deletes one official public-API key by id — used to free a slot before
+  re-minting an expired one when the account is already at the 5-keys-per-VIN
+  limit. Only keys we minted are deletable; the list endpoint returns no
+  foreign ids.
+
+  Implementation: SkodaClient.delete_api_key() in
+  custom_components/vag_connect/cariad/api/skoda.py.
+}

--- a/tests/test_skoda_auto_enroll.py
+++ b/tests/test_skoda_auto_enroll.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Škoda official-API auto-enrollment orchestration in the coordinator.
+
+An already-logged-in Škoda user is auto-enrolled: we mint a per-VIN X-API-Key from
+the existing mysmob login, persist it, arm the official failover channel, and raise
+a one-time HA repair. Idempotent (skip VINs with a stored key, honour the 5-key
+quota) + fail-soft + gated on a native login.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+from custom_components.vag_connect.const import CONF_BRAND, CONF_SKODA_OFFICIAL_KEYS
+
+VIN1, VIN2 = "TMBEL9NEXP1000001", "TMBEL9NEXP1000002"
+
+
+def _coord(entry_data: dict, client) -> VagConnectCoordinator:
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c.hass = MagicMock()
+    c.entry = MagicMock()
+    c.entry.entry_id = "e1"
+    c.entry.data = dict(entry_data)
+    c._cariad_client = client
+    return c
+
+
+def _client(can_mint: bool = True, remaining: int = 5):
+    cl = MagicMock()
+    cl.can_mint_official_key = can_mint
+    cl.list_api_keys = AsyncMock(return_value={
+        "maxKeys": 5,
+        "vehicleKeys": [
+            {"vin": VIN1, "keysRemaining": remaining},
+            {"vin": VIN2, "keysRemaining": remaining},
+        ],
+    })
+    cl.mint_api_key = AsyncMock(side_effect=lambda vin: {
+        "id": f"id-{vin}", "key": f"KEY-{vin}", "validUntil": "2027-09-01T00:00:00Z"})
+    cl.arm_supplementary_official = MagicMock()
+    return cl
+
+
+def test_enrolls_mints_persists_arms_and_notifies():
+    cl = _client()
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_enrolled"
+    ) as rep:
+        asyncio.run(c._auto_enroll_skoda_official([VIN1, VIN2]))
+    assert cl.mint_api_key.await_count == 2
+    kw = cl.arm_supplementary_official.call_args.kwargs
+    assert kw["keys_by_vin"] == {VIN1: f"KEY-{VIN1}", VIN2: f"KEY-{VIN2}"}
+    data = c.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert data[CONF_SKODA_OFFICIAL_KEYS][VIN1]["key"] == f"KEY-{VIN1}"
+    assert data[CONF_SKODA_OFFICIAL_KEYS][VIN1]["id"] == f"id-{VIN1}"
+    rep.assert_called_once()
+
+
+def test_non_skoda_is_noop():
+    cl = _client()
+    c = _coord({CONF_BRAND: "volkswagen"}, cl)
+    asyncio.run(c._auto_enroll_skoda_official([VIN1]))
+    cl.mint_api_key.assert_not_awaited()
+    cl.arm_supplementary_official.assert_not_called()
+
+
+def test_portal_fallback_gate_blocks_mint():
+    # can_mint_official_key False = portal-fallback / non-native login → never mint
+    cl = _client(can_mint=False)
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    asyncio.run(c._auto_enroll_skoda_official([VIN1]))
+    cl.mint_api_key.assert_not_awaited()
+
+
+def test_already_enrolled_arms_without_re_minting():
+    cl = _client()
+    c = _coord({
+        CONF_BRAND: "skoda",
+        CONF_SKODA_OFFICIAL_KEYS: {VIN1: {"key": "OLD", "id": "x", "validUntil": "y"}},
+    }, cl)
+    asyncio.run(c._auto_enroll_skoda_official([VIN1]))
+    cl.mint_api_key.assert_not_awaited()
+    assert cl.arm_supplementary_official.call_args.kwargs["keys_by_vin"] == {VIN1: "OLD"}
+    c.hass.config_entries.async_update_entry.assert_not_called()  # nothing new to persist
+
+
+def test_quota_full_raises_quota_repair_and_does_not_mint():
+    cl = _client(remaining=0)
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_quota"
+    ) as rep:
+        asyncio.run(c._auto_enroll_skoda_official([VIN1]))
+    cl.mint_api_key.assert_not_awaited()
+    rep.assert_called_once()
+    c.hass.config_entries.async_update_entry.assert_not_called()

--- a/tests/test_skoda_auto_enroll.py
+++ b/tests/test_skoda_auto_enroll.py
@@ -41,6 +41,7 @@ def _client(can_mint: bool = True, remaining: int = 5):
     cl.mint_api_key = AsyncMock(side_effect=lambda vin: {
         "id": f"id-{vin}", "key": f"KEY-{vin}", "validUntil": "2027-09-01T00:00:00Z"})
     cl.arm_supplementary_official = MagicMock()
+    cl.probe_outcomes = {}  # real dict so _skoda_probe captures (not a MagicMock attr)
     return cl
 
 
@@ -98,3 +99,38 @@ def test_quota_full_raises_quota_repair_and_does_not_mint():
     cl.mint_api_key.assert_not_awaited()
     rep.assert_called_once()
     c.hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_success_records_enrolled_probe():
+    cl = _client()
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    with patch("custom_components.vag_connect.repairs.raise_issue_skoda_official_enrolled"):
+        asyncio.run(c._auto_enroll_skoda_official([VIN1, VIN2]))
+    assert cl.probe_outcomes["skoda_official"] == "enrolled (2 new key(s))"
+
+
+def test_gate_block_records_probe():
+    cl = _client(can_mint=False)
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    asyncio.run(c._auto_enroll_skoda_official([VIN1]))
+    assert cl.probe_outcomes["skoda_official"] == "gate: not a native mysmob login"
+
+
+def test_quota_full_records_probe():
+    cl = _client(remaining=0)
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    with patch("custom_components.vag_connect.repairs.raise_issue_skoda_official_quota"):
+        asyncio.run(c._auto_enroll_skoda_official([VIN1]))
+    assert cl.probe_outcomes["skoda_official"].startswith("quota-full")
+
+
+def test_failed_mint_not_retried_same_session():
+    # A live mint that fails (returns None) must NOT be re-hammered every poll: the
+    # attempted-set caps it at one try per HA session; the keygen probe stays visible.
+    cl = _client()
+    cl.mint_api_key = AsyncMock(return_value=None)
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    asyncio.run(c._auto_enroll_skoda_official([VIN1, VIN2]))
+    asyncio.run(c._auto_enroll_skoda_official([VIN1, VIN2]))  # second poll, same session
+    assert cl.mint_api_key.await_count == 2  # once per VIN, not four times
+    assert cl.probe_outcomes["skoda_official"].startswith("no key minted")

--- a/tests/test_skoda_keygen.py
+++ b/tests/test_skoda_keygen.py
@@ -90,3 +90,43 @@ def test_list_and_delete() -> None:
     assert asyncio.run(c.delete_api_key("k1")) is True
     assert c._request.call_args.args[0] == "DELETE"
     assert c._request.call_args.args[1].endswith("/api/v2/public-api-keys/k1")
+
+
+def test_keygen_records_pii_free_probe_outcomes() -> None:
+    # The mint route is RE'd but never run live — diagnostics must report what it
+    # actually did, as a PII-free probe (status + response KEY names only).
+    from custom_components.vag_connect.cariad.exceptions import APIError
+
+    # success with validUntil
+    c = _native_client()
+    c._post = AsyncMock(return_value={  # type: ignore[method-assign]
+        "id": "k1", "key": "SECRET", "validUntil": "2027-01-01T00:00:00Z"})
+    asyncio.run(c.mint_api_key(VIN))
+    assert c.probe_outcomes["skoda_official_keygen"] == "POST 2xx key+validUntil"
+
+    # 4xx → status only, never the body (which could echo the VIN we sent)
+    c = _native_client()
+    c._post = AsyncMock(  # type: ignore[method-assign]
+        side_effect=APIError(400, "u", "vin TMBJJ7NX1M0000005 rejected"))
+    asyncio.run(c.mint_api_key(VIN))
+    assert c.probe_outcomes["skoda_official_keygen"] == "POST 400"
+    assert VIN not in c.probe_outcomes["skoda_official_keygen"]
+
+    # 2xx but no key secret → shape (key NAMES only), no values
+    c = _native_client()
+    c._post = AsyncMock(return_value={"id": "k1", "name": "x"})  # type: ignore[method-assign]
+    asyncio.run(c.mint_api_key(VIN))
+    assert c.probe_outcomes["skoda_official_keygen"] == "POST 2xx no-key [id,name]"
+
+    # list success → counts only
+    c = _native_client()
+    c._get = AsyncMock(return_value={  # type: ignore[method-assign]
+        "maxKeys": 5, "vehicleKeys": [{"vin": VIN, "keysRemaining": 4}]})
+    asyncio.run(c.list_api_keys())
+    assert c.probe_outcomes["skoda_official_keygen_list"] == "GET 2xx maxKeys=5 vins=1"
+
+    # list 401 → status only
+    c = _native_client()
+    c._get = AsyncMock(side_effect=APIError(401, "u", "body"))  # type: ignore[method-assign]
+    asyncio.run(c.list_api_keys())
+    assert c.probe_outcomes["skoda_official_keygen_list"] == "GET 401"

--- a/tests/test_skoda_keygen.py
+++ b/tests/test_skoda_keygen.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Official Škoda public-API key minting from the mysmob login (auto-enrollment).
+
+RE'd from MyŠkoda 8.16 (cz.myskoda.api.bff_public_api_keys.v2): the app POSTs to
+``mysmob.api.connect.skoda-auto.cz/api/v2/public-api-keys`` with the user's mysmob
+Bearer to create an X-API-Key. We reuse the exact Bearer SkodaClient already holds,
+gated on a native login and spoofing the real app User-Agent.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.vag_connect.cariad.api.skoda import (
+    SkodaClient,
+    _KEYGEN_USER_AGENT,
+    _OFFICIAL_KEY_NAME,
+)
+
+VIN = "TMBJJ7NX1M0000005"
+
+
+def _native_client() -> SkodaClient:
+    c = SkodaClient(MagicMock(), "u@t.de", "pw")
+    c._tokens = SimpleNamespace(strategy="", access_token="eyJhbGci.payload.sig")  # type: ignore[assignment]
+    c._eu_portal = None
+    return c
+
+
+def test_can_mint_gate() -> None:
+    c = _native_client()
+    assert c.can_mint_official_key is True
+    # portal-fallback connector present → never mint (no real Bearer)
+    c._eu_portal = object()
+    assert c.can_mint_official_key is False
+    # portal sentinel token (non-empty strategy) → never mint
+    c._eu_portal = None
+    c._tokens = SimpleNamespace(  # type: ignore[assignment]
+        strategy="data_act_portal", access_token="eu-data-act-portal-cookie-session")
+    assert c.can_mint_official_key is False
+    # non-JWT access token → never mint
+    c._tokens = SimpleNamespace(strategy="", access_token="not-a-jwt")  # type: ignore[assignment]
+    assert c.can_mint_official_key is False
+    # no token at all
+    c._tokens = None
+    assert c.can_mint_official_key is False
+
+
+def test_mint_posts_key_with_spoofed_ua() -> None:
+    c = _native_client()
+    c._post = AsyncMock(return_value={  # type: ignore[method-assign]
+        "id": "k1", "key": "SECRET-XYZ",
+        "name": _OFFICIAL_KEY_NAME, "validUntil": "2027-09-01T00:00:00Z"})
+    out = asyncio.run(c.mint_api_key(VIN))
+    kw = c._post.call_args.kwargs
+    assert c._post.call_args.args[0].endswith("/api/v2/public-api-keys")
+    assert kw["json"] == {"name": _OFFICIAL_KEY_NAME, "vin": VIN}
+    assert kw["headers"]["User-Agent"] == _KEYGEN_USER_AGENT
+    assert out is not None and out["key"] == "SECRET-XYZ"
+
+
+def test_mint_gated_out_never_calls_out() -> None:
+    c = _native_client()
+    c._eu_portal = object()          # portal-fallback → gated
+    c._post = AsyncMock()  # type: ignore[method-assign]
+    assert asyncio.run(c.mint_api_key(VIN)) is None
+    c._post.assert_not_awaited()
+
+
+def test_mint_is_failsoft() -> None:
+    c = _native_client()
+    c._post = AsyncMock(side_effect=Exception("boom"))  # type: ignore[method-assign]
+    assert asyncio.run(c.mint_api_key(VIN)) is None
+    # a 200 without a key secret is also treated as failure
+    c._post = AsyncMock(return_value={"id": "k1"})  # type: ignore[method-assign]
+    assert asyncio.run(c.mint_api_key(VIN)) is None
+
+
+def test_list_and_delete() -> None:
+    c = _native_client()
+    c._get = AsyncMock(return_value={  # type: ignore[method-assign]
+        "maxKeys": 5, "vehicleKeys": [{"vin": VIN, "keysRemaining": 4}]})
+    lst = asyncio.run(c.list_api_keys())
+    assert lst is not None and lst["vehicleKeys"][0]["keysRemaining"] == 4
+    assert c._get.call_args.kwargs["headers"]["User-Agent"] == _KEYGEN_USER_AGENT
+
+    c._request = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    assert asyncio.run(c.delete_api_key("k1")) is True
+    assert c._request.call_args.args[0] == "DELETE"
+    assert c._request.call_args.args[1].endswith("/api/v2/public-api-keys/k1")

--- a/tests/test_skoda_official_api.py
+++ b/tests/test_skoda_official_api.py
@@ -274,6 +274,24 @@ async def test_rate_limit_budget_self_blocks_when_exhausted():
 
 
 @pytest.mark.asyncio
+async def test_per_vin_key_selection_with_fallback():
+    # Auto-enrolled keys are VIN-bound: each VIN uses its own minted key, and a VIN
+    # without one falls back to the single manual key.
+    s = _FakeSession()
+    c = SkodaOfficialClient(
+        s, email="", password="FALLBACK", spin="",
+        keys_by_vin={"VIN1": "KEY-A", "vin2": "KEY-B"})
+    await c.get_status("VIN1")
+    assert s.calls[-1]["headers"]["X-API-Key"] == "KEY-A"
+    await c.get_status("VIN2")                       # map key is upper-cased
+    assert s.calls[-1]["headers"]["X-API-Key"] == "KEY-B"
+    await c.get_status("VIN9")                       # not enrolled → fallback
+    assert s.calls[-1]["headers"]["X-API-Key"] == "FALLBACK"
+    # the per-VIN map is itself an authoritative VIN list
+    assert set(await c.get_vehicles()) == {"VIN1", "VIN2"}
+
+
+@pytest.mark.asyncio
 async def test_retry_after_on_429_sets_block():
     from custom_components.vag_connect.cariad.exceptions import APIError
 


### PR DESCRIPTION
## Škoda official public API — automatic enrolment, zero setup

Škoda opened a public data API (MyŠkoda app v8.16+). This wires it up so an
**already-logged-in Škoda owner is enrolled automatically** — and new users get it
the same painless way, with nothing to paste and nothing to configure.

### How it works
On the normal poll, for a Škoda entry on a native login:
1. **Mint** a per-VIN API key from the existing login (the app's own key-management
   backend), spoofing the real app User-Agent in case the route is version-gated.
2. **Persist** it, so it's minted once and remembered across restarts.
3. **Arm** it as a durable failover read channel.
4. **Notify** the user once, via an HA repair, that it's live.

### Safety / correctness
- **Native-login gate.** Minting only runs when the entry holds a real login token
  (JWT). A portal-cookie-session fallback entry can't mint and is skipped — no 401s.
- **Idempotent.** VINs that already have a stored key are skipped; a second run is a
  no-op (no reload loop).
- **Quota-aware.** Honours the 5-keys-per-VIN limit; if the account is already full,
  it raises a guidance repair instead of failing.
- **Fail-soft.** The whole step is wrapped so it can never sink the poll.
- **Rate-limited.** The official channel stays capped at 20 requests/hour/VIN and is
  read only when the primary channel is down.

### Fallback
The manual key field stays in the options flow for the day the login/mint path breaks
— a single pasted key covers every VIN, VINs auto-discovered.

## Verification
- Full suite green (5574 passed, 15 skipped); 23 dedicated Škoda official-API tests
- Repair notices in 12 languages; translation-parity green (35/35)
- ruff clean, mypy strict clean

> Stacked on #1311 (uses the hardened official-API client). Review/merge that first;
> the diff here is just the auto-enrolment layer.

Part of #1286 (Škoda official API).
