### PR TITLE
Škoda #1286: don't skip auto-enrolment on a token-prefix check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **Škoda official-API auto-enrolment: don't skip a valid login over a token-format
+  check.** The auto-enrolment gate required the login token to look like a specific
+  JWT before it would mint the official-API key; a legitimate native token in a
+  slightly different shape was silently skipped, so the "it just works" enrolment
+  never fired. The gate now trusts a native login on its own terms and lets the mint
+  attempt run — if the backend rejects it, that's captured in the privacy-safe
+  diagnostics instead of the whole feature quietly no-op'ing (#1286).
+
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -182,17 +182,25 @@ class SkodaClient(CariadBaseClient):
 
     @property
     def can_mint_official_key(self) -> bool:
-        """True only on a NATIVE mysmob login. The keygen POST needs a real mysmob
-        Bearer (a JWT); a portal-fallback entry holds the cookie-session sentinel
-        (strategy ``data_act_portal``, ``_eu_portal`` set), so minting there would
-        401. Gate on: no portal connector, empty token strategy, JWT access token."""
+        """True only on a NATIVE mysmob login. The keygen POST needs the real mysmob
+        Bearer this client already holds; a portal-fallback entry holds a
+        cookie-session sentinel (strategy ``data_act_portal`` + ``_eu_portal`` set)
+        that would 401. Gate on: no portal connector + empty token strategy + a
+        non-empty access token.
+
+        #1286 — do NOT require a specific token prefix. The earlier ``ey`` (JWT)
+        check risked blocking a legitimate native token variant and silently
+        skipping enrolment; ``strategy == ""`` + ``_eu_portal is None`` already
+        establish the native login, and if the mint is nonetheless rejected it
+        fails soft and the ``skoda_official_keygen`` probe records the exact
+        status. Attempting-and-observing beats silently gating out."""
         if getattr(self, "_eu_portal", None) is not None:
             return False
         tok = self._tokens
         if tok is None or getattr(tok, "strategy", "") != "":
             return False
         at = getattr(tok, "access_token", "") or ""
-        return isinstance(at, str) and at.startswith("ey")
+        return isinstance(at, str) and bool(at)
 
     async def mint_api_key(
         self, vin: str, name: str = _OFFICIAL_KEY_NAME

--- a/tests/test_skoda_keygen.py
+++ b/tests/test_skoda_keygen.py
@@ -40,8 +40,12 @@ def test_can_mint_gate() -> None:
     c._tokens = SimpleNamespace(  # type: ignore[assignment]
         strategy="data_act_portal", access_token="eu-data-act-portal-cookie-session")
     assert c.can_mint_official_key is False
-    # non-JWT access token → never mint
+    # #1286 — a non-JWT native token is now allowed (we no longer gate on a token
+    # prefix; a rejected mint fails soft + is recorded in the keygen probe).
     c._tokens = SimpleNamespace(strategy="", access_token="not-a-jwt")  # type: ignore[assignment]
+    assert c.can_mint_official_key is True
+    # empty access token → still blocked (nothing to authorize the mint)
+    c._tokens = SimpleNamespace(strategy="", access_token="")  # type: ignore[assignment]
     assert c.can_mint_official_key is False
     # no token at all
     c._tokens = None


### PR DESCRIPTION
## #1286 — the zero-setup Škoda auto-enrolment could silently no-op on a valid login

Two Škoda owners on stable v4.5.0 report the flagship "it just works" official-API
enrolment not firing. The setup path IS reached (verified: it runs in `async_setup`
after the client has tokens), so the failure is at the gate or the mint.

This PR removes one avoidable failure mode: **the enrolment gate
(`can_mint_official_key`) required the login access token to *start with `ey`* (a JWT)**
before it would mint. A legitimate native mysmob login whose token is a slightly
different shape was silently skipped, and enrolment never ran.

`strategy == ""` **and** `_eu_portal is None` already establish a native (non-portal)
login — the `ey` prefix added nothing reliable and only risked blocking a valid token.
Relaxed to a non-empty access token (an empty token still blocks). If the mint is then
rejected by the backend, it **fails soft and is recorded in the `skoda_official_keygen`
diagnostics probe** (shipped in v4.5.0) — so we observe the real cause instead of the
whole feature quietly gating itself out.

The remaining unknown (does the RE'd keygen POST actually succeed live?) is answered by
that probe — diagnostics requested from the reporters.

## Verification
- Updated `test_can_mint_gate`: a non-JWT native token now mints; an empty token still
  blocks; a portal-fallback / non-empty-strategy entry still blocks.
- Škoda keygen + auto-enrol suites green; ruff + mypy strict clean.

Sits in `[Unreleased]` for the next beta.
