### PR TITLE
VW EU portal: auto-skip the optional marketing-consent page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **VW EU login: auto-skip the optional marketing-consent page.** VW's login
+  sometimes interjects an optional marketing-consent screen after your password is
+  accepted. On the EU Data Act portal channel that used to stop the login and ask
+  you to clear it yourself; now it's continued past automatically on the "not now"
+  path — no marketing consent granted, nothing to click. A genuine Terms &
+  Conditions page is deliberately left untouched (that's a real legal acceptance,
+  so it still points you to accept it in the app/portal once).
+
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 
 ### Added

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -38,7 +38,7 @@ import zipfile
 from collections.abc import Callable
 from html.parser import HTMLParser
 from typing import Any
-from urllib.parse import urljoin, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from aiohttp import ClientConnectionError, ClientSession, ClientTimeout
 
@@ -3487,6 +3487,54 @@ class EUDataActConnector:
         self.logged_in = True
         self.last_login_interaction = ""
 
+    async def _skip_marketing_consent_landing(
+        self, landing_url: str, headers: dict[str, str]
+    ) -> tuple[str, str, int] | None:
+        """Auto-continue past the OPTIONAL marketing-consent interstitial.
+
+        Port of ``idk._skip_marketing_consent`` (evcc PR #29980) to the EU Data
+        Act portal channel. The marketing-consent page's URL carries an OIDC
+        ``callback=`` param; following it completes the login on the "not now"
+        path — no marketing scopes granted, nothing accepted. Returns the new
+        ``(landing_url, html, status)`` on success, or ``None`` when the landing
+        is NOT a marketing page, carries no callback, or the follow fails — the
+        caller then falls through to the existing ``MarketingConsentError`` (safe,
+        no regression). The legal T&C page is intentionally NOT handled here — it
+        has no "not now" path and auto-accepting it would assert legal consent on
+        the user's behalf.
+        """
+        url_l = landing_url.lower()
+        if not any(m in url_l for m in _CONSENT_MARKERS):
+            return None
+        callback = parse_qs(urlparse(landing_url).query).get("callback", [""])[0]
+        if not callback:
+            _LOGGER.debug(
+                "EU Data Act portal: marketing-consent page at %s has no callback"
+                " — cannot auto-skip, leaving it to the classifier",
+                _safe_url(landing_url),
+            )
+            return None
+        cb_url = urljoin(landing_url, callback)
+        try:
+            async with self._session.get(
+                cb_url,
+                headers=headers,
+                allow_redirects=True,
+                timeout=ClientTimeout(total=_TIMEOUT_S),
+            ) as resp:
+                result = (str(resp.url), await resp.text(errors="replace"), resp.status)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "EU Data Act portal: marketing-consent auto-skip failed",
+                exc_info=True,
+            )
+            return None
+        _LOGGER.info(
+            "EU Data Act portal: skipped optional marketing consent "
+            "(followed callback, granted no marketing scopes)"
+        )
+        return result
+
     @staticmethod
     def _is_consent_landing(landing_url: str, landing_html: str) -> bool:
         """True if the post-credential landing is the generic consent grant page.
@@ -3698,6 +3746,19 @@ class EUDataActConnector:
             accepted = await self._accept_consent_page(landing, landing_html)
             if accepted is not None:
                 landing, landing_html, status = accepted
+
+        # v4.6.0 — OPTIONAL marketing-consent interstitial. Distinct from the
+        # generic OAuth grant above (which we accept) AND from the legal T&C wall
+        # below (which we deliberately do NOT auto-clear). VW randomly injects a
+        # marketing-consent page after a valid login; its URL carries an OIDC
+        # ``callback=`` that, when followed, completes the login WITHOUT granting
+        # marketing scopes (the "not now" path). Port of idk._skip_marketing_consent
+        # (evcc PR #29980) to the portal channel. Safe no-op: only fires on a
+        # detected marketing page that actually carries a callback — otherwise it
+        # returns None and we fall through to the existing MarketingConsentError.
+        skipped = await self._skip_marketing_consent_landing(landing, headers)
+        if skipped is not None:
+            landing, landing_html, status = skipped
 
         # A completed flow lands back on the portal host via
         # /services/callbacklogin. Anything else (HTTP >= 400, a

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -3529,7 +3529,10 @@ class EUDataActConnector:
                 exc_info=True,
             )
             return None
-        _LOGGER.info(
+        # DEBUG, not INFO: this is a silent "not now" no-op the user can't act on
+        # (nothing granted, nothing accepted) and VW injects the page on many
+        # otherwise-normal logins — at INFO it would be recurring log noise.
+        _LOGGER.debug(
             "EU Data Act portal: skipped optional marketing consent "
             "(followed callback, granted no marketing scopes)"
         )

--- a/tests/test_marketing_consent_skip.py
+++ b/tests/test_marketing_consent_skip.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""EU Data Act portal — auto-skip the OPTIONAL marketing-consent interstitial.
+
+VW randomly injects a marketing-consent page after an otherwise valid login. Its
+URL carries an OIDC ``callback=`` that, when followed, completes the login WITHOUT
+granting marketing scopes (the "not now" path). Ported from
+``idk._skip_marketing_consent`` (evcc PR #29980) to the portal channel.
+
+Contract:
+  (a) marketing-consent landing WITH a callback → auto-skipped, login completes;
+  (b) marketing-consent landing WITHOUT a callback → still MarketingConsentError
+      (safe fallback, no regression);
+  (c) a legal terms-and-conditions landing is NEVER skipped — it has no "not now"
+      path and auto-accepting it would assert legal consent on the user's behalf.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import EUDataActConnector
+from custom_components.vag_connect.cariad.exceptions import (
+    MarketingConsentError,
+    TermsAndConditionsError,
+)
+
+_SIGNIN_HTML = (
+    '<form action="/signin-service/v1/CLIENT/login/identifier">'
+    '<input type="hidden" name="hmac" value="email_hmac">'
+    '<input type="hidden" name="_csrf" value="csrf1">'
+    '<input type="hidden" name="relayState" value="rs1">'
+    '</form>'
+)
+_PASSWORD_HTML = (
+    '<script>window._IDK = {templateModel: '
+    '{"hmac":"fresh_pw_hmac","relayState":"rs1",'
+    '"postAction":"/signin-service/v1/CLIENT/login/authenticate"}, '
+    'csrf_token: "csrf2"};</script>'
+)
+_MARKETING_HTML = (
+    '<script>window._IDK = {templateModel: {"template":"marketing-consent"}};</script>'
+)
+_TC_HTML = (
+    '<script>window._IDK = {templateModel: '
+    '{"template":"terms-and-conditions",'
+    '"error":{"errorCode":"terms.not.accepted"}}};</script>'
+)
+_PORTAL_OK_LANDING = "https://eu-data-act.drivesomethinggreater.com/dashboard"
+
+# A marketing-consent landing whose URL carries the OIDC callback (the skippable
+# case) vs one without it (the fallback case).
+_MARKETING_WITH_CB = (
+    "https://identity.vwgroup.io/signin-service/v1/CLIENT/consent/marketing"
+    "?callback=https://identity.vwgroup.io/oidc/v1/callback/success"
+)
+_MARKETING_NO_CB = (
+    "https://identity.vwgroup.io/signin-service/v1/CLIENT/consent/marketing"
+)
+_TC_LANDING = (
+    "https://identity.vwgroup.io/signin-service/v1/CLIENT/terms-and-conditions"
+)
+
+
+class _FakeResp:
+    def __init__(self, url: str, *, status: int = 200, text: str = "") -> None:
+        self.url = url
+        self.status = status
+        self._text = text
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def text(self, errors: str | None = None) -> str:
+        return self._text
+
+
+class _Session:
+    """prime → authorize → identifier → credential POST → (marketing) → callback."""
+
+    def __init__(
+        self,
+        *,
+        cred_landing: tuple[str, int, str],
+        callback_landing: tuple[str, int, str] | None = None,
+    ) -> None:
+        self._cred = cred_landing
+        self._cb = callback_landing
+
+    def get(self, url: str, **kw: Any) -> _FakeResp:
+        if url.endswith("/") and "drivesomethinggreater" in url:
+            return _FakeResp(url, text="<html>portal</html>")
+        if "authorize" in url:
+            return _FakeResp(
+                "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/"
+                "identifier",
+                text=_SIGNIN_HTML,
+            )
+        if "/callback/" in url:  # the marketing-skip callback follow
+            assert self._cb is not None, "unexpected callback GET"
+            u, s, h = self._cb
+            return _FakeResp(u, status=s, text=h)
+        raise AssertionError(f"unmatched GET {url}")
+
+    def post(self, url: str, **kw: Any) -> _FakeResp:
+        if url.endswith("/login/identifier"):
+            return _FakeResp(
+                "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/"
+                "authenticate?relayState=rs1",
+                text=_PASSWORD_HTML,
+            )
+        if "/login/authenticate" in url:
+            u, s, h = self._cred
+            return _FakeResp(u, status=s, text=h)
+        raise AssertionError(f"unmatched POST {url}")
+
+
+@pytest.mark.asyncio
+async def test_marketing_consent_with_callback_is_skipped_login_completes() -> None:
+    session = _Session(
+        cred_landing=(_MARKETING_WITH_CB, 200, _MARKETING_HTML),
+        callback_landing=(_PORTAL_OK_LANDING, 200, "<html>logged in</html>"),
+    )
+    conn = EUDataActConnector(session)  # type: ignore[arg-type]
+    await conn.login("user@example.com", "secret")  # must NOT raise
+    assert conn.logged_in is True
+
+
+@pytest.mark.asyncio
+async def test_marketing_consent_without_callback_still_errors() -> None:
+    session = _Session(cred_landing=(_MARKETING_NO_CB, 200, _MARKETING_HTML))
+    conn = EUDataActConnector(session)  # type: ignore[arg-type]
+    with pytest.raises(MarketingConsentError):
+        await conn.login("user@example.com", "secret")
+
+
+@pytest.mark.asyncio
+async def test_terms_and_conditions_never_skipped() -> None:
+    # Legal T&C has no "not now" path — it must still raise, never auto-continue.
+    session = _Session(cred_landing=(_TC_LANDING, 200, _TC_HTML))
+    conn = EUDataActConnector(session)  # type: ignore[arg-type]
+    with pytest.raises(TermsAndConditionsError):
+        await conn.login("user@example.com", "secret")


### PR DESCRIPTION
## Auto-skip the optional marketing-consent page on VW EU portal login

VW sometimes interjects an **optional marketing-consent** screen right after a valid
password step. The device-grant channel (`idk.py`) already continues past it via the
OIDC "not now" callback (a port of evcc PR #29980); the **EU Data Act portal** channel
did not — it hard-failed with `MarketingConsentError` and made the user go clear it.

This ports the same callback-follow to the portal login:

- On a marketing-consent landing whose URL carries an OIDC `callback=`, follow it to
  complete the login **without granting any marketing scopes** ("not now").
- **Safe no-op:** it only fires on a detected marketing page that actually carries a
  callback; otherwise it returns `None` and we fall through to the existing
  `MarketingConsentError` — no behaviour change on any other path.

### Terms & Conditions is deliberately NOT touched
A legal T&C page has no "not now" path, and auto-accepting it would assert a binding
legal acceptance on the user's behalf (the stance evcc and WeConnect-python's default
also take). It keeps routing the user to accept it once in the app/portal — a test
pins that it is never skipped.

## Verification
- 3 new tests: marketing+callback → skipped & login completes; marketing without
  callback → still `MarketingConsentError`; T&C → still `TermsAndConditionsError`.
- Full suite green (5582 passed, 15 skipped); ruff + mypy strict clean.

Sits in `[Unreleased]` — no tag; collecting for the next release.
