### PR TITLE
Škoda official-API guardrails: multi-integration ban-risk warning + rate-limit education (#1286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **Škoda official API: a heads-up if another integration is using it too.** If the
+  account holds more official-API keys than we created, a second integration or app is
+  probably reading the same official Škoda API. That's fine to run, but both share the
+  same small per-car request budget — so you now get a dismissible notice explaining
+  that the combined usage can hit Škoda's rate limit sooner and, in the worst case,
+  get the account temporarily (or eventually permanently) blocked, plus how to remove
+  the key you don't need (#1286). All 12 languages.
+
+### Changed
+- **The Škoda official-API enrolment notice now explains it's a rate-limited standby
+  channel.** So nobody wonders why it isn't updating constantly: the official channel
+  is capped at a few requests an hour, sits on standby, and only reads when the main
+  connection can't — it won't slow anything down.
+
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 
 ### Added

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2558,13 +2558,16 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             po[key] = label
 
     def _check_skoda_multi_integration(
-        self, listing: Any, stored: dict[str, Any]
+        self, listing: Any, stored: dict[str, Any], our_vins: list[str]
     ) -> None:
-        """From the official-API key listing, detect keys we did NOT mint — a second
-        integration/app reading the same official Škoda API on this account — and
-        raise the ban-risk Repair. ``keysRemaining`` per VIN plus the account
-        ``maxKeys`` gives keys-in-use; more than the (at most one) key we hold for a
-        VIN means someone else minted keys too. PII-free, idempotent."""
+        """From the official-API key listing, detect keys we did NOT create — a
+        second integration/app reading the same official Škoda API on THIS car — and
+        raise the ban-risk Repair. ``keysRemaining`` + account ``maxKeys`` gives
+        keys-in-use; more than the keys WE hold for a VIN means someone else minted
+        one too. PII-free, idempotent. Only VINs this integration actually manages
+        are checked — a second, unmanaged Škoda on the same account legitimately has
+        its own app key and must not trip the warning. A manually-pasted fallback key
+        (the user's own) counts as ours so it never trips it either."""
         if not isinstance(listing, dict):
             return
         raw_max = listing.get("maxKeys")
@@ -2574,15 +2577,21 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             max_keys = int(raw_max)
         except ValueError:
             return
+        from .const import CONF_SKODA_OFFICIAL_API_KEY  # noqa: PLC0415
+        has_manual_key = bool(self.entry.data.get(CONF_SKODA_OFFICIAL_API_KEY))
         stored_upper = {str(k).upper() for k in (stored or {})}
+        managed = {str(v).upper() for v in (our_vins or [])} | stored_upper
         for vk in listing.get("vehicleKeys") or []:
             if not isinstance(vk, dict) or vk.get("vin") is None:
                 continue
+            vin_u = str(vk["vin"]).upper()
+            if vin_u not in managed:
+                continue  # a car we don't manage — its app key is not our concern
             try:
                 remaining = int(vk.get("keysRemaining", max_keys))
             except (TypeError, ValueError):
                 continue
-            ours = 1 if str(vk["vin"]).upper() in stored_upper else 0
+            ours = (1 if vin_u in stored_upper else 0) + (1 if has_manual_key else 0)
             if (max_keys - remaining) > ours:
                 from . import repairs  # noqa: PLC0415
                 repairs.raise_issue_skoda_official_multi_integration(
@@ -2635,7 +2644,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 if not getattr(self, "_skoda_multi_int_checked", False):
                     self._skoda_multi_int_checked = True
                     try:
-                        self._check_skoda_multi_integration(await list_keys(), stored)
+                        self._check_skoda_multi_integration(await list_keys(), stored, vins)
                     except Exception:  # noqa: BLE001
                         _LOGGER.debug(
                             "Škoda multi-integration check skipped", exc_info=True
@@ -2644,7 +2653,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Quota check (maxKeys 5 per VIN) — one GET before minting.
         remaining: dict[str, int] = {}
         listing = await list_keys()
-        self._check_skoda_multi_integration(listing, stored)
+        self._check_skoda_multi_integration(listing, stored, vins)
         if isinstance(listing, dict):
             for vk in listing.get("vehicleKeys") or []:
                 if isinstance(vk, dict) and vk.get("vin") is not None:

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2557,6 +2557,39 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if isinstance(po, dict):
             po[key] = label
 
+    def _check_skoda_multi_integration(
+        self, listing: Any, stored: dict[str, Any]
+    ) -> None:
+        """From the official-API key listing, detect keys we did NOT mint — a second
+        integration/app reading the same official Škoda API on this account — and
+        raise the ban-risk Repair. ``keysRemaining`` per VIN plus the account
+        ``maxKeys`` gives keys-in-use; more than the (at most one) key we hold for a
+        VIN means someone else minted keys too. PII-free, idempotent."""
+        if not isinstance(listing, dict):
+            return
+        raw_max = listing.get("maxKeys")
+        if not isinstance(raw_max, (int, str)):
+            return
+        try:
+            max_keys = int(raw_max)
+        except ValueError:
+            return
+        stored_upper = {str(k).upper() for k in (stored or {})}
+        for vk in listing.get("vehicleKeys") or []:
+            if not isinstance(vk, dict) or vk.get("vin") is None:
+                continue
+            try:
+                remaining = int(vk.get("keysRemaining", max_keys))
+            except (TypeError, ValueError):
+                continue
+            ours = 1 if str(vk["vin"]).upper() in stored_upper else 0
+            if (max_keys - remaining) > ours:
+                from . import repairs  # noqa: PLC0415
+                repairs.raise_issue_skoda_official_multi_integration(
+                    self.hass, self.entry.entry_id
+                )
+                return
+
     async def _auto_enroll_skoda_official(self, vins: list[str]) -> None:
         """Auto-enroll a logged-in Škoda user in the official public API: mint a
         per-VIN X-API-Key from the EXISTING mysmob login, persist it, arm the
@@ -2595,10 +2628,23 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if not to_mint:
             if stored:
                 self._arm_official_from_map(stored)
+                # Once per session: is ANOTHER integration/app using the same
+                # official API on this account? (shared per-car budget → faster
+                # rate-limit/ban). Only checked for already-enrolled users here —
+                # the mint path below checks its own listing.
+                if not getattr(self, "_skoda_multi_int_checked", False):
+                    self._skoda_multi_int_checked = True
+                    try:
+                        self._check_skoda_multi_integration(await list_keys(), stored)
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.debug(
+                            "Škoda multi-integration check skipped", exc_info=True
+                        )
             return
         # Quota check (maxKeys 5 per VIN) — one GET before minting.
         remaining: dict[str, int] = {}
         listing = await list_keys()
+        self._check_skoda_multi_integration(listing, stored)
         if isinstance(listing, dict):
             for vk in listing.get("vehicleKeys") or []:
                 if isinstance(vk, dict) and vk.get("vin") is not None:

--- a/custom_components/vag_connect/repairs.py
+++ b/custom_components/vag_connect/repairs.py
@@ -245,6 +245,26 @@ def raise_issue_skoda_official_quota(hass: HomeAssistant, entry_id: str) -> None
     )
 
 
+def raise_issue_skoda_official_multi_integration(
+    hass: HomeAssistant, entry_id: str
+) -> None:
+    """Another client holds official-API keys for this car (more keys are in use
+    than we minted), so a second integration/app is likely reading the same official
+    Škoda API. Warn the user (once, dismissibly): the shared per-car request budget
+    then depletes faster, which can trip a temporary — or eventually a permanent —
+    account rate-limit. Not auto-fixable; WARNING; idempotent."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"{entry_id}_skoda_official_multi_integration",
+        is_fixable=False,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="skoda_official_multi_integration",
+        learn_more_url="https://github.com/its-me-prash/vwgroup-connect-ha/issues/1286",
+    )
+
+
 def raise_issue_requirements_conflict(hass: HomeAssistant) -> None:
     """Raise a repair issue for configuration problems."""
     ir.async_create_issue(

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Škoda official API — you're now enrolled automatically",
-      "description": "Good news: we used your existing Škoda login to create an official Škoda API key for your car, so Home Assistant can now read it over Škoda's new official, durable channel — as an automatic backup if the normal connection ever struggles. Nothing to do on your side; this is just a heads-up, and you can dismiss it."
+      "description": "Good news: we used your existing Škoda login to create an official Škoda API key for your car, so Home Assistant can now read it over Škoda's new official, durable channel — as an automatic backup if the normal connection ever struggles. Because this official channel is rate-limited (only a small number of requests an hour), it stays on standby and only reads when your main connection can't — so it won't slow anything down. Nothing to do on your side; this is just a heads-up, and you can dismiss it."
     },
     "skoda_official_quota_full": {
       "title": "Škoda official API — key limit reached",
       "description": "We tried to set up Škoda's official API for your car automatically, but your account already has the maximum of 5 API keys for this vehicle. To use it, free a slot in the MyŠkoda app (Settings → API keys → delete an unused one) and reload the integration, or paste an existing key manually in the integration's options. Everything else keeps working as before."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Škoda official API — another integration is using it too",
+      "description": "We found more official-API keys on your Škoda account than this integration created — usually a sign that a second integration or app is also reading Škoda's official API. That's fine to run, but they share the same small per-car request budget, so the combined traffic can hit Škoda's rate limit sooner and, in the worst case, get the account temporarily — or eventually permanently — blocked. If you don't need both, remove the official-API key you're not using in the MyŠkoda app (Settings → API keys). You can dismiss this notice."
     }
   },
   "selector": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Oficiální API Škoda — nyní jste automaticky zaregistrováni",
-      "description": "Dobrá zpráva: pomocí vašeho stávajícího přihlášení Škoda jsme pro vaše auto vytvořili oficiální API klíč Škoda, takže ho Home Assistant teď dokáže načítat přes nový oficiální a trvalý kanál Škoda — jako automatickou zálohu pro případ, že by běžné připojení někdy mělo potíže. Z vaší strany není potřeba nic dělat; je to jen upozornění a můžete ho zavřít."
+      "description": "Dobrá zpráva: pomocí vašeho stávajícího přihlášení ke Škodě jsme pro vaše auto vytvořili oficiální klíč k API Škody, takže ho teď Home Assistant umí číst přes nový oficiální a trvalý kanál Škody — jako automatickou zálohu pro případ, že by běžné připojení někdy zlobilo. Protože je tento oficiální kanál omezený počtem požadavků (jen pár za hodinu), zůstává v pohotovosti a čte jen tehdy, když hlavní připojení nemůže — takže nic nezpomalí. Z vaší strany není potřeba nic dělat; berte to jen jako informaci a upozornění můžete zavřít."
     },
     "skoda_official_quota_full": {
       "title": "Oficiální API Škoda — dosažen limit klíčů",
       "description": "Pokusili jsme se pro vaše auto automaticky nastavit oficiální API Škoda, ale váš účet už má pro toto vozidlo maximum 5 API klíčů. Chcete-li ho používat, uvolněte v aplikaci MyŠkoda jedno místo (Nastavení → API klíče → smažte nepoužívaný) a znovu načtěte integraci, nebo v možnostech integrace ručně vložte existující klíč. Vše ostatní funguje dál jako dosud."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Oficiální API Škody — používá ho i jiná integrace",
+      "description": "Na vašem účtu Škoda jsme našli víc klíčů k oficiálnímu API, než kolik jich vytvořila tato integrace — obvykle to znamená, že oficiální API Škody čte i druhá integrace nebo aplikace. To vůbec nevadí, jenže si dělí stejný malý limit požadavků na jedno auto, takže společný provoz může narazit na limit Škody dřív a v nejhorším případě může být účet dočasně — a časem i trvale — zablokován. Pokud obě nepotřebujete, odeberte v aplikaci MyŠkoda ten klíč k oficiálnímu API, který nepoužíváte (Nastavení → API klíče). Toto upozornění můžete zavřít."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Škodas officielle API — du er nu tilmeldt automatisk",
-      "description": "Godt nyt: Vi brugte dit eksisterende Škoda-login til at oprette en officiel Škoda API-nøgle til din bil, så Home Assistant nu kan læse den via Škodas nye officielle og stabile kanal — som en automatisk reserve, hvis den normale forbindelse en dag driller. Du behøver ikke gøre noget; det er bare til info, og du kan roligt lukke beskeden."
+      "description": "Gode nyheder: Vi brugte dit eksisterende Škoda-login til at oprette en officiel Škoda-API-nøgle til din bil, så Home Assistant nu kan læse den via Škodas nye officielle og varige kanal — som en automatisk reserve, hvis den normale forbindelse en dag skulle få problemer. Fordi denne officielle kanal er hastighedsbegrænset (kun et lille antal anmodninger i timen), står den i standby og læser kun, når din hovedforbindelse ikke kan — så den bremser ikke noget. Du skal ikke gøre noget; det her er bare til orientering, og du kan roligt lukke den."
     },
     "skoda_official_quota_full": {
       "title": "Škodas officielle API — grænsen for nøgler er nået",
       "description": "Vi forsøgte at sætte Škodas officielle API op til din bil automatisk, men din konto har allerede det maksimale antal på 5 API-nøgler til denne bil. For at bruge den skal du frigøre en plads i MyŠkoda-appen (Indstillinger → API-nøgler → slet en, du ikke bruger) og genindlæse integrationen, eller indsætte en eksisterende nøgle manuelt i integrationens indstillinger. Alt andet fungerer som hidtil."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Škodas officielle API — en anden integration bruger det også",
+      "description": "Vi fandt flere officielle API-nøgler på din Škoda-konto, end denne integration har oprettet — som regel et tegn på, at en anden integration eller app også læser Škodas officielle API. Det er helt fint at have begge dele kørende, men de deler det samme lille anmodningsbudget pr. bil, så den samlede trafik kan ramme Škodas hastighedsgrænse hurtigere og i værste fald få kontoen midlertidigt — eller på sigt permanent — blokeret. Hvis du ikke har brug for begge, kan du fjerne den officielle API-nøgle, du ikke bruger, i MyŠkoda-appen (Indstillinger → API-nøgler). Du kan roligt lukke denne besked."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Offizielle Škoda-API — du bist jetzt automatisch dabei",
-      "description": "Gute Nachricht: Wir haben mit deinem bestehenden Škoda-Login automatisch einen offiziellen Škoda-API-Schlüssel für dein Auto erstellt. Home Assistant kann es jetzt über Škodas neuen offiziellen, dauerhaften Kanal lesen — als automatische Reserve, falls die normale Verbindung mal schwächelt. Für dich gibt es nichts zu tun; das ist nur ein Hinweis, den du ausblenden kannst."
+      "description": "Gute Nachricht: Wir haben mit deinem bestehenden Škoda-Login einen offiziellen Škoda-API-Schlüssel für dein Auto erstellt, sodass Home Assistant es jetzt über Škodas neuen, offiziellen und dauerhaften Kanal lesen kann — als automatisches Backup, falls die normale Verbindung mal schwächelt. Da dieser offizielle Kanal ratenbegrenzt ist (nur wenige Anfragen pro Stunde), bleibt er im Standby und liest nur, wenn deine Hauptverbindung nicht kann — er bremst also nichts. Von deiner Seite ist nichts zu tun; das ist nur ein Hinweis, den du schließen kannst."
     },
     "skoda_official_quota_full": {
       "title": "Offizielle Škoda-API — Schlüssel-Limit erreicht",
       "description": "Wir wollten Škodas offizielle API für dein Auto automatisch einrichten, aber dein Konto hat für dieses Fahrzeug bereits die maximal 5 API-Schlüssel. Um sie zu nutzen, gib in der MyŠkoda-App einen Platz frei (Einstellungen → API-Schlüssel → einen ungenutzten löschen) und lade die Integration neu — oder trage einen vorhandenen Schlüssel manuell in den Optionen ein. Alles andere läuft weiter wie bisher."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Škoda Offizielle API — eine andere Integration nutzt sie auch",
+      "description": "Wir haben auf deinem Škoda-Konto mehr Offizielle-API-Schlüssel gefunden, als diese Integration erstellt hat — meist ein Zeichen, dass eine zweite Integration oder App ebenfalls die offizielle Škoda-API liest. Das ist grundsätzlich in Ordnung, aber beide teilen sich dasselbe kleine Anfrage-Budget pro Fahrzeug, sodass die kombinierte Nutzung das Rate-Limit von Škoda schneller erreichen und im schlimmsten Fall das Konto vorübergehend — oder irgendwann dauerhaft — sperren kann. Wenn du nicht beide brauchst, entferne den nicht genutzten Offizielle-API-Schlüssel in der MyŠkoda-App (Einstellungen → API-Schlüssel). Du kannst diesen Hinweis schließen."
     }
   },
   "selector": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Škoda official API — you're now enrolled automatically",
