### PR TITLE
v4.7.0b3 — Škoda: clear the stored official API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b3] - 2026-09-02 — Škoda: clear the stored official API key from the options
+
+### Added
+- **Škoda: a switch to clear the stored official API key.** If you rotate or delete your
+  official API key (for example after it was exposed), you can now remove it from the
+  integration too. A **"Clear the stored Škoda official API key"** switch appears in the
+  integration's options when a key is stored — ticking it and submitting wipes both the
+  manually-entered key and the auto-enrolled per-car key(s). A native MyŠkoda login then
+  mints a fresh key automatically on the next update, so the official channel keeps
+  working with a clean key. Until now an auto-enrolled key had no removal control in the
+  UI (#1286). All 12 languages.
+
 ## [4.7.0b2] - 2026-09-02 — Škoda: last-trip sensors from real per-trip data · carries the 4.6.2 security + fixes
 
 ### Added

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -2084,6 +2084,25 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                 # (see the entry.options trap) then kept the stale value — so a
                 # per-VIN S-PIN could never be removed once set (#759 follow-up).
                 user_input[CONF_SPIN_BY_VIN] = _by_vin
+            # Škoda: "clear stored official API key" wipes the manual key AND the
+            # per-VIN auto-enrolled map here, so a rotated or exposed key can be
+            # removed from the integration (#1286, n3roGit) — until now there was no
+            # way to remove an auto-enrolled key. A native login then auto-creates a
+            # fresh one on the next update. Takes precedence over the key fields on
+            # the same submit, so a re-save with the key still pre-filled clears.
+            from .const import (  # noqa: PLC0415
+                CONF_SKODA_OFFICIAL_API_KEY,
+                CONF_SKODA_OFFICIAL_KEYS,
+            )
+            _clear_official = bool(user_input.pop("clear_skoda_official_key", False))
+            if _clear_official:
+                user_input[CONF_SKODA_OFFICIAL_API_KEY] = ""
+                user_input[CONF_SKODA_OFFICIAL_KEYS] = {}
+                for _kk in [
+                    k for k in list(user_input.keys())
+                    if k.startswith(f"{CONF_SKODA_OFFICIAL_KEYS}_")
+                ]:
+                    user_input.pop(_kk, None)
             # Škoda per-VIN official API keys — fold the transient
             # skoda_official_keys_<VIN> fields into the CONF_SKODA_OFFICIAL_KEYS
             # map {VIN: {"key": ...}}. Keys are VIN-bound, so this lets a multi-car
@@ -2093,8 +2112,8 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
             # recreate, and a password field may render blank on reopen, so
             # blanking must never silently delete a saved key. Start from the stored
             # map so untouched VINs (incl. auto-enrolled ones) are preserved.
-            from .const import CONF_SKODA_OFFICIAL_KEYS  # noqa: PLC0415
-            _off_fields = [
+            # Skipped entirely when the clear switch above fired.
+            _off_fields = [] if _clear_official else [
                 _k for _k in list(user_input.keys())
                 if _k.startswith(f"{CONF_SKODA_OFFICIAL_KEYS}_")
             ]
@@ -2481,6 +2500,27 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                     current_data.get(CONF_SKODA_OFFICIAL_API_KEY, ""),
                 )),
             )] = _PASSWORD_SELECTOR
+            # #1286 (n3roGit) — a switch to clear the stored official API key(s): the
+            # manual key AND the auto-enrolled per-VIN map. Until now an auto-enrolled
+            # key could not be removed from the UI. Shown only when a key is actually
+            # stored. Ticking it + submitting wipes them here (a native login then
+            # auto-mints a fresh one on the next update). Default off.
+            from .const import CONF_SKODA_OFFICIAL_KEYS  # noqa: PLC0415
+            _has_official = bool(
+                current_options.get(
+                    CONF_SKODA_OFFICIAL_API_KEY,
+                    current_data.get(CONF_SKODA_OFFICIAL_API_KEY, ""),
+                )
+            ) or bool(
+                current_options.get(
+                    CONF_SKODA_OFFICIAL_KEYS,
+                    current_data.get(CONF_SKODA_OFFICIAL_KEYS),
+                )
+            )
+            if _has_official:
+                schema[vol.Optional(
+                    "clear_skoda_official_key", default=False,
+                )] = _BOOL_SELECTOR
         # v2.17.5 (#759) — one optional S-PIN field per known VIN, shown only
         # when the account has more than one vehicle (each may carry its own
         # S-PIN). Empty leaves that vehicle on the shared CONF_SPIN above; values

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b2"
+  "version": "4.7.0b3"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: read odometer and service from Vehicle Health (navigates the app)",
           "companion_read_climate_detail": "Companion: read target and outside temperature (navigates the app)",
           "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)",
