### PR TITLE
auth: classify transient token-refresh rejections (no reauth on a blip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **A brief backend hiccup during a token refresh no longer forces you to log in
+  again.** When the login server rejected a token refresh, we treated every
+  rejection the same — including a temporary "try again later" one — and bounced
+  you to a fresh QR / password re-auth. Now only a genuinely dead login (the one
+  case a fresh sign-in actually fixes) does that; a transient server error, rate
+  blip or network wobble just retries on the next poll and your entry stays live.
+  Applies to both the device-code/QR login and the Car-Net (MBB) refresh path.
+
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 
 ### Added

--- a/custom_components/vag_connect/cariad/auth/_device_grant.py
+++ b/custom_components/vag_connect/cariad/auth/_device_grant.py
@@ -82,10 +82,17 @@ from typing import TYPE_CHECKING, Callable
 if TYPE_CHECKING:
     from aiohttp import ClientSession
 
-from ..exceptions import AuthenticationError
+from ..exceptions import AuthenticationError, TokenRefreshRetryError
 from ..models import TokenSet
 
 _LOGGER = logging.getLogger(__name__)
+
+# Refresh-exchange error codes that a fresh login actually fixes. ``invalid_grant``
+# is the ONLY hard case: the refresh token is dead/revoked, so re-prompting the QR
+# login is the correct remedy. Every other rejection (``invalid_client``,
+# ``server_error``, a 5xx, a network blip) is transient — retrying next poll is
+# right, and bouncing the user to a fresh QR prompt for it is the bug we fix here.
+_HARD_REFRESH_ERRORS: frozenset[str] = frozenset({"invalid_grant"})
 
 
 # IDP endpoints (both shared across all VW Group Brand IDs).
@@ -392,18 +399,28 @@ class DeviceAuthorizationGrant:
         except AuthenticationError:
             raise
         except Exception as exc:  # noqa: BLE001
-            raise AuthenticationError(
+            # network/transport blip — transient, NOT a dead refresh token
+            raise TokenRefreshRetryError(
                 f"Device grant refresh: request failed ({exc})"
             ) from exc
 
         if status != 200:
             err = payload.get("error", "") if isinstance(payload, dict) else ""
-            raise AuthenticationError(
-                f"Device grant refresh: IDP returned HTTP {status} ({err})"
+            # invalid_grant = the refresh token is dead → a fresh QR login is the
+            # only fix (hard). Everything else (invalid_client, server_error, a
+            # 5xx) is transient → retry next poll instead of a reauth prompt.
+            if err in _HARD_REFRESH_ERRORS:
+                raise AuthenticationError(
+                    f"Device grant refresh: IDP returned HTTP {status} ({err})"
+                )
+            raise TokenRefreshRetryError(
+                f"Device grant refresh: transient IDP rejection "
+                f"HTTP {status} ({err})"
             )
         access_token = payload.get("access_token", "")
         if not access_token:
-            raise AuthenticationError(
+            # 200 without a token is a server anomaly, not a dead grant → transient.
+            raise TokenRefreshRetryError(
                 "Device grant refresh: 200 but no access_token in payload"
             )
         return TokenSet(

--- a/custom_components/vag_connect/cariad/auth/_mbboauth.py
+++ b/custom_components/vag_connect/cariad/auth/_mbboauth.py
@@ -180,6 +180,14 @@ async def _post_token(
                     payload = json.loads(body)
                 except ValueError as exc:
                     raise _refresh_error(resp.status, body, retryable) from exc
+                # A 200 with a well-formed body but no access_token is a backend
+                # hiccup, not an invalid_grant — on the REFRESH path it must be
+                # transient (TokenRefreshRetryError), not a hard AuthenticationError
+                # that bounces the user to a fresh QR reauth. Classify it here (we
+                # still have `body` + `retryable`) before the defensive raise inside
+                # _parse_token_payload, which can't see either.
+                if not payload.get("access_token"):
+                    raise _refresh_error(resp.status, body, retryable)
                 return _parse_token_payload(payload)
         except ClientError as exc:
             raise _refresh_error(0, str(exc), retryable) from exc

--- a/custom_components/vag_connect/cariad/auth/_mbboauth.py
+++ b/custom_components/vag_connect/cariad/auth/_mbboauth.py
@@ -40,7 +40,29 @@ from typing import Any
 
 from aiohttp import ClientError, ClientSession, ClientTimeout
 
-from ..exceptions import AuthenticationError
+from ..exceptions import AuthenticationError, TokenRefreshRetryError
+
+# Only ``invalid_grant`` (dead/revoked refresh token) is a HARD refresh failure a
+# fresh login fixes; every other rejection is transient. See _device_grant.py.
+_HARD_REFRESH_ERRORS: frozenset[str] = frozenset({"invalid_grant"})
+
+
+def _refresh_error(status: int, body: str, retryable: bool) -> Exception:
+    """Build the exception for a failed token exchange. On the REFRESH path
+    (``retryable``), a non-``invalid_grant`` rejection is transient →
+    ``TokenRefreshRetryError`` (won't trigger a reauth prompt); the id_token LOGIN
+    exchange (``retryable=False``) keeps ``AuthenticationError``. The HTTP status +
+    body are preserved in the message (callers/tests match on it)."""
+    err_code = ""
+    try:
+        if body:
+            err_code = str(json.loads(body).get("error", ""))
+    except (ValueError, AttributeError):
+        err_code = ""
+    msg = f"MBB token exchange HTTP {status}: {body[:400]}"
+    if retryable and err_code not in _HARD_REFRESH_ERRORS:
+        return TokenRefreshRetryError(msg)
+    return AuthenticationError(msg)
 
 # ── Endpoints (DEX + live-probe confirmed 2026-06) ──────────────────────────
 MBB_OAUTH_BASE = "https://mbboauth-1d.prd.ece.vwg-connect.com/mbbcoauth"
@@ -125,12 +147,18 @@ def _parse_token_payload(payload: dict[str, Any]) -> MbbTokenSet:
 
 
 async def _post_token(
-    session: ClientSession, data: dict[str, str], client_id: str
+    session: ClientSession, data: dict[str, str], client_id: str,
+    *, retryable: bool = False,
 ) -> MbbTokenSet:
     # v2.15.12 (#584) — bounded retry/backoff on a TRANSIENT MBB 5xx before
     # surfacing the error verbatim. A ClientError (network) and any non-5xx
     # status still fail immediately with the exact same error envelope as before.
-    last_exc: AuthenticationError | None = None
+    # v4.6.0 — ``retryable=True`` (the REFRESH path) classifies a
+    # non-``invalid_grant`` rejection as ``TokenRefreshRetryError`` so a transient
+    # MBB hiccup no longer bounces the user to a fresh QR reauth. The id_token
+    # LOGIN exchange keeps ``retryable=False`` (a failure there really is a login
+    # failure). This was the upstream gap on the MBB refresh path.
+    last_exc: Exception | None = None
     for attempt in range(_TOKEN_5XX_MAX_ATTEMPTS):
         try:
             async with session.post(
@@ -139,9 +167,7 @@ async def _post_token(
             ) as resp:
                 body = await resp.text()
                 if 500 <= resp.status < 600:
-                    last_exc = AuthenticationError(
-                        f"MBB token exchange HTTP {resp.status}: {body[:400]}"
-                    )
+                    last_exc = _refresh_error(resp.status, body, retryable)
                     if attempt + 1 < _TOKEN_5XX_MAX_ATTEMPTS:
                         await asyncio.sleep(
                             _TOKEN_5XX_BASE_BACKOFF_S * (2 ** attempt)
@@ -149,21 +175,17 @@ async def _post_token(
                         continue
                     raise last_exc
                 if resp.status != 200:
-                    raise AuthenticationError(
-                        f"MBB token exchange HTTP {resp.status}: {body[:400]}"
-                    )
+                    raise _refresh_error(resp.status, body, retryable)
                 try:
                     payload = json.loads(body)
                 except ValueError as exc:
-                    raise AuthenticationError(
-                        f"MBB token response not JSON: {body[:120]}"
-                    ) from exc
+                    raise _refresh_error(resp.status, body, retryable) from exc
                 return _parse_token_payload(payload)
         except ClientError as exc:
-            raise AuthenticationError(f"MBB token exchange failed: {exc}") from exc
+            raise _refresh_error(0, str(exc), retryable) from exc
     # Unreachable in practice (the loop either returns or raises), but keep a
     # definite terminal raise so the type-checker sees a non-None return path.
-    raise last_exc or AuthenticationError("MBB token exchange failed")
+    raise last_exc or _refresh_error(0, "", retryable)
 
 
 async def exchange_id_token(
@@ -221,7 +243,9 @@ async def refresh(
         "refresh_token": refresh_token,
         "scope": _MBB_SCOPE,
     }
-    return await _post_token(session, data, client_id)
+    # REFRESH path → classify transient rejections as TokenRefreshRetryError so a
+    # temporary MBB hiccup doesn't force a QR reauth (only invalid_grant is hard).
+    return await _post_token(session, data, client_id, retryable=True)
 
 
 def jwt_aud(id_token: str) -> str | None:

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -264,6 +264,21 @@ class AuthenticationError(CariadError):
     """Login failed — wrong credentials or account issue."""
 
 
+class TokenRefreshRetryError(CariadError):
+    """A token refresh was rejected TRANSIENTLY — not a dead refresh token.
+
+    A refresh exchange can fail for reasons a fresh login does NOT fix: a
+    transient ``invalid_client`` / ``server_error`` / 5xx / network blip. Only a
+    genuinely dead grant (``invalid_grant``) needs a new login. Classifying the
+    rest as this error — deliberately a sibling of ``AuthenticationError``, NOT a
+    subclass — keeps a temporary hiccup from bouncing the user to a fresh QR /
+    credential reauth prompt: the poll loop reauths ONLY on ``AuthenticationError``
+    (``isinstance`` check), so this falls through to the transient-retry path and
+    the entry stays live until the next poll. Do NOT make it a subclass of
+    ``AuthenticationError`` — a test pins that, because it would silently undo the
+    whole point."""
+
+
 class NorthAmericaAttestationError(AuthenticationError):
     """#1165/#659 — VW North America blocks the sign-in token exchange behind
     Play-Integrity device attestation (~2026-07-30). The con-veh host 401s with a

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -173,9 +173,16 @@ def _is_selfhealing_poll_error(err: object) -> bool:
 
     Auth-interaction errors are de-escalated separately (they trigger reauth).
     """
-    from .cariad.exceptions import APIError, UpstreamUnavailableError  # noqa: PLC0415
+    from .cariad.exceptions import (  # noqa: PLC0415
+        APIError,
+        TokenRefreshRetryError,
+        UpstreamUnavailableError,
+    )
 
-    if isinstance(err, UpstreamUnavailableError):
+    # A transiently-rejected token refresh (invalid_client / server_error / 5xx /
+    # network) is a backend hiccup that self-heals on the next poll, not our bug —
+    # de-escalate it from the public Error Reporter like a 5xx.
+    if isinstance(err, (UpstreamUnavailableError, TokenRefreshRetryError)):
         return True
     if isinstance(err, APIError):
         status = getattr(err, "status", 0)

--- a/tests/test_refresh_retry_classification.py
+++ b/tests/test_refresh_retry_classification.py
@@ -132,6 +132,22 @@ def test_mbb_refresh_transient_is_retryable() -> None:
         asyncio.run(_mbboauth.refresh(_Session(_Resp(400, {"error": "server_error"})), "rt"))  # type: ignore[arg-type]
 
 
+def test_mbb_refresh_200_without_token_is_retryable() -> None:
+    # A 200 whose body parses fine but carries no access_token is a backend hiccup,
+    # not invalid_grant — on the refresh path it must be transient, mirroring the
+    # device-grant case above. Regresses to a hard AuthenticationError without the
+    # pre-parse guard in _post_token (pytest.raises would then not catch it).
+    with pytest.raises(TokenRefreshRetryError):
+        asyncio.run(_mbboauth.refresh(_Session(_Resp(200, {"expires_in": 3600})), "rt"))  # type: ignore[arg-type]
+
+
+def test_mbb_login_200_without_token_stays_auth_error() -> None:
+    # The LOGIN exchange (retryable=False) keeps the same 200-without-token as a
+    # hard AuthenticationError — a login that yields no token really did fail.
+    with pytest.raises(AuthenticationError):
+        asyncio.run(_mbboauth.exchange_id_token(_Session(_Resp(200, {"expires_in": 3600})), "idtok"))  # type: ignore[arg-type]
+
+
 def test_mbb_empty_refresh_token_is_hard() -> None:
     with pytest.raises(AuthenticationError):
         asyncio.run(_mbboauth.refresh(_Session(_Resp(200, {})), ""))  # type: ignore[arg-type]

--- a/tests/test_refresh_retry_classification.py
+++ b/tests/test_refresh_retry_classification.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Token-refresh rejection is CLASSIFIED, not blanket-failed.
+
+Only ``invalid_grant`` (a dead/revoked refresh token) is a hard failure a fresh
+login fixes. Every other rejection — ``invalid_client`` / ``server_error`` / a 5xx
+/ a network blip — is transient and must NOT bounce the user to a fresh QR /
+credential reauth prompt. ``TokenRefreshRetryError`` carries that case and is a
+SIBLING of ``AuthenticationError`` (not a subclass); the poll loop reauths only on
+``isinstance(err, AuthenticationError)``, so the transient case retries next poll.
+Covers the device-grant refresh AND the MBB refresh (the upstream gap), while the
+MBB id_token LOGIN exchange keeps raising ``AuthenticationError``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json as _json
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth import _mbboauth
+from custom_components.vag_connect.cariad.auth._device_grant import (
+    DeviceAuthorizationGrant,
+)
+from custom_components.vag_connect.cariad.exceptions import (
+    AuthenticationError,
+    TokenRefreshRetryError,
+)
+
+
+# ── the load-bearing invariant ──────────────────────────────────────────────
+
+def test_retry_error_is_not_a_subtype_of_auth_error() -> None:
+    # If this ever becomes a subclass, the poll loop's isinstance() reauth gate
+    # would catch it again and silently undo the whole fix.
+    assert not issubclass(TokenRefreshRetryError, AuthenticationError)
+    assert issubclass(TokenRefreshRetryError, Exception)
+    assert not isinstance(TokenRefreshRetryError("x"), AuthenticationError)
+
+
+def test_retry_error_is_self_healing_not_reporter_noise() -> None:
+    from custom_components.vag_connect.coordinator import _is_selfhealing_poll_error
+    assert _is_selfhealing_poll_error(TokenRefreshRetryError("x")) is True
+    assert _is_selfhealing_poll_error(AuthenticationError("x")) is False
+
+
+# ── fakes ───────────────────────────────────────────────────────────────────
+
+class _Resp:
+    def __init__(self, status: int, payload: Any = None, *, boom: bool = False):
+        self._status = status
+        self._payload = payload
+        self._boom = boom
+
+    async def __aenter__(self) -> "_Resp":
+        if self._boom:
+            raise ConnectionError("network down")
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    @property
+    def status(self) -> int:
+        return self._status
+
+    async def json(self, content_type: Any = None) -> Any:
+        return self._payload
+
+    async def text(self) -> str:
+        return _json.dumps(self._payload) if isinstance(self._payload, dict) else ""
+
+
+class _Session:
+    def __init__(self, resp: _Resp) -> None:
+        self._resp = resp
+
+    def post(self, *_a: Any, **_k: Any) -> _Resp:
+        return self._resp
+
+
+def _grant(resp: _Resp) -> DeviceAuthorizationGrant:
+    return DeviceAuthorizationGrant(_Session(resp), "client@apps_vw-dilab_com")  # type: ignore[arg-type]
+
+
+# ── device-grant refresh classification ─────────────────────────────────────
+
+def test_device_invalid_grant_is_hard_auth_error() -> None:
+    with pytest.raises(AuthenticationError):
+        asyncio.run(_grant(_Resp(400, {"error": "invalid_grant"})).refresh("rt"))
+
+
+@pytest.mark.parametrize("status,err", [
+    (400, "invalid_client"),
+    (503, "server_error"),
+    (400, "some_unknown_error"),
+    (400, ""),
+])
+def test_device_non_invalid_grant_is_retryable(status: int, err: str) -> None:
+    with pytest.raises(TokenRefreshRetryError):
+        asyncio.run(_grant(_Resp(status, {"error": err})).refresh("rt"))
+
+
+def test_device_network_blip_is_retryable() -> None:
+    with pytest.raises(TokenRefreshRetryError):
+        asyncio.run(_grant(_Resp(0, boom=True)).refresh("rt"))
+
+
+def test_device_200_without_token_is_retryable() -> None:
+    with pytest.raises(TokenRefreshRetryError):
+        asyncio.run(_grant(_Resp(200, {"expires_in": 3600})).refresh("rt"))
+
+
+def test_device_success_returns_tokenset() -> None:
+    ts = asyncio.run(
+        _grant(_Resp(200, {"access_token": "ey.a.b", "expires_in": 3600})).refresh("rt")
+    )
+    assert ts.access_token == "ey.a.b"
+
+
+# ── MBB refresh vs login classification ─────────────────────────────────────
+
+def test_mbb_refresh_invalid_grant_is_hard() -> None:
+    with pytest.raises(AuthenticationError):
+        asyncio.run(_mbboauth.refresh(_Session(_Resp(400, {"error": "invalid_grant"})), "rt"))  # type: ignore[arg-type]
+
+
+def test_mbb_refresh_transient_is_retryable() -> None:
+    # 400 (non-5xx) so no backoff-sleep; non-invalid_grant → retryable
+    with pytest.raises(TokenRefreshRetryError):
+        asyncio.run(_mbboauth.refresh(_Session(_Resp(400, {"error": "server_error"})), "rt"))  # type: ignore[arg-type]
+
+
+def test_mbb_empty_refresh_token_is_hard() -> None:
+    with pytest.raises(AuthenticationError):
+        asyncio.run(_mbboauth.refresh(_Session(_Resp(200, {})), ""))  # type: ignore[arg-type]
+
+
+def test_mbb_login_exchange_failure_stays_auth_error() -> None:
+    # The id_token LOGIN exchange must NOT be reclassified — pytest.raises(
+    # AuthenticationError) would not catch the sibling retry type, so this passing
+    # proves it stayed a hard auth error.
+    with pytest.raises(AuthenticationError):
+        asyncio.run(_mbboauth.exchange_id_token(_Session(_Resp(400, {"error": "server_error"})), "idtok"))  # type: ignore[arg-type]

--- a/tests/test_v21512_command_refresh_isolation.py
+++ b/tests/test_v21512_command_refresh_isolation.py
@@ -29,7 +29,10 @@ import pytest
 from custom_components.vag_connect.cariad.api import base as _base
 from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
 from custom_components.vag_connect.cariad.auth import _mbboauth
-from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+from custom_components.vag_connect.cariad.exceptions import (
+    AuthenticationError,
+    TokenRefreshRetryError,
+)
 from custom_components.vag_connect.cariad.models import TokenSet
 
 
@@ -156,14 +159,19 @@ class _SeqSession:
 
 
 def test_transient_5xx_retries_then_gives_up(monkeypatch) -> None:
-    """A persistent 500 is retried up to the cap, then surfaces verbatim."""
+    """A persistent 500 is retried up to the cap, then surfaces as a TRANSIENT
+    refresh error (not a hard auth failure — a 5xx is not a dead grant, so it must
+    not bounce the user to a reauth prompt)."""
     monkeypatch.setattr(asyncio, "sleep", _no_sleep)
     body = '{"error":"IllegalStateException"}'
     sess = _SeqSession(
         [_Resp(500, body) for _ in range(_mbboauth._TOKEN_5XX_MAX_ATTEMPTS)]
     )
-    with pytest.raises(AuthenticationError, match="MBB token exchange HTTP 500"):
+    with pytest.raises(TokenRefreshRetryError, match="MBB token exchange HTTP 500"):
         asyncio.run(_mbboauth.refresh(sess, "RT", client_id="CID"))
+    assert not isinstance(  # sibling of AuthenticationError, never a subtype
+        TokenRefreshRetryError("x"), AuthenticationError
+    )
     # It actually retried the full budget (not a single-shot fail).
     assert sess.n == _mbboauth._TOKEN_5XX_MAX_ATTEMPTS
 
@@ -183,12 +191,23 @@ def test_transient_5xx_then_success_recovers(monkeypatch) -> None:
 
 
 def test_non_5xx_still_fails_immediately(monkeypatch) -> None:
-    """A 403 is NOT retried (only 5xx is transient) — one shot, verbatim."""
+    """A 403 is NOT retried (only 5xx is transient) — one shot. On the REFRESH
+    path a 403 that isn't invalid_grant is transient → TokenRefreshRetryError, not a
+    reauth-forcing AuthenticationError."""
     monkeypatch.setattr(asyncio, "sleep", _no_sleep)
     sess = _SeqSession([_Resp(403, "Forbidden")])
-    with pytest.raises(AuthenticationError, match="403"):
+    with pytest.raises(TokenRefreshRetryError, match="403"):
         asyncio.run(_mbboauth.refresh(sess, "RT", client_id="CID"))
     assert sess.n == 1  # no retry on a non-5xx
+
+
+def test_mbb_refresh_invalid_grant_is_hard_auth(monkeypatch) -> None:
+    """The ONE hard case: invalid_grant (dead refresh token) → AuthenticationError,
+    because only a fresh login fixes it."""
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    sess = _SeqSession([_Resp(400, '{"error":"invalid_grant"}')])
+    with pytest.raises(AuthenticationError):
+        asyncio.run(_mbboauth.refresh(sess, "RT", client_id="CID"))
 
 
 async def _no_sleep(_secs: float) -> None:


### PR DESCRIPTION
## Classify a transient token-refresh rejection instead of forcing a reauth

A device-grant / QR login (and the MBB Car-Net refresh) raised `AuthenticationError`
on **any** non-200 refresh response, so a transient `invalid_client` / `server_error`
/ 5xx / network blip bounced the user to a fresh QR / password reauth prompt — the
exact same outcome as a genuinely dead refresh token.

### Change
- New **`TokenRefreshRetryError`**, deliberately a **sibling** of `AuthenticationError`
  (NOT a subclass). The poll loop reauths only on `isinstance(err, AuthenticationError)`,
  so this falls through to the transient-retry path and the entry stays live until the
  next poll.
- An **allowlist of HARD errors** — only `invalid_grant`, the one case a fresh login
  actually fixes. Everything else is retryable.
- Applied to **both** refresh paths: the device-grant refresh and the MBB refresh. The
  MBB **id_token LOGIN** exchange keeps `AuthenticationError` (a failure there really is
  a login failure — opt-in `retryable` flag threads the distinction).
- Added to `_is_selfhealing_poll_error` so a transient refresh hiccup is de-escalated
  from the public Error Reporter like a 5xx.

### Counter-check
The MBB paths shared the same blanket-fail gap and are fixed here too. A test pins that
the retry type is **not** a subclass of the auth type, so a later change can't silently
re-merge them and undo the fix.

## Verification
- New `test_refresh_retry_classification.py` (14 cases) + updated MBB isolation tests.
- Full suite green (5594 passed, 15 skipped); ruff + mypy strict clean.

Sits in `[Unreleased]` for the next beta.
