### PR TITLE
v4.7.0b5 — EU Data Act auto-request fix, portal observability, Škoda source mode, acpp tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   portal ever actually provides one. **Live-verified end-to-end**: the create now returns success
   and the 15-minute request appears on the account. Thanks @steemandavid for the diagnosis
   (#709, #966, #1273).
+- **Audi plug&play (OBD dongle): the car's location now always gets a map tracker.** The
+  dongle only reports GPS from its last parked snapshot, so the position comes and goes
+  between drives — and the device tracker could fail to appear (or get purged during a
+  gap), leaving the location unbound. It's now created unconditionally for plug&play
+  entries, the same way the volkswagen.de channel already is, so the car stays on the map
+  (reading unavailable between fixes).
 
 ### Added
 - **Diagnostic sensors that show what the EU Data Act portal feed is actually doing**, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b5] - 2026-09-02 — EU Data Act: the automatic data request actually gets created now
+
+### Fixed
+- **The automatic EU Data Act data-request creation was silently giving up on every account — now it goes through.**
+  Getting a car onto the portal feed depends on the integration creating a "continuous 15-minute"
+  data request for you (and the one-time historical export works the same way). Both were bailing
+  out *before ever sending the request*: they waited for a security token from the portal's older
+  page layer, and that token now comes back empty for everyone — so they waited forever and no feed
+  was ever created. The car just stayed empty, with nothing in the log but "no CSRF token". Turns
+  out the portal's data-request API is authenticated by your logged-in session, not by that token
+  at all. The request is now sent on your session directly; the token is only attached if the
+  portal ever actually provides one. **Live-verified end-to-end**: the create now returns success
+  and the 15-minute request appears on the account. Thanks @steemandavid for the diagnosis
+  (#709, #966, #1273).
+
 ## [4.7.0b4] - 2026-09-02 — EU Data Act: clearer "no vehicle data yet" guidance (carries 4.6.3)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
-## [4.7.0b5] - 2026-09-02 — EU Data Act: the automatic data request actually gets created now
+## [4.7.0b5] - 2026-09-02 — EU Data Act: the data request actually gets created + portal-feed observability
 
 ### Fixed
 - **The automatic EU Data Act data-request creation was silently giving up on every account — now it goes through.**
@@ -56,6 +56,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   portal ever actually provides one. **Live-verified end-to-end**: the create now returns success
   and the 15-minute request appears on the account. Thanks @steemandavid for the diagnosis
   (#709, #966, #1273).
+
+### Added
+- **Diagnostic sensors that show what the EU Data Act portal feed is actually doing**, so a
+  quiet car stops being a mystery. **Portal feed health** now tells a genuine VW-side portal
+  outage ("Portal error") apart from a request that simply isn't delivering yet, and names a
+  healthy feed **Live**. Plus four new per-car diagnostic sensors (portal-read cars only):
+  **Data request created** (when your continuous request was set up), **Last snapshot
+  received**, **Last no-data poll**, and **No-data polls** (how often the portal came back
+  empty). Thanks @HA28320 and @riteman for the feed samples that made this concrete
+  (#465, #1273). All 12 languages.
 
 ## [4.7.0b4] - 2026-09-02 — EU Data Act: clearer "no vehicle data yet" guidance (carries 4.6.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   received**, **Last no-data poll**, and **No-data polls** (how often the portal came back
   empty). Thanks @HA28320 and @riteman for the feed samples that made this concrete
   (#465, #1273). All 12 languages.
+- **Škoda: choose how the official manufacturer API is used.** A new per-car option
+  ("Škoda official-API source mode") lets you pick: **Automatic** (both channels, the
+  official API's readings preferred — the default, unchanged); **Prefer the official
+  API**; **Official API as failover only**; **Official API only** (turn the standard
+  channel off); or **Standard channel only** (turn the official API off entirely). So if
+  you'd rather not lean on the reverse-engineered channel — or would rather not use the
+  official one — it's a switch now instead of automatic. Thanks @n3roGit (#1286). All 12
+  languages.
 
 ## [4.7.0b4] - 2026-09-02 — EU Data Act: clearer "no vehicle data yet" guidance (carries 4.6.3)
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -310,6 +310,15 @@ class SkodaClient(CariadBaseClient):
         # AND as the hard-failure failover. Rate-limited to 20 req/hour/key, so both
         # read paths go through _official_read_rate_safe, which self-skips at quota.
         self._supplementary_official: Any = None
+        # #1286 — Škoda official-API source mode, pushed by the coordinator from
+        # CONF_SKODA_OFFICIAL_MODE. Only "official_only" changes THIS client's read
+        # routing (get_status below); the other modes are enforced coordinator-side
+        # (merge / failover / auto-enrol gating). Default "auto".
+        self._official_mode: str = "auto"
+
+    def set_official_mode(self, mode: str) -> None:
+        """Set the Škoda official-API source mode (CONF_SKODA_OFFICIAL_MODE)."""
+        self._official_mode = str(mode or "auto")
 
     def arm_supplementary_official(
         self, api_key: str = "", keys_by_vin: dict[str, str] | None = None,
@@ -1101,6 +1110,15 @@ class SkodaClient(CariadBaseClient):
                     await portal.login(self._email, self._password)
                 data = await portal.get_vehicle_data(vin)
             return data
+        # #1286 — "official_only" source mode: read the manufacturer public API as
+        # the PRIMARY source instead of the mysmob backend. Per-VIN degrade: if this
+        # car has no official key / the read is unavailable (rate-limited, quota,
+        # error), _official_read_rate_safe returns None and we fall through to the
+        # normal mysmob read rather than blanking the car.
+        if self._official_mode == "official_only":
+            off = await self._official_read_rate_safe(vin)
+            if off is not None:
+                return off
         v = self._val
         d = VehicleData(vin=vin)
 

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -1115,7 +1115,7 @@ class SkodaClient(CariadBaseClient):
         # car has no official key / the read is unavailable (rate-limited, quota,
         # error), _official_read_rate_safe returns None and we fall through to the
         # normal mysmob read rather than blanking the car.
-        if self._official_mode == "official_only":
+        if getattr(self, "_official_mode", "auto") == "official_only":
             off = await self._official_read_rate_safe(vin)
             if off is not None:
                 return off

--- a/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
@@ -831,22 +831,25 @@ class DataActScraper:
         deliver one. CSRF expires per-session so callers re-fetch
         before every POST that needs it.
 
-        v2.18.0 (#709) — every failure here used to return a bare None, and
-        the caller logged "no CSRF token - aborting" with no reason. That made
-        the whole kickoff undiagnosable: a reporter hands us a debug log and it
-        says the token is missing, without saying whether the portal answered
-        403 (session gone), 404 (the path moved), timed out, or simply started
-        naming the token something else. No CSRF means no data request, which
-        means no data at all — so this is the one failure we most need to be
-        able to read, and it was the one that told us the least.
+        v2.18.0 (#709) — every failure here used to return a bare None with no
+        reason, which made the kickoff undiagnosable: a reporter's log said the
+        token was missing without saying whether the portal answered 403 (session
+        gone), 404 (the path moved), timed out, or renamed the field. The detailed
+        logging below stays because that visibility is still worth having.
 
-        Worth knowing: _CSRF_TOKEN_PATH is an Adobe AEM endpoint
-        (/libs/granite/...). The portal is AEM-backed, so if VW ever moves off
-        it or renames the field, this goes silent for every single user at once
-        — and the log below is what would tell us which of those it was.
+        IMPORTANT (live-verified 2026-09-02): a missing token here NO LONGER
+        blocks anything, and the callers no longer abort on it. _CSRF_TOKEN_PATH
+        is an Adobe AEM endpoint (/libs/granite/...) that returns an empty body
+        with x-sky-isauth:0 for EVERY session — even a real logged-in browser — so
+        it never yields a token. The data-request POSTs (kickoff_custom_data_
+        request / kickoff_historical_export) do not need it: they go to the
+        /proxy_api/euda-apim layer, which authenticates via the session COOKIES (a
+        cookie-only POST with no CSRF header reaches the portal's own validation,
+        HTTP 400 "Invalid Duration", i.e. it authenticated). So the callers fetch
+        this best-effort and proceed regardless; a token is attached only if this
+        method ever starts returning one — forward-compat for a future portal
+        build that re-enables the Granite leg.
         """
-        from aiohttp import ClientTimeout  # noqa: PLC0415
-
         url = _PORTAL_BASE + _CSRF_TOKEN_PATH
         token, anonymous_at_aem = await self._csrf_get(url)
         if token is not None:
@@ -857,33 +860,71 @@ class DataActScraper:
             # warns about). Loading the page helps with neither, so stop here
             # and let the log above stand as the diagnosis.
             return None
-        # Empty body + anonymous at AEM: the AEM leg of the session is missing
-        # or lapsed while the proxy leg still works. Load the portal page once,
-        # exactly as a browser does, then retry. Best-effort — if the AEM leg
-        # cannot be revived from the cookies we hold, this simply fails again
-        # and the log above has already recorded why.
+        # Empty body + anonymous at AEM: the AEM leg of the session is missing or
+        # lapsed while the proxy leg still works. Revive it browser-style, then
+        # retry. Best-effort — if the AEM leg cannot be revived from the cookies we
+        # hold, this simply fails again and the log above has already recorded why.
+        #
+        # #1273 (steemandavid): the portal page GET can land HTTP 200 yet leave the
+        # AEM leg anonymous (x-sky-isauth stays 0) — loading /de/en/user.html alone
+        # does not complete the AEM SSO handoff on every account. So try TWO revive
+        # endpoints in turn — the user page, then the AEM permission-check service —
+        # re-fetching the token after each. _aem_revive_get logs the landing URL,
+        # the response's x-sky-isauth, and any Set-Cookie NAMES, so a reporter's
+        # diagnostics show exactly which leg (if any) completed the handoff.
         _LOGGER.debug(
             "CSRF token fetch: session is anonymous at the AEM layer — "
-            "loading %s once to try to revive it", _AEM_SESSION_PAGE_PATH,
+            "attempting to revive it (%s, then %s)",
+            _AEM_SESSION_PAGE_PATH, _AEM_PERMISSION_CHECK_PATH,
         )
+        for path in (_AEM_SESSION_PAGE_PATH, _AEM_PERMISSION_CHECK_PATH):
+            await self._aem_revive_get(path)
+            token, _ = await self._csrf_get(url)
+            if token is not None:
+                return token
+        return token
+
+    async def _aem_revive_get(self, path: str) -> None:
+        """Best-effort AEM-session revive: GET one portal path browser-style (follow
+        redirects) and log what it did — the landing URL, HTTP status, the response's
+        ``x-sky-isauth``, and the NAMES of any cookies it set. Never raises.
+
+        #1273 — loading the user page alone doesn't always complete the AEM SSO
+        handoff, so callers try more than one path. The Set-Cookie NAMES (values are
+        never logged) and the landing URL are what a reporter's diagnostics need to
+        show whether a leg actually re-authenticated the AEM tier, so the real fix
+        can be built from real data rather than guessed."""
+        from aiohttp import ClientTimeout  # noqa: PLC0415
+
         try:
             async with self._session.get(
-                _PORTAL_BASE + _AEM_SESSION_PAGE_PATH,
+                _PORTAL_BASE + path,
                 timeout=ClientTimeout(total=15),
                 allow_redirects=True,
             ) as page:
+                hdrs = getattr(page, "headers", {})
+                try:
+                    # getall is a CIMultiDict method (real aiohttp headers); the
+                    # {} fallback / a plain dict has no getall → AttributeError,
+                    # caught just below. type: ignore because mypy only sees the
+                    # dict arm of the union and can't know the guard handles it.
+                    cookie_names = [
+                        c.split("=", 1)[0].strip()
+                        for c in hdrs.getall("Set-Cookie", [])  # type: ignore[union-attr]
+                    ]
+                except (AttributeError, TypeError):
+                    cookie_names = []
                 _LOGGER.debug(
-                    "CSRF token fetch: portal page GET landed %s (HTTP %s)",
-                    str(page.url).split("?")[0][:100], page.status,
+                    "AEM revive GET %s → landed %s (HTTP %s) | x-sky-isauth=%s | "
+                    "set-cookie names: %s",
+                    path, str(page.url).split("?")[0][:100], page.status,
+                    hdrs.get("x-sky-isauth", "absent"),
+                    cookie_names or "none",
                 )
         except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "CSRF token fetch: portal page GET raised %s: %s",
-                type(exc).__name__, exc,
+                "AEM revive GET %s raised %s: %s", path, type(exc).__name__, exc,
             )
-            return None
-        token, _ = await self._csrf_get(url)
-        return token
 
     async def _csrf_get(self, url: str) -> tuple[str | None, bool]:
         """One CSRF fetch → ``(token, anonymous_at_aem)``.
@@ -1034,12 +1075,21 @@ class DataActScraper:
         import secrets as _secrets  # noqa: PLC0415
         from datetime import datetime, timedelta, timezone  # noqa: PLC0415
 
+        # The euda-apim data-request layer (Azure APIM behind /proxy_api) is
+        # authenticated by the portal SESSION COOKIES, not the Adobe-AEM Granite
+        # CSRF token. That AEM endpoint (_fetch_csrf_token → /libs/granite/csrf/
+        # token.json) returns an empty body with x-sky-isauth:0 for EVERY session,
+        # even a real logged-in browser (live-verified 2026-09-02) — so it can
+        # never yield a token, and the portal's own create call does not use one.
+        # Proof: a cookie-only POST with NO CSRF header reaches the portal's own
+        # Duration validation (HTTP 400 "Invalid Duration"), i.e. the request
+        # authenticated. Gating the kickoff on that always-empty token is why the
+        # auto-kickoff silently did nothing on every account (#709/#966): it
+        # aborted here before ever POSTing. Fetch it best-effort (a future portal
+        # build might expose it, and it is one cheap GET) but do NOT abort when it
+        # is absent; the POST below sends the header only when we actually have a
+        # token.
         csrf = await self._fetch_csrf_token()
-        if not csrf:
-            _LOGGER.debug(
-                "kickoff_custom_data_request: no CSRF token - aborting"
-            )
-            return None
 
         identifier = _secrets.token_hex(16)  # 32 chars
         now = datetime.now(timezone.utc).replace(microsecond=0)
@@ -1091,22 +1141,27 @@ class DataActScraper:
         url = _PORTAL_BASE + _CUSTOM_REQUEST_POST_PATH.format(vin=vin)
         for index, (duration, days) in enumerate(attempts):
             last = index == len(attempts) - 1
+            headers = {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                # Required by the euda-apim layer (see metadata GET above);
+                # without it the POST 503s at the AEM edge. Fresh per attempt.
+                "traceId": uuid.uuid4().hex,
+            }
+            if csrf:
+                # Best-effort: the Granite CSRF clientlib would set this on a
+                # same-origin non-GET, but /libs/granite/csrf/token.json is
+                # anonymous for everyone, so this branch is currently unreachable.
+                # Sent only when actually present (never as an empty string) so a
+                # future portal build that starts issuing a token keeps working.
+                # ``X-CSRF-Token`` was ours, and is not a thing here.
+                headers["CSRF-Token"] = csrf
             try:
                 async with self._session.post(
                     url,
                     json=_body(duration, days),
                     timeout=ClientTimeout(total=30),
-                    headers={
-                        "Accept": "application/json",
-                        "Content-Type": "application/json",
-                        # The portal's own Granite CSRF clientlib sets exactly
-                        # this one header on every non-GET same-origin request.
-                        # ``X-CSRF-Token`` was ours, and is not a thing here.
-                        "CSRF-Token": csrf,
-                        # Required by the euda-apim layer (see metadata GET
-                        # above); without it the POST 503s at the AEM edge.
-                        "traceId": uuid.uuid4().hex,
-                    },
+                    headers=headers,
                 ) as resp:
                     if resp.status == 401:
                         raise DataActSessionExpiredError(
@@ -1195,10 +1250,14 @@ class DataActScraper:
         from aiohttp import ClientTimeout  # noqa: PLC0415
         from datetime import datetime, timezone  # noqa: PLC0415
 
+        # Same story as kickoff_custom_data_request above: this POST goes to the
+        # same /proxy_api/euda-apim layer (requests/all), authenticated by the
+        # portal SESSION COOKIES — not the Adobe-AEM Granite CSRF token, which is
+        # anonymous/empty for every session (live-verified 2026-09-02). Fetch it
+        # best-effort but do NOT abort when it is absent; that abort silently
+        # blocked every one-time export too. The header below is sent only when a
+        # token actually exists.
         csrf = await self._fetch_csrf_token()
-        if not csrf:
-            _LOGGER.debug("kickoff_historical_export: no CSRF token - aborting")
-            return False
 
         # The browser sends millisecond precision (…:46.111Z); match it.
         now = datetime.now(timezone.utc)
@@ -1212,22 +1271,26 @@ class DataActScraper:
             "EmailFrequency": None,
         }
         url = _PORTAL_BASE + _ALL_REQUEST_POST_PATH.format(vin=vin)
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            # Origin is what the browser sends on this POST.
+            "Origin": _PORTAL_BASE,
+            # Required by the euda-apim edge; without it the POST 503s.
+            "traceId": uuid.uuid4().hex,
+        }
+        if csrf:
+            # Best-effort only — the AEM CSRF endpoint is anonymous for everyone,
+            # so this is currently unreachable; sent when present so a future
+            # portal build that issues a token keeps working. One header, matching
+            # the portal's own CSRF clientlib.
+            headers["CSRF-Token"] = csrf
         try:
             async with self._session.post(
                 url,
                 json=body,
                 timeout=ClientTimeout(total=30),
-                headers={
-                    "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    # Origin is what the browser sends on this POST; CSRF/traceId
-                    # are carried defensively (the requests/partial POST proves
-                    # the AEM edge accepts them).
-                    "Origin": _PORTAL_BASE,
-                    # One header, matching the portal's own CSRF clientlib.
-                    "CSRF-Token": csrf,
-                    "traceId": uuid.uuid4().hex,
-                },
+                headers=headers,
             ) as resp:
                 if resp.status == 401:
                     raise DataActSessionExpiredError(

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -138,7 +138,52 @@ _TRANSIENT_STATUSES = (400, 404, 410, 429, 500, 502, 503, 504)
 # stable state and return "no data" immediately, so we don't add latency to
 # the common not-set-up case.
 _RETRIABLE_STATUSES = frozenset({500, 502, 503, 504})
+# #465 observability — of the soft-transient statuses, these mean the PORTAL is
+# erroring/throttling (a VW-side outage → portal_health "portal_error"), as opposed
+# to 400/404/410 which mean "the data request isn't provisioned / no delivery yet"
+# (→ "delivery_not_ready"). Splitting them keeps a normal wait from reading as a fault.
+_PORTAL_OUTAGE_STATUSES = frozenset({429, 500, 502, 503, 504})
 _PORTAL_RETRY_DELAYS = (3.0, 6.0)  # backoff (s) before giving up on a soft call
+
+
+def _request_start_date(meta: Any, identifier: str) -> str | None:
+    """ISO ``StartDate`` of the metadata descriptor whose Identifier matches
+    ``identifier`` — i.e. WHEN that data request was created — or None.
+
+    Tolerant of the portal's two real shapes: a list of descriptors (the 15-min
+    metadata) and the bare-dict "all"/legacy dialect. Only a string StartDate is
+    returned; anything else yields None so a diagnostic sensor stays blank rather
+    than showing junk.
+    """
+    def _sd(node: Any) -> str | None:
+        if not isinstance(node, dict):
+            return None
+        ident = (
+            node.get("Identifier")
+            or node.get("identifier")
+            or node.get("dataRequestId")
+        )
+        if identifier and ident and str(ident) == str(identifier):
+            sd = (
+                node.get("StartDate")
+                or node.get("startDate")
+                or node.get("start_date")
+            )
+            return sd if isinstance(sd, str) and sd else None
+        return None
+
+    hit = _sd(meta)  # direct descriptor / bare-dict "all"
+    if hit:
+        return hit
+    seq: Any = meta
+    if isinstance(meta, dict):
+        seq = meta.get("items") or meta.get("requests") or meta.get("data") or []
+    if isinstance(seq, list):
+        for node in seq:
+            hit = _sd(node)
+            if hit:
+                return hit
+    return None
 
 
 # ── HTML / templateModel parsing (community-proven mechanics) ──────────────
@@ -3475,6 +3520,42 @@ class EUDataActConnector:
         # raw bytes ever touch the disk. Kept as a plain callback so the
         # connector stays Home-Assistant-free.
         self.on_raw_dataset: Callable[[str, bytes, str], None] | None = None
+        # --- Stage-0 observability (surfaced as diagnostic sensors via
+        # coordinator._enrich; #465/#1273). None/0 until the relevant event. ---
+        # _last_soft_status: HTTP status of the most recent soft _get_json that
+        # returned None, so get_vehicle_data can tell a 404 "not provisioned yet"
+        # (→ delivery_not_ready) apart from a 5xx/429 portal outage (→ portal_error).
+        self._last_soft_status: int | None = None
+        # StartDate (ISO-8601) of the currently-active data request — i.e. WHEN the
+        # portal data request was created. Refreshed each poll from the metadata.
+        self.data_request_started_at: str | None = None
+        # WHEN the portal last returned no usable data + HOW OFTEN it has this
+        # session; last_snapshot_at is the inverse (when a real dataset last parsed).
+        self.last_no_data_at: str | None = None
+        self.no_data_count: int = 0
+        self.last_snapshot_at: str | None = None
+
+    @staticmethod
+    def _now_iso() -> str:
+        """UTC now as an ISO-8601 string (the TIMESTAMP sensors parse this)."""
+        from datetime import datetime, timezone  # noqa: PLC0415
+
+        return datetime.now(timezone.utc).isoformat()
+
+    def _note_no_data(self, reason: str) -> None:
+        """Record a no-data poll outcome: reason + timestamp + running count.
+
+        Every early no-data return in ``get_vehicle_data`` funnels through here so
+        the diagnostic sensors (last no-data time / count) stay in one place.
+        """
+        self.last_no_data_reason = reason
+        self.last_no_data_at = self._now_iso()
+        self.no_data_count += 1
+
+    def _note_data_ok(self) -> None:
+        """Record a successful dataset poll: clear the reason, stamp the snapshot."""
+        self.last_no_data_reason = ""
+        self.last_snapshot_at = self._now_iso()
 
     def set_bearer(self, token: str) -> None:
         """Inject / refresh the device-grant access_token for Bearer mode.
@@ -3877,6 +3958,10 @@ class EUDataActConnector:
                             await asyncio.sleep(_PORTAL_RETRY_DELAYS[attempt])
                             continue
                         if soft and resp.status in _TRANSIENT_STATUSES:
+                            # Remember the status so a caller can tell a 404 "not
+                            # provisioned yet" (delivery_not_ready) from a 5xx/429
+                            # portal outage (portal_error).
+                            self._last_soft_status = resp.status
                             return None
                         raise AuthenticationError(
                             f"EU Data Act GET {url} → HTTP {resp.status}"
@@ -3971,7 +4056,7 @@ class EUDataActConnector:
                 or ""
             )
         if not identifier:
-            self.last_no_data_reason = "no_request"
+            self._note_no_data("no_request")
             _LOGGER.info(
                 "EU Data Act portal: no data-request yet for %s — enable the "
                 "continuous data request for this car on the VW data portal "
@@ -3980,24 +4065,34 @@ class EUDataActConnector:
                 vin[-6:],
             )
             return d
+        # #465 observability — record WHEN this data request was created (its
+        # StartDate) so a diagnostic sensor can show the active request's age.
+        self.data_request_started_at = _request_start_date(meta, identifier)
         # 2. list datasets → newest non-empty zip. Soft on transient 5xx:
         # during the VW outage this endpoint 500s constantly (#428-#431).
         # A 500 here is the portal misbehaving, not a dead session, so we
         # surface it as "no data this poll" (data_act_no_data notice) rather
         # than raising AuthenticationError and re-logging in pointlessly.
         # A genuine 401/403 still raises (→ session-expired path).
+        self._last_soft_status = None
         listing = await self._get_json(
             f"{_PORTAL_BASE}{_LIST_PATH.format(vin=vin, identifier=identifier)}",
             headers={"type": request_type},
             soft=True,
         )
         if listing is None:
-            self.last_no_data_reason = "empty"
+            # A 404/410 here means "no delivery yet" (delivery_not_ready); a
+            # 5xx/429 is a genuine VW-side outage (portal_error). _get_json records
+            # which on a soft miss, so a normal wait isn't mislabelled a fault.
+            self._note_no_data(
+                "portal_error"
+                if (self._last_soft_status or 0) in _PORTAL_OUTAGE_STATUSES
+                else "empty"
+            )
             _LOGGER.info(
-                "EU Data Act portal: data endpoint returned a transient error "
-                "for %s (most likely the ongoing VW-side portal outage). "
-                "Treating as no data this poll; will retry next cycle.",
-                vin[-6:],
+                "EU Data Act portal: dataset listing unavailable for %s "
+                "(HTTP %s); treating as no data this poll.",
+                vin[-6:], self._last_soft_status or "n/a",
             )
             return d
         files = listing if isinstance(listing, list) else listing.get("files", [])
@@ -4041,7 +4136,7 @@ class EUDataActConnector:
                 and f["name"].endswith(_NO_CONTENT_SUFFIX)
             )
             if _raw_n and _named == _raw_n and _nc == _raw_n:
-                self.last_no_data_reason = "no_content"
+                self._note_no_data("no_content")
                 _LOGGER.info(
                     "EU Data Act portal: %s has %d dataset file(s) this cycle but "
                     "all are 'no content' placeholders — the request is active, the "
@@ -4051,7 +4146,7 @@ class EUDataActConnector:
                     vin[-6:], _raw_n,
                 )
             else:
-                self.last_no_data_reason = "empty"
+                self._note_no_data("empty")
                 _LOGGER.debug(
                     "EU Data Act portal: no usable dataset files for %s yet "
                     "(raw=%d, named=%d, no_content=%d, listing=%s)",
@@ -4079,7 +4174,10 @@ class EUDataActConnector:
                 if resp.status in _TRANSIENT_STATUSES:
                     # Same outage story as the listing call — the ZIP download
                     # 500s mid-outage. Don't burn the session; just skip this poll.
-                    self.last_no_data_reason = "empty"
+                    self._note_no_data(
+                        "portal_error"
+                        if resp.status in _PORTAL_OUTAGE_STATUSES else "empty"
+                    )
                     _LOGGER.info(
                         "EU Data Act portal: dataset download returned a transient "
                         "error (HTTP %s) for %s; treating as no data this poll.",
@@ -4095,7 +4193,7 @@ class EUDataActConnector:
             # v2.14.8 — same as the soft GETs: a transport timeout/disconnect on
             # the ZIP download is a portal hiccup, not a dead session. Skip the
             # poll instead of letting a raw TimeoutError bubble to the coordinator.
-            self.last_no_data_reason = "empty"
+            self._note_no_data("portal_error")
             _LOGGER.info(
                 "EU Data Act portal: dataset download timed out / disconnected "
                 "for %s; treating as no data this poll.",
@@ -4115,9 +4213,9 @@ class EUDataActConnector:
         # raising) means no data this poll: flag it so the no-data notice fires,
         # and do NOT mark the vehicle online with a blank dataset.
         if not fields:
-            self.last_no_data_reason = "empty"
+            self._note_no_data("empty")
             return d
-        self.last_no_data_reason = ""
+        self._note_data_ok()
         d.no_data = False  # real dataset parsed → this is a genuine good poll
         d.connection_state = "online"
         # P1-5 — hand the RAW dataset ZIP to the opt-in diagnostic archive, but

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -2492,7 +2492,29 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
         # failover). This single field is the FALLBACK applied to any car without
         # its own per-VIN key below. Pre-filled so re-opening options never blanks it.
         if current_data.get(CONF_BRAND) == "skoda":
-            from .const import CONF_SKODA_OFFICIAL_API_KEY  # noqa: PLC0415
+            from .const import (  # noqa: PLC0415
+                CONF_SKODA_OFFICIAL_API_KEY,
+                CONF_SKODA_OFFICIAL_MODE,
+                SKODA_OFFICIAL_MODE_DEFAULT,
+                SKODA_OFFICIAL_MODES,
+            )
+            # #1286 (n3roGit) — pick how the official manufacturer API interacts
+            # with the primary "mysmob" channel (auto-merge / prefer-official /
+            # failover / official-only / mysmob-only). Options-then-data default so
+            # the options-trap (listener folds options into data) can't blank it.
+            schema[vol.Optional(
+                CONF_SKODA_OFFICIAL_MODE,
+                default=str(current_options.get(
+                    CONF_SKODA_OFFICIAL_MODE,
+                    current_data.get(
+                        CONF_SKODA_OFFICIAL_MODE, SKODA_OFFICIAL_MODE_DEFAULT
+                    ),
+                )),
+            )] = SelectSelector(SelectSelectorConfig(
+                options=list(SKODA_OFFICIAL_MODES),
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key=CONF_SKODA_OFFICIAL_MODE,
+            ))
             schema[vol.Optional(
                 CONF_SKODA_OFFICIAL_API_KEY,
                 default=str(current_options.get(

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -303,6 +303,19 @@ CONF_SKODA_OFFICIAL_API_KEY      = "skoda_official_api_key"
 # is a map, not a single key; CONF_SKODA_OFFICIAL_API_KEY stays the manual-fallback
 # single key for any VIN not auto-enrolled.
 CONF_SKODA_OFFICIAL_KEYS         = "skoda_official_keys"
+# Škoda official-API source mode (opt-in select, #1286 @n3roGit). Governs how the
+# official manufacturer API interacts with the primary "mysmob" channel:
+#   auto            → read both every poll, official's readings win (default)
+#   prefer_official → same active merge; official is the authoritative source
+#   failover        → mysmob only; official steps in solely on a hard failure
+#   official_only   → only the official API (mysmob off), per-VIN degrade to mysmob
+#                     for any car without a valid official key
+#   mysmob_only     → only the mysmob channel (official off entirely, no minting)
+CONF_SKODA_OFFICIAL_MODE         = "skoda_official_mode"
+SKODA_OFFICIAL_MODES: tuple[str, ...] = (
+    "auto", "prefer_official", "failover", "official_only", "mysmob_only",
+)
+SKODA_OFFICIAL_MODE_DEFAULT = "auto"
 
 # v2.15.0b3 — "hide entities without data" (default ON). When enabled, data
 # sensors / binary sensors whose value hasn't arrived are not created, so a

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1577,6 +1577,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 _LOGGER.debug("Škoda official auto-enroll skipped", exc_info=True)
             # Fetch status for all vehicles
+            self._push_official_mode()  # #1286 — official_only routing before read
             results = await asyncio.gather(
                 *[self._cariad_client.get_status(vin) for vin in vins],
                 return_exceptions=True,
@@ -2563,6 +2564,39 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         else:
             clear_issue_test_cohort_share(self.hass, self.entry.entry_id)
 
+    def _skoda_official_mode(self) -> str:
+        """The configured Škoda official-API source mode (#1286). Options-then-data
+        precedence like every other option; unknown/absent → the ``auto`` default."""
+        from .const import (  # noqa: PLC0415
+            CONF_SKODA_OFFICIAL_MODE,
+            SKODA_OFFICIAL_MODE_DEFAULT,
+            SKODA_OFFICIAL_MODES,
+        )
+        entry = getattr(self, "entry", None)
+        if entry is None:
+            return SKODA_OFFICIAL_MODE_DEFAULT
+        mode = str(
+            entry.options.get(
+                CONF_SKODA_OFFICIAL_MODE,
+                entry.data.get(
+                    CONF_SKODA_OFFICIAL_MODE, SKODA_OFFICIAL_MODE_DEFAULT
+                ),
+            )
+        )
+        return mode if mode in SKODA_OFFICIAL_MODES else SKODA_OFFICIAL_MODE_DEFAULT
+
+    def _push_official_mode(self, client: Any = None) -> None:
+        """Push the configured source mode onto the Škoda client so its primary-read
+        routing (``official_only``) reflects a live options change. Must run before
+        each status gather; a no-op for non-Škoda clients (no ``set_official_mode``).
+        Accepts an explicit ``client`` so the #584 captured-client path stays race-safe."""
+        setter = getattr(
+            client if client is not None else self._cariad_client,
+            "set_official_mode", None,
+        )
+        if setter is not None:
+            setter(self._skoda_official_mode())
+
     def _arm_official_from_map(self, keys_map: dict[str, Any]) -> None:
         """Arm the Škoda official failover channel from a persisted per-VIN key map
         ({vin: {key, id, validUntil}})."""
@@ -2716,6 +2750,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         from .const import CONF_BRAND, CONF_SKODA_OFFICIAL_KEYS  # noqa: PLC0415
         client = self._cariad_client
         if str(self.entry.data.get(CONF_BRAND, "")) != "skoda":
+            return
+        if self._skoda_official_mode() == "mysmob_only":
+            # Official channel switched off by the user → don't mint or arm it.
+            self._skoda_probe(
+                "skoda_official", "disabled by source mode (mysmob_only)"
+            )
             return
         if not getattr(client, "can_mint_official_key", False):
             # Record WHY the official channel can't auto-enrol (portal-fallback or a
@@ -3231,7 +3271,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # primary failure). Brand-isolated: the method exists only on the Škoda
         # client, so getattr → None for every other brand.
         official = getattr(client, "official_failover_read", None)
-        if official is not None:
+        if official is not None and self._skoda_official_mode() != "mysmob_only":
             try:
                 off_data: VehicleData | None = await official(vin)
                 if off_data is not None:
@@ -3387,6 +3427,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 # until a restart. update_interval is None here, so this loop —
                 # not _async_update_data — is the periodic path. No-op non-MBB.
                 await self._refresh_mbb_command_capabilities()
+                self._push_official_mode()  # #1286 — official_only routing before read
                 results = await asyncio.gather(
                     *[self._cariad_client.get_status(vin) for vin in vins],
                     return_exceptions=True,
@@ -3596,14 +3637,17 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         # healthy cycle, merge the manufacturer API's readings into
                         # the primary payload (rate-safe, brand-isolated, fail-soft).
                         # Must run BEFORE _compute_channel_status so the connectivity
-                        # map counts the official contribution.
-                        try:
-                            await self._merge_official_live(vin, enriched)
-                        except Exception:  # noqa: BLE001
-                            _LOGGER.debug(
-                                "official live-source merge skipped for %s",
-                                mask_vin(vin), exc_info=True,
-                            )
+                        # map counts the official contribution. #1286 — only in the
+                        # merge modes; "failover"/"official_only"/"mysmob_only" don't
+                        # overlay official onto a healthy primary cycle.
+                        if self._skoda_official_mode() in ("auto", "prefer_official"):
+                            try:
+                                await self._merge_official_live(vin, enriched)
+                            except Exception:  # noqa: BLE001
+                                _LOGGER.debug(
+                                    "official live-source merge skipped for %s",
+                                    mask_vin(vin), exc_info=True,
+                                )
                         # Per-source connectivity map for the connectivity
                         # binary_sensors (which sources this car is connected to,
                         # active vs standby, how many readings each provides). Fail-
@@ -6127,6 +6171,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # right after Reconfigure). The captured object stays valid (or fails
         # cleanly as a closed session, handled by the except → cached data).
         client = self._cariad_client
+        self._push_official_mode(client)  # #1286 — official_only routing (race-safe)
         # P1-5 — attach the opt-in raw-dataset archive hook (no-op when off).
         self._wire_dataset_archive()
         try:

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -92,9 +92,11 @@ _PORTAL_HEALTH_BY_REASON: dict[str, str] = {
     "no_request": "waiting_for_portal_data",  # no customised data request set up yet
     "no_content": "empty_snapshots",          # car asleep → only *_no_content_found.zip
     "empty": "delivery_not_ready",            # listing/metadata empty or not yet ready
+    "portal_error": "portal_error",           # VW-side portal outage/throttle (5xx/429)
 }
 PORTAL_HEALTH_STATES = (
-    "ok", "waiting_for_portal_data", "empty_snapshots", "delivery_not_ready", "stale",
+    "ok", "waiting_for_portal_data", "empty_snapshots", "delivery_not_ready",
+    "portal_error", "stale",
 )
 
 
@@ -5914,6 +5916,17 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 data["minutes_since_last_snapshot"] = (
                     int(_age // 60) if _age is not None else None
                 )
+                # #465/#1273 observability — surface the portal connector's own
+                # timestamps/counters so a user can see WHEN the data request was
+                # created, WHEN a real snapshot last arrived, and WHEN / HOW OFTEN
+                # the portal returned nothing. Set only in portal mode; None stays
+                # None (the TIMESTAMP sensors then read unavailable).
+                data["data_request_created_at"] = getattr(
+                    _portal, "data_request_started_at", None
+                )
+                data["last_snapshot_at"] = getattr(_portal, "last_snapshot_at", None)
+                data["last_no_data_at"] = getattr(_portal, "last_no_data_at", None)
+                data["no_data_count"] = getattr(_portal, "no_data_count", None)
                 # Stage-1 — the one-time historical export lifecycle state, set
                 # only while an export is actually in flight (or just finished) so
                 # the sensor stays hidden for the majority who never use it.

--- a/custom_components/vag_connect/device_tracker.py
+++ b/custom_components/vag_connect/device_tracker.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .cariad._util import json_safe_dict, mask_vin
-from .const import CONF_SUPPLEMENTARY_AUTHPROXY
+from .const import CONF_STRATEGY, CONF_SUPPLEMENTARY_AUTHPROXY
 from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity
 
@@ -48,7 +48,17 @@ async def async_setup_entry(
     # gets orphaned and eventually purged by HA, breaking maps/automations). If
     # that channel is configured we spawn the tracker regardless: it just reads
     # unavailable until a position returns after re-login, instead of vanishing.
-    supplementary_gps = bool(entry.data.get(CONF_SUPPLEMENTARY_AUTHPROXY))
+    #
+    # acpp (Audi plug&play OBD dongle, strategy "audi_acpp") has the SAME
+    # intermittency: the dongle only uploads a GPS fix from its last PARKED
+    # snapshot, so coordinates come and go between drives. Without an
+    # unconditional spawn the tracker never appears when the car is mid-drive at
+    # setup, and a registered one gets purged during a gap — so the car's location
+    # was never reliably bound to a tracker entity. Spawn it unconditionally for
+    # acpp too (reads unavailable between fixes rather than never binding).
+    supplementary_gps = bool(entry.data.get(CONF_SUPPLEMENTARY_AUTHPROXY)) or (
+        str(entry.data.get(CONF_STRATEGY, "")) == "audi_acpp"
+    )
 
     def _has_gps(vehicle: dict) -> bool:
         lat = vehicle.get("latitude")

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b4"
+  "version": "4.7.0b5"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -195,6 +195,7 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
             "waiting_for_portal_data",
             "empty_snapshots",
             "delivery_not_ready",
+            "portal_error",
             "stale",
         ],
     ),
@@ -220,6 +221,43 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:history",
         device_class=SensorDeviceClass.ENUM,
         options=["pending", "done", "timed_out"],
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # #465/#1273 EU Data Act observability — the portal connector's own lifecycle
+    # timestamps/counter, so a user can see WHEN the data request was created, WHEN
+    # a real snapshot last arrived, and WHEN / HOW OFTEN the portal returned nothing.
+    # Data-present gated (portal-only, spawn when the value first arrives — same as
+    # raw_api_fields) + diagnostic.
+    VagSensorDescription(
+        key="data_request_created_at",
+        translation_key="data_request_created_at",
+        data_key="data_request_created_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:calendar-plus",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="last_snapshot_at",
+        translation_key="last_snapshot_at",
+        data_key="last_snapshot_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:database-clock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="last_no_data_at",
+        translation_key="last_no_data_at",
+        data_key="last_no_data_at",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        icon="mdi:cloud-alert",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    VagSensorDescription(
+        key="no_data_count",
+        translation_key="no_data_count",
+        data_key="no_data_count",
+        icon="mdi:counter",
+        state_class=SensorStateClass.TOTAL_INCREASING,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # v2.22.0 (evcc) — normalized IEC-61851 charge status (A=unplugged /
@@ -3518,6 +3556,14 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # b1/A6 — raw-discovery sensor only spawns when the portal actually
     # delivered unmapped fields (empty dict on every other brand/channel).
     "raw_api_fields",
+    # #465/#1273 — EU-portal-only observability sensors: each spawns when its
+    # value first arrives (a request created / a snapshot / a no-data poll) and
+    # stays absent on non-portal channels. no_data_count is 0 (not None) in portal
+    # mode so it appears immediately; the timestamps appear on their first event.
+    "data_request_created_at",
+    "last_snapshot_at",
+    "last_no_data_at",
+    "no_data_count",
     # v2.17.1 (Scout #701, VW ID.7) — EU-portal-only interior temp,
     # HV-battery-derived charge-target time + profile user capacity.
     # Non-portal cars leave these None → no phantom entity.

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: read target and outside temperature (navigates the app)",
           "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)",
           "skoda_official_api_key": "Škoda official API key — adds the official manufacturer API as a live data source (and failover)",
-          "clear_skoda_official_key": "Clear the stored Škoda official API key (a fresh one is created automatically if your login supports it)"
+          "clear_skoda_official_key": "Clear the stored Škoda official API key (a fresh one is created automatically if your login supports it)",
+          "skoda_official_mode": "Škoda official-API source mode"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -2056,6 +2057,15 @@
         "stop_aux_heating": "Stop auxiliary heating",
         "start_ventilation": "Start ventilation",
         "stop_ventilation": "Stop ventilation"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatic (both sources, official preferred)",
+        "prefer_official": "Prefer the official API",
+        "failover": "Official API as failover only",
+        "official_only": "Official API only",
+        "mysmob_only": "Standard channel only"
       }
     }
   },

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -408,10 +408,11 @@
       "portal_health": {
         "name": "Portal feed health",
         "state": {
-          "ok": "OK",
+          "ok": "Live",
           "waiting_for_portal_data": "Waiting for portal data",
           "empty_snapshots": "Empty snapshots",
           "delivery_not_ready": "Delivery not ready",
+          "portal_error": "Portal error",
           "stale": "Stale"
         }
       },
@@ -1436,6 +1437,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Odometer at fill-up"
+      },
+      "data_request_created_at": {
+        "name": "Data request created"
+      },
+      "last_snapshot_at": {
+        "name": "Last snapshot received"
+      },
+      "last_no_data_at": {
+        "name": "Last no-data poll"
+      },
+      "no_data_count": {
+        "name": "No-data polls"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: číst cílovou a venkovní teplotu (naviguje v aplikaci)",
           "companion_read_parking_position": "Companion: číst pozici parkování z odkazu pro sdílení v aplikaci (naviguje v aplikaci)",
           "skoda_official_api_key": "Oficiální klíč API Škoda — přidá oficiální API výrobce jako živý zdroj dat (a zálohu)",
-          "clear_skoda_official_key": "Vymazat uložený oficiální klíč API Škoda (nový se vytvoří automaticky, pokud to vaše přihlášení podporuje)"
+          "clear_skoda_official_key": "Vymazat uložený oficiální klíč API Škoda (nový se vytvoří automaticky, pokud to vaše přihlášení podporuje)",
+          "skoda_official_mode": "Režim zdroje oficiálního API Škoda"
         },
         "data_description": {
           "scan_interval": "Jak často se stahují data (minuty). Minimum: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Zastavit nezávislé topení",
         "start_ventilation": "Spustit větrání",
         "stop_ventilation": "Zastavit větrání"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automaticky (oba zdroje, přednost oficiálnímu)",
+        "prefer_official": "Preferovat oficiální API",
+        "failover": "Oficiální API jen jako záloha",
+        "official_only": "Pouze oficiální API",
+        "mysmob_only": "Pouze standardní kanál"
       }
     }
   }

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Stav kanálu portálu",
         "state": {
-          "ok": "OK",
+          "ok": "Živě",
           "waiting_for_portal_data": "Čekání na data z portálu",
           "empty_snapshots": "Prázdné snímky",
           "delivery_not_ready": "Doručení není připraveno",
+          "portal_error": "Chyba portálu",
           "stale": "Zastaralé"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Stav tachometru při tankování"
+      },
+      "data_request_created_at": {
+        "name": "Datový požadavek vytvořen"
+      },
+      "last_snapshot_at": {
+        "name": "Poslední snímek přijat"
+      },
+      "last_no_data_at": {
+        "name": "Poslední dotaz bez dat"
+      },
+      "no_data_count": {
+        "name": "Dotazy bez dat"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: læs måltemperatur og udetemperatur (navigerer i appen)",
           "companion_read_parking_position": "Companion: læs parkeringsposition fra appens delingslink (navigerer i appen)",
           "skoda_official_api_key": "Officiel Škoda API-nøgle — tilføjer den officielle producent-API som live datakilde (og failover)",
-          "clear_skoda_official_key": "Ryd den gemte officielle Škoda API-nøgle (en ny oprettes automatisk, hvis dit login understøtter det)"
+          "clear_skoda_official_key": "Ryd den gemte officielle Škoda API-nøgle (en ny oprettes automatisk, hvis dit login understøtter det)",
+          "skoda_official_mode": "Škoda officiel API-kildetilstand"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Stop parkeringsvarmer",
         "start_ventilation": "Start ventilation",
         "stop_ventilation": "Stop ventilation"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatisk (begge kilder, officiel foretrukket)",
+        "prefer_official": "Foretræk det officielle API",
+        "failover": "Officielt API kun som failover",
+        "official_only": "Kun officielt API",
+        "mysmob_only": "Kun standardkanal"
       }
     }
   }

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Portal-feedets tilstand",
         "state": {
-          "ok": "OK",
+          "ok": "Live",
           "waiting_for_portal_data": "Venter på portaldata",
           "empty_snapshots": "Tomme snapshots",
           "delivery_not_ready": "Levering ikke klar",
+          "portal_error": "Portalfejl",
           "stale": "Forældet"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Kilometerstand ved optankning"
+      },
+      "data_request_created_at": {
+        "name": "Dataanmodning oprettet"
+      },
+      "last_snapshot_at": {
+        "name": "Sidste snapshot modtaget"
+      },
+      "last_no_data_at": {
+        "name": "Sidste forespørgsel uden data"
+      },
+      "no_data_count": {
+        "name": "Forespørgsler uden data"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Portal-Feed-Zustand",
         "state": {
-          "ok": "OK",
+          "ok": "Live",
           "waiting_for_portal_data": "Warte auf Portaldaten",
           "empty_snapshots": "Leere Snapshots",
           "delivery_not_ready": "Lieferung nicht bereit",
+          "portal_error": "Portal-Fehler",
           "stale": "Veraltet"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Kilometerstand bei Betankung"
+      },
+      "data_request_created_at": {
+        "name": "Datenabruf angelegt"
+      },
+      "last_snapshot_at": {
+        "name": "Letzter Snapshot empfangen"
+      },
+      "last_no_data_at": {
+        "name": "Letzte Abfrage ohne Daten"
+      },
+      "no_data_count": {
+        "name": "Abfragen ohne Daten"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: Solltemperatur und Außentemperatur lesen (navigiert in der App)",
           "companion_read_parking_position": "Companion: Parkposition aus dem Teilen-Link der App lesen (navigiert in der App)",
           "skoda_official_api_key": "Offizieller Škoda-API-Schlüssel — nutzt die offizielle Hersteller-API als Live-Datenquelle (und Failover)",
-          "clear_skoda_official_key": "Gespeicherten offiziellen Škoda-API-Schlüssel löschen (ein neuer wird automatisch erstellt, falls dein Login das unterstützt)"
+          "clear_skoda_official_key": "Gespeicherten offiziellen Škoda-API-Schlüssel löschen (ein neuer wird automatisch erstellt, falls dein Login das unterstützt)",
+          "skoda_official_mode": "Škoda Offizielle-API-Quellenmodus"
         },
         "data_description": {
           "enable_reverse_geocoding": "Sendet GPS der Parkposition an OpenStreetMap Nominatim, um Straße/Stadt zu ermitteln. Standard: aus (Datenschutz).",
@@ -2056,6 +2057,15 @@
         "stop_aux_heating": "Standheizung stoppen",
         "start_ventilation": "Lüftung starten",
         "stop_ventilation": "Lüftung stoppen"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatisch (beide, offizielle bevorzugt)",
+        "prefer_official": "Offizielle API bevorzugen",
+        "failover": "Offizielle API nur als Notfall",
+        "official_only": "Nur offizielle API",
+        "mysmob_only": "Nur Standard-Kanal"
       }
     }
   },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: read target and outside temperature (navigates the app)",
           "companion_read_parking_position": "Companion: read parking position from the app's share link (navigates the app)",
           "skoda_official_api_key": "Škoda official API key — adds the official manufacturer API as a live data source (and failover)",
-          "clear_skoda_official_key": "Clear the stored Škoda official API key (a fresh one is created automatically if your login supports it)"
+          "clear_skoda_official_key": "Clear the stored Škoda official API key (a fresh one is created automatically if your login supports it)",
+          "skoda_official_mode": "Škoda official-API source mode"
         },
         "data_description": {
           "scan_interval": "How often data is fetched (minutes). Minimum: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Stop auxiliary heating",
         "start_ventilation": "Start ventilation",
         "stop_ventilation": "Stop ventilation"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatic (both sources, official preferred)",
+        "prefer_official": "Prefer the official API",
+        "failover": "Official API as failover only",
+        "official_only": "Official API only",
+        "mysmob_only": "Standard channel only"
       }
     }
   }

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Portal feed health",
         "state": {
-          "ok": "OK",
+          "ok": "Live",
           "waiting_for_portal_data": "Waiting for portal data",
           "empty_snapshots": "Empty snapshots",
           "delivery_not_ready": "Delivery not ready",
+          "portal_error": "Portal error",
           "stale": "Stale"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Odometer at fill-up"
+      },
+      "data_request_created_at": {
+        "name": "Data request created"
+      },
+      "last_snapshot_at": {
+        "name": "Last snapshot received"
+      },
+      "last_no_data_at": {
+        "name": "Last no-data poll"
+      },
+      "no_data_count": {
+        "name": "No-data polls"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Estado del feed del portal",
         "state": {
-          "ok": "OK",
+          "ok": "En vivo",
           "waiting_for_portal_data": "Esperando datos del portal",
           "empty_snapshots": "Instantáneas vacías",
           "delivery_not_ready": "Entrega no lista",
+          "portal_error": "Error del portal",
           "stale": "Desactualizado"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Cuentakilómetros al repostar"
+      },
+      "data_request_created_at": {
+        "name": "Solicitud de datos creada"
+      },
+      "last_snapshot_at": {
+        "name": "Último snapshot recibido"
+      },
+      "last_no_data_at": {
+        "name": "Última consulta sin datos"
+      },
+      "no_data_count": {
+        "name": "Consultas sin datos"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: leer temperatura objetivo y exterior (navega por la app)",
           "companion_read_parking_position": "Companion: leer la posición de aparcamiento desde el enlace para compartir de la app (navega por la app)",
           "skoda_official_api_key": "Clave API oficial de Škoda — añade la API oficial del fabricante como fuente de datos en vivo (y conmutación por error)",
-          "clear_skoda_official_key": "Borrar la clave API oficial de Škoda guardada (se crea una nueva automáticamente si tu inicio de sesión lo permite)"
+          "clear_skoda_official_key": "Borrar la clave API oficial de Škoda guardada (se crea una nueva automáticamente si tu inicio de sesión lo permite)",
+          "skoda_official_mode": "Modo de fuente de la API oficial de Škoda"
         },
         "data_description": {
           "scan_interval": "Frecuencia de actualización (minutos). Mínimo: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Detener calefacción auxiliar",
         "start_ventilation": "Iniciar ventilación",
         "stop_ventilation": "Detener ventilación"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automático (ambas fuentes, se prefiere la oficial)",
+        "prefer_official": "Preferir la API oficial",
+        "failover": "API oficial solo como respaldo",
+        "official_only": "Solo API oficial",
+        "mysmob_only": "Solo canal estándar"
       }
     }
   }

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Portaalisyötteen tila",
         "state": {
-          "ok": "OK",
+          "ok": "Live",
           "waiting_for_portal_data": "Odotetaan portaalin tietoja",
           "empty_snapshots": "Tyhjät tilannevedokset",
           "delivery_not_ready": "Toimitus ei valmis",
+          "portal_error": "Portaalivirhe",
           "stale": "Vanhentunut"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Matkamittari tankattaessa"
+      },
+      "data_request_created_at": {
+        "name": "Datapyyntö luotu"
+      },
+      "last_snapshot_at": {
+        "name": "Viimeisin tilannevedos vastaanotettu"
+      },
+      "last_no_data_at": {
+        "name": "Viimeisin kysely ilman dataa"
+      },
+      "no_data_count": {
+        "name": "Kyselyt ilman dataa"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: lue tavoite- ja ulkolämpötila (navigoi sovelluksessa)",
           "companion_read_parking_position": "Companion: lue pysäköintipaikka sovelluksen jakolinkistä (navigoi sovelluksessa)",
           "skoda_official_api_key": "Virallinen Škoda-API-avain — lisää valmistajan virallisen API:n live-tietolähteeksi (ja vikasietona)",
-          "clear_skoda_official_key": "Tyhjennä tallennettu virallinen Škoda-API-avain (uusi luodaan automaattisesti, jos kirjautumisesi tukee sitä)"
+          "clear_skoda_official_key": "Tyhjennä tallennettu virallinen Škoda-API-avain (uusi luodaan automaattisesti, jos kirjautumisesi tukee sitä)",
+          "skoda_official_mode": "Škodan virallisen API:n lähdetila"
         },
         "data_description": {
           "scan_interval": "Kuinka usein tietoja haetaan (minuutteja). Vähintään: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Pysäytä lisälämmitin",
         "start_ventilation": "Käynnistä tuuletus",
         "stop_ventilation": "Pysäytä tuuletus"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automaattinen (molemmat, virallista suositaan)",
+        "prefer_official": "Suosi virallista API:a",
+        "failover": "Virallinen API vain varajärjestelmänä",
+        "official_only": "Vain virallinen API",
+        "mysmob_only": "Vain vakiokanava"
       }
     }
   }

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion : lire la température de consigne et extérieure (navigue dans l'app)",
           "companion_read_parking_position": "Companion : lire la position de stationnement depuis le lien de partage de l'app (navigue dans l'app)",
           "skoda_official_api_key": "Clé API officielle Škoda — ajoute l'API officielle du constructeur comme source de données en direct (et bascule)",
-          "clear_skoda_official_key": "Effacer la clé API officielle Škoda enregistrée (une nouvelle est créée automatiquement si votre connexion le permet)"
+          "clear_skoda_official_key": "Effacer la clé API officielle Škoda enregistrée (une nouvelle est créée automatiquement si votre connexion le permet)",
+          "skoda_official_mode": "Mode de source de l'API officielle Škoda"
         },
         "data_description": {
           "scan_interval": "Fréquence de mise à jour (minutes). Minimum: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Arrêter le chauffage d'appoint",
         "start_ventilation": "Démarrer la ventilation",
         "stop_ventilation": "Arrêter la ventilation"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatique (deux sources, officielle préférée)",
+        "prefer_official": "Préférer l'API officielle",
+        "failover": "API officielle en secours uniquement",
+        "official_only": "API officielle uniquement",
+        "mysmob_only": "Canal standard uniquement"
       }
     }
   }

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "État du flux du portail",
         "state": {
-          "ok": "OK",
+          "ok": "En direct",
           "waiting_for_portal_data": "En attente des données du portail",
           "empty_snapshots": "Instantanés vides",
           "delivery_not_ready": "Livraison pas encore prête",
+          "portal_error": "Erreur du portail",
           "stale": "Obsolète"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Compteur kilométrique au plein"
+      },
+      "data_request_created_at": {
+        "name": "Demande de données créée"
+      },
+      "last_snapshot_at": {
+        "name": "Dernier instantané reçu"
+      },
+      "last_no_data_at": {
+        "name": "Dernière interrogation sans données"
+      },
+      "no_data_count": {
+        "name": "Interrogations sans données"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: leggi temperatura impostata ed esterna (naviga nell'app)",
           "companion_read_parking_position": "Companion: leggi la posizione di parcheggio dal link di condivisione dell'app (naviga nell'app)",
           "skoda_official_api_key": "Chiave API ufficiale Škoda — aggiunge l'API ufficiale del costruttore come fonte dati in tempo reale (e failover)",
-          "clear_skoda_official_key": "Cancella la chiave API ufficiale Škoda memorizzata (ne viene creata una nuova automaticamente se il tuo accesso lo consente)"
+          "clear_skoda_official_key": "Cancella la chiave API ufficiale Škoda memorizzata (ne viene creata una nuova automaticamente se il tuo accesso lo consente)",
+          "skoda_official_mode": "Modalità sorgente API ufficiale Škoda"
         },
         "data_description": {
           "scan_interval": "Con quale frequenza vengono recuperati i dati (minuti). Minimo: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Arresta riscaldamento ausiliario",
         "start_ventilation": "Avvia ventilazione",
         "stop_ventilation": "Arresta ventilazione"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatico (entrambe, ufficiale preferita)",
+        "prefer_official": "Preferisci l'API ufficiale",
+        "failover": "API ufficiale solo come failover",
+        "official_only": "Solo API ufficiale",
+        "mysmob_only": "Solo canale standard"
       }
     }
   }

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Stato del feed del portale",
         "state": {
-          "ok": "OK",
+          "ok": "Attivo",
           "waiting_for_portal_data": "In attesa dei dati del portale",
           "empty_snapshots": "Snapshot vuoti",
           "delivery_not_ready": "Consegna non pronta",
+          "portal_error": "Errore del portale",
           "stale": "Obsoleto"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Contachilometri al rifornimento"
+      },
+      "data_request_created_at": {
+        "name": "Richiesta dati creata"
+      },
+      "last_snapshot_at": {
+        "name": "Ultimo snapshot ricevuto"
+      },
+      "last_no_data_at": {
+        "name": "Ultimo sondaggio senza dati"
+      },
+      "no_data_count": {
+        "name": "Sondaggi senza dati"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: les måltemperatur og utetemperatur (navigerer i appen)",
           "companion_read_parking_position": "Companion: les parkeringsposisjon fra appens delingslenke (navigerer i appen)",
           "skoda_official_api_key": "Offisiell Škoda API-nøkkel — legger til produsentens offisielle API som live datakilde (og failover)",
-          "clear_skoda_official_key": "Fjern den lagrede offisielle Škoda API-nøkkelen (en ny opprettes automatisk hvis påloggingen din støtter det)"
+          "clear_skoda_official_key": "Fjern den lagrede offisielle Škoda API-nøkkelen (en ny opprettes automatisk hvis påloggingen din støtter det)",
+          "skoda_official_mode": "Škoda offisiell API-kildemodus"
         },
         "data_description": {
           "scan_interval": "Hvor ofte data hentes (minutter). Minimum: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Stopp tilleggsvarme",
         "start_ventilation": "Start ventilasjon",
         "stop_ventilation": "Stopp ventilasjon"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatisk (begge kilder, offisiell foretrukket)",
+        "prefer_official": "Foretrekk det offisielle API-et",
+        "failover": "Offisielt API kun som failover",
+        "official_only": "Kun offisielt API",
+        "mysmob_only": "Kun standardkanal"
       }
     }
   }

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Portalfeed-tilstand",
         "state": {
-          "ok": "OK",
+          "ok": "Live",
           "waiting_for_portal_data": "Venter på portaldata",
           "empty_snapshots": "Tomme øyeblikksbilder",
           "delivery_not_ready": "Levering ikke klar",
+          "portal_error": "Portalfeil",
           "stale": "Foreldet"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Kilometerstand ved fylling"
+      },
+      "data_request_created_at": {
+        "name": "Dataforespørsel opprettet"
+      },
+      "last_snapshot_at": {
+        "name": "Siste øyeblikksbilde mottatt"
+      },
+      "last_no_data_at": {
+        "name": "Siste spørring uten data"
+      },
+      "no_data_count": {
+        "name": "Spørringer uten data"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Status portaalfeed",
         "state": {
-          "ok": "OK",
+          "ok": "Live",
           "waiting_for_portal_data": "Wachten op portaalgegevens",
           "empty_snapshots": "Lege snapshots",
           "delivery_not_ready": "Levering niet gereed",
+          "portal_error": "Portaalfout",
           "stale": "Verouderd"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Kilometerstand bij tanken"
+      },
+      "data_request_created_at": {
+        "name": "Gegevensverzoek aangemaakt"
+      },
+      "last_snapshot_at": {
+        "name": "Laatste momentopname ontvangen"
+      },
+      "last_no_data_at": {
+        "name": "Laatste polling zonder gegevens"
+      },
+      "no_data_count": {
+        "name": "Pollingen zonder gegevens"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: streef- en buitentemperatuur lezen (navigeert in de app)",
           "companion_read_parking_position": "Companion: parkeerpositie uit de deellink van de app lezen (navigeert in de app)",
           "skoda_official_api_key": "Officiële Škoda API-sleutel — voegt de officiële fabrikant-API toe als live databron (en failover)",
-          "clear_skoda_official_key": "Wis de opgeslagen officiële Škoda API-sleutel (er wordt automatisch een nieuwe aangemaakt als je login dit ondersteunt)"
+          "clear_skoda_official_key": "Wis de opgeslagen officiële Škoda API-sleutel (er wordt automatisch een nieuwe aangemaakt als je login dit ondersteunt)",
+          "skoda_official_mode": "Škoda officiële-API-bronmodus"
         },
         "data_description": {
           "scan_interval": "Hoe vaak gegevens worden opgehaald (minuten). Minimum: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Standkachel stoppen",
         "start_ventilation": "Ventilatie starten",
         "stop_ventilation": "Ventilatie stoppen"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatisch (beide bronnen, officieel voorkeur)",
+        "prefer_official": "Officiële API verkiezen",
+        "failover": "Officiële API alleen als failover",
+        "official_only": "Alleen officiële API",
+        "mysmob_only": "Alleen standaardkanaal"
       }
     }
   }

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: odczyt temperatury zadanej i zewnętrznej (nawiguje po aplikacji)",
           "companion_read_parking_position": "Companion: odczyt pozycji parkowania z linku udostępniania w aplikacji (nawiguje po aplikacji)",
           "skoda_official_api_key": "Oficjalny klucz API Škoda — dodaje oficjalne API producenta jako źródło danych na żywo (i przełączanie awaryjne)",
