### PR TITLE
v4.7.0b1 — Škoda official API: keygen matched byte-for-byte to the app + per-car manual keys (#1286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,28 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b1] - 2026-09-02 — Škoda official API: automatic key creation matched byte-for-byte to the app · per-car manual keys
+
+### Added
+- **Škoda: enter an official API key per car.** Official public-API keys are tied to one
+  vehicle each (you create them in the MyŠkoda app, up to 5 per car), so an account with
+  more than one Škoda now gets one key field per VIN in the integration's options — on top
+  of the single fallback field. Each car then reads its own official channel with its own
+  key. Single-car setups are unchanged: the one field still covers you. A blank per-car
+  field is left as-is, so it never wipes a key that was set or auto-created for that car
+  (#1286).
+
+### Fixed
+- **Škoda automatic official-API enrolment: the request now matches the app exactly.**
+  Automatic key creation was returning HTTP 400 for everyone. Reverse-engineering the
+  MyŠkoda app (8.16) showed its key-management endpoint requires the app's identity headers
+  — app version, platform, install id, device language/country and a trace id — that the
+  ordinary read endpoints don't ask for; our request sent only the token, so the backend
+  rejected it. Enrolment (and the key list/delete calls) now send the same header set as
+  the app, making the request byte-for-byte identical. This is being confirmed live with
+  Škoda owners on #1286; if your car couldn't auto-enrol before, this beta is the one to
+  test.
+
 ## [4.6.1] - 2026-09-02 — Škoda official API now reads live every cycle, not just on failover
 
 ### Changed

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -49,6 +49,16 @@ _OFFICIAL_KEY_NAME = "Home Assistant"
 # real app User-Agent on these calls so a possible min-app-version gate is satisfied
 # (verbatim from the 8.16 APK; MySkoda/Android/{versionName}/{versionCode}).
 _KEYGEN_USER_AGENT = "MySkoda/Android/8.16.0/260821007"
+# 1:1 with the app: the MyŠkoda "[bff-api-auth]" client attaches a full app-identity
+# header set on EVERY request (RE'd byte-for-byte from 8.16 br0/b.smali). The read
+# endpoints accept our token without it, but the key-management route (create/list/
+# delete) is stricter and 400s a request that omits these — the only app-vs-us
+# difference left after host/method/token/body were all confirmed identical. Every
+# value is client-generated (the installation-id is a locally-persisted UUID, not a
+# server-registered one; traceparent is random per request), so we reproduce them
+# exactly. Values verbatim from the APK.
+_KEYGEN_APP_VERSION_NAME = "8.16.0"
+_KEYGEN_APP_VERSION_CODE = "260821007"
 
 _COMBUSTION_ENGINE_TYPES = ("gasoline", "petrol", "diesel", "cng", "lpg")
 
@@ -317,6 +327,45 @@ class SkodaClient(CariadBaseClient):
         at = getattr(tok, "access_token", "") or ""
         return isinstance(at, str) and bool(at)
 
+    def _keygen_headers(self) -> dict[str, Any]:
+        """The MyŠkoda app's byte-for-byte app-identity header set for the official
+        api-keys management endpoint (create/list/delete). RE'd from 8.16
+        (br0/b.smali): the gateway 400s a key-management request that omits these,
+        even though the read endpoints accept the same Bearer without them. Every
+        value is client-generated so we can reproduce them exactly — a stable
+        per-instance installation id (a UUID, like the app's locally-persisted one),
+        the fixed app-version/platform, a device locale, and a fresh W3C traceparent
+        per call."""
+        import secrets  # noqa: PLC0415
+        import uuid  # noqa: PLC0415
+        install_id = getattr(self, "_keygen_install_id", "") or ""
+        if not install_id:
+            install_id = str(uuid.uuid4())
+            self._keygen_install_id = install_id
+        # X-DEVICE-LANGUAGE / X-DEVICE-COUNTRY mirror the app's Locale.getLanguage()
+        # and Locale.getCountry(): the coordinator feeds the HA instance locale
+        # (hass.config.language / .country) via _ha_language/_ha_country, and we
+        # normalize to the exact ISO forms the app sends — language ISO-639-1
+        # lower-case 2-letter (drop any region subtag, e.g. "en-GB" → "en"), country
+        # ISO-3166-1 alpha-2 upper-case. Fall back to a valid default when HA has none.
+        lang = str(getattr(self, "_ha_language", "") or "")
+        lang = lang.replace("_", "-").split("-", 1)[0].strip().lower()
+        if len(lang) != 2 or not lang.isalpha():
+            lang = "en"
+        ctry = str(getattr(self, "_ha_country", "") or "").strip().upper()
+        if len(ctry) != 2 or not ctry.isalpha():
+            ctry = "DE"
+        return {
+            "User-Agent": _KEYGEN_USER_AGENT,
+            "X-APP-VERSION-NAME": _KEYGEN_APP_VERSION_NAME,
+            "X-APP-VERSION-CODE": _KEYGEN_APP_VERSION_CODE,
+            "X-APP-PLATFORM": "Android",
+            "X-APP-INSTALLATION-ID": install_id,
+            "X-DEVICE-LANGUAGE": lang,
+            "X-DEVICE-COUNTRY": ctry,
+            "traceparent": f"00-{secrets.token_hex(16)}-{secrets.token_hex(8)}-00",
+        }
+
     async def mint_api_key(
         self, vin: str, name: str = _OFFICIAL_KEY_NAME
     ) -> dict[str, Any] | None:
@@ -337,8 +386,10 @@ class SkodaClient(CariadBaseClient):
         try:
             body = await self._post(
                 f"{_BASE}/api/v2/public-api-keys",
-                json={"name": name, "vin": vin.strip().upper()},
-                headers={"User-Agent": _KEYGEN_USER_AGENT},
+                # vin-first mirrors the app's reflective-Moshi field order (cosmetic,
+                # but keeps the request byte-identical); VIN canonical uppercase.
+                json={"vin": vin.strip().upper(), "name": name},
+                headers=self._keygen_headers(),
             )
         except APIError as err:
             self.probe_outcomes["skoda_official_keygen"] = f"POST {err.status}"
@@ -373,7 +424,7 @@ class SkodaClient(CariadBaseClient):
         try:
             body = await self._get(
                 f"{_BASE}/api/v2/public-api-keys",
-                headers={"User-Agent": _KEYGEN_USER_AGENT},
+                headers=self._keygen_headers(),
             )
         except APIError as err:
             self.probe_outcomes["skoda_official_keygen_list"] = f"GET {err.status}"
@@ -404,7 +455,7 @@ class SkodaClient(CariadBaseClient):
         try:
             await self._request(
                 "DELETE", f"{_BASE}/api/v2/public-api-keys/{key_id}",
-                headers={"User-Agent": _KEYGEN_USER_AGENT},
+                headers=self._keygen_headers(),
             )
             return True
         except Exception as err:  # noqa: BLE001

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -2084,6 +2084,36 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                 # (see the entry.options trap) then kept the stale value — so a
                 # per-VIN S-PIN could never be removed once set (#759 follow-up).
                 user_input[CONF_SPIN_BY_VIN] = _by_vin
+            # Škoda per-VIN official API keys — fold the transient
+            # skoda_official_keys_<VIN> fields into the CONF_SKODA_OFFICIAL_KEYS
+            # map {VIN: {"key": ...}}. Keys are VIN-bound, so this lets a multi-car
+            # account enter one per car. A typed key overrides that VIN's entry; a
+            # BLANK field keeps the existing entry (NOT a wipe) — unlike the S-PIN
+            # above, because an official key can be auto-enrolled and expensive to
+            # recreate, and a password field may render blank on reopen, so
+            # blanking must never silently delete a saved key. Start from the stored
+            # map so untouched VINs (incl. auto-enrolled ones) are preserved.
+            from .const import CONF_SKODA_OFFICIAL_KEYS  # noqa: PLC0415
+            _off_fields = [
+                _k for _k in list(user_input.keys())
+                if _k.startswith(f"{CONF_SKODA_OFFICIAL_KEYS}_")
+            ]
+            if _off_fields:
+                _stored = (
+                    self._config_entry.options.get(CONF_SKODA_OFFICIAL_KEYS)
+                    or self._config_entry.data.get(CONF_SKODA_OFFICIAL_KEYS)
+                )
+                _off_map = dict(_stored) if isinstance(_stored, dict) else {}
+                for _k in _off_fields:
+                    _vin = _k[len(CONF_SKODA_OFFICIAL_KEYS) + 1:].strip().upper()
+                    _val = str(user_input.pop(_k) or "").strip()
+                    if not _val:
+                        continue  # keep existing entry; never wipe on a blank field
+                    _prev = _off_map.get(_vin)
+                    if isinstance(_prev, dict) and _prev.get("key") == _val:
+                        continue  # unchanged
+                    _off_map[_vin] = {"key": _val, "source": "manual"}
+                user_input[CONF_SKODA_OFFICIAL_KEYS] = _off_map
             # b1/C1 — if the user ticked "add vw.de read channel", branch into
             # the login sub-flow; the remaining options are saved when it
             # completes. Default-False so untouched submits behave exactly as
@@ -2436,11 +2466,12 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                 schema[vol.Optional(
                     CONF_VWEU_DEVICE_GRANT, default=False,
                 )] = _BOOL_SELECTOR
-        # Škoda official public API — opt-in FAILOVER key. A Škoda entry may add
-        # an API key it minted in the app (Settings → Smart Home → API Keys,
-        # v8.16+); the official API is then read ONLY when the primary channel
-        # hard-fails (it is rate-limited to 20 req/hour/key, so never polled
-        # continuously). Pre-filled so re-opening options never blanks it.
+        # Škoda official public API — opt-in key. A Škoda entry may add an API key
+        # it minted in the MyŠkoda app (Settings → Smart Home → API Keys, v8.16+);
+        # the official API is then read live on every cycle and merged into the
+        # existing sensors as a live source (and also serves as the hard-failure
+        # failover). This single field is the FALLBACK applied to any car without
+        # its own per-VIN key below. Pre-filled so re-opening options never blanks it.
         if current_data.get(CONF_BRAND) == "skoda":
             from .const import CONF_SKODA_OFFICIAL_API_KEY  # noqa: PLC0415
             schema[vol.Optional(
@@ -2471,6 +2502,32 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                     f"{CONF_SPIN_BY_VIN}_{_vin}",
                     default=str(_cur_by_vin.get(_vin, "")),
                 )] = _SPIN_SELECTOR
+        # Škoda official public-API keys are VIN-bound (one key per car, minted in
+        # the MyŠkoda app, max 5/VIN). A multi-car Škoda account therefore gets one
+        # optional key field PER VIN, in addition to the single fallback field
+        # above. Pre-filled from the stored map so a re-save never wipes a saved or
+        # auto-enrolled key (options-trap safe); folded into CONF_SKODA_OFFICIAL_KEYS
+        # on submit. Only shown when the account has more than one vehicle — a
+        # single-car user just uses the one field above.
+        if (
+            current_data.get(CONF_BRAND) == "skoda"
+            and isinstance(_vehicles, dict)
+            and len(_vehicles) > 1
+        ):
+            from .const import CONF_SKODA_OFFICIAL_KEYS  # noqa: PLC0415
+            _off_map = current_options.get(
+                CONF_SKODA_OFFICIAL_KEYS,
+                current_data.get(CONF_SKODA_OFFICIAL_KEYS),
+            )
+            if not isinstance(_off_map, dict):
+                _off_map = {}
+            for _vin in _vehicles:
+                _rec = _off_map.get(_vin) or _off_map.get(str(_vin).upper()) or {}
+                _cur_key = _rec.get("key", "") if isinstance(_rec, dict) else ""
+                schema[vol.Optional(
+                    f"{CONF_SKODA_OFFICIAL_KEYS}_{_vin}",
+                    default=str(_cur_key),
+                )] = _PASSWORD_SELECTOR
         # v2.26.0 — companion (ADB) advanced opt-ins, surfaced only for a
         # companion entry (both default OFF: each TAPS the phone, so a user opts
         # in only after confirming the flow on their own device).

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2720,6 +2720,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # non-native login) so diagnostics explain its absence. PII-free.
             self._skoda_probe("skoda_official", "gate: not a native mysmob login")
             return
+        # Feed the client the HA instance locale so the app-identity keygen headers
+        # (X-DEVICE-LANGUAGE / X-DEVICE-COUNTRY) carry the user's real HA setting in
+        # the ISO form the app sends, instead of a hardcoded default. Fail-soft.
+        try:
+            setattr(client, "_ha_language", self.hass.config.language or "")
+            setattr(client, "_ha_country", self.hass.config.country or "")
+        except Exception:  # noqa: BLE001
+            pass
         mint = getattr(client, "mint_api_key", None)
         list_keys = getattr(client, "list_api_keys", None)
         if mint is None or list_keys is None:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.6.1"
+  "version": "4.7.0b1"
 }

--- a/tests/test_skoda_official_failover.py
+++ b/tests/test_skoda_official_failover.py
@@ -15,6 +15,9 @@ continuous-merge path) — its active read is the dedicated, budget-gated one in
 """
 from __future__ import annotations
 
+import re
+import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -229,3 +232,87 @@ async def test_no_official_on_other_brands_is_a_noop():
     client = MagicMock(spec=[])           # no attributes at all
     coord._cariad_client = client
     assert await coord._revive_after_hard_failure("V") is None
+
+
+def test_keygen_headers_match_the_app_byte_for_byte():
+    """The api-keys management endpoint 400s without the app-identity headers (host,
+    method, token, body were all confirmed identical to the app). _keygen_headers
+    reproduces the 8.16 br0/b.smali set byte-for-byte."""
+    c = _skoda_client()
+    h = c._keygen_headers()
+    assert h["User-Agent"] == "MySkoda/Android/8.16.0/260821007"
+    assert h["X-APP-VERSION-NAME"] == "8.16.0"
+    assert h["X-APP-VERSION-CODE"] == "260821007"
+    assert h["X-APP-PLATFORM"] == "Android"
+    assert h["X-DEVICE-LANGUAGE"] and h["X-DEVICE-COUNTRY"]
+    # installation id is a well-formed UUID and STABLE across calls (like the app's
+    # locally-persisted one — not a new id every request).
+    uuid.UUID(h["X-APP-INSTALLATION-ID"])
+    assert c._keygen_headers()["X-APP-INSTALLATION-ID"] == h["X-APP-INSTALLATION-ID"]
+    # W3C traceparent 00-<32hex>-<16hex>-00, fresh per call.
+    assert re.fullmatch(r"00-[0-9a-f]{32}-[0-9a-f]{16}-00", h["traceparent"])
+    assert c._keygen_headers()["traceparent"] != h["traceparent"]
+
+
+def test_keygen_headers_use_ha_locale_in_iso_form():
+    """X-DEVICE-LANGUAGE/-COUNTRY come from the HA instance locale, normalized to the
+    exact ISO forms the app sends: language ISO-639-1 lower 2-letter (region subtag
+    dropped), country ISO-3166-1 alpha-2 upper."""
+    c = _skoda_client()
+    c._ha_language = "en-GB"   # HA language with a region subtag
+    c._ha_country = "ch"       # lower-case country
+    h = c._keygen_headers()
+    assert h["X-DEVICE-LANGUAGE"] == "en"
+    assert h["X-DEVICE-COUNTRY"] == "CH"
+    c2 = _skoda_client()
+    c2._ha_language = "de_DE"  # underscore locale form
+    c2._ha_country = "DE"
+    h2 = c2._keygen_headers()
+    assert h2["X-DEVICE-LANGUAGE"] == "de"
+    assert h2["X-DEVICE-COUNTRY"] == "DE"
+
+
+def test_keygen_headers_fall_back_when_ha_locale_missing_or_garbage():
+    """Missing or malformed HA locale → a valid ISO default, never an empty/invalid
+    header (which could itself trip the backend)."""
+    c = _skoda_client()
+    c._ha_language = None
+    c._ha_country = None
+    h = c._keygen_headers()
+    assert h["X-DEVICE-LANGUAGE"] == "en"
+    assert h["X-DEVICE-COUNTRY"] == "DE"
+    c._ha_language = "zzzz"    # too long / not a 2-letter code
+    c._ha_country = "1"        # not alpha, wrong length
+    h2 = c._keygen_headers()
+    assert h2["X-DEVICE-LANGUAGE"] == "en"
+    assert h2["X-DEVICE-COUNTRY"] == "DE"
+
+
+@pytest.mark.asyncio
+async def test_mint_sends_app_identity_headers_and_vin_first_body():
+    """mint_api_key attaches the full app-identity header set and sends a vin-first
+    body with a canonical (upper-case) VIN — byte-for-byte with the app."""
+    c = _skoda_client()
+    c._eu_portal = None
+    c._tokens = SimpleNamespace(strategy="", access_token="tok")
+    c.probe_outcomes = {}
+    captured = {}
+
+    async def fake_post(url, json=None, headers=None):
+        captured.update(url=url, json=json, headers=headers)
+        return {"id": "i", "key": "msk_x", "name": "Home Assistant",
+                "validUntil": "2027-01-01"}
+
+    c._post = fake_post
+    out = await c.mint_api_key("wvwabc0000000001")
+    assert out and out["key"] == "msk_x"
+    # full app-identity header set on the create call
+    hdr = captured["headers"]
+    assert hdr["X-APP-VERSION-NAME"] == "8.16.0"
+    assert hdr["X-APP-PLATFORM"] == "Android"
+    assert "X-APP-INSTALLATION-ID" in hdr
+    assert hdr["traceparent"].startswith("00-")
+    # body is vin-first with a canonical upper-case VIN
+    assert list(captured["json"].keys()) == ["vin", "name"]
+    assert captured["json"]["vin"] == "WVWABC0000000001"
+    assert captured["json"]["name"] == "Home Assistant"

--- a/tests/test_skoda_official_per_vin_keys.py
+++ b/tests/test_skoda_official_per_vin_keys.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Manual per-VIN Škoda official-API keys in the options flow.
+
+Official public-API keys are VIN-bound (one per car, minted in the MyŠkoda app,
+max 5/VIN). A multi-car Škoda account therefore needs one key PER VIN, not a
+single shared key. The options flow renders one optional key field per VIN (in
+addition to the single fallback field) and folds them into the
+CONF_SKODA_OFFICIAL_KEYS map the coordinator already arms from.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from custom_components.vag_connect.config_flow import VagConnectOptionsFlow
+from custom_components.vag_connect.const import (
+    CONF_BRAND,
+    CONF_SCAN_INTERVAL,
+    CONF_SKODA_OFFICIAL_KEYS,
+)
+
+VIN_A = "TMBVINA0000000001"
+VIN_B = "TMBVINB0000000002"
+
+
+def _skoda_entry(data=None, options=None, vehicles=None):
+    entry = MagicMock()
+    entry.data = {CONF_SCAN_INTERVAL: 5, CONF_BRAND: "skoda", **(data or {})}
+    entry.options = options if options is not None else {}
+    if vehicles is not None:
+        entry.runtime_data = MagicMock()
+        entry.runtime_data.vehicles = vehicles
+    return entry
+
+
+def _submit(flow, user_input):
+    with patch.object(
+        flow, "async_create_entry", return_value={"type": "create_entry"}
+    ) as save:
+        asyncio.run(flow.async_step_init(user_input))
+    return save
+
+
+def test_per_vin_key_fields_render_only_for_multicar_skoda():
+    # two Škoda vehicles → one official-key field per VIN, pre-filled from the map
+    entry = _skoda_entry(
+        data={CONF_SKODA_OFFICIAL_KEYS: {VIN_A: {"key": "msk_existing_a"}}},
+        vehicles={VIN_A: {"vin": VIN_A}, VIN_B: {"vin": VIN_B}},
+    )
+    result = asyncio.run(VagConnectOptionsFlow(entry).async_step_init(None))
+    keys = {str(k) for k in result["data_schema"].schema}
+    assert f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_A}" in keys
+    assert f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_B}" in keys
+    # VIN_A field pre-filled from the stored map; VIN_B empty
+    defaults = {
+        str(k): (k.default() if callable(getattr(k, "default", None)) else None)
+        for k in result["data_schema"].schema
+    }
+    assert defaults[f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_A}"] == "msk_existing_a"
+    assert defaults[f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_B}"] == ""
+
+
+def test_per_vin_key_fields_absent_for_singlecar():
+    # one vehicle → no per-VIN fields (the single fallback field covers it)
+    entry = _skoda_entry(vehicles={VIN_A: {"vin": VIN_A}})
+    result = asyncio.run(VagConnectOptionsFlow(entry).async_step_init(None))
+    keys = {str(k) for k in result["data_schema"].schema}
+    assert not any(k.startswith(f"{CONF_SKODA_OFFICIAL_KEYS}_") for k in keys)
+
+
+def test_submit_folds_typed_keys_into_map_and_pops_transients():
+    entry = _skoda_entry()
+    save = _submit(
+        VagConnectOptionsFlow(entry),
+        {
+            CONF_SCAN_INTERVAL: 15,
+            f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_A}": "msk_aaa",
+            f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_B}": "",  # blank → no entry
+        },
+    )
+    data = save.call_args.kwargs["data"]
+    assert data[CONF_SKODA_OFFICIAL_KEYS] == {
+        VIN_A: {"key": "msk_aaa", "source": "manual"}
+    }
+    # transient per-field keys never persist as standalone options
+    assert not any(
+        str(k).startswith(f"{CONF_SKODA_OFFICIAL_KEYS}_") for k in data
+    )
+
+
+def test_submit_blank_keeps_existing_and_preserves_auto_enrolled():
+    entry = _skoda_entry(
+        data={
+            CONF_SKODA_OFFICIAL_KEYS: {
+                VIN_A: {"key": "auto_a", "id": "id1", "validUntil": "2027-01-01"},
+            }
+        },
+    )
+    save = _submit(
+        VagConnectOptionsFlow(entry),
+        {
+            CONF_SCAN_INTERVAL: 15,
+            f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_A}": "",  # blank → keep auto-enrolled
+            f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_B}": "msk_bbb",  # new manual
+        },
+    )
+    data = save.call_args.kwargs["data"]
+    assert data[CONF_SKODA_OFFICIAL_KEYS] == {
+        VIN_A: {"key": "auto_a", "id": "id1", "validUntil": "2027-01-01"},
+        VIN_B: {"key": "msk_bbb", "source": "manual"},
+    }
+
+
+def test_submit_typed_key_overrides_existing_and_drops_stale_id():
+    entry = _skoda_entry(
+        data={
+            CONF_SKODA_OFFICIAL_KEYS: {
+                VIN_A: {"key": "old_a", "id": "id1", "validUntil": "2027-01-01"},
+            }
+        },
+    )
+    save = _submit(
+        VagConnectOptionsFlow(entry),
+        {
+            CONF_SCAN_INTERVAL: 15,
+            f"{CONF_SKODA_OFFICIAL_KEYS}_{VIN_A}": "new_a",  # override
+        },
+    )
+    data = save.call_args.kwargs["data"]
+    # a new manual key replaces the record (stale id/validUntil of the old key gone)
+    assert data[CONF_SKODA_OFFICIAL_KEYS][VIN_A] == {
+        "key": "new_a",
+        "source": "manual",
+    }


### PR DESCRIPTION
## Škoda official API: keygen matched byte-for-byte to the app + per-car manual keys (#1286)

Beta for field validation of the automatic official-API key creation, plus per-car manual keys.

### Keygen 1:1 (the HTTP 400 root cause)
Two independent RE passes over MyŠkoda 8.16 (an Explore agent + a 5-facet workflow, each finding adversarially verified against the raw smali) decomposed the app's create-key call:
- **Host** = `mysmob.api.connect.skoda-auto.cz` (prod, `ih0/c.smali`) — identical to ours.
- **Method** = POST (`Lzq0/i;->g`) — identical.
- **Token** = the same MyŠkoda Connect login Bearer (prod client_id `7f045eee…`, no exchange, no distinct audience) — identical.
- **Body** = `{vin,name}` — identical (app emits vin-first; cosmetic).
- **Headers** = the ONLY difference. The `[bff-api-auth]` client attaches an app-identity header set on every request (`br0/b.smali`): `X-APP-VERSION-NAME/-CODE/-PLATFORM/-INSTALLATION-ID`, `X-DEVICE-LANGUAGE/-COUNTRY`, `traceparent`. The read endpoints accept the bare token, but the key-management endpoint 400s without these.

New `_keygen_headers()` reproduces the set byte-for-byte (all values client-generated: the install id is a local UUID, traceparent is random per call), on mint/list/delete; the create body is now vin-first. `X-DEVICE-LANGUAGE/-COUNTRY` are taken from the HA instance locale (`hass.config.language`/`country`) and normalized to the ISO forms the app sends (ISO-639-1 lower 2-letter / ISO-3166-1 alpha-2 upper), with a valid default when HA has none.

**This is a well-grounded hypothesis, not yet proven live** — it needs a native Škoda account to confirm the 400 is gone (the `skoda_official_keygen` diagnostic probe shows `POST 2xx` = fixed vs still `400`). It cannot regress: those calls already 400'd.

### Per-car manual keys
Official keys are VIN-bound, so a multi-car Škoda account now gets one key field per VIN in the options flow (mirroring the per-VIN S-PIN pattern), folded into the existing `CONF_SKODA_OFFICIAL_KEYS` map the coordinator already arms from. A blank per-car field keeps the existing entry, so it never wipes a set or auto-enrolled key.

### Verification
Full suite **5674 passed, 15 skipped**; new tests for the header set + ISO-locale normalization + fallback, the per-VIN field render/fold, and the mint request shape. ruff + mypy-strict clean.

Ships as prerelease `v4.7.0b1` for field validation on #1286.
