### PR TITLE
Škoda: fix 12V-vs-fuel mislabel + spawn trip-statistics sensors (#1310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **Škoda: the "12V battery" reading on petrol/diesel cars was actually the fuel
+  level.** On a combustion Škoda the backend sends the same number in the SoC and
+  fuel-level fields, and we'd been surfacing that as a 12V battery charge (from an
+  unverified early note). It's now only shown when it's a genuinely distinct value,
+  so a petrol car no longer gets a bogus 12V-battery sensor mirroring its tank.
+  Thanks to @indigomejor for the side-by-side raw captures that pinned it down.
+
+### Added
+- **Škoda: trip-statistics sensors now appear.** The last-trip distance, average
+  speed and average consumption are already read from Škoda's own channel, but the
+  sensors were gated to Audi/VW and never spawned. They now show up on Škoda too
+  (long-term aggregates stay hidden where the car doesn't report them). Reported by
+  @indigomejor (#1310).
+
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -46,6 +46,25 @@ _OFFICIAL_KEY_NAME = "Home Assistant (vag_connect)"
 # (verbatim from the 8.16 APK; MySkoda/Android/{versionName}/{versionCode}).
 _KEYGEN_USER_AGENT = "MySkoda/Android/8.16.0/260821007"
 
+_COMBUSTION_ENGINE_TYPES = ("gasoline", "petrol", "diesel", "cng", "lpg")
+
+
+def _primary_soc_or_none(
+    soc_i: int | None, fuel_i: int | None, engine_type: Any
+) -> int | None:
+    """Decide whether ``primaryEngineRange.currentSoCInPercent`` is a real 12V SoC.
+
+    #1310 (indigomejor, gasoline Škoda): the backend mirrors the fuel level into
+    ``currentSoCInPercent`` on a combustion primary engine (captured equal at
+    100/100 and 41/41 with the fuel gauge matching), so a "SoC" that equals the
+    fuel level there is the fuel duplicated, not a 12V reading. Return ``None`` in
+    that case; otherwise return the SoC unchanged (a genuinely distinct value, or a
+    non-combustion engine where the field is not a fuel mirror)."""
+    combustion = str(engine_type or "").lower() in _COMBUSTION_ENGINE_TYPES
+    if soc_i is not None and combustion and soc_i == fuel_i:
+        return None
+    return soc_i
+
 # driving-range.carType enum values that are pure-combustion (no HV battery, no
 # plug). EVs report "electric", PHEVs "hybrid" — deliberately absent, so a plug-in
 # car is NEVER matched. Used to skip the battery-only /charging read on a confirmed
@@ -1544,23 +1563,12 @@ class SkodaClient(CariadBaseClient):
                 driving_range, "secondaryEngineRange", "currentFuelLevelInPercent"
             )
             d.secondary_engine_fuel_level_pct = safe_int(sec_eng_fuel)
-            # v2.2.0 Phase 7 PR #1 — primaryEngineRange.currentSoCInPercent.
-            # On a gasoline car this is the 12V SoC (per #116 MavericklCS
-            # 2026-05-01 scout) — early-warning sensor for "modem can't
-            # keep itself awake". Defensive: missing key → field stays None.
-            primary_soc = v(
-                driving_range, "primaryEngineRange", "currentSoCInPercent"
-            )
-            d.primary_engine_soc_pct = safe_int(primary_soc)
-            # v2.2.1 Phase 8 PR #1 — alles-parsen strategy:
-            # primaryEngineRange.{engineType, currentFuelLevelInPercent}
-            # cross-brand reuse. engineType maps into existing
-            # `primary_engine_type` from PR #3 Phase 7 (CUPRA/SEAT) —
-            # zero-new-entity expanded coverage. fuelLevelInPercent is
-            # a new Skoda-only field (primary tank %), distinct vom
-            # existing `fuel_level` (measurements path) und mit dem
-            # bestehenden `secondary_engine_fuel_level_pct` als
-            # cross-brand sibling.
+            # v2.2.1 Phase 8 PR #1 — engineType + primary fuel level. Parsed
+            # FIRST so the 12V decision below can compare the SoC against them.
+            # engineType maps into existing `primary_engine_type` (cross-brand,
+            # CUPRA/SEAT). fuelLevelInPercent is the primary tank %, distinct from
+            # the measurements-path `fuel_level` and a sibling of the existing
+            # `secondary_engine_fuel_level_pct`.
             primary_eng_type = v(
                 driving_range, "primaryEngineRange", "engineType"
             )
@@ -1569,7 +1577,22 @@ class SkodaClient(CariadBaseClient):
             primary_fuel = v(
                 driving_range, "primaryEngineRange", "currentFuelLevelInPercent"
             )
-            d.primary_engine_fuel_level_pct = safe_int(primary_fuel)
+            fuel_i = safe_int(primary_fuel)
+            d.primary_engine_fuel_level_pct = fuel_i
+            # primaryEngineRange.currentSoCInPercent. The #116 scout read this as
+            # the 12V SoC on a gasoline car, but it was never verified — and #1310
+            # (indigomejor, gasoline Škoda) captured the backend sending the SAME
+            # number in currentSoCInPercent and currentFuelLevelInPercent (100/100
+            # full, 41/41 part-tank, fuel gauge matching). So on a combustion
+            # engine a "SoC" that equals the fuel level is just the fuel duplicated,
+            # NOT a 12V reading — don't surface it as one. Keep it only when it is a
+            # genuinely distinct value (or on a non-combustion engine).
+            soc_i = safe_int(
+                v(driving_range, "primaryEngineRange", "currentSoCInPercent")
+            )
+            d.primary_engine_soc_pct = _primary_soc_or_none(
+                soc_i, fuel_i, primary_eng_type
+            )
             # v2.2.1 Phase 8 PR #1 — carType (string enum diesel /
             # gasoline / electric / hybrid). Authoritative backend
             # classification der primary engine, distinct von den

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -3846,30 +3846,31 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "parked_since",
 })
 