-          "clear_skoda_official_key": "Wyczyść zapisany oficjalny klucz API Škoda (nowy zostanie utworzony automatycznie, jeśli Twoje logowanie to obsługuje)"
+          "clear_skoda_official_key": "Wyczyść zapisany oficjalny klucz API Škoda (nowy zostanie utworzony automatycznie, jeśli Twoje logowanie to obsługuje)",
+          "skoda_official_mode": "Tryb źródła oficjalnego API Škoda"
         },
         "data_description": {
           "scan_interval": "Jak często pobierane są dane (minuty). Minimum: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Zatrzymaj ogrzewanie postojowe",
         "start_ventilation": "Uruchom wentylację",
         "stop_ventilation": "Zatrzymaj wentylację"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatycznie (oba źródła, preferowane oficjalne)",
+        "prefer_official": "Preferuj oficjalne API",
+        "failover": "Oficjalne API tylko awaryjnie",
+        "official_only": "Tylko oficjalne API",
+        "mysmob_only": "Tylko kanał standardowy"
       }
     }
   }

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Stan kanału portalu",
         "state": {
-          "ok": "OK",
+          "ok": "Na żywo",
           "waiting_for_portal_data": "Oczekiwanie na dane portalu",
           "empty_snapshots": "Puste migawki",
           "delivery_not_ready": "Dostawa niegotowa",
+          "portal_error": "Błąd portalu",
           "stale": "Nieaktualne"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Przebieg przy tankowaniu"
+      },
+      "data_request_created_at": {
+        "name": "Utworzono żądanie danych"
+      },
+      "last_snapshot_at": {
+        "name": "Ostatnia migawka odebrana"
+      },
+      "last_no_data_at": {
+        "name": "Ostatnie odpytanie bez danych"
+      },
+      "no_data_count": {
+        "name": "Odpytania bez danych"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -375,10 +375,11 @@
       "portal_health": {
         "name": "Portalflödets status",
         "state": {
-          "ok": "OK",
+          "ok": "Live",
           "waiting_for_portal_data": "Väntar på portaldata",
           "empty_snapshots": "Tomma ögonblicksbilder",
           "delivery_not_ready": "Leverans inte klar",
+          "portal_error": "Portalfel",
           "stale": "Föråldrad"
         }
       },
@@ -1403,6 +1404,18 @@
       },
       "last_refuel_odometer_km": {
         "name": "Vägmätare vid tankning"
+      },
+      "data_request_created_at": {
+        "name": "Databegäran skapad"
+      },
+      "last_snapshot_at": {
+        "name": "Senaste ögonblicksbild mottagen"
+      },
+      "last_no_data_at": {
+        "name": "Senaste förfrågan utan data"
+      },
+      "no_data_count": {
+        "name": "Förfrågningar utan data"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -244,7 +244,8 @@
           "companion_read_climate_detail": "Companion: läs börtemperatur och utetemperatur (navigerar i appen)",
           "companion_read_parking_position": "Companion: läs parkeringsposition från appens delningslänk (navigerar i appen)",
           "skoda_official_api_key": "Officiell Škoda API-nyckel — lägger till tillverkarens officiella API som live-datakälla (och failover)",
-          "clear_skoda_official_key": "Rensa den lagrade officiella Škoda API-nyckeln (en ny skapas automatiskt om din inloggning stöder det)"
+          "clear_skoda_official_key": "Rensa den lagrade officiella Škoda API-nyckeln (en ny skapas automatiskt om din inloggning stöder det)",
+          "skoda_official_mode": "Škoda officiell API-källäge"
         },
         "data_description": {
           "scan_interval": "Hur ofta data hämtas (minuter). Minimum: 3.",
@@ -2278,6 +2279,15 @@
         "stop_aux_heating": "Stoppa parkeringsvärmare",
         "start_ventilation": "Starta ventilation",
         "stop_ventilation": "Stoppa ventilation"
+      }
+    },
+    "skoda_official_mode": {
+      "options": {
+        "auto": "Automatiskt (båda källor, officiell föredras)",
+        "prefer_official": "Föredra det officiella API:et",
+        "failover": "Officiellt API endast som reserv",
+        "official_only": "Endast officiellt API",
+        "mysmob_only": "Endast standardkanal"
       }
     }
   }

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -552,6 +552,27 @@ class TestDeviceTracker:
         )
         assert len(added) == 1
 
