### PR TITLE
fix: keep connection-status diagnostics available when a car's poll fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **When a car goes unreachable, the entities that explain why no longer vanish
+  with it.** A failed poll (past the tolerance window) took the whole car's
+  entities down — including "Vehicle Last Reported", the data-source and
+  connectivity indicators, and the error-reporter counts, i.e. exactly the ones
+  you'd look at to see what happened. Those connection-status diagnostics now stay
+  available regardless of the poll outcome, so you're never left blind at the
+  moment the car drops off.
+
 ## [4.6.0b1] - 2026-09-01 — Škoda data-quality wave · per-source connectivity · sturdier token refresh
 
 ### Added

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -1151,6 +1151,10 @@ class VagSourceConnectivitySensor(VagConnectEntity, BinarySensorEntity):
     for the EU Data Act portal its feed health — is exposed as attributes.
     """
 
+    # Stay visible when the car's poll fails — a connectivity indicator that
+    # disappears exactly when connectivity drops is worse than useless.
+    _stay_available_on_poll_failure = True
+
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_icon = "mdi:transit-connection-variant"

--- a/custom_components/vag_connect/entity_base.py
+++ b/custom_components/vag_connect/entity_base.py
@@ -22,6 +22,20 @@ def _device_name(vehicle: dict, brand: str) -> str:
     return f"{brand.title()} {vin[-6:]}" if vin else brand.title()
 
 
+# Connection-status diagnostics that must stay AVAILABLE even when the vehicle
+# poll is failing — otherwise the user is blinded to WHY the car went
+# unavailable exactly when they need to read it (the whole car went dark, so did
+# the "last reported", "data source", error-reporter and connectivity entities).
+# Keyed by entity_description.key; custom classes set ``_stay_available_on_poll_failure``.
+_CONNECTION_STATUS_KEYS = frozenset({
+    "last_updated_at",
+    "last_seen_at",
+    "data_source_channel",
+    "error_reporter_count",
+    "connection_active",
+})
+
+
 class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
     """Base entity shared by all VW Group Connect platforms.
 
@@ -78,7 +92,17 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
         v1.9.1 (Capability-Filter Phase 2): for command-bound entities,
         also returns False if the coordinator's ``FeatureState`` records a
         definitive "command not supported" outcome from a previous attempt.
+
+        Connection-status diagnostics (``_CONNECTION_STATUS_KEYS`` / classes that
+        set ``_stay_available_on_poll_failure``) stay available regardless of the
+        poll outcome, so a car going unreachable doesn't also hide the very
+        entities that explain why.
         """
+        desc = getattr(self, "entity_description", None)
+        if getattr(self, "_stay_available_on_poll_failure", False) or (
+            desc is not None and getattr(desc, "key", "") in _CONNECTION_STATUS_KEYS
+        ):
+            return True
         if not super().available:
             # Connector-level failure (``last_update_success``). That is a
             # statement about the poll, not about this car: a single-vehicle

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -4346,6 +4346,10 @@ class ReporterSensor(VagConnectSensor):
     becomes unavailable.
     """
 
+    # The reporter/scout counts are exactly what you need when a poll fails, so
+    # keep them available regardless of the per-vehicle poll outcome.
+    _stay_available_on_poll_failure = True
+
     @property
     def native_value(self) -> Any:
         key = self.entity_description.key

