### PR TITLE
feat(acpp): full trip logbook, fuel log, EcoScore & driver score mapping (Priority A→C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   sub-metre value (fresher and more accurate than the coarse snapshot one). The
   parked-position age now comes from the GPS fix's own timestamp instead of the
   unreliable sync stamp, so "how old is this location" is finally honest.
+- **Audi plug&play: EcoScore, refuel "from → to" litres, trip count and driver-score
+  points.** The dongle's logbook and fuel log now also surface the last trip's
+  EcoScore and average intake-air temperature, how many litres each fill-up added
+  (with the tank level before and after it, and the odometer at the time), how many
+  trips are on record, and your account's driver-score points — all diagnostic, and
+  only on plug&play cars that actually have the data. Full 12-language names.
 
 ## [4.6.0b1] - 2026-09-01 — Škoda data-quality wave · per-source connectivity · sturdier token refresh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **Audi plug&play (OBD dongle): last-trip stats, a precise odometer, and a real
+  "last parked" time.** The dongle's trip logbook now fills the last-trip distance,
+  duration and start odometer, and the main odometer switches to the driverlog's
+  sub-metre value (fresher and more accurate than the coarse snapshot one). The
+  parked-position age now comes from the GPS fix's own timestamp instead of the
+  unreliable sync stamp, so "how old is this location" is finally honest.
+
 ## [4.6.0b1] - 2026-09-01 — Škoda data-quality wave · per-source connectivity · sturdier token refresh
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/plugandplay.py
+++ b/custom_components/vag_connect/cariad/api/plugandplay.py
@@ -229,10 +229,12 @@ class PlugAndPlayCloudClient:
             # proper "ab Haus" model designation.
             ("carport", f"vehicle/{vin}/carport"),
             # driverlogs = the trip logbook (precise odometer + last-trip stats +
-            # EcoScore + start/end GPS); fuellog = refuel history ("von→auf" litres).
-            # Both only fill after the dongle syncs a drive/refuel; empty otherwise.
+            # EcoScore + start/end GPS); fuellog = refuel history ("von→auf" litres);
+            # achievements = the account driver-score ledger. All only fill after the
+            # dongle syncs a drive/refuel; empty otherwise.
             ("driverlogs", f"vehicle/{vin}/driverlogs"),
             ("fuellog", f"user/fuellog/{vin}"),
+            ("achievements", "user/achievements/v2"),
         ):
             try:
                 s, b = await self._get(sub)
@@ -373,6 +375,93 @@ class PlugAndPlayCloudClient:
         )
         if pos_at is not None:
             data.position_captured_at = pos_at
+
+        # ── EcoScore + intake-air + trip count + compact logbook (Priority B/C) ──
+        dl = snap.get("driverlogs")
+        dl_content = dl.get("content") if isinstance(dl, dict) else None
+        if isinstance(dl, dict):
+            total = dl.get("totalElements")
+            if isinstance(total, int) and not isinstance(total, bool):
+                data.trip_count = total
+            elif isinstance(dl_content, list):
+                data.trip_count = len(dl_content)
+        if trip is not None:
+            eco = (trip.get("ecoScore") or {}).get("ecoScore")
+            if isinstance(eco, (int, float)) and not isinstance(eco, bool):
+                data.last_trip_eco_score = int(round(eco))
+            iat = trip.get("averageInductionAirTemperature")
+            if isinstance(iat, (int, float)) and not isinstance(iat, bool):
+                data.last_trip_intake_air_temp_c = int(round(iat))
+        # Priority C — the last few trips (newest first) for the last-trip sensor's
+        # attributes: date / distance / duration / EcoScore / end time.
+        if isinstance(dl_content, list) and dl_content:
+            recent: list[dict[str, Any]] = []
+            for t in sorted(
+                (x for x in dl_content if isinstance(x, dict)),
+                key=lambda x: x.get("endTime") or 0,
+                reverse=True,
+            )[:10]:
+                dur = t.get("totalTripTime")
+                recent.append({
+                    "date": t.get("remark"),
+                    "distance_km": t.get("totalTripMileage"),
+                    "duration_min": (
+                        int(round(dur / 60000))
+                        if isinstance(dur, (int, float)) and not isinstance(dur, bool)
+                        else None
+                    ),
+                    "eco_score": (t.get("ecoScore") or {}).get("ecoScore"),
+                    "ended_at": _epoch_ms_to_datetime(t.get("endTime")),
+                })
+            if recent:
+                data.recent_trips = recent
+
+        # ── Fuel log — "von→auf" litres + odometer at the fill-up ──
+        fl = snap.get("fuellog")
+        fl_content = fl.get("content") if isinstance(fl, dict) else None
+        if isinstance(fl_content, list) and fl_content:
+            newest = max(
+                (r for r in fl_content if isinstance(r, dict)),
+                key=lambda r: r.get("createdTimestamp") or 0,
+                default=None,
+            )
+            if newest is not None:
+                amount = newest.get("amount")
+                after = newest.get("postFuelAmount")
+                amount_num = (
+                    float(amount)
+                    if isinstance(amount, (int, float)) and not isinstance(amount, bool)
+                    else None
+                )
+                if amount_num is not None:
+                    data.last_refuel_liters_added = round(amount_num, 1)
+                if isinstance(after, (int, float)) and not isinstance(after, bool):
+                    data.last_refuel_tank_after_l = round(float(after), 1)
+                    if amount_num is not None:
+                        data.last_refuel_tank_before_l = round(float(after) - amount_num, 1)
+                fodo = newest.get("odometer")
+                if isinstance(fodo, (int, float)) and not isinstance(fodo, bool):
+                    data.last_refuel_odometer_km = int(round(fodo))
+
+        # ── Driver-score points (account-level achievements ledger) ──
+        ach = snap.get("achievements")
+        ach_content = ach.get("content") if isinstance(ach, dict) else None
+        if isinstance(ach_content, list) and ach_content:
+            now_ms = datetime.now(tz=timezone.utc).timestamp() * 1000
+            total_pts = 0
+            seen = False
+            for a in ach_content:
+                if not isinstance(a, dict):
+                    continue
+                pts = a.get("points")
+                if not isinstance(pts, (int, float)) or isinstance(pts, bool):
+                    continue
+                exp = a.get("expirationDate") or 0  # 0 = never expires
+                if not exp or exp > now_ms:
+                    total_pts += int(pts)
+                    seen = True
+            if seen:
+                data.score_points_total = total_pts
 
         # Factory ("ab Haus") model designation from the carport master-data
         # record — e.g. brandCode "A" + modelDesc "A5" + engType "TDI CR".

--- a/custom_components/vag_connect/cariad/api/plugandplay.py
+++ b/custom_components/vag_connect/cariad/api/plugandplay.py
@@ -72,6 +72,41 @@ def _epoch_ms_to_date(val: Any) -> str | None:
         return None
 
 