-      "description": "Good news: we used your existing Škoda login to create an official Škoda API key for your car, so Home Assistant can now read it over Škoda's new official, durable channel — as an automatic backup if the normal connection ever struggles. Nothing to do on your side; this is just a heads-up, and you can dismiss it."
+      "description": "Good news: we used your existing Škoda login to create an official Škoda API key for your car, so Home Assistant can now read it over Škoda's new official, durable channel — as an automatic backup if the normal connection ever struggles. Because this official channel is rate-limited (only a small number of requests an hour), it stays on standby and only reads when your main connection can't — so it won't slow anything down. Nothing to do on your side; this is just a heads-up, and you can dismiss it."
     },
     "skoda_official_quota_full": {
       "title": "Škoda official API — key limit reached",
       "description": "We tried to set up Škoda's official API for your car automatically, but your account already has the maximum of 5 API keys for this vehicle. To use it, free a slot in the MyŠkoda app (Settings → API keys → delete an unused one) and reload the integration, or paste an existing key manually in the integration's options. Everything else keeps working as before."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Škoda official API — another integration is using it too",
+      "description": "We found more official-API keys on your Škoda account than this integration created — usually a sign that a second integration or app is also reading Škoda's official API. That's fine to run, but they share the same small per-car request budget, so the combined traffic can hit Škoda's rate limit sooner and, in the worst case, get the account temporarily — or eventually permanently — blocked. If you don't need both, remove the official-API key you're not using in the MyŠkoda app (Settings → API keys). You can dismiss this notice."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "API oficial de Škoda — ya estás inscrito automáticamente",
-      "description": "Buenas noticias: usamos el inicio de sesión de Škoda que ya tenías para crear una clave de la API oficial de Škoda para tu coche, así que ahora Home Assistant puede leerlo a través del nuevo canal oficial y duradero de Škoda, como copia de seguridad automática por si la conexión normal alguna vez falla. No tienes que hacer nada por tu parte; esto es solo un aviso y puedes descartarlo."
+      "description": "Buenas noticias: usamos tu inicio de sesión de Škoda para crear una clave de la API oficial de Škoda para tu coche, de modo que Home Assistant ya puede leerlo a través del nuevo canal oficial y duradero de Škoda, como copia de seguridad automática por si la conexión normal alguna vez tiene problemas. Como este canal oficial tiene un límite de peticiones (solo unas pocas por hora), permanece en espera y solo lee cuando tu conexión principal no puede, así que no ralentizará nada. No tienes que hacer nada; esto es solo un aviso y puedes descartarlo."
     },
     "skoda_official_quota_full": {
       "title": "API oficial de Škoda — límite de claves alcanzado",
       "description": "Intentamos configurar la API oficial de Škoda para tu coche automáticamente, pero tu cuenta ya tiene el máximo de 5 claves de API para este vehículo. Para usarla, libera un espacio en la app MyŠkoda (Ajustes → Claves de API → elimina una que no uses) y recarga la integración, o pega manualmente una clave existente en las opciones de la integración. Todo lo demás sigue funcionando como antes."
+    },
+    "skoda_official_multi_integration": {
+      "title": "API oficial de Škoda: otra integración también la está usando",
+      "description": "Encontramos más claves de la API oficial en tu cuenta de Škoda de las que creó esta integración, lo que suele indicar que una segunda integración o aplicación también está leyendo la API oficial de Škoda. No hay problema en usar ambas, pero comparten el mismo y reducido presupuesto de peticiones por coche, así que el tráfico combinado puede alcanzar antes el límite de peticiones de Škoda y, en el peor de los casos, hacer que la cuenta se bloquee temporalmente o, con el tiempo, de forma permanente. Si no necesitas las dos, elimina la clave de la API oficial que no estés usando en la aplicación MyŠkoda (Ajustes → Claves de API). Puedes descartar este aviso."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Škodan virallinen API — sinut on nyt liitetty automaattisesti",
-      "description": "Hyviä uutisia: käytimme nykyisiä Škoda-kirjautumistietojasi ja loimme autollesi virallisen Škoda-API-avaimen, joten Home Assistant voi nyt lukea autosi tiedot Škodan uuden virallisen ja pysyvän kanavan kautta — automaattisena varayhteytenä siltä varalta, että tavallinen yhteys joskus takkuaa. Sinun ei tarvitse tehdä mitään; tämä on vain tiedoksi, ja voit sulkea ilmoituksen."
+      "description": "Hyviä uutisia: käytimme olemassa olevaa Škoda-kirjautumistasi ja loimme autollesi virallisen Škoda API -avaimen, joten Home Assistant voi nyt lukea sen tietoja Škodan uuden, virallisen ja kestävän yhteyden kautta — automaattisena varayhteytenä siltä varalta, että tavallinen yhteys joskus takkuaa. Koska tätä virallista yhteyttä on rajoitettu (vain muutama pyyntö tunnissa), se pysyy valmiustilassa ja lukee tietoja vain silloin, kun pääyhteys ei siihen pysty — joten se ei hidasta mitään. Sinun ei tarvitse tehdä mitään; tämä on vain tiedoksi, ja voit sulkea tämän ilmoituksen."
     },
     "skoda_official_quota_full": {
       "title": "Škodan virallinen API — avainten yläraja saavutettu",
       "description": "Yritimme ottaa Škodan virallisen API:n automaattisesti käyttöön autollesi, mutta tililläsi on jo tälle ajoneuvolle enimmäismäärä eli 5 API-avainta. Ota se käyttöön vapauttamalla paikka MyŠkoda-sovelluksessa (Asetukset → API-avaimet → poista käyttämätön) ja lataamalla integraatio uudelleen, tai liitä olemassa oleva avain käsin integraation asetuksiin. Kaikki muu toimii kuten ennenkin."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Škodan virallinen API — myös toinen integraatio käyttää sitä",
+      "description": "Škoda-tililtäsi löytyi enemmän virallisen API:n avaimia kuin tämä integraatio on luonut — yleensä se on merkki siitä, että myös jokin toinen integraatio tai sovellus lukee Škodan virallista API:a. Se ei sinänsä haittaa, mutta ne jakavat saman pienen, autokohtaisen pyyntömäärän, joten yhteinen liikenne voi saavuttaa Škodan pyyntörajan aiemmin ja pahimmassa tapauksessa johtaa tilin väliaikaiseen — tai lopulta pysyvään — estoon. Jos et tarvitse molempia, poista virallisen API:n avain, jota et käytä, MyŠkoda-sovelluksessa (Asetukset → API-avaimet). Voit sulkea tämän ilmoituksen."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "API officielle Škoda — vous êtes désormais inscrit automatiquement",
-      "description": "Bonne nouvelle : nous avons utilisé votre connexion Škoda existante pour créer une clé API Škoda officielle pour votre voiture. Home Assistant peut donc maintenant la lire via le nouveau canal officiel et durable de Škoda — comme sauvegarde automatique si jamais la connexion habituelle rencontre des difficultés. Rien à faire de votre côté ; c'est juste une information, et vous pouvez la fermer."
+      "description": "Bonne nouvelle : nous avons utilisé votre connexion Škoda existante pour créer une clé d'API officielle Škoda pour votre voiture, afin que Home Assistant puisse désormais la lire via le nouveau canal officiel et durable de Škoda — comme sauvegarde automatique si la connexion habituelle rencontre un jour des difficultés. Comme ce canal officiel est limité en débit (seulement un petit nombre de requêtes par heure), il reste en veille et ne lit que lorsque votre connexion principale n'y arrive pas — il ne ralentira donc rien. Rien à faire de votre côté ; ceci est juste une information, et vous pouvez l'ignorer."
     },
     "skoda_official_quota_full": {
       "title": "API officielle Škoda — limite de clés atteinte",
       "description": "Nous avons essayé de configurer l'API officielle de Škoda pour votre voiture automatiquement, mais votre compte a déjà atteint le maximum de 5 clés API pour ce véhicule. Pour l'utiliser, libérez un emplacement dans l'application MyŠkoda (Paramètres → Clés API → supprimez-en une inutilisée) puis rechargez l'intégration, ou collez manuellement une clé existante dans les options de l'intégration. Tout le reste continue de fonctionner comme avant."
+    },
+    "skoda_official_multi_integration": {
+      "title": "API officielle Škoda — une autre intégration l'utilise aussi",
+      "description": "Nous avons trouvé sur votre compte Škoda plus de clés d'API officielle que cette intégration n'en a créé — c'est en général le signe qu'une deuxième intégration ou application lit elle aussi l'API officielle de Škoda. Rien ne vous empêche de garder les deux, mais elles se partagent le même petit budget de requêtes par voiture ; le trafic cumulé peut donc atteindre plus vite la limite de Škoda et, dans le pire des cas, faire bloquer le compte temporairement — voire un jour définitivement. Si vous n'avez pas besoin des deux, supprimez la clé d'API officielle que vous n'utilisez pas dans l'application MyŠkoda (Paramètres → Clés d'API). Vous pouvez ignorer cet avis."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "API ufficiale di Škoda — ora sei registrato in automatico",
-      "description": "Buone notizie: abbiamo usato il tuo accesso Škoda esistente per creare una chiave API ufficiale di Škoda per la tua auto, così Home Assistant può ora leggerla tramite il nuovo canale ufficiale e stabile di Škoda — come backup automatico nel caso la connessione normale dovesse dare problemi. Non devi fare niente: è solo un avviso, e puoi chiuderlo."
+      "description": "Buone notizie: abbiamo usato il tuo accesso Škoda esistente per creare una chiave API ufficiale Škoda per la tua auto, così Home Assistant può ora leggerla tramite il nuovo canale ufficiale e duraturo di Škoda — come backup automatico nel caso in cui la connessione normale dovesse avere difficoltà. Poiché questo canale ufficiale ha un limite di frequenza (solo poche richieste all'ora), resta in standby e legge solo quando la connessione principale non ci riesce — così non rallenterà nulla. Non devi fare nulla; è solo un promemoria, e puoi ignorarlo."
     },
     "skoda_official_quota_full": {
       "title": "API ufficiale di Škoda — limite di chiavi raggiunto",
       "description": "Abbiamo provato a configurare in automatico l'API ufficiale di Škoda per la tua auto, ma il tuo account ha già il massimo di 5 chiavi API per questo veicolo. Per usarla, libera uno slot nell'app MyŠkoda (Impostazioni → Chiavi API → eliminane una che non usi) e ricarica l'integrazione, oppure incolla a mano una chiave esistente nelle opzioni dell'integrazione. Tutto il resto continua a funzionare come prima."
+    },
+    "skoda_official_multi_integration": {
+      "title": "API ufficiale Škoda — la sta usando anche un'altra integrazione",
+      "description": "Sul tuo account Škoda abbiamo trovato più chiavi API ufficiali di quante ne abbia create questa integrazione — di solito è il segno che una seconda integrazione o app sta leggendo anch'essa l'API ufficiale di Škoda. Va benissimo tenerle attive, ma condividono lo stesso piccolo budget di richieste per veicolo, quindi il traffico combinato può raggiungere prima il limite di frequenza di Škoda e, nel peggiore dei casi, portare al blocco temporaneo — o col tempo definitivo — dell'account. Se non ti servono entrambe, rimuovi la chiave API ufficiale che non usi nell'app MyŠkoda (Impostazioni → Chiavi API). Puoi ignorare questo avviso."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Škoda offisielt API — du er nå automatisk påmeldt",
-      "description": "Gode nyheter: vi brukte den eksisterende Škoda-innloggingen din til å lage en offisiell Škoda API-nøkkel for bilen din, så Home Assistant nå kan lese den over Škodas nye offisielle og varige kanal — som en automatisk reserve hvis den vanlige tilkoblingen skulle få problemer. Du trenger ikke gjøre noe; dette er bare en beskjed, og du kan lukke den."
+      "description": "Gode nyheter: vi brukte den eksisterende Škoda-innloggingen din til å opprette en offisiell Škoda API-nøkkel for bilen din, så Home Assistant nå kan lese av bilen via Škodas nye, offisielle og varige kanal — som en automatisk reserve dersom den vanlige tilkoblingen skulle få problemer. Fordi denne offisielle kanalen har en forespørselsgrense (bare et lite antall forespørsler i timen), står den i beredskap og leser bare når hovedtilkoblingen ikke klarer det — så den bremser ingenting. Du trenger ikke gjøre noe; dette er bare til info, og du kan lukke varselet."
     },
     "skoda_official_quota_full": {
       "title": "Škoda offisielt API — grensen for nøkler er nådd",
       "description": "Vi prøvde å sette opp Škodas offisielle API for bilen din automatisk, men kontoen din har allerede maks 5 API-nøkler for dette kjøretøyet. For å bruke det må du frigjøre en plass i MyŠkoda-appen (Innstillinger → API-nøkler → slett en ubrukt) og laste inn integrasjonen på nytt, eller lime inn en eksisterende nøkkel manuelt i integrasjonens alternativer. Alt annet fungerer som før."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Škodas offisielle API — en annen integrasjon bruker det også",
+      "description": "Vi fant flere offisielle API-nøkler på Škoda-kontoen din enn denne integrasjonen har opprettet — vanligvis et tegn på at en annen integrasjon eller app også leser Škodas offisielle API. Det er helt greit å ha begge i gang, men de deler det samme lille forespørselsbudsjettet per bil, så den samlede trafikken kan nå Škodas forespørselsgrense raskere og i verste fall føre til at kontoen blir blokkert midlertidig — eller til slutt permanent. Trenger du ikke begge, kan du fjerne den offisielle API-nøkkelen du ikke bruker i MyŠkoda-appen (Innstillinger → API-nøkler). Du kan lukke dette varselet."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Officiële Škoda-API — je bent nu automatisch aangemeld",
-      "description": "Goed nieuws: we hebben je bestaande Škoda-login gebruikt om een officiële Škoda-API-sleutel voor je auto aan te maken, zodat Home Assistant hem nu kan uitlezen via het nieuwe, officiële en stabiele kanaal van Škoda — als automatische back-up voor als de normale verbinding het ooit laat afweten. Je hoeft zelf niets te doen; dit is gewoon een seintje, en je kunt het wegklikken."
+      "description": "Goed nieuws: we hebben je bestaande Škoda-login gebruikt om een officiële Škoda API-sleutel voor je auto aan te maken, zodat Home Assistant hem nu kan uitlezen via het nieuwe, officiële en duurzame kanaal van Škoda — als automatische back-up voor als de normale verbinding het ooit moeilijk heeft. Omdat dit officiële kanaal een aanvraaglimiet heeft (maar een klein aantal aanvragen per uur), blijft het op stand-by en leest het alleen uit wanneer je hoofdverbinding dat niet kan — zo vertraagt het niets. Je hoeft zelf niets te doen; dit is gewoon een seintje, en je kunt deze melding sluiten."
     },
     "skoda_official_quota_full": {
       "title": "Officiële Škoda-API — maximaal aantal sleutels bereikt",
       "description": "We probeerden de officiële API van Škoda automatisch voor je auto in te stellen, maar je account heeft voor deze auto al het maximum van 5 API-sleutels. Om hem te gebruiken, maak je een plek vrij in de MyŠkoda-app (Instellingen → API-sleutels → verwijder een ongebruikte) en herlaad je de integratie, of plak je zelf een bestaande sleutel in de opties van de integratie. Al het andere blijft gewoon werken zoals eerst."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Officiële Škoda API — een andere integratie gebruikt hem ook",
+      "description": "We vonden meer officiële API-sleutels op je Škoda-account dan deze integratie heeft aangemaakt — meestal een teken dat een tweede integratie of app ook de officiële Škoda API uitleest. Dat mag gerust naast elkaar draaien, maar ze delen hetzelfde kleine aanvraagbudget per auto, waardoor het gecombineerde verkeer de aanvraaglimiet van Škoda sneller kan bereiken en het account in het ergste geval tijdelijk — of uiteindelijk zelfs permanent — geblokkeerd kan raken. Heb je niet allebei nodig? Verwijder dan de officiële API-sleutel die je niet gebruikt in de MyŠkoda-app (Instellingen → API-sleutels). Je kunt deze melding sluiten."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Oficjalne API Škoda — masz już automatyczny dostęp",
-      "description": "Dobra wiadomość: wykorzystaliśmy Twoje istniejące dane logowania Škoda, aby utworzyć oficjalny klucz API Škoda dla Twojego samochodu. Dzięki temu Home Assistant może teraz odczytywać dane przez nowy, oficjalny i trwały kanał Škoda — jako automatyczne zabezpieczenie na wypadek, gdyby zwykłe połączenie kiedyś szwankowało. Nie musisz nic robić; to tylko informacja i możesz ją zamknąć."
+      "description": "Dobra wiadomość: użyliśmy Twojego istniejącego logowania Škoda, aby utworzyć dla Twojego samochodu oficjalny klucz API Škoda, więc Home Assistant może go teraz odczytywać przez nowy, oficjalny i trwały kanał Škoda — jako automatyczną kopię zapasową na wypadek, gdyby normalne połączenie kiedykolwiek miało trudności. Ponieważ ten oficjalny kanał ma limit zapytań (tylko niewielka liczba zapytań na godzinę), pozostaje w trybie gotowości i pobiera dane wyłącznie wtedy, gdy główne połączenie nie może — dzięki temu niczego nie spowalnia. Z Twojej strony nic nie trzeba robić; to tylko informacja, którą możesz zamknąć."
     },
     "skoda_official_quota_full": {
       "title": "Oficjalne API Škoda — osiągnięto limit kluczy",
       "description": "Próbowaliśmy automatycznie skonfigurować oficjalne API Škoda dla Twojego samochodu, ale na Twoim koncie jest już maksymalna liczba 5 kluczy API dla tego pojazdu. Aby z niego skorzystać, zwolnij jedno miejsce w aplikacji MyŠkoda (Ustawienia → Klucze API → usuń nieużywany) i przeładuj integrację, albo wklej istniejący klucz ręcznie w opcjach integracji. Cała reszta działa tak jak wcześniej."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Oficjalne API Škoda — używa go też inna integracja",
+      "description": "Na Twoim koncie Škoda znaleźliśmy więcej kluczy oficjalnego API, niż utworzyła ta integracja — zwykle to znak, że oficjalne API Škoda odczytuje też druga integracja lub aplikacja. Nie ma problemu, żeby działały razem, ale dzielą ten sam niewielki budżet zapytań na samochód, więc łączny ruch może szybciej osiągnąć limit Škoda, a w najgorszym przypadku doprowadzić do tymczasowego — a z czasem nawet trwałego — zablokowania konta. Jeśli nie potrzebujesz obu, usuń w aplikacji MyŠkoda nieużywany klucz oficjalnego API (Ustawienia → Klucze API). To powiadomienie możesz zamknąć."
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1987,11 +1987,15 @@
     },
     "skoda_official_enrolled": {
       "title": "Škodas officiella API – du är nu automatiskt ansluten",
-      "description": "Goda nyheter: vi använde din befintliga Škoda-inloggning för att skapa en officiell Škoda API-nyckel för din bil, så nu kan Home Assistant läsa av den via Škodas nya officiella, stabila kanal – som en automatisk reserv om den vanliga anslutningen någon gång krånglar. Du behöver inte göra något – det här är bara till info, och du kan stänga meddelandet."
+      "description": "Goda nyheter: vi använde din befintliga Škoda-inloggning för att skapa en officiell Škoda API-nyckel för din bil, så att Home Assistant nu kan läsa den via Škodas nya officiella, varaktiga kanal — som en automatisk reserv om den vanliga anslutningen någon gång krånglar. Eftersom den här officiella kanalen har en hastighetsgräns (bara ett litet antal förfrågningar per timme) står den i beredskap och läser bara när din huvudanslutning inte kan — så den saktar inte ner något. Du behöver inte göra något; det här är bara till din kännedom, och du kan avfärda det."
     },
     "skoda_official_quota_full": {
       "title": "Škodas officiella API – nyckelgränsen är nådd",
       "description": "Vi försökte ställa in Škodas officiella API för din bil automatiskt, men ditt konto har redan det maximala antalet på 5 API-nycklar för det här fordonet. För att kunna använda det, frigör en plats i MyŠkoda-appen (Inställningar → API-nycklar → ta bort en oanvänd) och ladda om integrationen, eller klistra in en befintlig nyckel manuellt i integrationens alternativ. Allt annat fungerar som vanligt."
+    },
+    "skoda_official_multi_integration": {
+      "title": "Škodas officiella API — en annan integration använder det också",
+      "description": "Vi hittade fler officiella API-nycklar på ditt Škoda-konto än den här integrationen skapade — oftast ett tecken på att en andra integration eller app också läser Škodas officiella API. Det är helt okej att köra, men de delar samma lilla förfrågningsbudget per bil, så den sammanlagda trafiken kan nå Škodas hastighetsgräns snabbare och i värsta fall få kontot tillfälligt — eller till slut permanent — blockerat. Om du inte behöver båda, ta bort den officiella API-nyckel du inte använder i MyŠkoda-appen (Inställningar → API-nycklar). Du kan avfärda det här meddelandet."
     }
   },
   "services": {

--- a/tests/test_skoda_auto_enroll.py
+++ b/tests/test_skoda_auto_enroll.py
@@ -124,6 +124,55 @@ def test_quota_full_records_probe():
     assert cl.probe_outcomes["skoda_official"].startswith("quota-full")
 
 
+def test_multi_integration_detected_raises_repair():
+    # maxKeys 5, 2 keys in use (remaining 3) but we hold only 1 → a foreign key
+    # exists → another integration/app is using the same official API.
+    cl = _client()
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    listing = {"maxKeys": 5, "vehicleKeys": [{"vin": VIN1, "keysRemaining": 3}]}
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
+    ) as rep:
+        c._check_skoda_multi_integration(listing, {VIN1: {"key": "K"}})
+    rep.assert_called_once()
+
+
+def test_only_our_key_no_multi_integration_repair():
+    cl = _client()
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    # 1 key in use (remaining 4) and it's ours → nobody else
+    listing = {"maxKeys": 5, "vehicleKeys": [{"vin": VIN1, "keysRemaining": 4}]}
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
+    ) as rep:
+        c._check_skoda_multi_integration(listing, {VIN1: {"key": "K"}})
+    rep.assert_not_called()
+
+
+def test_foreign_key_before_we_mint_raises():
+    # 1 key in use, we hold none yet (about to mint) → the existing key is foreign
+    cl = _client()
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    listing = {"maxKeys": 5, "vehicleKeys": [{"vin": VIN1, "keysRemaining": 4}]}
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
+    ) as rep:
+        c._check_skoda_multi_integration(listing, {})
+    rep.assert_called_once()
+
+
+def test_multi_integration_bad_listing_never_crashes():
+    cl = _client()
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
+    ) as rep:
+        for bad in (None, {}, {"maxKeys": "x"}, {"vehicleKeys": "nope"},
+                    {"maxKeys": 5, "vehicleKeys": [{"vin": None}]}):
+            c._check_skoda_multi_integration(bad, {})
+    rep.assert_not_called()
+
+
 def test_failed_mint_not_retried_same_session():
     # A live mint that fails (returns None) must NOT be re-hammered every poll: the
     # attempted-set caps it at one try per HA session; the keygen probe stays visible.

