### PR TITLE
v4.7.0b2 — Škoda: last-trip from per-trip data + fold in the 4.6.2 security/fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,25 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b2] - 2026-09-02 — Škoda: last-trip sensors from real per-trip data · carries the 4.6.2 security + fixes
+
+### Added
+- **Škoda: the last-trip sensors now populate from real per-trip data.** The last-trip
+  distance, duration, average speed and average fuel consumption weren't appearing on many
+  Škoda cars because the weekly trip-statistics overview returns those per-entry values
+  empty on combustion cars. We now read the dedicated single-trips endpoint — the one
+  source that carries genuine per-trip average speed and consumption — and fill the
+  last-trip sensors from your most recent trip. Reported by @indigomejor (#1310).
+
+### Security
+- Carries the 4.6.2 fix that **redacts the Škoda official API key in diagnostics** — it was
+  leaking in plaintext in the diagnostics download. If you've posted a diagnostics file
+  with an official key set, treat it as exposed and recreate it in the app (see 4.6.2) (#1286).
+
+### Fixed
+- Carries the 4.6.2 fix for the **official channel's 12V "state of charge" mirroring the
+  fuel level** on combustion Škodas (#1310).
+
 ## [4.7.0b1] - 2026-09-02 — Škoda official API: automatic key creation matched byte-for-byte to the app · per-car manual keys
 
 ### Added
@@ -54,15 +73,34 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   (#1286).
 
 ### Fixed
-- **Škoda automatic official-API enrolment: the request now matches the app exactly.**
-  Automatic key creation was returning HTTP 400 for everyone. Reverse-engineering the
-  MyŠkoda app (8.16) showed its key-management endpoint requires the app's identity headers
-  — app version, platform, install id, device language/country and a trace id — that the
-  ordinary read endpoints don't ask for; our request sent only the token, so the backend
-  rejected it. Enrolment (and the key list/delete calls) now send the same header set as
-  the app, making the request byte-for-byte identical. This is being confirmed live with
-  Škoda owners on #1286; if your car couldn't auto-enrol before, this beta is the one to
-  test.
+- **Škoda official-API enrolment now matches the app's request byte-for-byte.** Enrolment
+  and the key list/delete calls now send the same app-identity headers the MyŠkoda app
+  attaches (app version, platform, install id, device language/country, trace id), which
+  the ordinary read endpoints don't require. Field testing pinned what each part fixes:
+  these headers fix the **empty key list** on the official API — the endpoint was returning
+  "no eligible vehicles" until we asked with them, and now your key is listed correctly.
+  (The HTTP 400 on key *creation* was a separate issue — the key **name** — already fixed
+  in 4.6.1.) Thanks to @indigomejor and @n3roGit for the before/after captures (#1286).
+
+## [4.6.2] - 2026-09-02 — Security: Škoda official API key redacted in diagnostics · combustion 12V mirror on the official channel
+
+### Security
+- **The Škoda official API key was leaking in plaintext in the diagnostics download.**
+  The official public-API key — the single manual key and every auto-enrolled per-car
+  key — is a credential that grants access to your car's official API, but it was
+  missing from the diagnostics redaction set, so it appeared in clear text in the
+  config-entry diagnostics file people attach to GitHub issues. It is now masked (the
+  per-car map keeps its count for triage but hides each key). **If you have ever posted
+  a diagnostics file with an official key set, treat that key as exposed and recreate it
+  in the MyŠkoda app (Smart Home → Keys) — deleting the old one there.** (#1286)
+
+### Fixed
+- **Škoda official API channel: the 12V "state of charge" no longer mirrors the fuel
+  level on combustion cars.** On a petrol/diesel Škoda the official API mirrors the fuel
+  level into the engine "state of charge" field — the same quirk the reverse-engineered
+  channel has — so the official channel briefly re-introduced the mirror that 4.6.0
+  fixed (a "12V" reading that just tracked the tank). It now applies the same guard and
+  suppresses the duplicate. Reported by @indigomejor (#1310).
 
 ## [4.6.1] - 2026-09-02 — Škoda official API now reads live every cycle, not just on failover
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -156,6 +156,65 @@ def _apply_trip_statistics(trip_stats: Any, d: VehicleData) -> None:
                 d.trip_cost_currency = str(sub["costCurrency"])
                 break
 
+
+def _apply_single_trip(single_trips: Any, d: VehicleData) -> None:
+    """Fill the ``last_trip_*`` sensors from the mysmob single-trips endpoint (#1310).
+
+    The WEEK/MONTH/YEAR ``/trip-statistics`` overview returns a metric-HOLLOW
+    ``detailedStatistics`` on combustion cars (only a ``date``, no distance / speed /
+    consumption — indigomejor), so ``_apply_trip_statistics`` above could never
+    populate ``last_trip_*`` there. The ``/trip-statistics/{vin}/single-trips``
+    endpoint is the ONLY source carrying per-trip ``averageSpeedInKmph`` AND
+    ``averageFuelConsumption`` (RE'd from MyŠkoda 8.16 ``TripStatisticsApi`` /
+    ``SingleTripDto``). Response shape: ``{dailyTrips: [{date, trips: [SingleTripDto]}]}``.
+    Pick the most-recent trip (latest day ``date``, then latest ``endTime``) and fill
+    from it — a genuine per-trip record, not a per-day aggregate. Overrides the hollow
+    overview values when both are present (per-trip is the more accurate source).
+    """
+    if not isinstance(single_trips, dict):
+        return
+    daily = single_trips.get("dailyTrips")
+    if not isinstance(daily, list):
+        return
+    best_day = ""
+    best_key = ""
+    best: dict[str, Any] | None = None
+    for day in daily:
+        if not isinstance(day, dict):
+            continue
+        day_date = str(day.get("date") or "")
+        trips = day.get("trips")
+        if not isinstance(trips, list):
+            continue
+        for t in trips:
+            if not isinstance(t, dict):
+                continue
+            key = day_date + "T" + str(t.get("endTime") or t.get("startTime") or "")
+            if best is None or key > best_key:
+                best_key, best_day, best = key, day_date, t
+    if best is None:
+        return
+    _mi = best.get("mileageInKm")
+    if isinstance(_mi, (int, float)):
+        d.last_trip_distance_km = int(_mi)
+    _tt = best.get("travelTimeInMin")
+    if isinstance(_tt, (int, float)):
+        d.last_trip_duration_min = int(_tt)
+    _sp = best.get("averageSpeedInKmph")
+    if isinstance(_sp, (int, float)):
+        d.last_trip_avg_speed_kmh = int(_sp)
+    _fc = best.get("averageFuelConsumption")
+    if isinstance(_fc, (int, float)):
+        d.last_trip_avg_fuel_consumption_l_100km = float(_fc)
+    _ec = best.get("averageElectricConsumption")
+    if isinstance(_ec, (int, float)):
+        d.last_trip_avg_electric_consumption_kwh_100km = float(_ec)
+    _so = best.get("startMileageInKm")
+    if isinstance(_so, (int, float)):
+        d.last_trip_start_odometer_km = int(_so)
+    if best_day:
+        d.last_trip_timestamp = best_day
+
 # driving-range.carType enum values that are pure-combustion (no HV battery, no
 # plug). EVs report "electric", PHEVs "hybrid" — deliberately absent, so a plug-in
 # car is NEVER matched. Used to skip the battery-only /charging read on a confirmed
@@ -1094,12 +1153,21 @@ class SkodaClient(CariadBaseClient):
             # Skoda app update. POST body w/ VIN-filter on the
             # charging.cariad.digital host.
             self.get_charging_statistics(vin),
+            # #1310 (indigomejor) — per-TRIP records. The WEEK/MONTH/YEAR overview
+            # above returns metric-hollow detailedStatistics on combustion cars, so
+            # last_trip_* never populated; the single-trips endpoint (SingleTripDto)
+            # is the only source with per-trip avg speed + fuel consumption. RE'd
+            # from MyŠkoda 8.16 TripStatisticsApi. timezone=GMT (myskoda's canonical
+            # value; the daily buckets don't matter — we take the newest trip).
+            self._get(
+                f"{_BASE}/api/v1/trip-statistics/{vin}/single-trips?timezone=GMT"
+            ),
             return_exceptions=True,
         )
         (
             status, charging, ac, parking, driving_range,
             maintenance, readiness, sw_update, widget, driving_score,
-            health_v1, trip_stats, charging_stats_v2,
+            health_v1, trip_stats, charging_stats_v2, single_trips,
         ) = results
 
         # v1.9.0 — Vehicle Data Scout opt-in. Stash raw responses keyed by
@@ -1937,6 +2005,7 @@ class SkodaClient(CariadBaseClient):
         # overall_travel_time_in_min / overall_mileage_in_km + a
         # detailedStatistics list of per-period TripStatistics entries.
         _apply_trip_statistics(trip_stats, d)
+        _apply_single_trip(single_trips, d)
 
         # v2.11.0 (myskoda PR #586 source-verified): charging stats
         # from the replacement endpoint. monthSections[].entries[] each

--- a/custom_components/vag_connect/cariad/api/skoda_official.py
+++ b/custom_components/vag_connect/cariad/api/skoda_official.py
@@ -231,11 +231,25 @@ class SkodaOfficialClient:
         etype = prim.get("engineType")
         if isinstance(etype, str):
             d.primary_engine_type = etype
-        if isinstance(prim.get("currentFuelLevelInPercent"), (int, float)):
-            d.primary_engine_fuel_level_pct = int(prim["currentFuelLevelInPercent"])
-            d.fuel_level = int(prim["currentFuelLevelInPercent"])
-        if isinstance(prim.get("currentSoCInPercent"), (int, float)):
-            d.primary_engine_soc_pct = int(prim["currentSoCInPercent"])
+        _fuel_pct = prim.get("currentFuelLevelInPercent")
+        if isinstance(_fuel_pct, (int, float)):
+            d.primary_engine_fuel_level_pct = int(_fuel_pct)
+            d.fuel_level = int(_fuel_pct)
+        _soc_pct = prim.get("currentSoCInPercent")
+        if isinstance(_soc_pct, (int, float)):
+            # #1310 — apply the SAME combustion fuel-mirror guard as the mysmob path
+            # (indigomejor): on a combustion primary engine the backend mirrors the
+            # fuel level into currentSoCInPercent, so a "SoC" equal to the fuel level
+            # is the fuel duplicated, not a 12V reading. Reuse the one guard so the
+            # official channel cannot re-introduce the mirror we fixed on mysmob.
+            from .skoda import _primary_soc_or_none  # noqa: PLC0415
+            _guarded = _primary_soc_or_none(
+                int(_soc_pct),
+                int(_fuel_pct) if isinstance(_fuel_pct, (int, float)) else None,
+                etype,
+            )
+            if _guarded is not None:
+                d.primary_engine_soc_pct = _guarded
         if isinstance(prim.get("remainingRangeInKm"), (int, float)):
             if isinstance(etype, str) and etype.upper() == "ELECTRIC":
                 d.electric_range_km = int(prim["remainingRangeInKm"])

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -117,6 +117,14 @@ _REDACT_KEYS = frozenset({
     # redaction is independent of the companion module's own const import order.
     "companion_agent_token",
     "companion_addon_token",
+    # #1286 — the Škoda official public-API key IS a credential: it grants read
+    # (and charge-control) access to the car's official API. The single manual key
+    # (CONF_SKODA_OFFICIAL_API_KEY) leaked in PLAINTEXT in the diagnostics download
+    # users attach to GitHub issues — a real ``msk_…`` key was exposed publicly.
+    # Mask it here. The auto-enrolled per-VIN map (CONF_SKODA_OFFICIAL_KEYS) is a
+    # ``{VIN: {key, id, validUntil}}`` dict and is routed through
+    # _redact_identifier_map below (keeps the enrolment count, masks each record).
+    "skoda_official_api_key",
 })
 
 
@@ -307,9 +315,12 @@ def _scrub(value: Any, *, gps_round: bool = False) -> Any:
                     scrubbed[sk] = round(float(v), 1)
                 else:
                     scrubbed[sk] = "**REDACTED**"
-            elif k == CONF_DATA_ACT_IDENTIFIERS:
+            elif k == CONF_DATA_ACT_IDENTIFIERS or k == "skoda_official_keys":
                 # #923/#1222 — mask the {VIN: portal-identifier} values, which
                 # the string branch below would otherwise pass through.
+                # #1286 — same shape for the Škoda official per-VIN key map
+                # ({VIN: {key, id, validUntil}}): mask each record (the ``key`` is a
+                # live credential) while keeping the masked-VIN count for triage.
                 scrubbed[sk] = _redact_identifier_map(v)
             else:
                 scrubbed[sk] = _scrub(v, gps_round=gps_round)

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b1"
+  "version": "4.7.0b2"
 }

--- a/tests/bruno/skoda/55_GET_single_trips.bru
+++ b/tests/bruno/skoda/55_GET_single_trips.bru
@@ -1,0 +1,59 @@
+meta {
+  name: GET single trips
+  type: http
+  seq: 55
+}
+
+get {
+  url: {{base_url}}/api/v1/trip-statistics/{{vin}}/single-trips?timezone=GMT
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{access_token}}
+}
+
+headers {
+  Accept: application/json
+}
+
+params:query {
+  timezone: GMT
+}
+
+docs {
+  v4.7.0b2 (#1310, indigomejor) - real per-TRIP records. The WEEK/MONTH/YEAR
+  /trip-statistics/{vin} overview returns a metric-hollow detailedStatistics
+  on combustion cars (only a date, no distance/speed/consumption), so
+  last_trip_* never populated. This single-trips endpoint is the ONLY source
+  carrying per-trip averageSpeedInKmph AND averageFuelConsumption. RE'd from
+  MySkoda 8.16 (cz.myskoda.api.bff.v1.TripStatisticsApi -> SingleTripDto).
+
+  Query params (all optional except path vin): timezone, cursor (pagination
+  via nextPageCursor), from/to (OffsetDateTime), tripType (PERSONAL|BUSINESS).
+
+  Response shape:
+    {
+      "dailyTrips": [
+        {
+          "date": "2026-09-06",
+          "overallMileage": 41,
+          "overallCost": { ... },
+          "trips": [
+            {
+              "id": "...", "startTime": "...", "endTime": "...",
+              "mileageInKm": 33, "travelTimeInMin": 40,
+              "averageSpeedInKmph": 49, "averageFuelConsumption": 5.8,
+              "startMileageInKm": 1012, "endMileageInKm": 1045
+            }
+          ]
+        }
+      ],
+      "nextPageCursor": "..."
+    }
+
+  Used by SkodaClient.get_status() -> _apply_single_trip() to fill
+  last_trip_distance_km / _duration_min / _avg_speed_kmh /
+  _avg_fuel_consumption_l_100km / _start_odometer_km from the most recent trip.
+}

--- a/tests/test_1286_skoda_official_key_redaction.py
+++ b/tests/test_1286_skoda_official_key_redaction.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1286 — the Škoda official public-API key is a credential and MUST be redacted.
+
+It leaked in PLAINTEXT in the diagnostics download users attach to public issues
+(a real ``msk_…`` key was exposed): neither the single manual key
+(``skoda_official_api_key``) nor the auto-enrolled per-VIN map
+(``skoda_official_keys``, ``{VIN: {key, id, validUntil}}``) was in the redaction set.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.diagnostics import _scrub
+
+_SECRET = "msk_409c1f3c3928_zzSECRETzz"
+_VIN = "TMBJJ7NE9L0123456"
+
+
+def test_single_manual_official_key_is_redacted():
+    out = _scrub({"skoda_official_api_key": _SECRET})
+    assert out["skoda_official_api_key"] == "**REDACTED**"
+    assert "SECRET" not in repr(out)
+
+
+def test_per_vin_official_key_map_masks_records_keeps_count():
+    data = {
+        "skoda_official_keys": {
+            _VIN: {"key": _SECRET, "id": "id1", "validUntil": "2027-03-01"},
+        }
+    }
+    out = _scrub(data)
+    m = out["skoda_official_keys"]
+    # one enrolled VIN still visible as a count, but the record (incl. the key) gone
+    assert len(m) == 1
+    assert list(m.values()) == ["**REDACTED**"]
+    assert "SECRET" not in repr(out)
+    assert "id1" not in repr(out)
+
+
+def test_no_official_secret_survives_a_full_entry_scrub():
+    entry_data = {
+        "brand": "skoda",
+        "skoda_official_api_key": _SECRET,
+        "skoda_official_keys": {_VIN: {"key": _SECRET + "2", "id": "i", "validUntil": "x"}},
+        "scan_interval": 10,
+    }
+    out = _scrub(dict(entry_data))
+    assert "SECRET" not in repr(out)
+    assert out["scan_interval"] == 10          # non-secret fields untouched
+    assert out["brand"] == "skoda"
+
+
+def test_empty_official_key_stays_visibly_empty():
+    # an unset key must not read as a fake redaction (triage needs the truth)
+    out = _scrub({"skoda_official_api_key": ""})
+    assert out["skoda_official_api_key"] == ""

--- a/tests/test_1310_single_trips.py
+++ b/tests/test_1310_single_trips.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1310 — last_trip_* from the mysmob single-trips endpoint.
+
+The WEEK/MONTH/YEAR trip-statistics overview returns a metric-hollow
+detailedStatistics on combustion cars (only a date), so last_trip_* never spawned
+(indigomejor). The single-trips endpoint carries genuine per-trip records
+(SingleTripDto with mileageInKm + travelTimeInMin + averageSpeedInKmph +
+averageFuelConsumption); _apply_single_trip picks the most recent and fills from it.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.api.skoda import _apply_single_trip
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def test_single_trip_fills_last_trip_from_most_recent():
+    payload = {"dailyTrips": [
+        {"date": "2026-09-05", "trips": [
+            {"endTime": "2026-09-05T08:00:00", "mileageInKm": 12, "travelTimeInMin": 20,
+             "averageSpeedInKmph": 36, "averageFuelConsumption": 6.1,
+             "startMileageInKm": 1000},
+        ]},
+        {"date": "2026-09-06", "trips": [  # newest day
+            {"endTime": "2026-09-06T07:00:00", "mileageInKm": 33, "travelTimeInMin": 40,
+             "averageSpeedInKmph": 49, "averageFuelConsumption": 5.8,
+             "startMileageInKm": 1012},
+            {"endTime": "2026-09-06T18:30:00", "mileageInKm": 8, "travelTimeInMin": 15,
+             "averageSpeedInKmph": 32, "averageFuelConsumption": 7.2,
+             "startMileageInKm": 1045},  # latest endTime within the newest day
+        ]},
+    ]}
+    d = VehicleData(vin="V")
+    _apply_single_trip(payload, d)
+    assert d.last_trip_distance_km == 8
+    assert d.last_trip_duration_min == 15
+    assert d.last_trip_avg_speed_kmh == 32
+    assert d.last_trip_avg_fuel_consumption_l_100km == 7.2
+    assert d.last_trip_start_odometer_km == 1045
+    assert d.last_trip_timestamp == "2026-09-06"
+
+
+def test_single_trip_partial_trip_fills_only_present_metrics():
+    d = VehicleData(vin="V")
+    _apply_single_trip({"dailyTrips": [{"date": "2026-09-06", "trips": [
+        {"endTime": "t", "mileageInKm": 33, "travelTimeInMin": 40}]}]}, d)
+    assert d.last_trip_distance_km == 33
+    assert d.last_trip_duration_min == 40
+    assert d.last_trip_avg_speed_kmh is None      # absent → stays None, no crash
+    assert d.last_trip_avg_fuel_consumption_l_100km is None
+
+
+def test_single_trip_tolerates_empty_or_missing():
+    d = VehicleData(vin="V")
+    for bad in (None, {}, {"dailyTrips": []}, {"dailyTrips": [{"date": "x", "trips": []}]},
+                {"dailyTrips": "nope"}, {"dailyTrips": [None, {"trips": None}]}):
+        _apply_single_trip(bad, d)
+    assert d.last_trip_distance_km is None

--- a/tests/test_skoda_official_api.py
+++ b/tests/test_skoda_official_api.py
@@ -121,6 +121,27 @@ def test_parse_hybrid_classification():
     assert d.combustion_range_km == 420
 
 
+def test_parse_suppresses_combustion_soc_fuel_mirror():
+    """#1310 (indigomejor) — on a combustion primary engine the backend mirrors the
+    fuel level into currentSoCInPercent, so the official channel must apply the same
+    guard as the mysmob path and NOT re-introduce the 12V=fuel mirror."""
+    # combustion, SoC == fuel → suppressed (it's the fuel duplicated, not a 12V SoC)
+    d = SkodaOfficialClient._parse_vehicle("V", {"fuelStatus": {"primaryEngineRange": {
+        "engineType": "GASOLINE", "currentFuelLevelInPercent": 92,
+        "currentSoCInPercent": 92}}})
+    assert d.fuel_level == 92
+    assert d.primary_engine_soc_pct is None
+    # combustion, SoC != fuel → a genuinely distinct value is kept
+    d2 = SkodaOfficialClient._parse_vehicle("V", {"fuelStatus": {"primaryEngineRange": {
+        "engineType": "DIESEL", "currentFuelLevelInPercent": 92,
+        "currentSoCInPercent": 55}}})
+    assert d2.primary_engine_soc_pct == 55
+    # electric primary → never a fuel mirror, kept unchanged
+    d3 = SkodaOfficialClient._parse_vehicle("V", {"fuelStatus": {"primaryEngineRange": {
+        "engineType": "ELECTRIC", "currentSoCInPercent": 80}}})
+    assert d3.primary_engine_soc_pct == 80
+
+
 def test_parse_tolerates_sparse_body():
     d = SkodaOfficialClient._parse_vehicle("V", {})
     assert d.vin == "V"


### PR DESCRIPTION
## Škoda: last-trip from per-trip data + fold the 4.6.2 security/fixes into the beta line (v4.7.0b2)

### Added — last-trip sensors now populate (bug A, #1310)
The last-trip distance / duration / average speed / average consumption weren't spawning on many Škoda cars. RE'd from MyŠkoda 8.16 (TripStatisticsApi), verified against raw smali:
- the `offsetType` enum on the `/trip-statistics` overview is WEEK / MONTH / YEAR only (no `day`), and its `detailedStatistics` per-entry metrics come back null on combustion cars — so no `offsetType` change ever populates last-trip;
- the real per-trip records live on `/trip-statistics/{vin}/single-trips` (`SingleTripDto` carries `mileageInKm` + `travelTimeInMin` + `averageSpeedInKmph` + `averageFuelConsumption` + start/endMileageInKm) — the only source with per-trip averages.

New `_apply_single_trip` fetches single-trips in the existing parallel batch and fills `last_trip_*` from the most recent trip (latest day, then latest endTime).

### Carried from 4.6.2 (so beta users get them too)
- **Security** — redact the Škoda official API key in diagnostics: `skoda_official_api_key` and the per-VIN `skoda_official_keys` map were leaking a live `msk_` key in plaintext in the diagnostics download (#1286).
- **Fixed** — the official channel no longer re-introduces the combustion 12V = fuel mirror (reuses the `_primary_soc_or_none` guard) (#1310).

### Corrected b1 framing
Field testing (@indigomejor, @n3roGit) showed the app-identity headers fix the empty key **list** (`vins=0` → `1`), not the create-400 — that was the key **name**, already fixed in 4.6.1. Headers stay.

### Verification
Full suite **5682 passed, 15 skipped**; new tests for single-trips parsing, the official-key redaction, and the 12V-mirror guard. ruff + mypy-strict clean.

Ships as prerelease `v4.7.0b2`.
