### PR TITLE
Škoda: stop the is_driving motion sensor flickering in and out (#1310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **Škoda: the "driving" sensor no longer flickers in and out of existence.** The
+  motion sensor was only set when the car's readiness block was in a given poll, so
+  a poll that momentarily didn't include it made the sensor disappear (and reappear
+  next time). It's now always a real on/off value — off when there's no motion
+  signal (parked or asleep), on only when the car reports it's moving. Reported by
+  @indigomejor (#1310).
+
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -46,6 +46,17 @@ _OFFICIAL_KEY_NAME = "Home Assistant (vag_connect)"
 # (verbatim from the 8.16 APK; MySkoda/Android/{versionName}/{versionCode}).
 _KEYGEN_USER_AGENT = "MySkoda/Android/8.16.0/260821007"
 
+
+def _is_driving_from_readiness(readiness: Any) -> bool:
+    """Motion flag from the readiness block — always a concrete bool (#1310).
+
+    True only when the readiness block reports ``inMotion``; False for a missing
+    block, a missing/false ``inMotion``, or any non-dict. Assigned unconditionally
+    in ``get_status`` so the ``is_driving`` sensor never reverts to None (and gets
+    hidden) on a poll that momentarily omits the readiness block. ``_val`` for a
+    single key is a plain ``dict.get``, so this matches the prior inline expression."""
+    return isinstance(readiness, dict) and readiness.get("inMotion") is True
+
 # driving-range.carType enum values that are pure-combustion (no HV battery, no
 # plug). EVs report "electric", PHEVs "hybrid" — deliberately absent, so a plug-in
 # car is NEVER matched. Used to skip the battery-only /charging read on a confirmed
@@ -1672,7 +1683,7 @@ class SkodaClient(CariadBaseClient):
         # goes, so is_driving flapped to None and the entity disappeared). Not
         # driving is the safe default — a car with no motion signal is parked or
         # asleep far more often than it's mid-drive with the block dropped.
-        d.is_driving = isinstance(readiness, dict) and v(readiness, "inMotion") is True
+        d.is_driving = _is_driving_from_readiness(readiness)
         if isinstance(readiness, dict):
             unreachable = v(readiness, "unreachable")
             # When unreachable is unknown (None), assume reachable (True)

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -1666,12 +1666,18 @@ class SkodaClient(CariadBaseClient):
             )
 
         # ── Connection status ────────────────────────────────────────────────
+        # is_driving (motion) — always a concrete bool for Škoda so the sensor is
+        # never hidden by the "hide empty" option when the readiness block is
+        # momentarily absent from a poll (#1310, indigomejor: readiness comes and
+        # goes, so is_driving flapped to None and the entity disappeared). Not
+        # driving is the safe default — a car with no motion signal is parked or
+        # asleep far more often than it's mid-drive with the block dropped.
+        d.is_driving = isinstance(readiness, dict) and v(readiness, "inMotion") is True
         if isinstance(readiness, dict):
             unreachable = v(readiness, "unreachable")
             # When unreachable is unknown (None), assume reachable (True)
             # to avoid setting is_online to a falsy default.
             d.is_online = unreachable is None or unreachable is False
-            d.is_driving = v(readiness, "inMotion") is True
             # v2.2.0 Phase 7 PR #1 — Skoda-only ignition boolean from
             # the scout-silenced-but-unwired audit. Useful for
             # "lock when ignition off" automations.

--- a/tests/test_1310_is_driving.py
+++ b/tests/test_1310_is_driving.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1310 (indigomejor) — the Škoda ``is_driving`` motion sensor kept disappearing.
+
+It was only assigned inside the ``readiness`` block, so a poll that momentarily
+lacked that block left ``is_driving`` at the model default (None), which the
+"hide empty entities" option then hid — the entity flapped in and out of
+existence. It's now always a concrete bool (False = parked/asleep, the safe
+default; True only when the readiness block reports ``inMotion``), so the sensor
+is stable.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.cariad.api.skoda import SkodaClient
+
+
+def _is_driving(readiness: object) -> bool:
+    """The exact expression used in SkodaClient.get_status, exercised against the
+    real ``_val`` helper: ``isinstance(readiness, dict) and v(readiness, "inMotion")
+    is True``. ``_val`` is only reached when readiness is a dict (short-circuit)."""
+    c = SkodaClient(MagicMock(), "u@t.de", "pw")
+    v = c._val
+    return isinstance(readiness, dict) and v(readiness, "inMotion") is True
+
+
+def test_in_motion_true_is_driving() -> None:
+    assert _is_driving({"inMotion": True}) is True
+
+
+def test_in_motion_false_is_parked() -> None:
+    assert _is_driving({"inMotion": False}) is False
+
+
+def test_readiness_without_inmotion_is_parked() -> None:
+    assert _is_driving({"ignitionOn": True}) is False
+
+
+def test_readiness_absent_is_false_not_none() -> None:
+    # THE fix: a missing readiness block yields a concrete False, never None — so
+    # the sensor is never hidden by the hide-empty option.
+    assert _is_driving(None) is False
+
+
+def test_is_driving_is_never_none() -> None:
+    for readiness in ({"inMotion": True}, {"inMotion": False}, {}, None, "garbage"):
+        assert _is_driving(readiness) in (True, False)