+def _epoch_ms_to_datetime(val: Any) -> str | None:
+    """acpp trip / refuel / parking timestamps are epoch-millisecond ints.
+
+    Return a full ISO-8601 UTC datetime (time-of-day matters for a trip end or a
+    position fix, unlike the carport dates), or None on anything unparseable.
+    """
+    try:
+        ms = int(str(val))
+    except (TypeError, ValueError):
+        return None
+    if ms <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _newest_driverlog(snap: dict[str, Any]) -> dict[str, Any] | None:
+    """The most-recent trip from the ``driverlogs`` page (newest ``endTime``).
+
+    The endpoint paginates (``content[]``); page 0 already holds the latest trips,
+    and we only need the newest one for the last-trip fields. Defensive: any shape
+    surprise → None, so a missing/odd logbook never breaks the status read.
+    """
+    dl = snap.get("driverlogs")
+    content = dl.get("content") if isinstance(dl, dict) else None
+    if not isinstance(content, list) or not content:
+        return None
+    trips = [t for t in content if isinstance(t, dict)]
+    if not trips:
+        return None
+    return max(trips, key=lambda t: t.get("endTime") or 0)
+
+
 class PlugAndPlayCloudClient:
     """Read-only cloud client for the Audi connect plug&play (acpp) backend.
 
@@ -193,6 +228,11 @@ class PlugAndPlayCloudClient:
             # carport = factory master data (model, engine, fuel, power) for the
             # proper "ab Haus" model designation.
             ("carport", f"vehicle/{vin}/carport"),
+            # driverlogs = the trip logbook (precise odometer + last-trip stats +
+            # EcoScore + start/end GPS); fuellog = refuel history ("von→auf" litres).
+            # Both only fill after the dongle syncs a drive/refuel; empty otherwise.
+            ("driverlogs", f"vehicle/{vin}/driverlogs"),
+            ("fuellog", f"user/fuellog/{vin}"),
         ):
             try:
                 s, b = await self._get(sub)
@@ -294,6 +334,45 @@ class PlugAndPlayCloudClient:
         tank = veh.get("tankFuelAmount")
         if isinstance(tank, (int, float)) and not isinstance(tank, bool) and tank >= 0:
             data.fuel_level_liters = float(tank)
+
+        # ── Trip logbook (driverlogs) — precise odometer + last-trip stats ──
+        # The dongle's driverlog carries a fresher, sub-metre odometer than the
+        # coarse/lagging root value, plus the last trip's distance, duration, start
+        # odometer and end time. Only present after a synced drive. Reuse the
+        # existing BFF trip columns so the same sensors light up — brand clients
+        # are mutually exclusive per vehicle, so there's no clobber (#1310).
+        trip = _newest_driverlog(snap)
+        if trip is not None:
+            end_odo = (trip.get("endData") or {}).get("odometer")
+            if isinstance(end_odo, (int, float)) and not isinstance(end_odo, bool):
+                data.odometer_km = int(round(end_odo))  # precise → overrides root
+            start_odo = (trip.get("startData") or {}).get("odometer")
+            if isinstance(start_odo, (int, float)) and not isinstance(start_odo, bool):
+                data.last_trip_start_odometer_km = int(round(start_odo))
+            dist = trip.get("totalTripMileage")
+            if isinstance(dist, (int, float)) and not isinstance(dist, bool):
+                data.last_trip_distance_km = round(float(dist), 2)
+            dur_ms = trip.get("totalTripTime")
+            if (
+                isinstance(dur_ms, (int, float))
+                and not isinstance(dur_ms, bool)
+                and dur_ms > 0
+            ):
+                data.last_trip_duration_min = int(round(dur_ms / 60000))
+            end_ts = _epoch_ms_to_datetime(trip.get("endTime"))
+            if end_ts is not None:
+                data.last_trip_timestamp = end_ts
+
+        # ── Parked-position freshness ──
+        # last-parking-position.recordedAt is the TRUE age of the GPS fix; the root
+        # registrationDate/mainCheck "Datenstand" is unreliable and doesn't move
+        # across a drive. Feed the existing position-age column (has carry-forward
+        # TTL machinery), not a new one.
+        pos_at = _epoch_ms_to_datetime(
+            (snap.get("last_parking_position") or {}).get("recordedAt")
+        )
+        if pos_at is not None:
+            data.position_captured_at = pos_at
 
         # Factory ("ab Haus") model designation from the carport master-data
         # record — e.g. brandCode "A" + modelDesc "A5" + engType "TDI CR".

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1520,6 +1520,18 @@ class VehicleData:
     lifetime_avg_fuel_consumption_l_100km: float | None = None
     lifetime_avg_electric_consumption_kwh_100km: float | None = None
     recent_trips: list[dict[str, Any]] = field(default_factory=list)
+    # Audi plug&play (acpp) trip logbook + fuel log extras — acpp-only, so every
+    # other brand leaves them None and the sensors are phantom-protected via
+    # ``_DATA_PRESENT_REQUIRED`` (sensor.py). Distinct from the Škoda ``last_refuel_*``
+    # dict keys on purpose (those are set by a coordinator hook, not this dataclass).
+    last_trip_eco_score: int | None = None            # driving-style EcoScore 0-100
+    last_trip_intake_air_temp_c: int | None = None    # avg intake-air temp for the trip
+    trip_count: int | None = None                     # total trips in the logbook
+    score_points_total: int | None = None             # account driver-score points
+    last_refuel_liters_added: float | None = None      # litres dispensed at the pump
+    last_refuel_tank_before_l: float | None = None     # tank level before the fill-up
+    last_refuel_tank_after_l: float | None = None      # tank level after the fill-up
+    last_refuel_odometer_km: int | None = None         # odometer at the fill-up
     # v2.12.0 (myskoda PR #575) — trip overall-cost breakdown. Currency
     # carried separately so the sensor can set native_unit_of_measurement
     # to the ISO code. None on accounts/firmwares that don't ship costs.

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -655,6 +655,75 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # Audi plug&play (acpp) trip-logbook + fuel-log extras. All phantom-gated via
+    # _DATA_PRESENT_REQUIRED → they only spawn on an acpp car that has synced a
+    # drive/refuel; every other brand leaves the field None.
+    VagSensorDescription(
+        key="last_trip_eco_score",
+        translation_key="last_trip_eco_score",
+        data_key="last_trip_eco_score",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:leaf",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="last_trip_intake_air_temp_c",
+        translation_key="last_trip_intake_air_temp_c",
+        data_key="last_trip_intake_air_temp_c",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        icon="mdi:air-filter",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="trip_count",
+        translation_key="trip_count",
+        data_key="trip_count",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:road-variant",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="score_points_total",
+        translation_key="score_points_total",
+        data_key="score_points_total",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:trophy-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="last_refuel_liters_added",
+        translation_key="last_refuel_liters_added",
+        data_key="last_refuel_liters_added",
+        native_unit_of_measurement="L",
+        icon="mdi:fuel",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="last_refuel_tank_before_l",
+        translation_key="last_refuel_tank_before_l",
+        data_key="last_refuel_tank_before_l",
+        native_unit_of_measurement="L",
+        icon="mdi:gauge-low",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="last_refuel_tank_after_l",
+        translation_key="last_refuel_tank_after_l",
+        data_key="last_refuel_tank_after_l",
+        native_unit_of_measurement="L",
+        icon="mdi:gauge-full",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="last_refuel_odometer_km",
+        translation_key="last_refuel_odometer_km",
+        data_key="last_refuel_odometer_km",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        icon="mdi:counter",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v2.31.0 (8.15.0 APK) — Škoda pay-to-park current/last session (read-only;
     # phantom-gated → only spawns for pay-to-park users).
     VagSensorDescription(
@@ -3536,6 +3605,16 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "last_refuel_fuel_type",
     "last_refuel_station",
     "last_refuel_at",
+    # Audi plug&play (acpp) trip-logbook + fuel-log extras — acpp-only, so every
+    # other brand leaves these None and no phantom entity spawns.
+    "last_trip_eco_score",
+    "last_trip_intake_air_temp_c",
+    "trip_count",
+    "score_points_total",
+    "last_refuel_liters_added",
+    "last_refuel_tank_before_l",
+    "last_refuel_tank_after_l",
+    "last_refuel_odometer_km",
     # v2.31.0 — Škoda pay-to-park; only present for enrolled users.
     "parking_location",
     "parking_cost",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1411,6 +1411,30 @@
       },
       "parked_since": {
         "name": "Parked since"
+      },
+      "last_trip_eco_score": {
+        "name": "Last trip eco score"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Last trip intake air temperature"
+      },
+      "trip_count": {
+        "name": "Logged trips"
+      },
+      "score_points_total": {
+        "name": "Driver score points"
+      },
+      "last_refuel_liters_added": {
+        "name": "Fuel added"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Tank before fill-up"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Tank after fill-up"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Odometer at fill-up"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Zaparkováno od"
+      },
+      "last_trip_eco_score": {
+        "name": "EcoSkóre poslední jízdy"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Teplota nasávaného vzduchu poslední jízdy"
+      },
+      "trip_count": {
+        "name": "Zaznamenané jízdy"
+      },
+      "score_points_total": {
+        "name": "Body skóre řidiče"
+      },
+      "last_refuel_liters_added": {
+        "name": "Natankováno"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Nádrž před tankováním"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Nádrž po tankování"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Stav tachometru při tankování"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Parkeret siden"
+      },
+      "last_trip_eco_score": {
+        "name": "Sidste turs eco-score"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Indsugningslufttemperatur sidste tur"
+      },
+      "trip_count": {
+        "name": "Registrerede ture"
+      },
+      "score_points_total": {
+        "name": "Førerscorepoint"
+      },
+      "last_refuel_liters_added": {
+        "name": "Påfyldt brændstof"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Tank før optankning"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Tank efter optankning"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Kilometerstand ved optankning"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Geparkt seit"
+      },
+      "last_trip_eco_score": {
+        "name": "EcoScore der letzten Fahrt"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Ansauglufttemperatur der letzten Fahrt"
+      },
+      "trip_count": {
+        "name": "Erfasste Fahrten"
+      },
+      "score_points_total": {
+        "name": "Fahrer-Score-Punkte"
+      },
+      "last_refuel_liters_added": {
+        "name": "Getankte Menge"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Tank vor Betankung"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Tank nach Betankung"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Kilometerstand bei Betankung"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Parked since"
+      },
+      "last_trip_eco_score": {
+        "name": "Last trip eco score"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Last trip intake air temperature"
+      },
+      "trip_count": {
+        "name": "Logged trips"
+      },
+      "score_points_total": {
+        "name": "Driver score points"
+      },
+      "last_refuel_liters_added": {
+        "name": "Fuel added"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Tank before fill-up"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Tank after fill-up"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Odometer at fill-up"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Aparcado desde"
+      },
+      "last_trip_eco_score": {
+        "name": "Ecopuntuación del último trayecto"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Temperatura del aire de admisión del último trayecto"
+      },
+      "trip_count": {
+        "name": "Trayectos registrados"
+      },
+      "score_points_total": {
+        "name": "Puntos de puntuación del conductor"
+      },
+      "last_refuel_liters_added": {
+        "name": "Combustible repostado"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Depósito antes de repostar"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Depósito después de repostar"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Cuentakilómetros al repostar"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Pysäköity"
+      },
+      "last_trip_eco_score": {
+        "name": "Viime matkan ekopisteet"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Viime matkan imuilman lämpötila"
+      },
+      "trip_count": {
+        "name": "Kirjatut matkat"
+      },
+      "score_points_total": {
+        "name": "Kuljettajan pistemäärä"
+      },
+      "last_refuel_liters_added": {
+        "name": "Lisätty polttoaine"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Säiliö ennen tankkausta"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Säiliö tankkauksen jälkeen"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Matkamittari tankattaessa"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Stationné depuis"
+      },
+      "last_trip_eco_score": {
+        "name": "Éco-score du dernier trajet"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Température d'air d'admission du dernier trajet"
+      },
+      "trip_count": {
+        "name": "Trajets enregistrés"
+      },
+      "score_points_total": {
+        "name": "Points de score conducteur"
+      },
+      "last_refuel_liters_added": {
+        "name": "Carburant ajouté"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Réservoir avant le plein"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Réservoir après le plein"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Compteur kilométrique au plein"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Parcheggiata da"
+      },
+      "last_trip_eco_score": {
+        "name": "Eco-score dell'ultimo viaggio"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Temperatura aria aspirata ultimo viaggio"
+      },
+      "trip_count": {
+        "name": "Viaggi registrati"
+      },
+      "score_points_total": {
+        "name": "Punti punteggio conducente"
+      },
+      "last_refuel_liters_added": {
+        "name": "Carburante aggiunto"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Serbatoio prima del rifornimento"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Serbatoio dopo il rifornimento"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Contachilometri al rifornimento"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Parkert siden"
+      },
+      "last_trip_eco_score": {
+        "name": "Øko-score for siste tur"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Innsugslufttemperatur siste tur"
+      },
+      "trip_count": {
+        "name": "Registrerte turer"
+      },
+      "score_points_total": {
+        "name": "Førerscorepoeng"
+      },
+      "last_refuel_liters_added": {
+        "name": "Fylt drivstoff"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Tank før fylling"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Tank etter fylling"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Kilometerstand ved fylling"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Geparkeerd sinds"
+      },
+      "last_trip_eco_score": {
+        "name": "Eco-score laatste rit"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Aanzuigluchttemperatuur laatste rit"
+      },
+      "trip_count": {
+        "name": "Geregistreerde ritten"
+      },
+      "score_points_total": {
+        "name": "Bestuurdersscorepunten"
+      },
+      "last_refuel_liters_added": {
+        "name": "Getankte hoeveelheid"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Tank vóór tanken"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Tank ná tanken"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Kilometerstand bij tanken"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Zaparkowano od"
+      },
+      "last_trip_eco_score": {
+        "name": "Eko-wynik ostatniej podróży"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Temperatura powietrza dolotowego ostatniej podróży"
+      },
+      "trip_count": {
+        "name": "Zarejestrowane podróże"
+      },
+      "score_points_total": {
+        "name": "Punkty wyniku kierowcy"
+      },
+      "last_refuel_liters_added": {
+        "name": "Zatankowane paliwo"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Zbiornik przed tankowaniem"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Zbiornik po tankowaniu"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Przebieg przy tankowaniu"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1378,6 +1378,30 @@
       },
       "parked_since": {
         "name": "Parkerad sedan"
+      },
+      "last_trip_eco_score": {
+        "name": "Eco-poäng senaste resa"
+      },
+      "last_trip_intake_air_temp_c": {
+        "name": "Insugslufttemperatur senaste resa"
+      },
+      "trip_count": {
+        "name": "Loggade resor"
+      },
+      "score_points_total": {
+        "name": "Förarpoäng"
+      },
+      "last_refuel_liters_added": {
+        "name": "Tankad mängd"
+      },
+      "last_refuel_tank_before_l": {
+        "name": "Tank före tankning"
+      },
+      "last_refuel_tank_after_l": {
+        "name": "Tank efter tankning"
+      },
+      "last_refuel_odometer_km": {
+        "name": "Vägmätare vid tankning"
       }
     },
     "binary_sensor": {

--- a/docs/research/plugandplay_cloud_reader.md
+++ b/docs/research/plugandplay_cloud_reader.md
@@ -1,9 +1,21 @@
 # DataPlug / plug&play cloud reader — handoff
 
-**Status:** Audi (acpp) **live-validated** 2026-08-24 (real enrolled A5 B8). VW (wcg) **tester-gated**
+**Status:** Audi (acpp) **live-validated** (real enrolled A5 B8) — last re-pull **2026-09-02** after a
+drive + refuel, which woke up three data channels that were empty before. VW (wcg) **tester-gated**
 (endpoints mapped, login not wired). New source; foundation committed on
-`feat/plugandplay-cloud-reader`. Integration (config-flow / factory / coordinator / sensors) is
-left for the main OBD-solution work — see **Integration TODO** below.
+`feat/plugandplay-cloud-reader` / `feat/acpp-carport-enrichment`. Integration (config-flow / factory /
+coordinator / sensors) is left for the main OBD-solution work — see **Integration TODO** below.
+
+> **2026-09-02 addendum.** After the owner drove the car a little and refuelled, a fresh pull surfaced
+> data channels + fields we were NOT ingesting. The big ones: a full **driver logbook** (`driverlogs`)
+> with GPS tracks, **precise odometer**, **EcoScore** (per-trip engine snapshots exist too, but read
+> 0/at-standstill on the observed trips — unproven); a **fuel log**
+> (`fuellog`, "von→auf Liter"); the **GPS `recordedAt`** freshness stamp; and the account **score/ranking**
+> ledger (`achievements/v2`). Full field schemas + recommended mapping in **New data channels** and
+> **Recommended VehicleData mapping** below. Two earlier statements are corrected there: (a) the carport
+> 500 is solved (single-tag `Accept-Language`), and (b) the "no engine telemetry in the cloud at all"
+> claim is refined — continuous live PIDs are indeed absent, but the logbook stores trip-boundary engine
+> snapshots.
 
 ## Why this exists
 
@@ -13,9 +25,13 @@ The plug&play apps — `de.audi.connectplugandplay` (Audi connect plug&play) and
 EU-Data-Act portal, so **this is the only cloud read path** for a dongle-equipped Touareg / e-up! /
 pre-connectivity A4/A5/Golf, etc. It is attestation-free and hands out a **durable refresh token**.
 
-The dongle uploads a **snapshot** on sync (odometer, 12V battery, fuel, service, tyres, warnings).
-Live engine PIDs (speed/rpm/coolant/boost/…) are **not** in the cloud — they stay dongle-local and
-are read over Bluetooth (that is the separate `dataplug-reconnect` local reader project).
+The dongle uploads a **snapshot** on sync (odometer, 12V battery, fuel, service, tyres, warnings) plus
+an **event history** (trips, refuels, score). **Continuous live PIDs** (speed/rpm/coolant/boost while
+driving) are **not** in the cloud — `provalue` / `measurements` / `status` all 404 (see **Live PIDs —
+status**). They stay dongle-local and are read over Bluetooth (the separate `dataplug-reconnect` local
+reader). The one nuance: the logbook DOES carry engine-value **snapshots at each trip's start/end**
+(coolant, engineSpeed, speed, acceleration, altitude) — but those are captured at standstill, so on the
+trips observed so far they read 0. Real-time engine data still requires the BT-local path.
 
 ## Audi (acpp) — validated flow
 
@@ -37,27 +53,246 @@ IDKAuth(session, BRAND_AUDI_ACPP, token_url_override="https://prod.acpp.cariad.d
 `BRAND_AUDI_ACPP.name == "audi_acpp"` (NOT `"audi"`) so `IDKAuth._exchange_code()` takes the
 plain-OAuth branch instead of the CARIAD BFF x-qmauth branch, and honours the `token_url_override`.
 
-### Data endpoints (Bearer <acpp access token>)
+**Header gotcha (live-verified):** the `carport` (master-data) endpoint reads the language from
+`Accept-Language` and needs a **single** tag. It **500s** when the header is absent and **400s** on a
+multi-value / q-weighted value (`"de-DE, en-US;q=0.9"`). A bare `"de-DE"` returns 200. `_get()` now
+sends a single tag on every request. *(This supersedes the earlier "carport 500 / lang-param mismatch,
+TODO" note — solved.)*
+
+### Data endpoints (Bearer `<acpp access token>`)
 
 Only VINs **enrolled in the account** exist — an unknown VIN returns
-`404 {"message":"Vehicle with vin ... does not exist"}` (Prash's S6 was not enrolled → 404).
+`404 {"message":"Vehicle with vin ... does not exist"}` (the owner's S6 was not enrolled → 404). All
+data endpoints are VIN-addressed; there is no per-user garage resource, so enumerate cars via `GET /vehicles`.
 
-| path | method | returns (observed on the B8) |
+| path | method | returns | mapped? |
+|---|---|---|---|
+| `vehicles` | GET 200 | array of the `vehicle/{vin}` snapshot shape → we take the VINs | ✅ `get_vehicles()` |
+| `vehicle/{vin}` | GET 200 | root snapshot (odometer, 12V, fuel L, sync dates, dealer) | ✅ partial |
+| `vehicle/{vin}/warning-lights` | GET 200 | `{"warningLights":[...]}` | ✅ count/active |
+| `vehicle/{vin}/carport` | GET 200 | factory master data (model/engine/fuel/power/colors/dates) | ✅ enriched |
+| `vehicle/{vin}/last-parking-position` | GET 200 | `{"recordedAt":<ms>,"gpsLocation":{lat,lon}}` | ⚠️ lat/lon only — `recordedAt` **NOT** mapped |
+| `vehicle/{vin}/tires` | GET 200 | `[{id,mileage,manufacturer,changeDate,tireActive,...}]` (placeholder on B8) | ❌ |
+| `vehicle/{vin}/driverlogs` | GET 200 | **driver logbook** — trips + EcoScore + engine snapshots (0 on observed trips / unproven) (full schema below) | ❌ **NEW** |
+| `user/fuellog/{vin}` | GET 200 | **fuel log** — refuel events, von→auf Liter (full schema below) | ❌ **NEW** |
+| `user/achievements/v2` | GET 200 | **score/ranking** points ledger (full schema below) | ❌ **NEW** |
+| `vehicle/{vin}/vehicle_app_services` | GET 200 | push-notification toggles (schema below) | ❌ |
+| `vehicle/{vin}/appointment` | GET 200 | `[]` (service appointments — empty on B8) | ❌ |
+| `vehicle/{vin}/details` | GET 405 | POST-only endpoint | — |
+| `vehicle/{vin}/{provalue,measurements,status,state,statistics}` | 404 | **live PIDs are NOT stored** (dongle-local only) | — |
+| `user/fingerprints/{vin}` | 404 | not present | — |
+| `user/cars/{vin}/…` | 404 | wrong family (early dead end); the live family is `vehicle/{vin}/…` | — |
+
+## New data channels — full field schema (grounded 2026-09-02, post-drive)
+
+### `vehicle/{vin}` — root snapshot
+
+```jsonc
+{ "vehicle": { "id", "vin", "carPlatform": "KWP2000" },   // carPlatform present → pre-connectivity combustion/PHEV
+  "odometer": 369290.0,          // ⚠️ COARSE / rounded int-ish, and it LAGS (see odometer note)
+  "batteryVoltage": 13.98,       // 12V rail read on sync (11.76 before drive → 13.98 after = alternator charged)
+  "tankFuelAmount": 23.0,        // absolute litres (NOT %), 3.0 before refuel → 23.0 after
+  "registrationDate": "2026-08-23T16:40:06Z",  // STALE "Datenstand" stamp — did NOT move across the drive;
+  "mainCheck":        "2026-08-23T16:40:06Z",  // NOT a real reg date. Use driverlog endTime / parking
+                                               // recordedAt for TRUE freshness (this stamp is unreliable).
+  "vehicleSpecificDealer": { "dealer": { "kvpsId": "DEUA…" } } }
+```
+
+> **Odometer caveat (important).** The root `odometer` is coarse and stale — it stayed `369290` across a
+> drive while `registrationDate`/`mainCheck` also did not move. The **precise, fresher** odometer lives
+> in `driverlogs[].endData.odometer` (`369291.0` after the 01.09 trip; sub-metre float). **Recommendation:
+> source `odometer_km` from the newest driverlog `endData.odometer`, fall back to root `odometer`.**
+
+### `vehicle/{vin}/driverlogs` — driver logbook (Fahrtenbuch) — **the big find**
+
+Paginated (`content[]`, `totalElements`). Each entry is one trip:
+
+```jsonc
+{ "id": 121022141,
+  "driverLogId": "x-coredata://…/Trip/p2",
+  "remark": "01.09.2026",              // trip date label
+  "manualtrip": false,
+  "startTime": 1788273197740,          // epoch-ms
+  "endTime":   1788273444410,          // epoch-ms
+  "totalTripTime": 246670,             // ms (≈ 4 min 7 s)
+  "totalTripMileage": 1.3778710913,    // km (precise float)
+  "totalTripStandingTime": 0.0,
+  "averageInductionAirTemperature": 24,   // °C — Ansauglufttemperatur
+  "avgFuelConsumption": 0.0,              // unit unconfirmed (0 on observed trips) — VERIFY before labelling
+  "startData": { …engine snapshot at trip start… },
+  "endData":   { …engine snapshot at trip end… },
+  "ecoScore":  { …driving-style score… } }
+```
+
+**`startData` / `endData` — engine + position snapshot at each trip boundary:**
+
+```jsonc
+{ "recordedAt": 1788273444410,       // epoch-ms
+  "odometer": 369291.0,              // PRECISE odometer (sub-metre) — fresher than root
+  "gpsLocation": { "latitude": 47.696…, "longitude": 8.064… },  // trip start/end coordinates → GPS track
+  "coolant": 0.0,                    // coolant temp   ┐
+  "engineSpeed": 0.0,                // RPM            │ engine-value snapshot fields —
+  "speed": 0.0,                      // km/h           │ present in schema, but 0 on the
+  "acceleration": 0.0,               // g              │ observed trips (captured at standstill)
+  "altitude": 0.0,                   // m              ┘
+  "isSmooth": true }
+```
+
+**`ecoScore` — per-trip driving-style rating:**
+
+```jsonc
+{ "ecoScore": 98,                    // overall 0–100
+  "accelerationResult": 100, "accelerationPositiveCount": 15, "accelerationNegativeCount": 0,
+  "brakeResult": 92,         "brakePositiveCount": 12,        "brakeNegativeCount": 1,   // 1 hard brake → 92
+  "engineSpeedResult": 100,  "engineSpeedPositiveCount": 32,  "engineSpeedNegativeCount": 0,
+  "speedResult": 100,        "speedPositiveCount": 32,        "speedNegativeCount": 0,
+  "coolantTemperatureResult": 100, "coolantTempPositiveCount": 0, "coolantTempNegativeCount": 0 }
+```
+
+Observed on the B8: `totalElements: 2` — a 35 s / 6.5 m shunt (29.08, EcoScore 100) and a
+4 min / 1.38 km trip (01.09, EcoScore 98). The **useful** driverlog signal is: precise odometer, trip
+distance/duration, EcoScore, and the start/end GPS coordinates (a "last trip" track / device_tracker
+trail). The raw engine-snapshot fields exist but are boundary-at-rest (0 here); do not over-promise them.
+
+### `user/fuellog/{vin}` — fuel log (Tankungen, "von→auf Liter")
+
+Paginated (`content[]`). Each entry is one refuel event:
+
+```jsonc
+{ "id": 5653155,
+  "fuelLogId": "x-coredata://…/RefuellingStop/p1",
+  "createdTimestamp": 1788273155000,   // epoch-ms
+  "amount": 21.0, "amountUnit": "l",           // litres ADDED
+  "postFuelAmount": 24.0, "postFuelAmountUnit": "l",  // tank AFTER fill → "3 L → +21 L → 24 L"
+  "odometer": 369290.0,                        // odometer at refuel
+  "mileageSinceFueled": 0.0, "mileageSinceFueledUnit": "km",
+  "currency": "EUR", "price": 0.0,             // price/station captured only if the user fills them in
+  "shopCoordinates": { "latitude": 0.0, "longitude": 0.0 },  // station GPS (0/0 = not captured here)
+  "stationName": "", "stationAddress": "",
+  "driverName": "null null", "hasBeenShown": true }
+```
+
+The "von→auf Liter" the owner asked for = `postFuelAmount - amount` before → `postFuelAmount` after
+(here **3 L → 24 L**, +21 L). `amount` = litres added, `postFuelAmount` = tank level after.
+
+### `vehicle/{vin}/last-parking-position` — parking GPS + freshness
+
+```jsonc
+{ "recordedAt": 1788289854000,   // epoch-ms — REAL freshness of the fix (NOT mapped today)
+  "gpsLocation": { "latitude": 47.696…, "longitude": 8.064… } }
+```
+
+Before the drive this was `0/0` (null-island, no fix); after driving+parking it became a real fix with a
+real `recordedAt`. `recordedAt` is the **true position age** and is fresher than the root
+`registrationDate`/`mainCheck` "Datenstand" — map it onto the existing `position_captured_at` field
+(models.py:798), not a new column.
+
+### `user/achievements/v2` — score / ranking (gamification ledger)
+
+Account-level (not per-VIN), paginated. A points ledger — this is the "Score/Ranking" surface, distinct
+from the per-trip EcoScore above:
+
+```jsonc
+{ "content": [
+    { "id": 138082031, "special_purpose": "SCORE_FULL_REGISTRATION", "points": 3000,
+      "achievedAt": 1785883324000, "expirationDate": 0 },          // 0 = never expires
+    { "id": 138082030, "special_purpose": "SCORE_DAILY_POINTS", "points": 120,
+      "achievedAt": 1785883279000, "expirationDate": 1819749599000 },
+    { "special_purpose": "MONTHLY_POINT_JOB", "points": 0, … } ] }
+```
+
+`special_purpose` seen: `SCORE_FULL_REGISTRATION` (3000), `SCORE_DAILY_POINTS` (120 each),
+`MONTHLY_POINT_JOB`. Sum the non-expired `points` for a "total score" figure if surfaced.
+
+### `vehicle/{vin}/vehicle_app_services` — push-notification toggles
+
+```jsonc
+{ "settings": [ { "setting_name": "notifications_warning",    "setting_enabled": true },
+                { "setting_name": "notifications_refuel",     "setting_enabled": true },
+                { "setting_name": "notifications_inspection", "setting_enabled": true },
+                { "setting_name": "notifications_oil",        "setting_enabled": true },
+                { "setting_name": "notifications_tire",       "setting_enabled": true },
+                { "setting_name": "notifications_challenge",  "setting_enabled": true },
+                { "setting_name": "notifications_all",        "setting_enabled": true } ] }
+```
+
+Config/diagnostic only — not vehicle telemetry.
+
+## Live PIDs — status (explicit)
+
+- **Continuous / real-time PIDs are NOT in the acpp cloud.** `vehicle/{vin}/provalue`,
+  `…/measurements`, `…/status`, `…/state`, `…/statistics` all return **404** ("No static resource …").
+  Gegenprobe: the `vehicle/{vin}` family itself answers 200, so these specific resources genuinely do
+  not exist — it is not an auth/path artefact.
+- **The only engine values in the cloud** are the trip-boundary snapshots inside
+  `driverlogs[].startData/endData` (coolant, engineSpeed, speed, acceleration, altitude) — captured at
+  standstill, hence 0 on the short trips seen. Whether a longer motorway trip populates non-zero boundary
+  values is **untested**.
+- **For real-time speed/rpm/coolant/boost, use the BT-local reader** (`dataplug-reconnect`). The cloud
+  and the dongle-BT path are complementary: cloud = history + snapshot (works remotely, no car nearby);
+  BT = live PIDs (car in range only).
+
+## Recommended VehicleData mapping (priority)
+
+`get_status()` today fills: `odometer_km`, `has_combustion`, `warning_count/active`, `model_year`,
+`voltage_12v`, `fuel_level_liters`, `data_captured_at`, `latitude/longitude`, plus the carport enrichment
+(`manufacturer`, `model`, `engine_power`, `registration_date`, colors, `engine_torque_nm`,
+`engine_cylinders`, `engine_displacement_ccm`, `engine_code`, `fuel_type`, `transmission`,
+`warranty_until`).
+
+**Important — reuse the existing trip/position fields, do NOT invent parallel ones.** `models.py`
+`VehicleData` already carries a CARIAD-BFF trip-statistics family (`last_trip_distance_km` :1508,
+`last_trip_duration_min` :1509, `last_trip_avg_speed_kmh` :1510,
+`last_trip_avg_fuel_consumption_l_100km` :1511, `last_trip_timestamp` :1513,
+`last_trip_start_odometer_km` :1723, `recent_trips` :1522) plus `position_captured_at` :798. Brand
+clients are **mutually exclusive per vehicle**, so the acpp driverlog mapper should **populate those same
+fields** (they already have HA sensors) rather than add `last_trip_*` / `gps_recorded_at` duplicates —
+adding `last_trip_distance_km` again would redefine/clobber the dataclass field. Only fields with no
+existing home are genuinely new. Semantics note: the BFF parser stores consumption as int×10÷10 and backs
+`last_trip_distance_km`'s attributes with `recent_trips`; acpp gives a plain float and no such attribute
+backing, so match the value, not the parser.
+
+**Priority A — map now (clear value):**
+
+| VehicleData field | reuse / new | acpp source | note |
+|---|---|---|---|
+| `odometer_km` | reuse (change source) | newest `driverlogs[].endData.odometer` → fallback root `odometer` | root lags & is coarse |
+| `last_trip_distance_km` | **reuse** :1508 | newest `driverlogs[].totalTripMileage` | sensor exists |
+| `last_trip_timestamp` | **reuse** :1513 | newest `driverlogs[].endTime` (ms → ISO) | sensor exists |
+| `last_trip_start_odometer_km` | **reuse** :1723 | newest `driverlogs[].startData.odometer` | sensor exists |
+| `position_captured_at` | **reuse** :798 | `last-parking-position.recordedAt` (ms → ISO) | true position age; has carry-forward-TTL machinery |
+| `last_trip_eco_score` | **new** | newest `driverlogs[].ecoScore.ecoScore` (0–100) | acpp-specific, no BFF equivalent |
+| `last_refuel_liters_added` | **new** | `fuellog.content[0].amount` | litres added (21) |
+| `last_refuel_tank_before_l` | **new** | `postFuelAmount − amount` | the **"von"** side (3) |
+| `last_refuel_tank_after_l` | **new** | `fuellog.content[0].postFuelAmount` | the **"auf"** side (24) → renders "3 → 24" |
+| `last_refuel_at` | **new** | `fuellog.content[0].createdTimestamp` (ms → ISO) | TIMESTAMP |
+
+**Priority B — nice-to-have:**
+
+| VehicleData field | reuse / new | acpp source |
 |---|---|---|
-| `vehicle/{vin}` | GET 200 | `{"vehicle":{"id","vin","carPlatform":"KWP2000"},"odometer":369290.0,"batteryVoltage":11.76,"tankFuelAmount":3.0,"registrationDate","mainCheck","vehicleSpecificDealer":{...}}` |
-| `vehicle/{vin}/tires` | GET 200 | `[{"id","mileage","manufacturer","changeDate","tireActive",...}]` |
-| `vehicle/{vin}/warning-lights` | GET 200 | `{"warningLights":[]}` |
-| `vehicle/{vin}/last-parking-position` | GET 200 | `{"gpsLocation":{"latitude","longitude"}}` (0/0 with this dongle) |
-| `vehicle/{vin}/driverlogs` | GET 200 | paginated logbook |
-| `vehicle/{vin}/appointment` | GET 200 | `[]` |
-| `vehicle/{vin}/vehicle_app_services` | GET 200 | notification settings |
-| `user/fuellog/{vin}` | GET 200 | paginated fuel log |
-| `user/achievements/v2` | GET 200 | gamification points |
-| `vehicle/{vin}/details` | 405 (POST) · `vehicle/{vin}/carport` | 500 without a `lang` param (query `?lang=de` did **not** satisfy it — likely a header/param name mismatch, TODO) |
-| `vehicle/{vin}/{status,state,measurements,statistics,...}` | 404 | **live PIDs are NOT stored** — dongle-local only |
-| `user/cars/{vin}/…` | 404 | wrong family (early dead end); the live family is `vehicle/{vin}/…` |
+| `last_trip_duration_min` | **reuse** :1509 | newest `totalTripTime` ÷ 60000 |
+| `last_trip_avg_fuel_consumption_l_100km` | **reuse** :1511 | newest `avgFuelConsumption` — **verify unit is l/100km first** (0 on observed trips) |
+| `recent_trips` | **reuse** :1522 | the full `driverlogs.content` list (see full-logbook note in Priority C) |
+| `last_trip_intake_air_temp_c` | **new** | newest `driverlogs[].averageInductionAirTemperature` (24 °C — a real, non-zero trip datum) |
+| `last_refuel_odometer_km` | **new** | `fuellog.content[0].odometer` |
+| `trip_count` | **new** (or `len(recent_trips)`) | `driverlogs.totalElements` |
+| `score_points_total` | **new** | Σ non-expired `achievements/v2 … points` |
 
-### Token does NOT open the BFF
+**Priority C — rich / optional:**
+- **Full logbook** (the owner asked for the *whole* Fahrtenbuch): put ALL trips into `recent_trips` :1522
+  (list attribute), paging through every entry — not just page 0 — or a dedicated logbook entity. Per
+  entry: distance / duration / EcoScore / start+end GPS. This is where "all engine snapshots" live
+  (schema-complete but 0-valued so far).
+- Last-trip **GPS track** (start+end coords) → a device_tracker trail or a "last trip" map card.
+- EcoScore sub-scores (`brakeResult`/`accelerationResult`/`engineSpeedResult`/`speedResult`) as attributes.
+- Per-trip engine boundary snapshots (coolant/rpm/speed/accel) — low value while they read 0; revisit if a
+  long trip shows non-zero.
+
+Reuse the existing `_epoch_ms_to_date` helper; add an ms→ISO-**datetime** sibling for the trip/refuel/
+position timestamps (ms since epoch, same as carport dates but wanting time-of-day, not just the date).
+
+## Token does NOT open the BFF
 
 The acpp access token (`aud` = the acpp client itself, `scp: profile email openid`) is **not
 BFF-whitelisted**: `emea.bff.cariad.digital/vehicle/v1/*` → `403 "clientId in the token claim is
@@ -79,27 +314,36 @@ signin-service it returns `HTTP 400` at the identifier POST
 (`identity.legacy.vwgroup.io/signin-service/v1/{client_id}/login/identifier`). Implement the
 signin-service legs (identifier → authenticate → code) — `auth/_vweu_twoway_login.py` already has
 this pattern — then point `token_url_override` at the legacy token endpoint. Not live-testable here
-(no VW dongle car available); gate behind a tester like the other unvalidated paths.
+(no VW dongle car available); gate behind a tester like the other unvalidated paths. The wcg data
+channels (driverlogs/fuellog equivalents) are unmapped — expect a similar but plural-path shape.
 
 ## Integration TODO (for the main OBD-solution work)
 
 1. **config-flow**: add a "DataPlug / plug&play (OBD dongle)" source option (email+password; Audi
    ready, VW behind a tester flag).
-2. **factory.py**: register `PlugAndPlayCloudClient` (acpp) — it already mirrors the
+2. **factory.py**: register `PlugAndPlayCloudClient` (acpp) — already mirrors the
    `(session, brand, email, password, spin="")` constructor and exposes `authenticate()` +
-   `get_status(vin)`.
-3. **VehicleData mapping**: `get_status()` fills `odometer_km`, `warning_active/count`,
-   `model_year`, `has_combustion`. acpp fields with **no current column** — 12V `batteryVoltage`,
-   `tankFuelAmount` (litres), `registrationDate`, `mainCheck`, per-tyre records — come back via
-   `get_raw_snapshot()`. Decide: add columns (e.g. `battery_12v_voltage`, `fuel_litres`,
-   `service_due_date`) or surface them as extra state attributes.
-4. **Poll cadence**: snapshot only updates when the dongle syncs (i.e. after a drive); a slow poll
-   is fine. No live PIDs here — pair with the local BT reader for real-time data.
+   `get_status(vin)`. *(Done in `feat/acpp-carport-enrichment` — verify it's present.)*
+3. **VehicleData mapping**: extend `get_status()` with the **Priority A** fields above. **Reuse** the
+   existing BFF trip/position columns (`last_trip_distance_km`, `last_trip_timestamp`,
+   `last_trip_start_odometer_km`, `last_trip_duration_min`, `last_trip_avg_fuel_consumption_l_100km`,
+   `recent_trips`, `position_captured_at`) — do NOT add duplicates (they would clobber the dataclass
+   fields) — and switch `odometer_km` to the precise driverlog source. Add ONLY the genuinely-new
+   columns to `models.py`: `last_trip_eco_score`, `last_trip_intake_air_temp_c`,
+   `last_refuel_liters_added` / `_tank_before_l` / `_tank_after_l` / `_at` / `_odometer_km`,
+   `trip_count`, `score_points_total`. Extend `get_raw_snapshot()` to also fetch `driverlogs` +
+   `user/fuellog/{vin}` — page through ALL driverlog entries for the full logbook, not just page 0.
+4. **Poll cadence**: snapshot + history only update when the dongle syncs (after a drive); a slow poll
+   is fine. No live PIDs here — pair with the BT-local reader for real-time data.
 5. **wcg**: implement the legacy signin-service login + wire `WCGCloudClient`, tester-gated.
+6. **Unit checks before shipping**: confirm `avgFuelConsumption` unit, and whether `driverlogs`/`fuellog`
+   pagination is newest-first or needs an explicit sort/`?page=` param (only 1–2 entries observed).
 
 ## Reference
 
 Working, credential-driven probes used to validate this live are in the session scratchpad
-(`acpp_login.py`, `acpp_read.sh`, `acpp_bff.sh`) — not committed (they read `~/.claude/private`
-creds and cache a token in `~/.claude/private/acpp_token.json`). The committed code
-(`api/plugandplay.py`) is the clean-room equivalent that reuses `IDKAuth`.
+(`acpp_login.py`, `acpp_read.sh`, `acpp_bff.sh`, plus 2026-09-02 re-probes of driverlogs / fuellog /
+achievements / parking) — **not committed** (they read `~/.claude/private` creds and cache a token in
+`~/.claude/private/acpp_token.json`). The committed code (`api/plugandplay.py`) is the clean-room
+equivalent that reuses `IDKAuth`. All live values above are from a real enrolled A5 B8; VIN/serial are
+never committed.

--- a/tests/test_plugandplay_cloud.py
+++ b/tests/test_plugandplay_cloud.py
@@ -278,6 +278,46 @@ async def test_get_status_no_driverlogs_falls_back_to_root_odometer():
     assert data.position_captured_at is None
 
 
+async def test_get_status_maps_ecoscore_refuel_and_score():
+    import time
+    future_ms = int((time.time() + 86400) * 1000)
+    past_ms = 1
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2009}": (200, {"vehicle": {"vin": VIN_2009}, "odometer": 369290}),
+        f"vehicle/{VIN_2009}/warning-lights": (200, {"warningLights": []}),
+        f"vehicle/{VIN_2009}/driverlogs": (200, {"totalElements": 2, "content": [
+            {"remark": "01.09.2026", "endTime": 1788273444410,
+             "totalTripMileage": 1.38, "totalTripTime": 246670,
+             "averageInductionAirTemperature": 24,
+             "startData": {"odometer": 369289.7}, "endData": {"odometer": 369291.0},
+             "ecoScore": {"ecoScore": 98}},
+            {"remark": "29.08.2026", "endTime": 1788000000000,
+             "totalTripMileage": 0.5, "ecoScore": {"ecoScore": 100}},
+        ]}),
+        f"user/fuellog/{VIN_2009}": (200, {"content": [
+            {"createdTimestamp": 1788273155000, "amount": 21.0,
+             "postFuelAmount": 24.0, "odometer": 369290.0},
+        ]}),
+        "user/achievements/v2": (200, {"content": [
+            {"points": 3000, "expirationDate": 0},         # never expires
+            {"points": 120, "expirationDate": future_ms},  # still valid
+            {"points": 50, "expirationDate": past_ms},     # expired → excluded
+        ]}),
+    })
+    data = await c.get_status(VIN_2009)
+    assert data.last_trip_eco_score == 98
+    assert data.last_trip_intake_air_temp_c == 24
+    assert data.trip_count == 2
+    assert data.last_refuel_liters_added == 21.0
+    assert data.last_refuel_tank_after_l == 24.0
+    assert data.last_refuel_tank_before_l == 3.0      # 24 − 21 ("von→auf")
+    assert data.last_refuel_odometer_km == 369290
+    assert data.score_points_total == 3120            # 3000 + 120, expired 50 dropped
+    assert len(data.recent_trips) == 2                # full logbook (Priority C)
+    assert data.recent_trips[0]["eco_score"] == 98    # newest first
+
+
 def test_epoch_ms_to_datetime():
     from custom_components.vag_connect.cariad.api.plugandplay import (
         _epoch_ms_to_datetime,

--- a/tests/test_plugandplay_cloud.py
+++ b/tests/test_plugandplay_cloud.py
@@ -232,6 +232,62 @@ async def test_get_status_carport_missing_is_graceful():
     assert data.odometer_km == 12000  # the rest still maps
 
 
+# ── driverlogs (trip logbook) — precise odometer + last-trip stats + freshness ──
+
+async def test_get_status_maps_driverlog_trip_and_parking_freshness():
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2009}": (200, {
+            "vehicle": {"vin": VIN_2009, "carPlatform": "KWP2000"},
+            "odometer": 369290.0,  # coarse root — the driverlog end odo must win
+        }),
+        f"vehicle/{VIN_2009}/warning-lights": (200, {"warningLights": []}),
+        f"vehicle/{VIN_2009}/driverlogs": (200, {"content": [
+            # older trip first — the mapper must pick the newest by endTime
+            {"endTime": 1788000000000, "totalTripMileage": 0.5,
+             "startData": {"odometer": 369280.0}, "endData": {"odometer": 369280.5}},
+            {"endTime": 1788273444410, "totalTripMileage": 1.3778710913,
+             "totalTripTime": 246670,
+             "startData": {"odometer": 369289.7}, "endData": {"odometer": 369291.0}},
+        ]}),
+        f"vehicle/{VIN_2009}/last-parking-position": (200, {
+            "recordedAt": 1788289854000,
+            "gpsLocation": {"latitude": 47.696, "longitude": 8.064},
+        }),
+    })
+    data = await c.get_status(VIN_2009)
+    assert data.odometer_km == 369291                 # precise driverlog end odo, not root 369290
+    assert data.last_trip_start_odometer_km == 369290  # round(369289.7)
+    assert data.last_trip_distance_km == 1.38          # rounded to 2dp
+    assert data.last_trip_duration_min == 4            # 246670 ms → 4 min
+    assert data.last_trip_timestamp == "2026-09-01T14:37:24.410000+00:00"
+    assert data.position_captured_at == "2026-09-01T19:10:54+00:00"
+
+
+async def test_get_status_no_driverlogs_falls_back_to_root_odometer():
+    c = _client()
+    _stub_get(c, {
+        f"vehicle/{VIN_2020}": (200, {"vehicle": {"vin": VIN_2020}, "odometer": 12000}),
+        f"vehicle/{VIN_2020}/warning-lights": (200, {"warningLights": []}),
+        # no driverlogs / no parking → those fields stay None, root odo stands
+    })
+    data = await c.get_status(VIN_2020)
+    assert data.odometer_km == 12000
+    assert data.last_trip_distance_km is None
+    assert data.last_trip_timestamp is None
+    assert data.position_captured_at is None
+
+
+def test_epoch_ms_to_datetime():
+    from custom_components.vag_connect.cariad.api.plugandplay import (
+        _epoch_ms_to_datetime,
+    )
+    assert _epoch_ms_to_datetime("1788273444410") == "2026-09-01T14:37:24.410000+00:00"
+    assert _epoch_ms_to_datetime("0") is None
+    assert _epoch_ms_to_datetime(None) is None
+    assert _epoch_ms_to_datetime("nope") is None
+
+
 def test_epoch_ms_to_date():
     from custom_components.vag_connect.cariad.api.plugandplay import _epoch_ms_to_date
     assert _epoch_ms_to_date("1219795200000") == "2008-08-27"


### PR DESCRIPTION
Brings the Audi plug&play (acpp) cloud reader up to a clean, complete source. The client + config-flow source + factory were already on `main`; this adds the data mapping the 2026-09-02 post-drive research (see `docs/research/plugandplay_cloud_reader.md`, included here) uncovered.

## What

`get_raw_snapshot` now also fetches the trip logbook (`driverlogs`), the fuel log (`user/fuellog`) and the account score ledger (`achievements/v2`). `get_status` maps them:

**Priority A — reuse existing columns (no new sensors/i18n):**
- precise sub-metre odometer from the newest driverlog `endData.odometer` (falls back to the coarse root value)
- `last_trip_distance_km` / `_duration_min` / `_start_odometer_km` / `_timestamp`
- `position_captured_at` from `last-parking-position.recordedAt` (the true fix age, not the unreliable sync stamp)

**Priority B/C — new acpp-only columns + sensors (phantom-gated via `_DATA_PRESENT_REQUIRED`):**
- `last_trip_eco_score`, `last_trip_intake_air_temp_c`, `trip_count`, `score_points_total` (sums only non-expired achievements)
- fuel-log "von→auf": `last_refuel_liters_added` / `_tank_before_l` / `_tank_after_l` / `_odometer_km`
- `recent_trips` filled with the compact per-trip logbook (date / distance / duration / EcoScore / end-time, newest first)

New sensor names added in **all 12 languages**. `avgFuelConsumption` is deliberately left unmapped until its unit is confirmed live (0 on every observed trip).

## Test

- New mapping tests (trip logbook, EcoScore/refuel/score, no-data fallbacks) + an epoch-ms→ISO-datetime helper test.
- Full suite green (5651); ruff + mypy (strict) clean; JSON valid; translation-parity green; pre-commit gate passed.