+    def test_setup_spawns_tracker_for_acpp_entry_without_gps(self):
+        # acpp (audi_acpp) reports GPS only from the dongle's intermittent parked
+        # snapshot, so a car mid-drive at setup has no coordinates yet. The tracker
+        # must still spawn (same reasoning as the vw.de channel, #984) so the car's
+        # location is always bound to a tracker instead of never appearing / being
+        # purged during a between-drives gap.
+        import asyncio
+        from custom_components.vag_connect.const import CONF_STRATEGY
+        from custom_components.vag_connect.device_tracker import async_setup_entry
+        coord = _make_coordinator()
+        vin = list(coord.data.keys())[0]
+        coord.data[vin]["latitude"] = None
+        coord.vehicles[vin]["latitude"] = None
+        entry = _make_entry(coord, data={CONF_STRATEGY: "audi_acpp"})
+        added = []
+        def _collect(entities, **kw): added.extend(entities)
+        asyncio.run(
+            async_setup_entry(MagicMock(), entry, _collect)
+        )
+        assert len(added) == 1
+
 
 # ── climate ────────────────────────────────────────────────────────────────────
 

--- a/tests/test_euda_observability.py
+++ b/tests/test_euda_observability.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Stage-0 EU Data Act observability — the connector's own lifecycle bookkeeping.
+
+The portal connector records WHEN its data request was created, WHEN a real
+snapshot last arrived, and WHEN / HOW OFTEN a poll came back empty — plus it now
+splits a genuine VW-side outage (5xx/429) from a normal "not delivered yet" wait
+(404/410). The coordinator surfaces these as diagnostic sensors (#465, #1273).
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth import _eu_data_act as m
+
+
+def _conn() -> m.EUDataActConnector:
+    """A bare connector with only the observability attributes initialised."""
+    c = m.EUDataActConnector.__new__(m.EUDataActConnector)
+    c.last_no_data_reason = ""
+    c.last_no_data_at = None
+    c.no_data_count = 0
+    c.last_snapshot_at = None
+    return c
+
+
+def test_note_no_data_sets_reason_timestamp_and_increments():
+    c = _conn()
+    c._note_no_data("no_request")
+    assert c.last_no_data_reason == "no_request"
+    assert isinstance(c.last_no_data_at, str) and c.last_no_data_at
+    assert c.no_data_count == 1
+    c._note_no_data("portal_error")
+    assert c.last_no_data_reason == "portal_error"
+    assert c.no_data_count == 2
+
+
+def test_note_data_ok_clears_reason_and_stamps_snapshot_without_bumping_count():
+    c = _conn()
+    c._note_no_data("empty")
+    assert c.no_data_count == 1
+    c._note_data_ok()
+    assert c.last_no_data_reason == ""
+    assert isinstance(c.last_snapshot_at, str) and c.last_snapshot_at
+    # a good poll must NOT count as a no-data poll
+    assert c.no_data_count == 1
+
+
+def test_request_start_date_from_list_descriptor():
+    meta = [
+        {"Identifier": "AAA", "StartDate": "2026-09-01T10:00:00Z", "Frequency": "15mins"},
+        {"Identifier": "BBB", "StartDate": "2026-09-02T20:30:25Z", "Frequency": "15mins"},
+    ]
+    assert m._request_start_date(meta, "BBB") == "2026-09-02T20:30:25Z"
+    # an identifier that isn't present yields None (no phantom timestamp)
+    assert m._request_start_date(meta, "ZZZ") is None
+
+
+def test_request_start_date_from_bare_dict_all_dialect():
+    meta = {"Identifier": "CCC", "StartDate": "2026-09-02T20:34:51Z"}
+    assert m._request_start_date(meta, "CCC") == "2026-09-02T20:34:51Z"
+
+
+def test_request_start_date_from_wrapped_items():
+    meta = {"items": [{"Identifier": "DDD", "StartDate": "2026-09-03T00:00:00Z"}]}
+    assert m._request_start_date(meta, "DDD") == "2026-09-03T00:00:00Z"
+
+
+def test_request_start_date_ignores_non_string_startdate():
+    meta = [{"Identifier": "EEE", "StartDate": 12345}]
+    assert m._request_start_date(meta, "EEE") is None
+    # no identifier at all → None, never a crash
+    assert m._request_start_date([], "EEE") is None
+    assert m._request_start_date(None, "EEE") is None
+
+
+def test_portal_outage_statuses_split_error_from_not_ready():
+    # 5xx / 429 are a VW-side portal fault → portal_error; 400/404/410 mean the
+    # request just isn't provisioned / no delivery yet → delivery_not_ready.
+    for outage in (429, 500, 502, 503, 504):
+        assert outage in m._PORTAL_OUTAGE_STATUSES
+    for not_ready in (400, 404, 410):
+        assert not_ready not in m._PORTAL_OUTAGE_STATUSES

--- a/tests/test_euda_portal_health.py
+++ b/tests/test_euda_portal_health.py
@@ -32,6 +32,9 @@ def test_no_data_reasons_map_to_their_states():
     assert _portal_health({"no_data": True}, "no_request", None, None) == "waiting_for_portal_data"
     assert _portal_health({"no_data": True}, "no_content", None, None) == "empty_snapshots"
     assert _portal_health({"no_data": True}, "empty", None, None) == "delivery_not_ready"
+    # #465 — a VW-side portal outage/throttle (5xx/429) is its own state, distinct
+    # from "delivery not ready", so a fault doesn't read as a normal wait.
+    assert _portal_health({"no_data": True}, "portal_error", None, None) == "portal_error"
 
 
 def test_unknown_no_data_reason_defaults_to_waiting():
@@ -71,6 +74,7 @@ def test_every_result_is_a_declared_state():
         ({"no_data": True}, "no_request"),
         ({"no_data": True}, "no_content"),
         ({"no_data": True}, "empty"),
+        ({"no_data": True}, "portal_error"),
         ({"no_data": True}, ""),
     ):
         assert _portal_health(data, reason, 99 * _HOUR, 72 * _HOUR) in PORTAL_HEALTH_STATES