--- a/tests/test_skoda_auto_enroll.py
+++ b/tests/test_skoda_auto_enroll.py
@@ -133,7 +133,7 @@ def test_multi_integration_detected_raises_repair():
     with patch(
         "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
     ) as rep:
-        c._check_skoda_multi_integration(listing, {VIN1: {"key": "K"}})
+        c._check_skoda_multi_integration(listing, {VIN1: {"key": "K"}}, [VIN1])
     rep.assert_called_once()
 
 
@@ -145,7 +145,7 @@ def test_only_our_key_no_multi_integration_repair():
     with patch(
         "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
     ) as rep:
-        c._check_skoda_multi_integration(listing, {VIN1: {"key": "K"}})
+        c._check_skoda_multi_integration(listing, {VIN1: {"key": "K"}}, [VIN1])
     rep.assert_not_called()
 
 
@@ -157,7 +157,7 @@ def test_foreign_key_before_we_mint_raises():
     with patch(
         "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
     ) as rep:
-        c._check_skoda_multi_integration(listing, {})
+        c._check_skoda_multi_integration(listing, {}, [VIN1])
     rep.assert_called_once()
 
 
@@ -169,7 +169,38 @@ def test_multi_integration_bad_listing_never_crashes():
     ) as rep:
         for bad in (None, {}, {"maxKeys": "x"}, {"vehicleKeys": "nope"},
                     {"maxKeys": 5, "vehicleKeys": [{"vin": None}]}):