--- a/tests/test_connection_status_stays_available.py
+++ b/tests/test_connection_status_stays_available.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Connection-status diagnostics stay available when the vehicle poll fails.
+
+When a car's poll fails past the tolerance window every one of its entities goes
+unavailable — which used to include the "last reported", "data source",
+error-reporter and per-source connectivity entities, i.e. exactly the ones that
+explain WHY the car went dark. Those now stay available regardless of the poll
+outcome (by ``entity_description.key`` or a class ``_stay_available_on_poll_failure``),
+so the user is never blinded at the moment they need the diagnostics.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.entity_base import (
+    _CONNECTION_STATUS_KEYS,
+    VagConnectEntity,
+)
+
+
+def _coord(*, poll_ok: bool, vehicle_ok: bool) -> MagicMock:
+    c = MagicMock()
+    c.last_update_success = poll_ok
+    c.is_vehicle_available.return_value = vehicle_ok
+    c.vehicle_last_good_at = {}  # no last-known-good → normal entities go unavailable
+    return c
+
+
+def _entity(coord: MagicMock, *, key: str | None = None, flag: bool = False) -> VagConnectEntity:
+    e = VagConnectEntity.__new__(VagConnectEntity)
+    e.coordinator = coord
+    e._vin = "VIN1"
+    e._command_id = None
+    if key is not None:
+        desc = MagicMock()
+        desc.key = key
+        e.entity_description = desc  # type: ignore[attr-defined]
+    if flag:
+        e._stay_available_on_poll_failure = True  # type: ignore[attr-defined]
+    return e
+
+
+def test_connection_status_keys_stay_available_on_total_poll_failure() -> None:
+    coord = _coord(poll_ok=False, vehicle_ok=False)  # worst case: everything down
+    for key in _CONNECTION_STATUS_KEYS:
+        assert _entity(coord, key=key).available is True, key
+
+
+def test_flagged_class_stays_available_on_total_poll_failure() -> None:
+    coord = _coord(poll_ok=False, vehicle_ok=False)
+    assert _entity(coord, flag=True).available is True
+
+
+def test_ordinary_entity_still_goes_unavailable() -> None:
+    # a normal per-car entity (not a connection-status one) must still disappear
+    # when the poll has genuinely failed and there is no last-known-good snapshot
+    coord = _coord(poll_ok=False, vehicle_ok=False)
+    assert _entity(coord, key="doors_locked").available is False
+
+
+def test_connection_status_still_available_when_healthy() -> None:
+    coord = _coord(poll_ok=True, vehicle_ok=True)
+    assert _entity(coord, key="connection_active").available is True
+    assert _entity(coord, key="doors_locked").available is True


### PR DESCRIPTION
## Why

Per-VIN availability already tolerates transient failures (3-strike grace + a 6h stale-cache window in `is_vehicle_available`). But once a car genuinely drops past that window, **every** entity of that car goes unavailable — including the ones that explain the outage: *Vehicle Last Reported*, the data-source channel, the per-source connectivity indicators, the online flag, and the error-reporter / scout counts. Losing those exactly when a car goes dark leaves the user blind (observed on a real VW-EU entry whose read channel had been failing for weeks — the only surviving entity was the push-event one, because `event.py` already overrides `available`).

## What

- **`entity_base.py`** — `available` now returns `True` for connection-status diagnostics regardless of the poll outcome, selected by `entity_description.key` (`_CONNECTION_STATUS_KEYS`: `last_updated_at`, `last_seen_at`, `data_source_channel`, `error_reporter_count`, `connection_active`) or a `_stay_available_on_poll_failure` class flag.
- **`sensor.py` / `binary_sensor.py`** — set that flag on `ReporterSensor` (error-reporter + scout counts) and `VagSourceConnectivitySensor` (per-source connectivity — an indicator that vanishes when connectivity drops is worse than useless).
- Ordinary per-car entities are unchanged: they still go unavailable past the tolerance window.

## Test

- New `tests/test_connection_status_stays_available.py` (4 cases: keys + flagged class stay up under total poll failure; an ordinary entity still goes down; both stay up when healthy).
- Availability / source-connectivity / reporter / entity-base regression slice: 118 passed. ruff + mypy (strict) clean; pre-commit gate passed.

## Not in this PR

- Persisting the last-known-good timestamp across a restart (so restored cache shows for its 6h window instead of collapsing) is a separate, follow-up change — it carries a stale-data-visibility trade-off and wants the cache-timestamp plumbing done carefully.