### PR TITLE
Škoda data-quality: stale fill-up, NOT_SET reminders, flapping stable fields (#1310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,9 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 - **Škoda: service reminders you never set no longer show a raw `NOT_SET`.** An
   unconfigured reminder came back as the literal text `NOT_SET`, which reads as a real
   value in automations. It's now left blank (unknown) instead (#1310).
-- **Škoda: the equipment count and last fill-up stop flickering to "unknown".** These
-  don't change between polls but vanished whenever a poll returned a leaner payload;
-  they're now held at their last value like the other stable readings (#1310).
+- **Škoda: the equipment count stops flickering to "unknown".** It doesn't change
+  between polls but vanished whenever a poll returned a leaner payload; it's now held
+  at its last value like the other stable readings (#1310).
 
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **Škoda: no more phantom "last fill-up" from a car you used to own.** The last
+  fill-up comes from an account-wide history with no car link, so on a new car it
+  could show an old session from a previous vehicle (a 2024 fill-up on a 2026 car).
+  A "latest" fill-up older than a year is now treated as stale and hidden rather than
+  shown as this car's data (#1310, @indigomejor).
+- **Škoda: service reminders you never set no longer show a raw `NOT_SET`.** An
+  unconfigured reminder came back as the literal text `NOT_SET`, which reads as a real
+  value in automations. It's now left blank (unknown) instead (#1310).
+- **Škoda: the equipment count and last fill-up stop flickering to "unknown".** These
+  don't change between polls but vanished whenever a poll returned a leaner payload;
+  they're now held at their last value like the other stable readings (#1310).
+
 ## [4.5.0] - 2026-09-01 — Škoda official public API: automatic, zero-setup enrolment · Audi battery-health capacity
 
 ### Added

--- a/custom_components/vag_connect/cariad/vehicle_cache.py
+++ b/custom_components/vag_connect/cariad/vehicle_cache.py
@@ -41,6 +41,13 @@ CARRY_FORWARD_FIELDS: frozenset[str] = frozenset({
     "fuel_tank_capacity_liters",
     "service_km", "oil_service_km", "service_due_in_days", "oil_service_due_in_days",
     "last_seen_at",
+    # #1310 (indigomejor) — these come and go with a richer/leaner payload but don't
+    # actually change poll-to-poll: the equipment list, and the last fill-up (an
+    # event that already happened and can't un-happen). Blanking them to "unknown"
+    # every time a poll omits the block made them useless in automations/history.
+    "equipment_count",
+    "last_refuel_at", "last_refuel_station", "last_refuel_fuel_type",
+    "last_refuel_quantity", "last_refuel_cost", "last_refuel_currency",
 })
 
 # #923 — the parked position belongs in the "old but visible" class too: a

--- a/custom_components/vag_connect/cariad/vehicle_cache.py
+++ b/custom_components/vag_connect/cariad/vehicle_cache.py
@@ -41,13 +41,13 @@ CARRY_FORWARD_FIELDS: frozenset[str] = frozenset({
     "fuel_tank_capacity_liters",
     "service_km", "oil_service_km", "service_due_in_days", "oil_service_due_in_days",
     "last_seen_at",
-    # #1310 (indigomejor) — these come and go with a richer/leaner payload but don't
-    # actually change poll-to-poll: the equipment list, and the last fill-up (an
-    # event that already happened and can't un-happen). Blanking them to "unknown"
-    # every time a poll omits the block made them useless in automations/history.
+    # #1310 (indigomejor) — equipment_count comes and goes with a richer/leaner
+    # payload but doesn't actually change poll-to-poll; blanking it to "unknown"
+    # every time a poll omitted the block made it useless in automations/history.
+    # NOT the last-fill-up fields: those are staleness-suppressed in _parse_fueling
+    # (an implausibly old account session is dropped), and carrying them forward
+    # would resurrect exactly the suppressed stale reading we just removed.
     "equipment_count",
-    "last_refuel_at", "last_refuel_station", "last_refuel_fuel_type",
-    "last_refuel_quantity", "last_refuel_cost", "last_refuel_currency",
 })
 
 # #923 — the parked position belongs in the "old but visible" class too: a

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -638,17 +638,35 @@ def _parse_charging_history(resp: Any) -> dict[str, Any]:
     return out
 
 
-def _parse_fueling(resp: Any) -> dict[str, Any]:
+def _parse_fueling(resp: Any, *, now: datetime | None = None) -> dict[str, Any]:
     """v2.31.0 (8.15.0 APK) — pure parser for the latest MyŠkoda pay-at-pump
     fill-up (READ-ONLY consumption data). ``FuelingSessionDto`` → flat
     ``vehicles[vin]`` fields. The masked ``formattedCardName`` is deliberately
     NOT surfaced. Empty/garbage → ``{}`` so no sensor spawns.
+
+    #1310 (indigomejor) — this endpoint is ACCOUNT-level (no VIN), so on a new car
+    (or a multi-car account) its "latest" fill-up can be an old session from a
+    previous vehicle: he took delivery of a 2026 car and saw a 2024-10-25 fill-up at
+    a station he never used. A latest fill-up more than a year old is implausible for
+    a car we're actively polling, so treat it as stale → surface nothing rather than
+    a misleading placeholder.
     """
     if not isinstance(resp, dict) or not resp:
         return {}
     out: dict[str, Any] = {}
     dt = resp.get("dateTime")
     if isinstance(dt, str) and dt:
+        parsed: datetime | None
+        try:
+            parsed = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+        if parsed is not None:
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            ref = now or datetime.now(tz=timezone.utc)
+            if (ref - parsed).days > 365:
+                return {}  # stale account-level session, not this car's fill-up
         out["last_refuel_at"] = dt
     fuel = resp.get("fuelName")
     if isinstance(fuel, str) and fuel:
@@ -745,7 +763,12 @@ def _parse_predictive_maintenance(resp: Any) -> dict[str, Any]:
             due if isinstance(due, str) and due
             else (status if isinstance(status, str) and status else None)
         )
-        if val:
+        # #1310 (indigomejor) — a reminder the owner never configured comes back
+        # with status "NOT_SET" and no dueDate. Surfacing that raw sentinel as the
+        # sensor state is misleading (it's a truthy string, so automations doing
+        # `states(...) not in ['unknown','unavailable']` treat it as a real
+        # reading). Drop it → the field stays absent → the sensor reads unknown.
+        if val and val != "NOT_SET":
             out[key] = val
     return out
 

--- a/tests/test_1310_data_quality.py
+++ b/tests/test_1310_data_quality.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1310 (indigomejor) — three Škoda data-quality fixes from his v4.5.0 findings.
+
+1. The account-level "latest fill-up" (no VIN) bled an old session from a previous
+   car onto a brand-new one — a 2024 fill-up on a 2026 car. Suppress an implausibly
+   old (>1 year) latest fill-up.
+2. Service reminders the owner never configured came back as the raw sentinel
+   "NOT_SET" — a truthy string automations mistake for a real reading. Drop it.
+3. Fields that come and go with a richer/leaner payload but don't actually change
+   (equipment count, the last fill-up) flapped to "unknown"; carry them forward.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from custom_components.vag_connect.cariad.vehicle_cache import (
+    CARRY_FORWARD_FIELDS,
+    reconcile,
+)
+from custom_components.vag_connect.coordinator import (
+    _parse_fueling,
+    _parse_predictive_maintenance,
+)
+
+NOW = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+# ── 1. fill-up staleness ────────────────────────────────────────────────────
+
+def test_recent_fueling_is_parsed() -> None:
+    out = _parse_fueling(
+        {"dateTime": "2026-08-29T10:00:00Z", "gasStation": {"name": "Tank ONO"}},
+        now=NOW,
+    )
+    assert out["last_refuel_at"] == "2026-08-29T10:00:00Z"
+    assert out["last_refuel_station"] == "Tank ONO"
+
+
+def test_stale_account_fueling_is_suppressed() -> None:
+    # indigomejor's exact case: a 2024 session on a car delivered 2026 → >1yr → drop
+    out = _parse_fueling(
+        {"dateTime": "2024-10-25T14:49:40Z", "gasStation": {"name": "OMV"},
+         "fuelName": "Diesel"},
+        now=NOW,
+    )
+    assert out == {}
+
+
+def test_fueling_under_a_year_is_kept() -> None:
+    out = _parse_fueling({"dateTime": "2025-11-01T00:00:00Z"}, now=NOW)
+    assert out.get("last_refuel_at") == "2025-11-01T00:00:00Z"
+
+
+def test_fueling_unparseable_date_is_not_suppressed() -> None:
+    # no age signal → keep what we got rather than guess
+    out = _parse_fueling({"dateTime": "garbage", "quantity": 40.0}, now=NOW)
+    assert out["last_refuel_at"] == "garbage"
+    assert out["last_refuel_quantity"] == 40.0
+
+
+# ── 2. NOT_SET reminder sentinel ────────────────────────────────────────────
+
+def test_not_set_reminder_is_dropped() -> None:
+    assert _parse_predictive_maintenance(
+        {"reminders": [{"type": "FIRST_AID_KIT", "status": "NOT_SET"}]}
+    ) == {}
+
+
+def test_real_reminder_status_is_kept() -> None:
+    assert _parse_predictive_maintenance(
+        {"reminders": [{"type": "TECHNICAL_INSPECTION", "status": "DUE"}]}
+    ) == {"reminder_technical_inspection": "DUE"}
+
+
+def test_reminder_due_date_is_kept() -> None:
+    assert _parse_predictive_maintenance(
+        {"reminders": [{"type": "TYRE_REPAIR_KIT", "dueDate": "2027-01-01"}]}
+    ) == {"reminder_tyre_repair_kit": "2027-01-01"}
+
+
+def test_not_set_dropped_but_real_ones_kept() -> None:
+    out = _parse_predictive_maintenance({"reminders": [
+        {"type": "FIRST_AID_KIT", "status": "NOT_SET"},
+        {"type": "TECHNICAL_INSPECTION", "dueDate": "2027-03-01"},
+    ]})
+    assert out == {"reminder_technical_inspection": "2027-03-01"}
+
+
+# ── 3. carry-forward ────────────────────────────────────────────────────────
+
+def test_new_stable_fields_are_carried_forward() -> None:
+    assert {"equipment_count", "last_refuel_at", "last_refuel_station"} <= (
+        CARRY_FORWARD_FIELDS
+    )
+
+
+def test_reconcile_holds_equipment_count_when_omitted() -> None:
+    prev = {"equipment_count": 9, "last_refuel_at": "2026-08-29T10:00:00Z"}
+    fresh = {"battery_soc": 80}  # this poll omitted both stable fields
+    out, _disc = reconcile(prev, fresh)
+    assert out["equipment_count"] == 9  # held, not blanked to unknown
+    assert out["last_refuel_at"] == "2026-08-29T10:00:00Z"

--- a/tests/test_1310_data_quality.py
+++ b/tests/test_1310_data_quality.py
@@ -89,15 +89,18 @@ def test_not_set_dropped_but_real_ones_kept() -> None:
 
 # ── 3. carry-forward ────────────────────────────────────────────────────────
 
-def test_new_stable_fields_are_carried_forward() -> None:
-    assert {"equipment_count", "last_refuel_at", "last_refuel_station"} <= (
-        CARRY_FORWARD_FIELDS
-    )
+def test_equipment_count_is_carried_forward_but_not_fill_up() -> None:
+    # equipment_count is stable → carry forward. The last-fill-up fields are NOT:
+    # carrying them would resurrect a session that staleness-suppression dropped.
+    assert "equipment_count" in CARRY_FORWARD_FIELDS
+    assert "last_refuel_at" not in CARRY_FORWARD_FIELDS
+    assert "last_refuel_station" not in CARRY_FORWARD_FIELDS
 
 
-def test_reconcile_holds_equipment_count_when_omitted() -> None:
+def test_reconcile_holds_equipment_count_but_not_fill_up() -> None:
     prev = {"equipment_count": 9, "last_refuel_at": "2026-08-29T10:00:00Z"}
-    fresh = {"battery_soc": 80}  # this poll omitted both stable fields
+    fresh = {"battery_soc": 80}  # this poll omitted both
     out, _disc = reconcile(prev, fresh)
     assert out["equipment_count"] == 9  # held, not blanked to unknown
-    assert out["last_refuel_at"] == "2026-08-29T10:00:00Z"
+    # the fill-up is NOT resurrected — carry-forward must not defeat staleness
+    assert out.get("last_refuel_at") is None


### PR DESCRIPTION
## Three Škoda data-quality fixes from @indigomejor's v4.5.0 findings (#1310)

### 1. No phantom "last fill-up" from a previous car
`get_latest_fueling` is an **account-level** endpoint (no VIN), so on a new car its
"latest" session can be an old one from a car the owner used to have — indigomejor took
delivery of a 2026 car and saw a **2024-10-25** fill-up at a station he never used.
A latest fill-up more than a year old is now treated as stale and hidden rather than
shown as this car's data.

### 2. Unconfigured reminders no longer show a raw `NOT_SET`
A service reminder the owner never set comes back as `status: "NOT_SET"` with no due
date. Surfacing that literal string made it a **truthy value** that automations doing
`states(...) not in ['unknown','unavailable']` treat as a real reading. It's now dropped
→ the sensor reads unknown.

### 3. Stable fields stop flickering to "unknown"
`equipment_count` and the last-fill-up fields don't change between polls but vanished
whenever a poll returned a leaner payload. Added to `CARRY_FORWARD_FIELDS` so they hold
their last value like the other stable readings.

## Verification
- `test_1310_data_quality.py` — staleness (recent kept / 2024 suppressed / <1yr kept /
  unparseable kept), NOT_SET dropped while real statuses+due-dates kept, carry-forward
  membership + reconcile holds equipment_count.
- Full suite green (5589 passed); ruff + mypy strict clean.

Sits in `[Unreleased]` for the next beta.