-            c._check_skoda_multi_integration(bad, {})
+            c._check_skoda_multi_integration(bad, {}, [VIN1])
+    rep.assert_not_called()
+
+
+def test_second_unmanaged_skoda_does_not_trip_repair():
+    # A DIFFERENT Škoda on the same account (VIN2, not managed by this entry) has
+    # its own legitimate app key — it must NOT trip the multi-integration warning.
+    cl = _client()
+    c = _coord({CONF_BRAND: "skoda"}, cl)
+    listing = {"maxKeys": 5, "vehicleKeys": [
+        {"vin": VIN1, "keysRemaining": 4},   # ours, only our key
+        {"vin": VIN2, "keysRemaining": 4},   # a second, unmanaged car with a key
+    ]}
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
+    ) as rep:
+        c._check_skoda_multi_integration(listing, {VIN1: {"key": "K"}}, [VIN1])
+    rep.assert_not_called()
+
+
+def test_manual_fallback_key_counts_as_ours():
+    # The user's own manually-pasted key is one of the account's keys; it must not
+    # be mistaken for another integration.
+    from custom_components.vag_connect.const import CONF_SKODA_OFFICIAL_API_KEY
+    cl = _client()
+    c = _coord({CONF_BRAND: "skoda", CONF_SKODA_OFFICIAL_API_KEY: "PASTED"}, cl)
+    # 1 key in use (the manual one), we hold no auto-minted key → still ours
+    listing = {"maxKeys": 5, "vehicleKeys": [{"vin": VIN1, "keysRemaining": 4}]}
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_multi_integration"
+    ) as rep:
+        c._check_skoda_multi_integration(listing, {}, [VIN1])
     rep.assert_not_called()
 
 