--- a/tests/test_portal_kickoff_format.py
+++ b/tests/test_portal_kickoff_format.py
@@ -104,6 +104,40 @@ async def test_kickoff_post_sends_traceid() -> None:
 
 
 @pytest.mark.asyncio
+async def test_no_csrf_still_posts_cookie_authenticated() -> None:
+    """The euda-apim requests/partial layer authenticates via the portal SESSION
+    COOKIES, not the Adobe-AEM Granite CSRF token — that token endpoint is
+    anonymous/empty for every session, even a real logged-in browser (live-
+    verified 2026-09-02: a cookie-only POST with no CSRF header reaches the
+    portal's own Duration validation, i.e. it authenticated). A missing CSRF must
+    NOT abort the kickoff — that abort is why the auto-kickoff silently did
+    nothing on every account (#709/#966)."""
+    sess = _CaptureSession(post_status=201)
+    scraper = _scraper(sess)
+    scraper._fetch_csrf_token = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    _confirm_readback(scraper)
+    ident = await scraper.kickoff_custom_data_request(_VIN)
+    assert ident, "kickoff must still succeed without an AEM CSRF token"
+    assert sess.post_calls, "no POST was made — the empty AEM CSRF must not abort"
+    headers = sess.post_calls[-1][1]["headers"]
+    assert "CSRF-Token" not in headers  # never sent as an empty/None value
+    assert headers.get("traceId")       # still required by the euda-apim edge
+
+
+@pytest.mark.asyncio
+async def test_csrf_is_sent_when_the_portal_ever_provides_one() -> None:
+    """Best-effort forward-compat: a future portal build that starts issuing a
+    Granite CSRF token still gets it attached (the branch is currently
+    unreachable because that endpoint is anonymous for everyone)."""
+    sess = _CaptureSession(post_status=201)
+    scraper = _scraper(sess)
+    scraper._fetch_csrf_token = AsyncMock(return_value="TOK")  # type: ignore[method-assign]
+    _confirm_readback(scraper)
+    await scraper.kickoff_custom_data_request(_VIN)
+    assert sess.post_calls[-1][1]["headers"].get("CSRF-Token") == "TOK"
+
+
+@pytest.mark.asyncio
 async def test_metadata_probe_sends_traceid() -> None:
     """``get_active_custom_request_identifier`` sends a traceId on its GET, and a
     404 (no request) resolves to None (not an error)."""