-# v1.14.0 (#24) — Trip Statistics is brand-restricted. The long-term aggregates
-# come from the CARIAD-BFF (Audi + VW EU); Škoda additionally fills the per-trip
-# keys from its own mysmob /trip-statistics parse (#1310). Gate at setup so
-# SEAT/CUPRA/Porsche/VW NA users — whose clients don't expose trip data — don't
-# get "unknown" sensors per VIN. Capability gating (Phase 3, #56) further hides
-# them when the subscription is absent.
+# v1.14.0 (#24) — Trip Statistics is brand-restricted. Audi + VW EU fill these
+# from the CARIAD-BFF; Škoda fills the SAME keys from its own mysmob
+# /trip-statistics parse (#1310). Gate at setup so SEAT/CUPRA/Porsche/VW NA
+# users — whose clients don't expose trip data — don't get "unknown" sensors per
+# VIN. Capability gating (Phase 3, #56) further hides them when the subscription
+# is absent.
 _TRIP_STATS_KEYS: frozenset[str] = frozenset({
     "last_trip_distance_km",
     "last_trip_avg_speed_kmh",
     "last_trip_avg_fuel_consumption_l_100km",
     "last_trip_avg_electric_consumption_kwh_100km",
-    # v2.0.0 (Big-Bang) — long-term aggregates from /tripstatistics?type=longTerm
-    # (CARIAD-BFF only). Same brand gate as the per-trip keys above.
+    # v2.0.0 (Big-Bang) — long-term aggregates. Audi/VW EU read them from the
+    # CARIAD-BFF /tripstatistics?type=longTerm; Škoda from the overview block of
+    # its mysmob /trip-statistics response. Same brand gate as the per-trip keys.
     "lifetime_distance_km",
     "lifetime_avg_fuel_consumption_l_100km",
     "lifetime_avg_electric_consumption_kwh_100km",
 })
-# audi + volkswagen fill these from the CARIAD-BFF /tripstatistics endpoint.
-# #1310 (indigomejor): Škoda fills the per-trip keys (last_trip_*) from its own
-# mysmob /trip-statistics parse (skoda.py), so it belongs here too — the
-# last_trip_* entities then spawn and populate. The CARIAD-BFF FETCH gate stays
-# audi/volkswagen only (coordinator._TRIP_STATS_BRANDS), so no wrong call fires
-# for Škoda; the lifetime_* keys stay empty on Škoda and are hidden by the
-# default "hide empty entities" option rather than showing as unknown.
+# #1310 (indigomejor): Škoda populates BOTH groups — the 4 last_trip_* keys (from
+# detailedStatistics[0]) AND the 3 lifetime_* aggregates (from the overview) — in
+# its own get_status parse (skoda.py), so all ~7 trip-stat sensors spawn and
+# populate on Škoda, not just the per-trip ones. The CARIAD-BFF FETCH gate stays
+# audi/volkswagen only (coordinator._TRIP_STATS_BRANDS) because Škoda already has
+# the data inline — so no wrong BFF call fires for Škoda and nothing shows as
+# "unknown".
 _TRIP_STATS_BRANDS: frozenset[str] = frozenset({"audi", "volkswagen", "skoda"})
 
 # Per-window opening position (% open), from the EU-DA window-lifter positions

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -3846,11 +3846,12 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "parked_since",
 })
 
