### PR TITLE
v4.6.1 — Škoda official API: active live source, not just failover (#1286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,29 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.6.1] - 2026-09-02 — Škoda official API now reads live every cycle, not just on failover
+
+### Changed
+- **Škoda official API is now an active live data source.** If you have connected Škoda's
+  official public API (with an API key), it is now read on every regular update — not only
+  as an emergency failover when your main channel goes down. Its manufacturer-grade
+  readings (odometer, battery/fuel, range, lock and opening status, climate, charging and
+  the GPS parking position) are merged straight into your existing sensors as an
+  authoritative live source, so the values you already have simply get fresher and
+  steadier — there are no new entities to adopt. It still doubles as the failover on a hard
+  outage, and it stays inside Škoda's 20-requests-per-hour budget: the read self-skips once
+  the quota is spent, so normal poll intervals (5–10 min) never breach it. Existing values
+  are never overwritten by a blank — the official read only ever fills or refreshes a real
+  reading, and "last seen" is never moved backwards. The connectivity sensor now reports
+  the official channel as "active" (with its live reading count) while it is contributing,
+  instead of always "standby (failover)" (#1286).
+
+### Fixed
+- **Škoda official API: key created with a plain name.** Automatic enrolment now names the
+  API key simply "Home Assistant" (previously "Home Assistant (vag_connect)"), matching the
+  format the Škoda app itself uses — ruling the key name out as a factor in the enrolment
+  rejection some accounts still see (#1286).
+
 ## [4.6.0] - 2026-09-02 — Škoda data-quality wave · per-source connectivity · sturdier token refresh · Audi plug&play logbook
 
 ### Added

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -1030,7 +1030,8 @@ async def async_setup_entry(
             entities.append(VagLightSensor(coordinator, vin, light_id))
         # 5) Per-source connectivity sensors — one per armed read channel, so a
         # user can see which sources this car is connected to (active vs standby),
-        # incl. a standby failover like the Škoda official API (#1286). Cross-brand.
+        # incl. the Škoda official API (active live source + failover) (#1286).
+        # Cross-brand.
         for token in (vehicle.get("channel_status") or {}):
             entities.append(VagSourceConnectivitySensor(coordinator, vin, token))
         return entities
@@ -1144,8 +1145,9 @@ class VagSourceConnectivitySensor(VagConnectEntity, BinarySensorEntity):
     """Connectivity indicator for ONE read channel (data source).
 
     ON = the car is connected to that source, whether it is actively feeding values
-    or sitting on standby (e.g. the Škoda official API is a failover that only reads
-    when the primary channel is down). Answers "which sources am I connected to",
+    or sitting on standby (e.g. the Škoda official API contributes as an active live
+    source on healthy cycles and also serves as the hard-failure failover). Answers
+    "which sources am I connected to",
     per source, across every brand (#1286). The live detail — active vs standby, how
     many of the car's readings this source provides, when it last contributed, and
     for the EU Data Act portal its feed health — is exposed as attributes.

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -40,7 +40,11 @@ _BASE = "https://mysmob.api.connect.skoda-auto.cz"
 # secret once), GET lists remaining quota per VIN, DELETE removes one by id. Keys
 # are VIN-bound; max 5 per VIN. Path inlined at each call site (literal, so the
 # Bruno drift-check resolves it) — kept here for documentation.
-_OFFICIAL_KEY_NAME = "Home Assistant (vag_connect)"
+# #1286 — plain alphanumeric + a single space, no parentheses/underscore. The
+# mysmob create-key POST 400s for real users (n3roGit + indigomejor); the backend
+# may validate the key ``name`` (charset/length), and the app's names are simple
+# user-typed strings, so keep ours conservative to remove that as a 400 cause.
+_OFFICIAL_KEY_NAME = "Home Assistant"
 # The key-management route is only exercised by the MyŠkoda app (v8.16+); spoof the
 # real app User-Agent on these calls so a possible min-app-version gate is satisfied
 # (verbatim from the 8.16 APK; MySkoda/Android/{versionName}/{versionCode}).

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -235,20 +235,21 @@ class SkodaClient(CariadBaseClient):
         # stops 403-hammering that endpoint. Empty on a fresh restart → charging is
         # attempted once, carType is learned, then skipped from poll 2 on.
         self._powertrain: dict[str, str] = {}
-        # Škoda OFFICIAL public-API client, armed opt-in as a FAILOVER-ONLY read
-        # source (see arm_supplementary_official). None unless the user configured
-        # an API key. Never consulted on a healthy poll — only when the primary
-        # mysmob read hard-fails — because the official API is rate-limited to
-        # 20 req/hour/key.
+        # Škoda OFFICIAL public-API client, armed opt-in (see
+        # arm_supplementary_official). None unless the user configured an API key.
+        # Consulted as an ACTIVE live source on every healthy poll (rate permitting)
+        # AND as the hard-failure failover. Rate-limited to 20 req/hour/key, so both
+        # read paths go through _official_read_rate_safe, which self-skips at quota.
         self._supplementary_official: Any = None
 
     def arm_supplementary_official(
         self, api_key: str = "", keys_by_vin: dict[str, str] | None = None,
     ) -> None:
-        """Arm the official Škoda public API as a failover source (opt-in). Keys are
-        vehicle-bound server-side, so ``get_status(vin)`` is called per-VIN on
-        failover. ``keys_by_vin`` carries the auto-enrolled per-VIN keys; ``api_key``
-        is the single manual-fallback key (applied to any VIN without its own)."""
+        """Arm the official Škoda public API (opt-in) as an active live source plus
+        hard-failure failover. Keys are vehicle-bound server-side, so
+        ``get_status(vin)`` is called per-VIN. ``keys_by_vin`` carries the
+        auto-enrolled per-VIN keys; ``api_key`` is the single manual-fallback key
+        (applied to any VIN without its own)."""
         if not api_key and not keys_by_vin:
             self._supplementary_official = None
             return
@@ -258,22 +259,36 @@ class SkodaClient(CariadBaseClient):
             keys_by_vin=keys_by_vin,
         )
 
-    async def official_failover_read(self, vin: str) -> "VehicleData | None":
-        """Read one VIN via the official public API — the FAILOVER path, invoked
-        only when the primary channel raised. Fail-soft: any error returns None so
-        the failover can never itself sink the poll."""
+    async def _official_read_rate_safe(self, vin: str) -> "VehicleData | None":
+        """Shared body for the official public-API reads (failover + active
+        live-source). Honours the official channel's 20/hour/key budget: if the
+        server has told us we're out (RateLimit-Remaining 0, or a 429/503
+        Retry-After), skip the read until the window resets rather than breaching
+        the quota. Fail-soft: any error returns None so an official hiccup can
+        never itself sink the poll."""
         off = self._supplementary_official
         if off is None:
             return None
-        # Honour the official channel's 20/hour/key budget: if the server has told
-        # us we're out (RateLimit-Remaining 0, or a 429/503 Retry-After), skip the
-        # failover read until the window resets rather than breaching the quota.
         if getattr(off, "over_rate_limit", False) is True:
             return None
         try:
             return await off.get_status(vin)  # type: ignore[no-any-return]
         except Exception:  # noqa: BLE001
             return None
+
+    async def official_failover_read(self, vin: str) -> "VehicleData | None":
+        """Read one VIN via the official public API — the FAILOVER path, invoked
+        only when the primary channel hard-fails
+        (coordinator._revive_from_supplementary)."""
+        return await self._official_read_rate_safe(vin)
+
+    async def official_live_read(self, vin: str) -> "VehicleData | None":
+        """Read one VIN via the official public API on a HEALTHY cycle — the ACTIVE
+        live-source path (as opposed to official_failover_read). The official
+        manufacturer API is queried every poll (rate permitting) and its readings
+        are merged into the primary payload as an authoritative live source, rather
+        than being held back purely as a hard-failure failover."""
+        return await self._official_read_rate_safe(vin)
 
     # -- official public-API key minting (mysmob BFF) -------------------------
     # Auto-enrollment: mint the official X-API-Key from the user's existing mysmob

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2580,7 +2580,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
 
     def _armed_data_channels(self, vin: str) -> list[str]:
         """Tokens of the read channels armed for this vehicle (data sources) —
-        primary + supplementary + the Škoda official failover — enumerated WITHOUT
+        primary + supplementary + the Škoda official channel — enumerated WITHOUT
         creating reader coroutines. Order-stable, de-duplicated. Brand-agnostic."""
         client = self._cariad_client
         tokens: list[str] = [self._primary_channel_name()]
@@ -2606,8 +2606,10 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         """Per-source connectivity status for the connectivity binary_sensors: for
         each armed data channel, whether it is currently contributing values
         (active) vs armed-but-idle (standby), how many readings it owns of the total,
-        and when it last contributed. The Škoda official channel is a FAILOVER whose
-        data wears the brand token, so it is reported as armed with no live count."""
+        and when it last contributed. The Škoda official channel is now BOTH an
+        active live source (it contributes on healthy cycles, tagged skoda_official)
+        AND the hard-failure failover, so it is reported with its live count and
+        failover:True."""
         field_sources = data.get("field_sources")
         if not isinstance(field_sources, dict):
             field_sources = {}
@@ -2621,9 +2623,15 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         status: dict[str, dict[str, Any]] = {}
         for token in self._armed_data_channels(vin):
             if token == "skoda_official":
+                # Active live source now: count the fields it actually contributed
+                # this cycle. Still failover:True — it also serves on hard failure.
+                n = sum(1 for t in field_sources.values() if t == token)
+                active = n > 0
+                if active:
+                    vin_last[token] = now_iso
                 status[token] = {
-                    "armed": True, "failover": True, "active": False,
-                    "active_values": None, "total_values": total,
+                    "armed": True, "failover": True, "active": active,
+                    "active_values": n, "total_values": total,
                     "last_active": vin_last.get(token),
                 }
                 continue
@@ -3229,6 +3237,71 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 )
         return None
 
+    async def _merge_official_live(
+        self, vin: str, enriched: dict[str, Any]
+    ) -> None:
+        """ACTIVE Škoda-official live read on a HEALTHY cycle: query the official
+        manufacturer public API and merge its readings into the just-built primary
+        payload as an authoritative live source (not merely a failover). Runs before
+        _compute_channel_status so the connectivity map reflects the contribution.
+
+        - Brand-isolated: official_live_read exists only on the Škoda client, so this
+          is a no-op for every other brand (getattr → None).
+        - Rate-safe: the 20/hour/key budget guard lives inside official_live_read,
+          which self-skips at quota; fail-soft, so an official hiccup never sinks the
+          poll.
+        - Official wins for the fields it actually populated. asdict() emits every
+          declared field including untouched False/0/"" defaults, which would clobber
+          a real primary value — so a field is merged only when it differs from a
+          fresh VehicleData baseline (i.e. the official parse genuinely set it).
+        - last_seen_at is gap-filled only, never overwritten, so the vehicle's
+          "last seen" can't jump backwards to an older official capture timestamp.
+        """
+        client = self._cariad_client
+        read = getattr(client, "official_live_read", None)
+        if read is None:
+            return
+        try:
+            off = await read(vin)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "official live-read raised for %s", mask_vin(vin), exc_info=True
+            )
+            return
+        if off is None:
+            return
+        try:
+            od = off.to_dict()
+            base = VehicleData(vin=vin).to_dict()
+        except Exception:  # noqa: BLE001
+            return
+        if not isinstance(od, dict) or not isinstance(base, dict):
+            return
+        field_sources = enriched.get("field_sources")
+        if not isinstance(field_sources, dict):
+            field_sources = {}
+            enriched["field_sources"] = field_sources
+        merged = 0
+        for key, val in od.items():
+            if key in ("vin", "field_sources", "source_channel"):
+                continue
+            if val is None or val == base.get(key):
+                continue
+            if isinstance(val, (str, list, dict)) and not val:
+                continue
+            if key == "last_seen_at":
+                # advance-only: skip if the primary already carries a timestamp.
+                if enriched.get(key):
+                    continue
+            enriched[key] = val
+            field_sources[key] = "skoda_official"
+            merged += 1
+        if merged:
+            _LOGGER.debug(
+                "official live-source merged %d field(s) for %s",
+                merged, mask_vin(vin),
+            )
+
     async def _poll_loop(self) -> None:
         """Background polling loop — runs independently of HA scheduler.
 
@@ -3509,6 +3582,18 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         # the raw backend snapshot straight over a just-issued
                         # command's optimistic value (e.g. lock → doors_locked
                         # snaps back to the stale poll reading for ~150 s).
+                        # Škoda official public API as an ACTIVE live source: on a
+                        # healthy cycle, merge the manufacturer API's readings into
+                        # the primary payload (rate-safe, brand-isolated, fail-soft).
+                        # Must run BEFORE _compute_channel_status so the connectivity
+                        # map counts the official contribution.
+                        try:
+                            await self._merge_official_live(vin, enriched)
+                        except Exception:  # noqa: BLE001
+                            _LOGGER.debug(
+                                "official live-source merge skipped for %s",
+                                mask_vin(vin), exc_info=True,
+                            )
                         # Per-source connectivity map for the connectivity
                         # binary_sensors (which sources this car is connected to,
                         # active vs standby, how many readings each provides). Fail-

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.6.0"
+  "version": "4.6.1"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: read odometer and service from Vehicle Health (navigates the app)",
           "companion_read_climate_detail": "Companion: read target and outside temperature (navigates the app)",
           "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)",
-          "skoda_official_api_key": "Škoda official API key — failover when the main channel is down"
+          "skoda_official_api_key": "Škoda official API key — adds the official manufacturer API as a live data source (and failover)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: číst stav tachometru a servis ze stavu vozidla (naviguje v aplikaci)",
           "companion_read_climate_detail": "Companion: číst cílovou a venkovní teplotu (naviguje v aplikaci)",
           "companion_read_parking_position": "Companion: číst pozici parkování z odkazu pro sdílení v aplikaci (naviguje v aplikaci)",
-          "skoda_official_api_key": "Oficiální klíč API Škoda — záloha, když hlavní kanál nefunguje"
+          "skoda_official_api_key": "Oficiální klíč API Škoda — přidá oficiální API výrobce jako živý zdroj dat (a zálohu)"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: læs kilometerstand og service fra køretøjstjek (navigerer i appen)",
           "companion_read_climate_detail": "Companion: læs måltemperatur og udetemperatur (navigerer i appen)",
           "companion_read_parking_position": "Companion: læs parkeringsposition fra appens delingslink (navigerer i appen)",
-          "skoda_official_api_key": "Officiel Škoda API-nøgle — failover når hovedkanalen er nede"
+          "skoda_official_api_key": "Officiel Škoda API-nøgle — tilføjer den officielle producent-API som live datakilde (og failover)"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: Kilometerstand und Service aus dem Fahrzeugcheck lesen (navigiert in der App)",
           "companion_read_climate_detail": "Companion: Solltemperatur und Außentemperatur lesen (navigiert in der App)",
           "companion_read_parking_position": "Companion: Parkposition aus dem Teilen-Link der App lesen (navigiert in der App)",
-          "skoda_official_api_key": "Offizieller Škoda-API-Schlüssel — Failover, wenn der Hauptkanal ausfällt"
+          "skoda_official_api_key": "Offizieller Škoda-API-Schlüssel — nutzt die offizielle Hersteller-API als Live-Datenquelle (und Failover)"
         },
         "data_description": {
           "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: read odometer and service from Vehicle Health (navigates the app)",
           "companion_read_climate_detail": "Companion: read target and outside temperature (navigates the app)",
           "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)",
-          "skoda_official_api_key": "Škoda official API key — failover when the main channel is down"
+          "skoda_official_api_key": "Škoda official API key — adds the official manufacturer API as a live data source (and failover)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: leer cuentakilómetros y servicio desde el estado del vehículo (navega por la app)",
           "companion_read_climate_detail": "Companion: leer temperatura objetivo y exterior (navega por la app)",
           "companion_read_parking_position": "Companion: leer la posición de aparcamiento desde el enlace para compartir de la app (navega por la app)",
-          "skoda_official_api_key": "Clave API oficial de Škoda — conmutación por error si falla el canal principal"
+          "skoda_official_api_key": "Clave API oficial de Škoda — añade la API oficial del fabricante como fuente de datos en vivo (y conmutación por error)"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: lue mittarilukema ja huolto ajoneuvon kunnosta (navigoi sovelluksessa)",
           "companion_read_climate_detail": "Companion: lue tavoite- ja ulkolämpötila (navigoi sovelluksessa)",
           "companion_read_parking_position": "Companion: lue pysäköintipaikka sovelluksen jakolinkistä (navigoi sovelluksessa)",
-          "skoda_official_api_key": "Virallinen Škoda-API-avain — vikasieto, kun pääkanava on poissa käytöstä"
+          "skoda_official_api_key": "Virallinen Škoda-API-avain — lisää valmistajan virallisen API:n live-tietolähteeksi (ja vikasietona)"
         },
         "data_description": {
           "scan_interval": "Kuinka usein tietoja haetaan (minuutteja). Vähintään: 3.",

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion : lire le kilométrage et l'entretien dans l'état du véhicule (navigue dans l'app)",
           "companion_read_climate_detail": "Companion : lire la température de consigne et extérieure (navigue dans l'app)",
           "companion_read_parking_position": "Companion : lire la position de stationnement depuis le lien de partage de l'app (navigue dans l'app)",
-          "skoda_official_api_key": "Clé API officielle Škoda — bascule si le canal principal tombe"
+          "skoda_official_api_key": "Clé API officielle Škoda — ajoute l'API officielle du constructeur comme source de données en direct (et bascule)"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: leggi contachilometri e tagliando da Vehicle Health (naviga nell'app)",
           "companion_read_climate_detail": "Companion: leggi temperatura impostata ed esterna (naviga nell'app)",
           "companion_read_parking_position": "Companion: leggi la posizione di parcheggio dal link di condivisione dell'app (naviga nell'app)",
-          "skoda_official_api_key": "Chiave API ufficiale Škoda — failover se il canale principale non è disponibile"
+          "skoda_official_api_key": "Chiave API ufficiale Škoda — aggiunge l'API ufficiale del costruttore come fonte dati in tempo reale (e failover)"
         },
         "data_description": {
           "scan_interval": "Con quale frequenza vengono recuperati i dati (minuti). Minimo: 3.",

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: les kilometerstand og service fra kjøretøysjekk (navigerer i appen)",
           "companion_read_climate_detail": "Companion: les måltemperatur og utetemperatur (navigerer i appen)",
           "companion_read_parking_position": "Companion: les parkeringsposisjon fra appens delingslenke (navigerer i appen)",
-          "skoda_official_api_key": "Offisiell Škoda API-nøkkel — failover når hovedkanalen er nede"
+          "skoda_official_api_key": "Offisiell Škoda API-nøkkel — legger til produsentens offisielle API som live datakilde (og failover)"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: kilometerstand en onderhoud uit de voertuigcheck lezen (navigeert in de app)",
           "companion_read_climate_detail": "Companion: streef- en buitentemperatuur lezen (navigeert in de app)",
           "companion_read_parking_position": "Companion: parkeerpositie uit de deellink van de app lezen (navigeert in de app)",
-          "skoda_official_api_key": "Officiële Škoda API-sleutel — failover als het hoofdkanaal uitvalt"
+          "skoda_official_api_key": "Officiële Škoda API-sleutel — voegt de officiële fabrikant-API toe als live databron (en failover)"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: odczyt przebiegu i serwisu ze stanu pojazdu (nawiguje po aplikacji)",
           "companion_read_climate_detail": "Companion: odczyt temperatury zadanej i zewnętrznej (nawiguje po aplikacji)",
           "companion_read_parking_position": "Companion: odczyt pozycji parkowania z linku udostępniania w aplikacji (nawiguje po aplikacji)",
-          "skoda_official_api_key": "Oficjalny klucz API Škoda — przełączanie awaryjne, gdy główny kanał nie działa"
+          "skoda_official_api_key": "Oficjalny klucz API Škoda — dodaje oficjalne API producenta jako źródło danych na żywo (i przełączanie awaryjne)"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -243,7 +243,7 @@
           "companion_read_vehicle_health": "Companion: läs mätarställning och service från fordonsstatus (navigerar i appen)",
           "companion_read_climate_detail": "Companion: läs börtemperatur och utetemperatur (navigerar i appen)",
           "companion_read_parking_position": "Companion: läs parkeringsposition från appens delningslänk (navigerar i appen)",
-          "skoda_official_api_key": "Officiell Škoda API-nyckel — failover när huvudkanalen är nere"
+          "skoda_official_api_key": "Officiell Škoda API-nyckel — lägger till tillverkarens officiella API som live-datakälla (och failover)"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",

--- a/tests/bruno/skoda/52_POST_create_api_key.bru
+++ b/tests/bruno/skoda/52_POST_create_api_key.bru
@@ -22,7 +22,7 @@ headers {
 
 body:json {
   {
-    "name": "Home Assistant (vag_connect)",
+    "name": "Home Assistant",
     "vin": "{{vin}}"
   }
 }

--- a/tests/test_skoda_official_failover.py
+++ b/tests/test_skoda_official_failover.py
@@ -1,12 +1,17 @@
 # Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Škoda official public API as a FAILOVER-ONLY source.
+"""Škoda official public API — active live source AND hard-failure failover.
 
-When the primary (unofficial mysmob) Škoda channel HARD-fails, the coordinator's
-``_revive_after_hard_failure`` falls back to the official public API — but only
-there, never on a healthy poll, because the official API is rate-limited to
-20 requests/hour/key. These tests pin both the delegation and, crucially, that
-the official channel is NOT wired into the continuous supplementary merge.
+The official public API contributes on TWO paths, both rate-safe (20 req/hour/key):
+- ACTIVE live source: on a healthy poll, ``_merge_official_live`` queries the
+  manufacturer API and merges its readings into the primary payload as an
+  authoritative live source (Prash: update existing entities live, not failover-only).
+- FAILOVER: when the primary channel HARD-fails, ``_revive_after_hard_failure``
+  falls back to the official API as a last resort.
+
+Both go through the SAME rate guard (``_official_read_rate_safe``), and the official
+channel is deliberately kept OUT of ``supplementary_readers`` (the rate-unsafe
+continuous-merge path) — its active read is the dedicated, budget-gated one instead.
 """
 from __future__ import annotations
 
@@ -57,15 +62,132 @@ async def test_official_failover_read_delegates_and_failsoft():
     assert await c.official_failover_read("V") is None
 
 
-def test_official_is_failover_only_never_continuous_merge():
-    """The 20/h/key rate limit means the official API must NEVER be a
-    continuous-merge supplementary — only a failover. Even when armed, it must
-    not appear in supplementary_readers (which is consulted every poll)."""
+def test_official_stays_out_of_continuous_supplementary_readers():
+    """The 20/h/key rate limit means the official API must NEVER go through the
+    rate-unsafe continuous-merge path (``supplementary_readers``, consulted every
+    poll with no budget guard). Its active read happens via the dedicated,
+    budget-gated ``_merge_official_live`` instead — so even when armed it must not
+    appear in supplementary_readers."""
     c = _skoda_client()
     c.arm_supplementary_official("key")
     names = [name for name, _ in c.supplementary_readers("V")]
     assert "skoda_official" not in names
-    assert names == []   # nothing else armed → readers empty (failover stays out)
+    assert names == []   # nothing else armed → readers empty (official stays out)
+
+
+@pytest.mark.asyncio
+async def test_official_live_read_delegates_and_failsoft():
+    """The ACTIVE live-source path mirrors the failover path: delegates to the
+    official client's get_status, is fail-soft, and honours the rate budget."""
+    c = _skoda_client()
+    # not armed → None
+    assert await c.official_live_read("V") is None
+    # armed → delegates
+    c._supplementary_official = MagicMock()
+    c._supplementary_official.over_rate_limit = False
+    c._supplementary_official.get_status = AsyncMock(
+        return_value=VehicleData(vin="V", battery_soc=61)
+    )
+    d = await c.official_live_read("V")
+    assert d is not None and d.battery_soc == 61
+    # over budget → skip the read entirely (do not breach the 20/h/key quota)
+    c._supplementary_official.over_rate_limit = True
+    c._supplementary_official.get_status.reset_mock()
+    assert await c.official_live_read("V") is None
+    c._supplementary_official.get_status.assert_not_called()
+    # any error → None (must never sink the poll)
+    c._supplementary_official.over_rate_limit = False
+    c._supplementary_official.get_status = AsyncMock(side_effect=RuntimeError("boom"))
+    assert await c.official_live_read("V") is None
+
+
+@pytest.mark.asyncio
+async def test_merge_official_live_merges_and_tags_provenance():
+    """On a healthy cycle the official read merges its populated fields into the
+    primary payload and tags their provenance as skoda_official."""
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    client = MagicMock()
+    client.official_live_read = AsyncMock(
+        return_value=VehicleData(vin="V", odometer_km=308, battery_soc=77)
+    )
+    coord._cariad_client = client
+    enriched = {"odometer_km": 300, "field_sources": {"odometer_km": "primary"}}
+    await coord._merge_official_live("V", enriched)
+    # official wins for the fields it populated; provenance re-tagged
+    assert enriched["odometer_km"] == 308
+    assert enriched["battery_soc"] == 77
+    assert enriched["field_sources"]["odometer_km"] == "skoda_official"
+    assert enriched["field_sources"]["battery_soc"] == "skoda_official"
+
+
+@pytest.mark.asyncio
+async def test_merge_official_live_never_clobbers_with_defaults():
+    """asdict() emits untouched False/0 defaults; those must NOT overwrite a real
+    primary value. is_electric defaults False, so an official read that never set it
+    must leave a primary is_electric=True untouched."""
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    client = MagicMock()
+    client.official_live_read = AsyncMock(
+        return_value=VehicleData(vin="V", odometer_km=308)  # is_electric stays default False
+    )
+    coord._cariad_client = client
+    enriched = {"is_electric": True, "field_sources": {"is_electric": "primary"}}
+    await coord._merge_official_live("V", enriched)
+    assert enriched["is_electric"] is True                       # not clobbered
+    assert enriched["field_sources"]["is_electric"] == "primary"  # provenance intact
+    assert enriched["odometer_km"] == 308                        # real value still merged
+
+
+@pytest.mark.asyncio
+async def test_merge_official_live_last_seen_is_gap_fill_only():
+    """last_seen_at must never jump backwards: if the primary already carries one,
+    the official capture timestamp does not overwrite it; if absent, it fills."""
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    client = MagicMock()
+    client.official_live_read = AsyncMock(
+        return_value=VehicleData(vin="V", last_seen_at="2026-09-02T09:00:00Z")
+    )
+    coord._cariad_client = client
+    # primary already has a (newer) timestamp → keep it
+    enriched = {"last_seen_at": "2026-09-02T10:00:00Z", "field_sources": {}}
+    await coord._merge_official_live("V", enriched)
+    assert enriched["last_seen_at"] == "2026-09-02T10:00:00Z"
+    assert "last_seen_at" not in enriched["field_sources"]
+    # primary has none → gap-fill from official
+    enriched2 = {"field_sources": {}}
+    await coord._merge_official_live("V", enriched2)
+    assert enriched2["last_seen_at"] == "2026-09-02T09:00:00Z"
+    assert enriched2["field_sources"]["last_seen_at"] == "skoda_official"
+
+
+@pytest.mark.asyncio
+async def test_merge_official_live_noop_on_other_brands():
+    """A non-Škoda client has no official_live_read → getattr None → no-op."""
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    coord._cariad_client = MagicMock(spec=[])   # no attributes at all
+    enriched = {"odometer_km": 300, "field_sources": {"odometer_km": "primary"}}
+    await coord._merge_official_live("V", enriched)
+    assert enriched == {"odometer_km": 300, "field_sources": {"odometer_km": "primary"}}
+
+
+def test_channel_status_reports_official_active_when_contributing():
+    """Once the official read merges values, the connectivity map must report the
+    skoda_official channel as active (with its live count) while still flagging it
+    failover:True (it also serves on hard failure)."""
+    coord = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    coord._channel_last_active = {}
+    coord._armed_data_channels = lambda vin: ["primary", "skoda_official"]
+    # official contributed one reading this cycle
+    data = {"field_sources": {"odometer_km": "primary", "battery_soc": "skoda_official"}}
+    status = coord._compute_channel_status("V", data)
+    assert status["skoda_official"]["active"] is True
+    assert status["skoda_official"]["active_values"] == 1
+    assert status["skoda_official"]["failover"] is True
+    # official armed but idle this cycle → not active (binary_sensor shows standby)
+    data2 = {"field_sources": {"odometer_km": "primary"}}
+    status2 = coord._compute_channel_status("V", data2)
+    assert status2["skoda_official"]["active"] is False
+    assert status2["skoda_official"]["active_values"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_source_connectivity.py
+++ b/tests/test_source_connectivity.py
@@ -76,14 +76,23 @@ def test_status_active_counts_from_field_sources() -> None:
     assert st["skoda"]["last_active"] is not None
 
 
-def test_status_official_is_standby_failover_without_count() -> None:
+def test_status_official_active_when_contributing_else_standby() -> None:
     c = _coord({"brand": "skoda"}, _client(_supplementary_official=object()))
-    # official contributes nothing (its data wears the brand token)
+    # idle this cycle: armed + failover, active False, and a REAL zero count now
+    # (the official channel is an active live source, so it reports a live count
+    # like every other channel — not the old sentinel None).
     st = c._compute_channel_status(VIN, {"field_sources": {"battery_soc": "skoda"}})
     assert st["skoda_official"]["armed"] is True
     assert st["skoda_official"]["failover"] is True
     assert st["skoda_official"]["active"] is False
-    assert st["skoda_official"]["active_values"] is None
+    assert st["skoda_official"]["active_values"] == 0
+    # contributing this cycle: its readings wear the skoda_official token → active
+    st2 = c._compute_channel_status(
+        VIN, {"field_sources": {"battery_soc": "skoda", "odometer_km": "skoda_official"}}
+    )
+    assert st2["skoda_official"]["active"] is True
+    assert st2["skoda_official"]["active_values"] == 1
+    assert st2["skoda_official"]["failover"] is True  # still the failover too
 
 
 def test_status_portal_carries_health_attributes() -> None:


### PR DESCRIPTION
## Škoda official API: active live source, not just failover (#1286)

The Škoda official public API is now queried actively and used as a live source that updates existing entities, instead of being held back purely as a hard-failure failover. Shipped as the v4.6.1 patch.

### What changed
- **`official_live_read()`** (skoda.py) — the active-cycle read, sharing the failover's rate-safe body + the 20/h/key budget guard via a new `_official_read_rate_safe()`.
- **`_merge_official_live()`** (coordinator.py) — on every healthy poll, reads the official API and merges its populated fields into the primary payload, tagging `field_sources = "skoda_official"`. Injected just before `_compute_channel_status` so the connectivity map counts the contribution.
- **Merge safety** — a field is taken only when it differs from a fresh `VehicleData` baseline, so `asdict()`'s untouched `False`/`0` defaults can never clobber a real primary value; `last_seen_at` is gap-filled only (never moved backwards).
- **`_compute_channel_status`** — `skoda_official` now reports `active` + a live count (was hardcoded `active: False`), while still flagging `failover: True` (it also serves on a hard outage).
- **No new entities** — `_parse_vehicle` fills existing `VehicleData` fields, so "update existing as a live source" = merge into the primary payload.
- Config-flow key label reworded ("live data source (and failover)") across `strings.json` + all 12 locales.

Also bundled: the parked name-fix (`_OFFICIAL_KEY_NAME` → plain "Home Assistant", #1286).

### Verification
- Full suite: **5665 passed, 15 skipped**; +12 new/updated tests (delegation, rate-guard, merge, default-clobber guard, `last_seen` gap-fill, brand no-op, channel-status active).
- ruff clean; mypy strict (pre-commit) clean.

Does not close #1286 on its own — the keygen-endpoint question there stays open; this ships the live-source behaviour that was requested.