--- a/tests/test_skoda_source_mode.py
+++ b/tests/test_skoda_source_mode.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1286 (@n3roGit) — the Škoda official-API source mode.
+
+A user can choose how the official manufacturer API interacts with the primary
+"mysmob" channel: auto (merge, official preferred) / prefer_official / failover /
+official_only (mysmob off, per-VIN degrade) / mysmob_only (official off). The
+coordinator reads a single per-entry mode and pushes it onto the Škoda client so
+"official_only" reroutes the primary read; the other modes gate the merge /
+failover / auto-enrol coordinator-side.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.skoda import SkodaClient
+from custom_components.vag_connect.cariad.models import VehicleData
+from custom_components.vag_connect.const import SKODA_OFFICIAL_MODES
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+
+def _coord(options: dict | None = None, data: dict | None = None) -> VagConnectCoordinator:
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c.entry = SimpleNamespace(options=options or {}, data=data or {})  # type: ignore[attr-defined]
+    return c
+
+
+def test_all_five_modes_are_declared():
+    assert SKODA_OFFICIAL_MODES == (
+        "auto", "prefer_official", "failover", "official_only", "mysmob_only",
+    )
+
+
+def test_mode_defaults_to_auto():
+    assert _coord()._skoda_official_mode() == "auto"
+
+
+def test_mode_reads_from_entry_data():
+    assert _coord(data={"skoda_official_mode": "failover"})._skoda_official_mode() == "failover"
+
+
+def test_mode_options_win_over_data():
+    # options-then-data precedence (the entry.options-trap safe read)
+    c = _coord(
+        options={"skoda_official_mode": "official_only"},
+        data={"skoda_official_mode": "auto"},
+    )
+    assert c._skoda_official_mode() == "official_only"
+
+
+def test_unknown_mode_falls_back_to_auto():
+    assert _coord(data={"skoda_official_mode": "bogus"})._skoda_official_mode() == "auto"
+
+
+def test_push_official_mode_sets_client_attribute():
+    c = _coord(data={"skoda_official_mode": "official_only"})
+    client = MagicMock()
+    c._cariad_client = client  # type: ignore[attr-defined]
+    c._push_official_mode()
+    client.set_official_mode.assert_called_once_with("official_only")
+
+
+def test_push_official_mode_is_a_noop_for_non_skoda_clients():
+    # a client with no set_official_mode (getattr → None) must never raise
+    c = _coord()
+    c._cariad_client = SimpleNamespace()  # type: ignore[attr-defined]
+    c._push_official_mode()  # no exception
+
+
+def test_push_official_mode_accepts_an_explicit_client():
+    # the #584 captured-client path passes the client explicitly
+    c = _coord(data={"skoda_official_mode": "prefer_official"})
+    c._cariad_client = None  # type: ignore[attr-defined]
+    captured = MagicMock()
+    c._push_official_mode(captured)
+    captured.set_official_mode.assert_called_once_with("prefer_official")
+
+
+def test_set_official_mode_stores_on_client():
+    client = SkodaClient.__new__(SkodaClient)
+    client.set_official_mode("official_only")
+    assert client._official_mode == "official_only"
+    client.set_official_mode("")  # empty → auto
+    assert client._official_mode == "auto"
+
+
+@pytest.mark.asyncio
+async def test_official_only_routes_get_status_to_the_official_api():
+    client = SkodaClient.__new__(SkodaClient)
+    client._eu_portal = None
+    client._official_mode = "official_only"
+    off = VehicleData(vin="V", battery_soc=55)
+    client._official_read_rate_safe = AsyncMock(return_value=off)  # type: ignore[method-assign]
+    result = await client.get_status("V")
+    assert result is off  # served straight from the official API, no mysmob read
+    client._official_read_rate_safe.assert_awaited_once_with("V")
+
+
+@pytest.mark.asyncio
+async def test_official_only_degrades_to_mysmob_when_no_official_read():
+    # per-VIN degrade: no official key / rate-limited → official read is None, so
+    # get_status must NOT return early — it falls through to the mysmob path. We
+    # prove the fall-through by leaving the mysmob internals unset so the very next
+    # access (self._val) raises AttributeError rather than returning None early.
+    client = SkodaClient.__new__(SkodaClient)
+    client._eu_portal = None
+    client._official_mode = "official_only"
+    client._official_read_rate_safe = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    with pytest.raises(AttributeError):
+        await client.get_status("V")
+    client._official_read_rate_safe.assert_awaited_once_with("V")

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -519,7 +519,10 @@ async def test_get_vehicle_data_listing_500_is_graceful() -> None:
     d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
     assert d.battery_soc is None
     assert d.connection_state is None