-          "skoda_official_api_key": "Škoda official API key — adds the official manufacturer API as a live data source (and failover)"
+          "skoda_official_api_key": "Škoda official API key — adds the official manufacturer API as a live data source (and failover)",
+          "clear_skoda_official_key": "Clear the stored Škoda official API key (a fresh one is created automatically if your login supports it)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: číst stav tachometru a servis ze stavu vozidla (naviguje v aplikaci)",
           "companion_read_climate_detail": "Companion: číst cílovou a venkovní teplotu (naviguje v aplikaci)",
           "companion_read_parking_position": "Companion: číst pozici parkování z odkazu pro sdílení v aplikaci (naviguje v aplikaci)",
-          "skoda_official_api_key": "Oficiální klíč API Škoda — přidá oficiální API výrobce jako živý zdroj dat (a zálohu)"
+          "skoda_official_api_key": "Oficiální klíč API Škoda — přidá oficiální API výrobce jako živý zdroj dat (a zálohu)",
+          "clear_skoda_official_key": "Vymazat uložený oficiální klíč API Škoda (nový se vytvoří automaticky, pokud to vaše přihlášení podporuje)"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: læs kilometerstand og service fra køretøjstjek (navigerer i appen)",
           "companion_read_climate_detail": "Companion: læs måltemperatur og udetemperatur (navigerer i appen)",
           "companion_read_parking_position": "Companion: læs parkeringsposition fra appens delingslink (navigerer i appen)",
-          "skoda_official_api_key": "Officiel Škoda API-nøgle — tilføjer den officielle producent-API som live datakilde (og failover)"
+          "skoda_official_api_key": "Officiel Škoda API-nøgle — tilføjer den officielle producent-API som live datakilde (og failover)",
+          "clear_skoda_official_key": "Ryd den gemte officielle Škoda API-nøgle (en ny oprettes automatisk, hvis dit login understøtter det)"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: Kilometerstand und Service aus dem Fahrzeugcheck lesen (navigiert in der App)",
           "companion_read_climate_detail": "Companion: Solltemperatur und Außentemperatur lesen (navigiert in der App)",
           "companion_read_parking_position": "Companion: Parkposition aus dem Teilen-Link der App lesen (navigiert in der App)",