-# v1.14.0 (#24) — Trip Statistics is brand-restricted at the API level
-# (CARIAD-BFF only — Audi + VW EU). Other brands' clients don't expose
-# ``get_trip_statistics``. Gate at setup so SEAT/CUPRA/Skoda/Porsche/VW NA
-# users don't get four "unknown" sensors per VIN. Capability gating
-# (Phase 3, #56) further hides them when the subscription is absent.
+# v1.14.0 (#24) — Trip Statistics is brand-restricted. The long-term aggregates
+# come from the CARIAD-BFF (Audi + VW EU); Škoda additionally fills the per-trip
+# keys from its own mysmob /trip-statistics parse (#1310). Gate at setup so
+# SEAT/CUPRA/Porsche/VW NA users — whose clients don't expose trip data — don't
+# get "unknown" sensors per VIN. Capability gating (Phase 3, #56) further hides
+# them when the subscription is absent.
 _TRIP_STATS_KEYS: frozenset[str] = frozenset({
     "last_trip_distance_km",
     "last_trip_avg_speed_kmh",
@@ -3862,7 +3863,14 @@ _TRIP_STATS_KEYS: frozenset[str] = frozenset({
     "lifetime_avg_fuel_consumption_l_100km",
     "lifetime_avg_electric_consumption_kwh_100km",
 })
-_TRIP_STATS_BRANDS: frozenset[str] = frozenset({"audi", "volkswagen"})
+# audi + volkswagen fill these from the CARIAD-BFF /tripstatistics endpoint.
+# #1310 (indigomejor): Škoda fills the per-trip keys (last_trip_*) from its own
+# mysmob /trip-statistics parse (skoda.py), so it belongs here too — the
+# last_trip_* entities then spawn and populate. The CARIAD-BFF FETCH gate stays
+# audi/volkswagen only (coordinator._TRIP_STATS_BRANDS), so no wrong call fires
+# for Škoda; the lifetime_* keys stay empty on Škoda and are hidden by the
+# default "hide empty entities" option rather than showing as unknown.
+_TRIP_STATS_BRANDS: frozenset[str] = frozenset({"audi", "volkswagen", "skoda"})
 
 # Per-window opening position (% open), from the EU-DA window-lifter positions
 # (``position_*_door_window_lifter``). Parsed into ``windows_position`` — a slot

--- a/tests/test_1310_indigomejor_fixes.py
+++ b/tests/test_1310_indigomejor_fixes.py
@@ -7,9 +7,10 @@
    mirrors the fuel level into that field on a combustion engine (100/100 full,
    41/41 part-tank, fuel gauge matching), so a "SoC" equal to the fuel level is
    the fuel duplicated, not a 12V reading — it must not surface as one.
-2. Škoda fills the per-trip statistics (last_trip_*) from its own mysmob parse,
-   so it belongs in the sensor-spawn brand gate — while the CARIAD-BFF FETCH gate
-   stays audi/volkswagen only, so no wrong trip-stats call fires for Škoda.
+2. Škoda fills BOTH trip-stat groups from its own mysmob parse — the 4 per-trip
+   keys (last_trip_*) AND the 3 lifetime_* aggregates — so it belongs in the
+   sensor-spawn brand gate. The CARIAD-BFF FETCH gate stays audi/volkswagen only
+   (Škoda has the data inline), so no wrong trip-stats call fires for Škoda.
 """
 from __future__ import annotations
 
@@ -62,6 +63,21 @@ def test_skoda_in_sensor_spawn_gate() -> None:
     from custom_components.vag_connect.sensor import _TRIP_STATS_BRANDS
     assert "skoda" in _TRIP_STATS_BRANDS
     assert {"audi", "volkswagen"} <= _TRIP_STATS_BRANDS
+
+
+def test_spawn_gate_covers_both_trip_stat_groups() -> None:
+    # Škoda populates last_trip_* AND lifetime_*, so both groups must be in the
+    # spawn key-set — otherwise the lifetime_* sensors would never appear for it.
+    from custom_components.vag_connect.sensor import _TRIP_STATS_KEYS
+    assert {
+        "last_trip_distance_km",
+        "last_trip_avg_speed_kmh",
+    } <= _TRIP_STATS_KEYS
+    assert {
+        "lifetime_distance_km",
+        "lifetime_avg_fuel_consumption_l_100km",
+        "lifetime_avg_electric_consumption_kwh_100km",
+    } <= _TRIP_STATS_KEYS
 
 
 def test_skoda_not_in_coordinator_fetch_gate() -> None:

--- a/tests/test_1310_indigomejor_fixes.py
+++ b/tests/test_1310_indigomejor_fixes.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1310 (indigomejor) — two grounded fixes from his debug captures.
+
+1. The Škoda ``primaryEngineRange.currentSoCInPercent`` was mapped to a 12V SoC
+   sensor on an unverified #116 scout note. His raw payloads show the backend
+   mirrors the fuel level into that field on a combustion engine (100/100 full,
+   41/41 part-tank, fuel gauge matching), so a "SoC" equal to the fuel level is
+   the fuel duplicated, not a 12V reading — it must not surface as one.
+2. Škoda fills the per-trip statistics (last_trip_*) from its own mysmob parse,
+   so it belongs in the sensor-spawn brand gate — while the CARIAD-BFF FETCH gate
+   stays audi/volkswagen only, so no wrong trip-stats call fires for Škoda.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.skoda import _primary_soc_or_none
+
+
+# ── 1. 12V-vs-fuel mirror guard ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("soc,fuel,engine", [
+    (41, 41, "gasoline"),
+    (100, 100, "gasoline"),
+    (33, 33, "diesel"),
+    (60, 60, "PETROL"),  # case-insensitive
+    (50, 50, "cng"),
+])
+def test_combustion_soc_equal_to_fuel_is_suppressed(soc, fuel, engine) -> None:
+    # a combustion "SoC" that equals the fuel level is the fuel duplicated → None
+    assert _primary_soc_or_none(soc, fuel, engine) is None
+
+
+@pytest.mark.parametrize("soc,fuel,engine", [
+    (80, 41, "gasoline"),   # genuinely distinct value on a combustion car → kept
+    (12, 90, "diesel"),
+])
+def test_combustion_soc_distinct_from_fuel_is_kept(soc, fuel, engine) -> None:
+    assert _primary_soc_or_none(soc, fuel, engine) == soc
+
+
+@pytest.mark.parametrize("engine", ["electric", "hybrid", "", None])
+def test_non_combustion_soc_always_kept(engine) -> None:
+    # not a combustion engine → the field is not a fuel mirror; keep it even if it
+    # happens to equal the fuel value (e.g. an HV SoC on a hybrid).
+    assert _primary_soc_or_none(80, 80, engine) == 80
+
+
+def test_none_soc_stays_none() -> None:
+    assert _primary_soc_or_none(None, 41, "gasoline") is None
+
+
+def test_missing_fuel_keeps_soc() -> None:
+    # no fuel value to compare against → cannot be a mirror, keep the SoC
+    assert _primary_soc_or_none(55, None, "gasoline") == 55
+
+
+# ── 2. Trip-stats brand gates (spawn includes Škoda; fetch does not) ─────────
+
+def test_skoda_in_sensor_spawn_gate() -> None:
+    from custom_components.vag_connect.sensor import _TRIP_STATS_BRANDS
+    assert "skoda" in _TRIP_STATS_BRANDS
+    assert {"audi", "volkswagen"} <= _TRIP_STATS_BRANDS
+
+
+def test_skoda_not_in_coordinator_fetch_gate() -> None:
+    # the CARIAD-BFF /tripstatistics fetch must NOT fire for Škoda (its trip data
+    # comes from the mysmob parse), so the fetch gate stays audi/volkswagen only.
+    from custom_components.vag_connect.coordinator import VagConnectCoordinator
+    assert "skoda" not in VagConnectCoordinator._TRIP_STATS_BRANDS
+    assert set(VagConnectCoordinator._TRIP_STATS_BRANDS) == {"audi", "volkswagen"}


### PR DESCRIPTION
## Two grounded Škoda fixes from @indigomejor's debug captures (#1310)

### 1. The "12V battery" reading was the fuel level on combustion cars
`primaryEngineRange.currentSoCInPercent` was mapped to a 12V battery SoC on an
unverified early note (#116). @indigomejor's paired raw payloads show the backend
sends the **same number** in `currentSoCInPercent` and `currentFuelLevelInPercent`
on a combustion engine (100/100 full, 41/41 part-tank, fuel gauge matching) — so
it's the fuel duplicated, not a 12V reading.

Fix: a small testable helper (`_primary_soc_or_none`) — on a combustion engine, keep
the value only when it's genuinely distinct from the fuel level; otherwise drop it.
Non-combustion engines are unaffected (an HV SoC on a hybrid is never a fuel mirror).

### 2. Škoda trip-statistics sensors now spawn
`last_trip_*` are already parsed from Škoda's own mysmob channel, but the
sensor-spawn gate `_TRIP_STATS_BRANDS` was audi/volkswagen only, so they never
appeared. Add `"skoda"` to the **spawn** gate; long-term aggregates stay hidden via
the default hide-empty option, and the CARIAD-BFF **fetch** gate stays
audi/volkswagen so no wrong trip-stats call fires for Škoda.

## Verification
- New tests: the 12V mirror-guard (combustion equal → dropped, distinct → kept,
  non-combustion → kept, edge cases) and the spawn-vs-fetch gate split.
- Full suite green (5594 passed, 15 skipped); ruff + mypy strict clean.

Sits in `[Unreleased]` for the next beta.