-    assert conn.last_no_data_reason == "empty"
+    # #465 — a 5xx here is a genuine VW-side portal outage, now reported as its
+    # own reason (portal_error) rather than the catch-all "empty", so the health
+    # sensor can distinguish an outage from a not-yet-provisioned request.
+    assert conn.last_no_data_reason == "portal_error"
 
 
 @pytest.mark.asyncio
@@ -544,7 +547,8 @@ async def test_get_vehicle_data_download_503_is_graceful() -> None:
     d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
     assert d.battery_soc is None
     assert d.connection_state is None
-    assert conn.last_no_data_reason == "empty"
+    # #465 — 5xx on the download is the same VW-side outage story → portal_error.
+    assert conn.last_no_data_reason == "portal_error"
 
 
 @pytest.mark.asyncio

--- a/tests/test_v2150a10_failsafe.py
+++ b/tests/test_v2150a10_failsafe.py
@@ -46,8 +46,11 @@ class TestPortalNoDataFlag:
         assert conn.last_no_data_reason == "no_request"
 
     def test_empty_listing_sets_no_data_true(self) -> None:
-        """Metadata OK but the dataset listing is a transient None (soft 5xx) →
-        no_data=True so the coordinator carries last-good forward."""
+        """Metadata OK but the dataset listing is None → no_data=True so the
+        coordinator carries last-good forward. With no recorded HTTP status (the
+        mock doesn't set one), this defaults to the softer "empty"
+        (delivery_not_ready); a real 5xx/429 would record its status and read as
+        "portal_error" instead (see test_v2120_eu_data_act_connector)."""
         conn = _conn()
         conn._get_json = AsyncMock(side_effect=[{"identifier": "abc"}, None])
         d = asyncio.run(conn.get_vehicle_data(_VIN))

