### PR TITLE
Per-source connectivity binary_sensors — which channels each car is on (#1286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **See which data sources each car is connected to.** A new connectivity sensor per
+  source (EU Data Act portal, vw.de website, Car-Net, the brand app, the Škoda official
+  API, …) shows at a glance which channels your car is on — including a standby failover
+  like the Škoda official API that only reads when your main channel is down. Each one
+  carries attributes: whether it's actively feeding data or on standby, how many of the
+  car's readings it currently provides, when it last delivered, and — for the EU Data Act
+  portal — its feed health. Works across all brands (#1286).
+
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 
 ### Added

--- a/custom_components/vag_connect/_channel_labels.py
+++ b/custom_components/vag_connect/_channel_labels.py
@@ -28,6 +28,7 @@ _CHANNEL_LABELS: dict[str, str] = {
     "companion_relay": "Companion app (relay)",
     "brand_native": "Brand app",
     "primary": "Main login",
+    "skoda_official": "Škoda official API",
 }
 
 

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -1175,7 +1175,9 @@ class VagSourceConnectivitySensor(VagConnectEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         s = self._status()
-        # No status entry (channel no longer armed) → unavailable, not "off".
+        # No status entry (channel no longer armed) → None, which HA renders as
+        # state "unknown" (not "unavailable", which would need `available=False`,
+        # and not a misleading "off"/disconnected).
         return bool(s.get("armed")) if s else None
 
     def _platform_attributes(self) -> dict[str, Any] | None:

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -1028,6 +1028,11 @@ async def async_setup_entry(
         # 4) Per-light sensors (v1.12.0 #91 leftover)
         for light_id in vehicle.get("lights_individual", {}):
             entities.append(VagLightSensor(coordinator, vin, light_id))
+        # 5) Per-source connectivity sensors — one per armed read channel, so a
+        # user can see which sources this car is connected to (active vs standby),
+        # incl. a standby failover like the Škoda official API (#1286). Cross-brand.
+        for token in (vehicle.get("channel_status") or {}):
+            entities.append(VagSourceConnectivitySensor(coordinator, vin, token))
         return entities
 
     register_dynamic_spawner(entry, coordinator, async_add_entities, _build_for_vin)
@@ -1132,6 +1137,66 @@ class VagAbrpDataChangedSensor(VagConnectEntity, BinarySensorEntity):
         attrs: dict[str, Any] = {
             "last_upload_recorded": last is not None,
         }
+        return attrs
+
+
+class VagSourceConnectivitySensor(VagConnectEntity, BinarySensorEntity):
+    """Connectivity indicator for ONE read channel (data source).
+
+    ON = the car is connected to that source, whether it is actively feeding values
+    or sitting on standby (e.g. the Škoda official API is a failover that only reads
+    when the primary channel is down). Answers "which sources am I connected to",
+    per source, across every brand (#1286). The live detail — active vs standby, how
+    many of the car's readings this source provides, when it last contributed, and
+    for the EU Data Act portal its feed health — is exposed as attributes.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_icon = "mdi:transit-connection-variant"
+    _attr_translation_key = "data_source"
+
+    def __init__(
+        self, coordinator: VagConnectCoordinator, vin: str, token: str
+    ) -> None:
+        super().__init__(coordinator, vin, f"connectivity_{token}")
+        self._token = token
+        from ._channel_labels import channel_display_name  # noqa: PLC0415
+        self._attr_translation_placeholders = {"source": channel_display_name(token)}
+
+    def _status(self) -> dict[str, Any]:
+        cs = self._vehicle.get("channel_status")
+        if isinstance(cs, dict):
+            s = cs.get(self._token)
+            if isinstance(s, dict):
+                return s
+        return {}
+
+    @property
+    def is_on(self) -> bool | None:
+        s = self._status()
+        # No status entry (channel no longer armed) → unavailable, not "off".
+        return bool(s.get("armed")) if s else None
+
+    def _platform_attributes(self) -> dict[str, Any] | None:
+        s = self._status()
+        if not s:
+            return None
+        if s.get("active"):
+            status = "active"
+        elif s.get("failover"):
+            status = "standby (failover)"
+        else:
+            status = "standby"
+        attrs: dict[str, Any] = {"status": status}
+        if s.get("active_values") is not None:
+            attrs["active_entities"] = s.get("active_values")
+            attrs["total_entities"] = s.get("total_values")
+        if s.get("last_active"):
+            attrs["last_active"] = s.get("last_active")
+        for k in ("portal_health", "minutes_since_last_snapshot"):
+            if s.get(k) is not None:
+                attrs[k] = s.get(k)
         return attrs
 
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2548,6 +2548,72 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 _LOGGER.debug("Škoda official arm-from-map failed", exc_info=True)
 
+    def _armed_data_channels(self, vin: str) -> list[str]:
+        """Tokens of the read channels armed for this vehicle (data sources) —
+        primary + supplementary + the Škoda official failover — enumerated WITHOUT
+        creating reader coroutines. Order-stable, de-duplicated. Brand-agnostic."""
+        client = self._cariad_client
+        tokens: list[str] = [self._primary_channel_name()]
+        for attr, token in (
+            ("_supplementary_authproxy", "website_authproxy"),
+            ("_supplementary_eu_portal", "eu_data_act"),
+            ("_supplementary_tibber", "tibber"),
+            ("_supplementary_official", "skoda_official"),
+        ):
+            if getattr(client, attr, None) is not None:
+                tokens.append(token)
+        seen: set[str] = set()
+        out: list[str] = []
+        for t in tokens:
+            if t and t not in seen:
+                seen.add(t)
+                out.append(t)
+        return out
+
+    def _compute_channel_status(
+        self, vin: str, data: dict[str, Any]
+    ) -> dict[str, dict[str, Any]]:
+        """Per-source connectivity status for the connectivity binary_sensors: for
+        each armed data channel, whether it is currently contributing values
+        (active) vs armed-but-idle (standby), how many readings it owns of the total,
+        and when it last contributed. The Škoda official channel is a FAILOVER whose
+        data wears the brand token, so it is reported as armed with no live count."""
+        field_sources = data.get("field_sources")
+        if not isinstance(field_sources, dict):
+            field_sources = {}
+        total = len(field_sources)
+        now_iso = datetime.now(tz=timezone.utc).isoformat()
+        last = getattr(self, "_channel_last_active", None)
+        if not isinstance(last, dict):
+            last = {}
+            self._channel_last_active = last
+        vin_last: dict[str, str] = last.setdefault(vin, {})
+        status: dict[str, dict[str, Any]] = {}
+        for token in self._armed_data_channels(vin):
+            if token == "skoda_official":
+                status[token] = {
+                    "armed": True, "failover": True, "active": False,
+                    "active_values": None, "total_values": total,
+                    "last_active": vin_last.get(token),
+                }
+                continue
+            n = sum(1 for t in field_sources.values() if t == token)
+            active = n > 0
+            if active:
+                vin_last[token] = now_iso
+            entry: dict[str, Any] = {
+                "armed": True, "failover": False, "active": active,
+                "active_values": n, "total_values": total,
+                "last_active": vin_last.get(token),
+            }
+            if token == "eu_data_act":
+                entry["portal_health"] = data.get("portal_health")
+                entry["minutes_since_last_snapshot"] = data.get(
+                    "minutes_since_last_snapshot"
+                )
+            status[token] = entry
+        return status
+
     def _skoda_probe(self, key: str, label: str) -> None:
         """Write a PII-free outcome label into the client's ``probe_outcomes`` so the
         integration diagnostics surface it. No-op if the client has no such sink.
@@ -3358,6 +3424,18 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         # the raw backend snapshot straight over a just-issued
                         # command's optimistic value (e.g. lock → doors_locked
                         # snaps back to the stale poll reading for ~150 s).
+                        # Per-source connectivity map for the connectivity
+                        # binary_sensors (which sources this car is connected to,
+                        # active vs standby, how many readings each provides). Fail-
+                        # soft — a compute hiccup must never sink the poll.
+                        try:
+                            enriched["channel_status"] = self._compute_channel_status(
+                                vin, enriched
+                            )
+                        except Exception:  # noqa: BLE001
+                            _LOGGER.debug(
+                                "channel-status compute skipped", exc_info=True
+                            )
                         fresh[vin] = self._apply_optimistic_hold(vin, enriched)
                         any_success = True
                         self.vehicle_success[vin] = True

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1716,6 +1716,9 @@
       },
       "marketing_consent_given": {
         "name": "Marketing consent given"
+      },
+      "data_source": {
+        "name": "Source: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Marketingový souhlas udělen"
+      },
+      "data_source": {
+        "name": "Zdroj: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Marketingsamtykke givet"
+      },
+      "data_source": {
+        "name": "Kilde: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Marketing-Zustimmung erteilt"
+      },
+      "data_source": {
+        "name": "Quelle: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Marketing consent given"
+      },
+      "data_source": {
+        "name": "Source: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Consentimiento de marketing otorgado"
+      },
+      "data_source": {
+        "name": "Fuente: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Markkinointisuostumus annettu"
+      },
+      "data_source": {
+        "name": "Lähde: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Consentement marketing donné"
+      },
+      "data_source": {
+        "name": "Source : {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Consenso marketing dato"
+      },
+      "data_source": {
+        "name": "Fonte: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Markedsføringssamtykke gitt"
+      },
+      "data_source": {
+        "name": "Kilde: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Marketingtoestemming gegeven"
+      },
+      "data_source": {
+        "name": "Bron: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Udzielono zgody marketingowej"
+      },
+      "data_source": {
+        "name": "Źródło: {source}"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1683,6 +1683,9 @@
       },
       "marketing_consent_given": {
         "name": "Marknadsföringssamtycke givet"
+      },
+      "data_source": {
+        "name": "Källa: {source}"
       }
     },
     "switch": {

--- a/tests/test_source_connectivity.py
+++ b/tests/test_source_connectivity.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Per-source connectivity binary_sensors (#1286) — which read channels a car is
+connected to, active vs standby, how many of its readings each source provides.
+
+Brand-agnostic: driven off the coordinator's armed-channel enumeration + the
+per-field provenance (field_sources) that the multi-channel merge already writes.
+The Škoda official channel is a FAILOVER whose data wears the brand token, so it is
+reported as an armed standby source with no live count.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.binary_sensor import VagSourceConnectivitySensor
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+VIN = "TMBEL9NEXP1000001"
+
+
+def _coord(entry_data: dict, client) -> VagConnectCoordinator:
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c.hass = MagicMock()
+    c.entry = MagicMock()
+    c.entry.data = dict(entry_data)
+    c._cariad_client = client
+    return c
+
+
+def _client(**armed) -> SimpleNamespace:
+    # only the attrs set to a truthy object count as "armed"
+    defaults = dict(
+        _supplementary_authproxy=None, _supplementary_eu_portal=None,
+        _supplementary_tibber=None, _supplementary_official=None, _eu_portal=None,
+    )
+    defaults.update(armed)
+    return SimpleNamespace(**defaults)
+
+
+# ── armed-channel enumeration ───────────────────────────────────────────────
+
+def test_armed_channels_skoda_native_plus_official() -> None:
+    c = _coord({"brand": "skoda"}, _client(_supplementary_official=object()))
+    assert c._armed_data_channels(VIN) == ["skoda", "skoda_official"]
+
+
+def test_armed_channels_vw_portal_plus_vwde() -> None:
+    c = _coord(
+        {"brand": "volkswagen"},
+        _client(_supplementary_eu_portal=object(), _supplementary_authproxy=object()),
+    )
+    got = c._armed_data_channels(VIN)
+    assert got[0] == "volkswagen"  # primary
+    assert set(got) == {"volkswagen", "eu_data_act", "website_authproxy"}
+
+
+def test_armed_channels_deduped_when_primary_is_supplementary_token() -> None:
+    # VW-EU whose PRIMARY is the portal + also a supplementary portal → one entry
+    c = _coord({"brand": "volkswagen", "website_authproxy": True},
+               _client(_supplementary_authproxy=object()))
+    got = c._armed_data_channels(VIN)
+    assert got.count("website_authproxy") == 1  # primary + supp collapse to one
+
+
+# ── channel-status computation ──────────────────────────────────────────────
+
+def test_status_active_counts_from_field_sources() -> None:
+    c = _coord({"brand": "skoda"}, _client())
+    data = {"field_sources": {"battery_soc": "skoda", "odometer": "skoda",
+                              "range_km": "eu_data_act"}}
+    st = c._compute_channel_status(VIN, data)
+    assert st["skoda"]["active"] is True
+    assert st["skoda"]["active_values"] == 2
+    assert st["skoda"]["total_values"] == 3
+    assert st["skoda"]["last_active"] is not None
+
+
+def test_status_official_is_standby_failover_without_count() -> None:
+    c = _coord({"brand": "skoda"}, _client(_supplementary_official=object()))
+    # official contributes nothing (its data wears the brand token)
+    st = c._compute_channel_status(VIN, {"field_sources": {"battery_soc": "skoda"}})
+    assert st["skoda_official"]["armed"] is True
+    assert st["skoda_official"]["failover"] is True
+    assert st["skoda_official"]["active"] is False
+    assert st["skoda_official"]["active_values"] is None
+
+
+def test_status_portal_carries_health_attributes() -> None:
+    c = _coord({"brand": "volkswagen"}, _client(_supplementary_eu_portal=object()))
+    data = {"field_sources": {"battery_soc": "eu_data_act"},
+            "portal_health": "ok", "minutes_since_last_snapshot": 7}
+    st = c._compute_channel_status(VIN, data)
+    assert st["eu_data_act"]["portal_health"] == "ok"
+    assert st["eu_data_act"]["minutes_since_last_snapshot"] == 7
+
+
+def test_status_last_active_carries_forward_when_idle() -> None:
+    c = _coord({"brand": "skoda"}, _client())
+    # poll 1: active → records a timestamp
+    c._compute_channel_status(VIN, {"field_sources": {"soc": "skoda"}})
+    ts = c._channel_last_active[VIN]["skoda"]
+    # poll 2: nothing from skoda → still reports the last time it was active
+    st = c._compute_channel_status(VIN, {"field_sources": {"soc": "eu_data_act"}})
+    assert st["skoda"]["active"] is False
+    assert st["skoda"]["last_active"] == ts
+
+
+# ── the sensor ──────────────────────────────────────────────────────────────
+
+def _sensor(token: str, channel_status: dict) -> VagSourceConnectivitySensor:
+    s = VagSourceConnectivitySensor.__new__(VagSourceConnectivitySensor)
+    s._token = token
+    s._vin = VIN
+    s.coordinator = SimpleNamespace(data={VIN: {"channel_status": channel_status}})
+    return s
+
+
+def test_sensor_on_when_armed_attrs_reflect_active() -> None:
+    s = _sensor("skoda", {"skoda": {
+        "armed": True, "active": True, "failover": False,
+        "active_values": 12, "total_values": 40, "last_active": "2026-09-01T00:00:00Z",
+    }})
+    assert s.is_on is True
+    a = s._platform_attributes()
+    assert a["status"] == "active"
+    assert a["active_entities"] == 12 and a["total_entities"] == 40
+
+
+def test_sensor_standby_failover_label() -> None:
+    s = _sensor("skoda_official", {"skoda_official": {
+        "armed": True, "active": False, "failover": True, "active_values": None,
+        "total_values": 40, "last_active": None,
+    }})
+    assert s.is_on is True
+    assert s._platform_attributes()["status"] == "standby (failover)"
+    # no live count for the failover
+    assert "active_entities" not in s._platform_attributes()
+
+
+def test_sensor_unavailable_when_channel_gone() -> None:
+    s = _sensor("tibber", {})  # token not in status → no longer armed
+    assert s.is_on is None
+    assert s._platform_attributes() is None

--- a/tests/test_source_connectivity.py
+++ b/tests/test_source_connectivity.py
@@ -138,7 +138,9 @@ def test_sensor_standby_failover_label() -> None:
     assert "active_entities" not in s._platform_attributes()
 
 
-def test_sensor_unavailable_when_channel_gone() -> None:
-    s = _sensor("tibber", {})  # token not in status → no longer armed
+def test_sensor_state_unknown_when_channel_gone() -> None:
+    # token not in status → no longer armed → is_on None (HA state "unknown",
+    # not "unavailable" and not a misleading "off")
+    s = _sensor("tibber", {})
     assert s.is_on is None
     assert s._platform_attributes() is None


### PR DESCRIPTION
## Per-source connectivity sensors — "which sources is my car connected to?" (#1286)

A connectivity `binary_sensor` per armed read channel, so a user can see at a glance
which sources their car is on — **including a standby failover** like the Škoda
official API that only reads when the primary channel is down. `ON` = connected.

Sources covered (whichever are armed for the entry): EU Data Act portal · vw.de
website · Car-Net (MBB) · the brand app · the Škoda official API · Tibber · the main
login. **Brand-agnostic** — driven off the per-field provenance the multi-channel
merge already writes, so it works the same on every brand.

### How it's computed
The coordinator enumerates the armed channels **without** creating reader coroutines,
then from `field_sources` marks each channel **active vs standby**, counts how many of
the car's readings it currently provides (`active_entities` / `total_entities`), and
records **when it last contributed** (`last_active`). The Škoda official channel is a
failover whose data wears the brand token, so it's reported as an armed standby with no
live count. The EU Data Act portal sensor also carries `portal_health` +
`minutes_since_last_snapshot`.

Dynamic-spawn per VIN (a channel that arms later — e.g. the official API after
enrolment — appears on the next poll). Friendly channel names via `channel_display_name`;
the entity name is translated in all 12 languages.

## Verification
- `test_source_connectivity.py` — armed-channel enumeration (native+official, portal+vw.de,
  dedup), active/standby counts, official-failover standby, portal health attrs, last-active
  carry-forward, and the sensor (on/attrs/unavailable-when-gone).
- Full suite green; translation-parity green; ruff + mypy strict clean.

Sits in `[Unreleased]` for the next beta.