-          "skoda_official_api_key": "Offizieller Škoda-API-Schlüssel — nutzt die offizielle Hersteller-API als Live-Datenquelle (und Failover)"
+          "skoda_official_api_key": "Offizieller Škoda-API-Schlüssel — nutzt die offizielle Hersteller-API als Live-Datenquelle (und Failover)",
+          "clear_skoda_official_key": "Gespeicherten offiziellen Škoda-API-Schlüssel löschen (ein neuer wird automatisch erstellt, falls dein Login das unterstützt)"
         },
         "data_description": {
           "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: read odometer and service from Vehicle Health (navigates the app)",
           "companion_read_climate_detail": "Companion: read target and outside temperature (navigates the app)",
           "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)",
-          "skoda_official_api_key": "Škoda official API key — adds the official manufacturer API as a live data source (and failover)"
+          "skoda_official_api_key": "Škoda official API key — adds the official manufacturer API as a live data source (and failover)",
+          "clear_skoda_official_key": "Clear the stored Škoda official API key (a fresh one is created automatically if your login supports it)"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: leer cuentakilómetros y servicio desde el estado del vehículo (navega por la app)",
           "companion_read_climate_detail": "Companion: leer temperatura objetivo y exterior (navega por la app)",
           "companion_read_parking_position": "Companion: leer la posición de aparcamiento desde el enlace para compartir de la app (navega por la app)",
-          "skoda_official_api_key": "Clave API oficial de Škoda — añade la API oficial del fabricante como fuente de datos en vivo (y conmutación por error)"
+          "skoda_official_api_key": "Clave API oficial de Škoda — añade la API oficial del fabricante como fuente de datos en vivo (y conmutación por error)",
+          "clear_skoda_official_key": "Borrar la clave API oficial de Škoda guardada (se crea una nueva automáticamente si tu inicio de sesión lo permite)"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: lue mittarilukema ja huolto ajoneuvon kunnosta (navigoi sovelluksessa)",
           "companion_read_climate_detail": "Companion: lue tavoite- ja ulkolämpötila (navigoi sovelluksessa)",
           "companion_read_parking_position": "Companion: lue pysäköintipaikka sovelluksen jakolinkistä (navigoi sovelluksessa)",
-          "skoda_official_api_key": "Virallinen Škoda-API-avain — lisää valmistajan virallisen API:n live-tietolähteeksi (ja vikasietona)"
+          "skoda_official_api_key": "Virallinen Škoda-API-avain — lisää valmistajan virallisen API:n live-tietolähteeksi (ja vikasietona)",
+          "clear_skoda_official_key": "Tyhjennä tallennettu virallinen Škoda-API-avain (uusi luodaan automaattisesti, jos kirjautumisesi tukee sitä)"
         },
         "data_description": {
           "scan_interval": "Kuinka usein tietoja haetaan (minuutteja). Vähintään: 3.",

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion : lire le kilométrage et l'entretien dans l'état du véhicule (navigue dans l'app)",
           "companion_read_climate_detail": "Companion : lire la température de consigne et extérieure (navigue dans l'app)",
           "companion_read_parking_position": "Companion : lire la position de stationnement depuis le lien de partage de l'app (navigue dans l'app)",
-          "skoda_official_api_key": "Clé API officielle Škoda — ajoute l'API officielle du constructeur comme source de données en direct (et bascule)"
+          "skoda_official_api_key": "Clé API officielle Škoda — ajoute l'API officielle du constructeur comme source de données en direct (et bascule)",
+          "clear_skoda_official_key": "Effacer la clé API officielle Škoda enregistrée (une nouvelle est créée automatiquement si votre connexion le permet)"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: leggi contachilometri e tagliando da Vehicle Health (naviga nell'app)",
           "companion_read_climate_detail": "Companion: leggi temperatura impostata ed esterna (naviga nell'app)",
           "companion_read_parking_position": "Companion: leggi la posizione di parcheggio dal link di condivisione dell'app (naviga nell'app)",
-          "skoda_official_api_key": "Chiave API ufficiale Škoda — aggiunge l'API ufficiale del costruttore come fonte dati in tempo reale (e failover)"
+          "skoda_official_api_key": "Chiave API ufficiale Škoda — aggiunge l'API ufficiale del costruttore come fonte dati in tempo reale (e failover)",
+          "clear_skoda_official_key": "Cancella la chiave API ufficiale Škoda memorizzata (ne viene creata una nuova automaticamente se il tuo accesso lo consente)"
         },
         "data_description": {
           "scan_interval": "Con quale frequenza vengono recuperati i dati (minuti). Minimo: 3.",

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: les kilometerstand og service fra kjøretøysjekk (navigerer i appen)",
           "companion_read_climate_detail": "Companion: les måltemperatur og utetemperatur (navigerer i appen)",
           "companion_read_parking_position": "Companion: les parkeringsposisjon fra appens delingslenke (navigerer i appen)",
-          "skoda_official_api_key": "Offisiell Škoda API-nøkkel — legger til produsentens offisielle API som live datakilde (og failover)"
+          "skoda_official_api_key": "Offisiell Škoda API-nøkkel — legger til produsentens offisielle API som live datakilde (og failover)",
+          "clear_skoda_official_key": "Fjern den lagrede offisielle Škoda API-nøkkelen (en ny opprettes automatisk hvis påloggingen din støtter det)"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: kilometerstand en onderhoud uit de voertuigcheck lezen (navigeert in de app)",
           "companion_read_climate_detail": "Companion: streef- en buitentemperatuur lezen (navigeert in de app)",
           "companion_read_parking_position": "Companion: parkeerpositie uit de deellink van de app lezen (navigeert in de app)",
-          "skoda_official_api_key": "Officiële Škoda API-sleutel — voegt de officiële fabrikant-API toe als live databron (en failover)"
+          "skoda_official_api_key": "Officiële Škoda API-sleutel — voegt de officiële fabrikant-API toe als live databron (en failover)",
+          "clear_skoda_official_key": "Wis de opgeslagen officiële Škoda API-sleutel (er wordt automatisch een nieuwe aangemaakt als je login dit ondersteunt)"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: odczyt przebiegu i serwisu ze stanu pojazdu (nawiguje po aplikacji)",
           "companion_read_climate_detail": "Companion: odczyt temperatury zadanej i zewnętrznej (nawiguje po aplikacji)",
           "companion_read_parking_position": "Companion: odczyt pozycji parkowania z linku udostępniania w aplikacji (nawiguje po aplikacji)",
-          "skoda_official_api_key": "Oficjalny klucz API Škoda — dodaje oficjalne API producenta jako źródło danych na żywo (i przełączanie awaryjne)"
+          "skoda_official_api_key": "Oficjalny klucz API Škoda — dodaje oficjalne API producenta jako źródło danych na żywo (i przełączanie awaryjne)",
+          "clear_skoda_official_key": "Wyczyść zapisany oficjalny klucz API Škoda (nowy zostanie utworzony automatycznie, jeśli Twoje logowanie to obsługuje)"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -243,7 +243,8 @@
           "companion_read_vehicle_health": "Companion: läs mätarställning och service från fordonsstatus (navigerar i appen)",
           "companion_read_climate_detail": "Companion: läs börtemperatur och utetemperatur (navigerar i appen)",
           "companion_read_parking_position": "Companion: läs parkeringsposition från appens delningslänk (navigerar i appen)",
-          "skoda_official_api_key": "Officiell Škoda API-nyckel — lägger till tillverkarens officiella API som live-datakälla (och failover)"
+          "skoda_official_api_key": "Officiell Škoda API-nyckel — lägger till tillverkarens officiella API som live-datakälla (och failover)",
+          "clear_skoda_official_key": "Rensa den lagrade officiella Škoda API-nyckeln (en ny skapas automatiskt om din inloggning stöder det)"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",

--- a/tests/test_skoda_official_per_vin_keys.py
+++ b/tests/test_skoda_official_per_vin_keys.py
@@ -17,6 +17,7 @@ from custom_components.vag_connect.config_flow import VagConnectOptionsFlow
 from custom_components.vag_connect.const import (
     CONF_BRAND,
     CONF_SCAN_INTERVAL,
+    CONF_SKODA_OFFICIAL_API_KEY,
     CONF_SKODA_OFFICIAL_KEYS,
 )
 
@@ -110,6 +111,39 @@ def test_submit_blank_keeps_existing_and_preserves_auto_enrolled():
         VIN_A: {"key": "auto_a", "id": "id1", "validUntil": "2027-01-01"},
         VIN_B: {"key": "msk_bbb", "source": "manual"},
     }
+
+
+def test_clear_official_key_wipes_manual_and_map():
+    # #1286 — the clear switch removes BOTH the manual key and the auto-enrolled map
+    entry = _skoda_entry(
+        data={
+            CONF_SKODA_OFFICIAL_API_KEY: "msk_manual",
+            CONF_SKODA_OFFICIAL_KEYS: {VIN_A: {"key": "msk_auto", "id": "i"}},
+        },
+    )
+    save = _submit(
+        VagConnectOptionsFlow(entry),
+        {
+            CONF_SCAN_INTERVAL: 15,
+            CONF_SKODA_OFFICIAL_API_KEY: "msk_manual",  # pre-filled, still submitted
+            "clear_skoda_official_key": True,
+        },
+    )
+    data = save.call_args.kwargs["data"]
+    assert data[CONF_SKODA_OFFICIAL_API_KEY] == ""      # manual key wiped
+    assert data[CONF_SKODA_OFFICIAL_KEYS] == {}         # auto-enrolled map wiped
+    assert "clear_skoda_official_key" not in data       # transient switch popped
+
+
+def test_clear_toggle_renders_only_when_a_key_is_stored():
+    with_key = _skoda_entry(
+        data={CONF_SKODA_OFFICIAL_API_KEY: "msk_x"}, vehicles={VIN_A: {"vin": VIN_A}}
+    )
+    r1 = asyncio.run(VagConnectOptionsFlow(with_key).async_step_init(None))
+    assert "clear_skoda_official_key" in {str(k) for k in r1["data_schema"].schema}
+    no_key = _skoda_entry(vehicles={VIN_A: {"vin": VIN_A}})
+    r2 = asyncio.run(VagConnectOptionsFlow(no_key).async_step_init(None))
+    assert "clear_skoda_official_key" not in {str(k) for k in r2["data_schema"].schema}
 
 
 def test_submit_typed_key_overrides_existing_and_drops_stale_id():


### PR DESCRIPTION
## Škoda: clear the stored official API key from the options (#1286)

@n3roGit rotated an exposed official API key in the MyŠkoda app but had no way to remove it from the integration — the manual key could be blanked in the options, but an auto-enrolled per-VIN key had no removal control.

A new **"Clear the stored Škoda official API key"** switch (shown only when a key is stored) wipes both the manually-entered key (`CONF_SKODA_OFFICIAL_API_KEY`) and the auto-enrolled per-car map (`CONF_SKODA_OFFICIAL_KEYS`) on submit, taking precedence over the key fields on the same save. A native MyŠkoda login then mints a fresh key automatically on the next update, so the official channel keeps working with a clean key.

### Verification
Full suite **5684 passed, 15 skipped**; 2 new tests (clear wipes both stores; the switch renders only when a key is stored). ruff + mypy-strict clean. Label in all 12 languages.

Ships as prerelease `v4.7.0b3`.