--- a/tests/test_v2180_709_csrf_diagnosable.py
+++ b/tests/test_v2180_709_csrf_diagnosable.py
@@ -195,6 +195,25 @@ async def test_anonymous_triggers_one_page_load_and_a_retry() -> None:
 
 
 @pytest.mark.asyncio
+async def test_second_revive_endpoint_recovers_the_token() -> None:
+    """#1273 (steemandavid) — the user-page GET can land 200 yet leave the AEM leg
+    anonymous, so the permission-check service is tried as a second revive; a token
+    from that second retry is used."""
+    s = _seq_scraper(
+        _HeaderResp(200, {}, {"x-sky-isauth": "0"}),               # fetch: anonymous
+        _HeaderResp(200, {}),                                       # revive 1: user.html
+        _HeaderResp(200, {}, {"x-sky-isauth": "0"}),               # retry 1: still anon
+        _HeaderResp(200, {}),                                       # revive 2: permissioncheck
+        _HeaderResp(200, {"token": "T"}, {"x-sky-isauth": "1"}),  # retry 2: token!
+    )
+    assert await s._fetch_csrf_token() == "T"
+    calls = s._session.calls  # type: ignore[attr-defined]
+    assert any("/de/en/user.html" in c for c in calls), calls
+    assert any("/services/permissioncheck" in c for c in calls), calls
+    assert sum("token.json" in c for c in calls) == 3, calls   # initial + 2 retries
+
+
+@pytest.mark.asyncio
 async def test_authenticated_but_empty_does_not_retry(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_v2180_historical_export_kickoff.py
+++ b/tests/test_v2180_historical_export_kickoff.py
@@ -116,9 +116,31 @@ async def test_401_raises_session_expired() -> None:
 
 
 @pytest.mark.asyncio
-async def test_no_csrf_aborts_without_posting() -> None:
+async def test_no_csrf_still_posts_cookie_authenticated() -> None:
+    """The euda-apim requests/all layer authenticates via the portal SESSION
+    COOKIES, not the Adobe-AEM Granite CSRF token — that token endpoint is
+    anonymous/empty for every session, even a real logged-in browser (live-
+    verified 2026-09-02). A cookie-only POST with no CSRF header reaches the
+    portal's own validation, so a missing CSRF must NOT abort the export: the
+    POST still goes out and simply carries no CSRF-Token header. The old abort
+    silently blocked every one-time export on every account (#709/#966)."""
     sess = _CaptureSession(post_status=201)
     s = DataActScraper(sess, brand_name="audi")
     s._fetch_csrf_token = AsyncMock(return_value=None)  # type: ignore[method-assign]
-    assert await s.kickoff_historical_export(_VIN) is False
-    assert sess.post_calls == []
+    assert await s.kickoff_historical_export(_VIN) is True
+    assert sess.post_calls, "no POST was made — the empty AEM CSRF must not abort"
+    headers = sess.post_calls[-1][1]["headers"]
+    assert "CSRF-Token" not in headers  # never sent as an empty/None value
+    assert headers.get("traceId")       # still required by the euda-apim edge
+
+
+@pytest.mark.asyncio
+async def test_csrf_is_sent_when_the_portal_ever_provides_one() -> None:
+    """Best-effort forward-compat: if a future portal build starts issuing a
+    Granite CSRF token, we still attach it (the branch is currently unreachable
+    because that endpoint is anonymous for everyone)."""
+    sess = _CaptureSession(post_status=201)
+    s = DataActScraper(sess, brand_name="audi")
+    s._fetch_csrf_token = AsyncMock(return_value="TOK")  # type: ignore[method-assign]
+    assert await s.kickoff_historical_export(_VIN) is True
+    assert sess.post_calls[-1][1]["headers"].get("CSRF-Token") == "TOK"


### PR DESCRIPTION
Beta 4.7.0b5. Five commits on top of 4.7.0b4.

**Fixed**
- EU Data Act: the automatic data-request creation no longer aborts on the empty AEM CSRF token — the euda-apim data-request layer is cookie-authenticated, so both the 15-minute feed and the one-time export now go through. Live-verified end-to-end (POST returns 201 and the request appears on metadata). (#709, #966, #1273)
- Audi plug&play (OBD dongle): the car's location is now bound to a device_tracker unconditionally, the same way the volkswagen.de channel already is, so the dongle's intermittent parked GPS always has a tracker entity.

**Added**
- Portal feed observability: portal_health gains a "portal_error" state (a genuine VW-side outage vs a request that just isn't delivering yet) and a clearer "Live" label, plus four diagnostic sensors — data request created, last snapshot received, last no-data poll, and no-data count. All 12 languages. (#465, #1273)
- Škoda official-API source mode: a per-car select (auto / prefer official / failover / official only / standard only) to choose how the official API and the standard channel interact. All 12 languages. (#1286)

Full test suite: 5707 passed, 15 skipped. CHANGELOG updated.