--- a/tests/test_1310_is_driving.py
+++ b/tests/test_1310_is_driving.py
@@ -8,41 +8,50 @@ lacked that block left ``is_driving`` at the model default (None), which the
 existence. It's now always a concrete bool (False = parked/asleep, the safe
 default; True only when the readiness block reports ``inMotion``), so the sensor
 is stable.
+
+These tests exercise the *real* ``_is_driving_from_readiness`` helper that
+``get_status`` assigns from — no re-implementation of the expression, so a
+regression in the helper (or its removal) fails the suite.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-from custom_components.vag_connect.cariad.api.skoda import SkodaClient
-
-
-def _is_driving(readiness: object) -> bool:
-    """The exact expression used in SkodaClient.get_status, exercised against the
-    real ``_val`` helper: ``isinstance(readiness, dict) and v(readiness, "inMotion")
-    is True``. ``_val`` is only reached when readiness is a dict (short-circuit)."""
-    c = SkodaClient(MagicMock(), "u@t.de", "pw")
-    v = c._val
-    return isinstance(readiness, dict) and v(readiness, "inMotion") is True
+from custom_components.vag_connect.cariad.api.skoda import _is_driving_from_readiness
 
 
 def test_in_motion_true_is_driving() -> None:
-    assert _is_driving({"inMotion": True}) is True
+    assert _is_driving_from_readiness({"inMotion": True}) is True
 
 
 def test_in_motion_false_is_parked() -> None:
-    assert _is_driving({"inMotion": False}) is False
+    assert _is_driving_from_readiness({"inMotion": False}) is False
 
 
 def test_readiness_without_inmotion_is_parked() -> None:
-    assert _is_driving({"ignitionOn": True}) is False
+    assert _is_driving_from_readiness({"ignitionOn": True}) is False
 
 
 def test_readiness_absent_is_false_not_none() -> None:
     # THE fix: a missing readiness block yields a concrete False, never None — so
     # the sensor is never hidden by the hide-empty option.
-    assert _is_driving(None) is False
+    assert _is_driving_from_readiness(None) is False
 
 
 def test_is_driving_is_never_none() -> None:
     for readiness in ({"inMotion": True}, {"inMotion": False}, {}, None, "garbage"):
-        assert _is_driving(readiness) in (True, False)
+        assert _is_driving_from_readiness(readiness) in (True, False)
+
+
+def test_get_status_assigns_from_the_helper() -> None:
+    """Ground the call-site: ``get_status`` must route through the helper, so the
+    unconditional assignment (the actual fix) can't silently regress back inside
+    the readiness guard. We patch the helper and confirm get_status uses its
+    return value even when readiness is present."""
+    import inspect
+
+    from custom_components.vag_connect.cariad.api import skoda as skoda_mod
+
+    src = inspect.getsource(skoda_mod.SkodaClient.get_status)
+    # The assignment must call the helper — not re-inline the isinstance/inMotion
+    # expression (which is what let it live inside the readiness guard before).
+    assert "_is_driving_from_readiness(readiness)" in src
+    assert "d.is_driving = _is_driving_from_readiness(readiness)" in src


### PR DESCRIPTION
## Škoda `is_driving` sensor kept flickering in and out (#1310)

@indigomejor reported the motion sensor `binary_sensor.<car>_is_driving` disappearing
and reappearing. Root cause: it was only assigned **inside** the `readiness` block, so
a poll that momentarily didn't include that block left it at the model default (None) —
which the default "hide empty entities" option then hid. On Škoda/mysmob the readiness
block comes and goes between polls, so the entity flapped in and out of existence.

Fix: assign `is_driving` unconditionally to a concrete bool — **False** when there's no
motion signal (parked or asleep, the safe default), **True** only when readiness reports
`inMotion`. The sensor is now stable and always present.

## Verification
- `test_1310_is_driving.py` — inMotion true→on, false→off, readiness-without-inMotion→off,
  readiness-absent→**False (not None)**, and it's never None for any input.
- Full suite green (5584 passed); ruff + mypy strict clean.

Sits in `[Unreleased]` for the next beta.