### PR DESCRIPTION
## Škoda official-API guardrails (#1286)

Two safety/UX guardrails for the official Škoda public API we auto-enrol into.

### A — warn if another integration is using the same official API
The official API is **rate-limited per car** (a small number of requests an hour), and
the limit is **shared across every client on the account**. If a second integration or
app also uses it, the combined traffic can hit the limit sooner and — worst case — get
the account temporarily, or eventually permanently, blocked.

Detection: from `list_api_keys`, `maxKeys - keysRemaining` gives keys-in-use; more than
the one key we hold for a VIN means someone else minted keys too. Raised as a dismissible
WARNING repair that explains the ban risk and how to remove the unused key in the MyŠkoda
app. Checked in the auto-enrol flow — once per session for already-enrolled users, and on
the mint listing for new ones. **All 12 languages.**

### B — explain the rate-limited standby nature
The enrolment notice now says the official channel is rate-limited, sits on standby, and
only reads when the main channel can't — so nobody wonders why it isn't updating
constantly (and doesn't file "it's slow" reports).

## Verification
- `test_skoda_auto_enroll.py`: multi-integration detected → repair; only-our-key → none;
  foreign key before we mint → repair; malformed listing never crashes.
- Full suite green; translation-parity green (35/35); ruff + mypy strict clean.

Sits in `[Unreleased]` for the next beta.
