### PR TITLE
v4.7.0b6 (part) — Volkswagen Commercial Vehicles (Nutzfahrzeuge) + portal state-order cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,24 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b6] - 2026-09-03 — Volkswagen Commercial Vehicles (Nutzfahrzeuge)
+
+### Added
+- **Volkswagen Commercial Vehicles is now its own brand.** VW runs Passenger Cars and
+  Commercial Vehicles (Nutzfahrzeuge) as **separate** data-controllers in the EU Data Act
+  portal — so a T6.1 / Transporter / Crafter registered under the commercial realm never
+  delivered through the "Volkswagen EU" setup (it showed as a car but stayed empty). Pick
+  **Volkswagen Commercial Vehicles** at setup — or add it as a second entry alongside your
+  passenger VW — and its portal feed comes through. Read-only via the EU Data Act portal,
+  same as passenger VW. Thanks @EcksteinU for the clear ID.3 + T6.1 report (#1316).
+
+### Fixed
+- **EU Data Act portal login: the state locale order is now correct for non-matching
+  country/language.** The portal expects `{country}__{language}` (a German account viewing in
+  English is `de__en`); a secondary login helper had the two halves reversed. The active
+  reader was already correct, so this only tidies the dormant helper — no behaviour change
+  for the de_DE majority — with a regression guard added.
+
 ## [4.7.0b5] - 2026-09-02 — EU Data Act: the data request actually gets created + portal-feed observability
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/_capabilities.py
+++ b/custom_components/vag_connect/cariad/_capabilities.py
@@ -338,6 +338,21 @@ DECLARED_CAPABILITIES: dict[str, dict[str, bool]] = {
         "fcm_push": True,
         "dag_login": False,
     },
+    "volkswagen_commercial": {
+        # #1316 — VW Commercial Vehicles is routed PORTAL-ONLY (base.py: the
+        # native BFF is attestation-walled, so the strategy chain is just
+        # data_act_portal). The read-only portal offers no commands and no push,
+        # so it declares nothing — every capability False, like audi_acpp — and
+        # diagnostics never imply a command it can't do.
+        "auxiliary_heating": False,
+        "charging": False,
+        "climatisation": False,
+        "trip_statistics": False,
+        "brake_service": False,
+        "ola_push": False,
+        "fcm_push": False,
+        "dag_login": False,
+    },
     "skoda": {
         "auxiliary_heating": False,
         "charging": True,

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -371,6 +371,14 @@ class CariadBaseClient:
                 ("idk", {"hybrid_full": False}),
                 ("data_act_portal", {}),
             ]
+        elif self._brand.name == "volkswagen_commercial":
+            # #1316 — VW Commercial Vehicles (Nutzfahrzeuge). Native BFF/IDK is
+            # attestation-walled exactly like passenger VW, so go straight to the
+            # read-only EU-Data-Act portal (its state_brand routes to the
+            # commercial realm). Must NOT fall through to the ``else`` below —
+            # that arms IDK only, never the portal, and the car silently gets no
+            # data.
+            strategies = [("data_act_portal", {})]
         elif self._brand.name == "audi":
             strategies = [
                 ("idk", {"hybrid_full": False}),

--- a/custom_components/vag_connect/cariad/api/commercial.py
+++ b/custom_components/vag_connect/cariad/api/commercial.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Volkswagen Commercial Vehicles (Nutzfahrzeuge) client — EU Data Act portal.
+
+#1316 — VW Commercial Vehicles is a SEPARATE EU Data Act data-controller realm
+from passenger VW: on one account the ID.3 lives in the passenger realm and a
+T6.1 in the commercial realm, each with its own consent + data delivery. The
+native BFF/IDK path is attestation-walled exactly like passenger VW, so this
+brand reads through the read-only EU-Data-Act portal, where the SOLE difference
+is the OIDC ``state_brand`` ``VOLKSWAGEN_COMMERCIAL_VEHICLES`` (live-confirmed
+2026-09-02; wired in ``cariad/auth/_eu_data_act.py``). The data + command surface
+is inherited unchanged from ``VWEUClient``.
+"""
+from __future__ import annotations
+
+import logging
+
+from aiohttp import ClientSession
+
+from ..models import BRAND_VW_COMMERCIAL
+from .vw_eu import VWEUClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VWCommercialClient(VWEUClient):
+    """VW Commercial Vehicles client — reads via the EU Data Act portal.
+
+    Mirrors ``BentleyClient``: ``VWEUClient`` hardcodes ``BRAND_VW_EU`` in its own
+    ``__init__``, so we must call ``CariadBaseClient.__init__`` directly with
+    ``BRAND_VW_COMMERCIAL`` — that distinct brand name is what steers the portal
+    OIDC state to the commercial realm (``base.py`` builds the state from
+    ``self._brand.name``). Native BFF is attestation-walled (same as passenger
+    VW), so the strategy chain resolves straight to ``data_act_portal``.
+    """
+
+    def __init__(
+        self,
+        session: ClientSession,
+        email: str,
+        password: str,
+        spin: str = "",
+    ) -> None:
+        from .base import CariadBaseClient  # noqa: PLC0415
+
+        CariadBaseClient.__init__(
+            self, session, BRAND_VW_COMMERCIAL, email, password, spin
+        )
+        _LOGGER.info(
+            "VW Commercial Vehicles client instantiated (EU Data Act portal, "
+            "read-only; commercial realm). Brand: %s",
+            BRAND_VW_COMMERCIAL.name,
+        )

--- a/custom_components/vag_connect/cariad/api/factory.py
+++ b/custom_components/vag_connect/cariad/api/factory.py
@@ -15,6 +15,7 @@ from .porsche import PorscheClient
 from .vw_na import VWNAClient
 from .audi_na import AudiNAClient
 from .bentley import BentleyClient
+from .commercial import VWCommercialClient
 from .plugandplay import PlugAndPlayCloudClient
 from .skoda_official import SkodaOfficialClient
 
@@ -40,6 +41,8 @@ class CariadClientFactory:
 
         Supported brands:
           volkswagen    — VW EU (WeConnect ID, EMEA BFF)
+          volkswagen_commercial — VW Commercial Vehicles / Nutzfahrzeuge
+                          (EU-Data-Act portal realm, read-only)
           audi          — Audi EU (myAudi, EMEA BFF)
           skoda         — Škoda (MyŠkoda, mysmob.api.connect.skoda-auto.cz)
           seat          — SEAT (OLA server)
@@ -58,6 +61,10 @@ class CariadClientFactory:
         lower = brand.lower()
         if lower == "volkswagen":
             return VWEUClient(session, email, password, spin)
+        if lower == "volkswagen_commercial":
+            # #1316 — VW Commercial Vehicles (Nutzfahrzeuge): a separate EU-Data-Act
+            # realm, reads via the portal (state_brand VOLKSWAGEN_COMMERCIAL_VEHICLES).
+            return VWCommercialClient(session, email, password, spin)
         if lower == "audi":
             return AudiClient(session, email, password, spin)
         if lower == "skoda":
@@ -96,6 +103,6 @@ class CariadClientFactory:
             return SkodaOfficialClient(session, email, password, spin)
         raise ValueError(
             f"Unknown brand '{brand}'. Supported: "
-            "volkswagen, audi, skoda, seat, cupra, volkswagen_na, audi_na, "
-            "porsche, bentley"
+            "volkswagen, volkswagen_commercial, audi, skoda, seat, cupra, "
+            "volkswagen_na, audi_na, porsche, bentley"
         )

--- a/custom_components/vag_connect/cariad/auth/_data_act_portal.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_portal.py
@@ -110,15 +110,23 @@ _PORTAL_REQUEST_TIMEOUT_S = 30
 def _build_state(brand_name: str, country: str, language: str) -> str:
     """Return the state-string expected by the portal router.
 
-    Format: ``{language}__{country}__{brand_suffix}`` (e.g.
-    ``de__de__VOLKSWAGEN_PASSENGER_CARS``). The portal's state-string
-    routing decodes the language first, then the country, then the
-    brand-suffix that matches its internal brand-routing enum.
+    Format: ``{country}__{language}__{brand_suffix}`` (e.g.
+    ``de__en__VOLKSWAGEN_COMMERCIAL_VEHICLES`` for a German account viewing in
+    English). The portal decodes the country first, then the language, then the
+    brand-suffix that matches its internal brand-routing enum — confirmed against a
+    live portal authorize 2026-09-02 (``datahubConfig`` ``country=de`` /
+    ``language=en`` produced a real ``state=de__en__…``; the portal's
+    ``validLocales`` are all ``{country}/{language}``). The active reader
+    ``EUDataActConnector`` builds the same ``{country}__{language}__{brand}`` order
+    (``_eu_data_act.py``).
 
-    Pre-v2.10.2 we shipped the wrong order ``{country}__{language}``
-    which works for de_DE users (both halves identical) but routes the
-    wrong locale for any non-matching country/language pair. Verified
-    against a live portal trace 2026-06-03.
+    Historical note: a v2.10.2 change flipped this to ``{language}__{country}`` on a
+    mistaken reading of a symmetric ``de_DE`` trace, where the two halves are
+    identical so the order is invisible; that is wrong for any asymmetric
+    country/language pair and is corrected here. This helper is only ever
+    constructed with the symmetric DE/de defaults in the shipped integration, so
+    the flip is a no-op in practice — it just keeps the state honest for any future
+    non-default caller and matches the active reader.
 
     Falls back to VOLKSWAGEN_PASSENGER_CARS for unknown brand names so
     the login at least lands somewhere instead of erroring out.
@@ -126,7 +134,7 @@ def _build_state(brand_name: str, country: str, language: str) -> str:
     brand_suffix = _BRAND_STATE_FRAGMENTS.get(
         brand_name.lower(), _BRAND_STATE_FRAGMENTS["volkswagen"],
     )
-    return f"{language.lower()}__{country.lower()}__{brand_suffix}"
+    return f"{country.lower()}__{language.lower()}__{brand_suffix}"
 
 
 def _make_pkce() -> tuple[str, str]:

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -88,6 +88,11 @@ _EUDA_CUPRA_SEAT = {
 }
 _EUDA_BRANDS: dict[str, dict[str, str]] = {
     "volkswagen": _EUDA_VW,
+    # #1316 — VW Commercial Vehicles (Nutzfahrzeuge): SAME portal client as
+    # passenger VW, only the state_brand differs. Must be explicit — the unknown-
+    # brand fallback (~L3489) would build "VOLKSWAGEN_COMMERCIAL" (brand.upper()),
+    # missing the "_VEHICLES" suffix the live-confirmed state needs (2026-09-02).
+    "volkswagen_commercial": {**_EUDA_VW, "state_brand": "VOLKSWAGEN_COMMERCIAL_VEHICLES"},
     "cupra": {**_EUDA_CUPRA_SEAT, "state_brand": "CUPRA"},
     "seat": {**_EUDA_CUPRA_SEAT, "state_brand": "SEAT"},
     "skoda": {**_EUDA_VW, "state_brand": "SKODA"},

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -70,6 +70,24 @@ BRAND_VW_EU = BrandConfig(
     android_package_name="de.volkswagen.weconnect",
 )
 
+# #1316 — VW Commercial Vehicles (Nutzfahrzeuge) is a SEPARATE EU Data Act
+# data-controller realm from passenger VW. Its native BFF is the same
+# attestation-walled path as passenger VW, so it reads through the EU-Data-Act
+# portal — where the ONLY difference is the OIDC ``state_brand``
+# ``VOLKSWAGEN_COMMERCIAL_VEHICLES`` (live-confirmed 2026-09-02; wired in
+# _eu_data_act.py). Every other field mirrors BRAND_VW_EU; the DISTINCT ``name``
+# is what steers the portal to the commercial realm (base.py builds the state
+# from ``self._brand.name``), so it must NOT reuse "volkswagen".
+BRAND_VW_COMMERCIAL = BrandConfig(
+    name="volkswagen_commercial",
+    client_id="a24fba63-34b3-4d43-b181-942111e6bda8@apps_vw-dilab_com",
+    redirect_uri="weconnect://authenticated",
+    user_agent="Volkswagen/4.2.1-android/14",
+    api_base="https://emea.bff.cariad.digital",
+    scope="openid profile badge cars dealers vin",
+    android_package_name="de.volkswagen.weconnect",
+)
+
 # ── DataPlug / plug&play cloud (OBD-dongle cars WITHOUT built-in connectivity) ──
 # A separate read source served by api/plugandplay.py. Reaches OLD dongle-equipped
 # cars that the BFF + EU-Data-Act portal do not serve. Auth is plain
@@ -326,7 +344,8 @@ BRAND_CUPRA_STANDALONE = BrandConfig(
 )
 
 BRANDS: dict[str, BrandConfig] = {
-    "volkswagen":    BRAND_VW_EU,
+    "volkswagen":            BRAND_VW_EU,
+    "volkswagen_commercial": BRAND_VW_COMMERCIAL,  # #1316 — Nutzfahrzeuge realm
     "audi":          BRAND_AUDI,
     "skoda":         BRAND_SKODA,
     "seat":          BRAND_SEAT,

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -90,6 +90,8 @@ def _brand_label(brand: str) -> str:
 _BRAND_OPTIONS: list[SelectOptionDict] = [
     SelectOptionDict(value="audi",          label="Audi (myAudi)"),
     SelectOptionDict(value="volkswagen",    label="Volkswagen EU (WeConnect ID)"),
+    # #1316 — VW Commercial Vehicles (Nutzfahrzeuge): separate EU-Data-Act realm.
+    SelectOptionDict(value="volkswagen_commercial", label="Volkswagen Commercial Vehicles"),
     SelectOptionDict(value="skoda",         label="Škoda (MyŠkoda)"),
     SelectOptionDict(value="seat",          label="SEAT"),
     SelectOptionDict(value="cupra",         label="CUPRA"),

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -357,6 +357,7 @@ CONF_ABRP_USER_TOKEN         = "abrp_user_token"
 BRANDS = {
     "audi":           "Audi (myAudi)",
     "volkswagen":     "Volkswagen EU (WeConnect ID)",
+    "volkswagen_commercial": "Volkswagen Commercial Vehicles",  # #1316 Nutzfahrzeuge
     "skoda":          "Škoda (MyŠkoda)",
     "seat":           "SEAT",
     "cupra":          "CUPRA",
@@ -390,6 +391,7 @@ BRANDS = {
 DEEPLINK_SCHEMES: dict[str, str] = {
     "audi":          "myaudi://",          # DEX: myAudi 5.5.1
     "volkswagen":    "weconnect://",       # DEX: We Connect 4.0.3 (was wecharge://)
+    "volkswagen_commercial": "weconnect://",  # #1316 — same We Connect app
     "skoda":         "myskoda://",         # DEX: MySkoda 8.14.0
     "seat":          "seat://",            # DEX: My SEAT 2.19.1 (was myseat://)
     "cupra":         "cupra://",           # DEX: My CUPRA 2.18.1 (was mycupra://)

--- a/custom_components/vag_connect/entity_base.py
+++ b/custom_components/vag_connect/entity_base.py
@@ -13,13 +13,30 @@ from .const import DOMAIN
 from .coordinator import VagConnectCoordinator
 
 
+# #1316 — brands whose slug title-cases badly (underscores / mixed case). This
+# display override keeps the device page + entity names clean; every other brand
+# falls back to ``brand.title()`` unchanged, so no existing device is renamed.
+_BRAND_DISPLAY: dict[str, str] = {
+    "volkswagen_commercial": "Volkswagen Commercial Vehicles",
+}
+
+
+def _brand_display(brand: str) -> str:
+    """Human-readable brand label for the HA device (manufacturer + name).
+
+    HA registry ``manufacturer``/``name`` are plain strings (not translatable),
+    so this is one canonical English label — consistent with ``const.BRANDS``."""
+    return _BRAND_DISPLAY.get((brand or "").lower()) or brand.title()
+
+
 def _device_name(vehicle: dict, brand: str) -> str:
     """Return "{Brand} {Model}" or "{Brand} {VIN[-6:]}" as device name."""
+    label = _brand_display(brand)
     model = (vehicle.get("model") or "").strip()
     if model and model.lower() not in ("vag vehicle", "unknown", ""):
-        return f"{brand.title()} {model}"
+        return f"{label} {model}"
     vin = vehicle.get("vin", "")
-    return f"{brand.title()} {vin[-6:]}" if vin else brand.title()
+    return f"{label} {vin[-6:]}" if vin else label
 
 
 # Connection-status diagnostics that must stay AVAILABLE even when the vehicle
@@ -140,6 +157,7 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
         # durable section landing page over a deep link that gets renamed.
         "audi":          "https://my.audi.com/",
         "volkswagen":    "https://www.volkswagen.de/de/besitzer-und-nutzer.html",
+        "volkswagen_commercial": "https://www.volkswagen-nutzfahrzeuge.de/",  # #1316
         "skoda":         "https://www.skoda-auto.com/",
         "seat":          "https://www.seat.com/owners",
         "cupra":         "https://www.cupraofficial.com/services/mycupra.html",
@@ -201,9 +219,10 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
             name=name,
             model=_model_str,
             # Prefer an explicit manufacturer the reader resolved (e.g. acpp maps
-            # brandCode "A" → "Audi"); else the config brand, title-cased. This
-            # avoids ugly labels like "Audi_Acpp" for the plug&play source.
-            manufacturer=vehicle.get("manufacturer") or brand.title(),
+            # brandCode "A" → "Audi"); else the display label for the config brand
+            # (#1316: "Volkswagen Commercial Vehicles", not "Volkswagen_Commercial";
+            # unmapped brands stay title-cased as before).
+            manufacturer=vehicle.get("manufacturer") or _brand_display(brand),
             serial_number=self._vin,
             hw_version=(str(_year) if _year else None),
             sw_version=vehicle.get("firmware_version"),

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b5"
+  "version": "4.7.0b6"
 }

--- a/tests/test_1316_vw_commercial_brand.py
+++ b/tests/test_1316_vw_commercial_brand.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1316 — the ``volkswagen_commercial`` brand (VW Commercial Vehicles / Nutzfahrzeuge).
+
+A SEPARATE EU Data Act data-controller realm from passenger VW (one account can
+hold an ID.3 in the passenger realm and a T6.1 in the commercial one), reached via
+the SAME portal client with ``state_brand`` ``VOLKSWAGEN_COMMERCIAL_VEHICLES``.
+Adding a brand is cross-cutting; these pin the wiring (factory routing, registry,
+BrandConfig parity, clean device label, display/deeplink maps) so it can't
+half-exist. The portal-state guard lives in test_v2120_eu_data_act_connector.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.cariad.api.commercial import VWCommercialClient
+from custom_components.vag_connect.cariad.api.factory import CariadClientFactory
+from custom_components.vag_connect.cariad.models import (
+    BRANDS,
+    BRAND_VW_COMMERCIAL,
+    BRAND_VW_EU,
+)
+from custom_components.vag_connect.const import BRANDS as BRAND_LABELS
+from custom_components.vag_connect.const import DEEPLINK_SCHEMES
+from custom_components.vag_connect.entity_base import _brand_display, _device_name
+
+
+def test_factory_creates_vw_commercial_client():
+    client = CariadClientFactory.create(
+        "volkswagen_commercial", MagicMock(), "u@t.de", "pw",
+    )
+    assert isinstance(client, VWCommercialClient)
+    # the distinct brand name is what routes the portal to the commercial realm
+    assert client._brand.name == "volkswagen_commercial"
+
+
+def test_registry_and_brandconfig_parity():
+    assert BRANDS["volkswagen_commercial"] is BRAND_VW_COMMERCIAL
+    assert BRAND_VW_COMMERCIAL.name == "volkswagen_commercial"
+    # every field except the name mirrors passenger VW (same BFF/portal surface)
+    assert BRAND_VW_COMMERCIAL.client_id == BRAND_VW_EU.client_id
+    assert BRAND_VW_COMMERCIAL.scope == BRAND_VW_EU.scope
+    assert BRAND_VW_COMMERCIAL.api_base == BRAND_VW_EU.api_base
+    assert BRAND_VW_COMMERCIAL.redirect_uri == BRAND_VW_EU.redirect_uri
+    assert BRAND_VW_COMMERCIAL.name != BRAND_VW_EU.name
+
+
+def test_clean_device_label_not_the_raw_slug():
+    # the raw brand.title() would be "Volkswagen_Commercial" — must not leak out
+    assert _brand_display("volkswagen_commercial") == "Volkswagen Commercial Vehicles"
+    name = _device_name({"vin": "WVWZZZ0000000001"}, "volkswagen_commercial")
+    assert name.startswith("Volkswagen Commercial Vehicles")
+    assert "_" not in name
+    # an unmapped brand is unchanged (still title-cased) — no blast radius
+    assert _brand_display("audi") == "Audi"
+
+
+def test_display_and_deeplink_maps_have_the_brand():
+    assert BRAND_LABELS["volkswagen_commercial"] == "Volkswagen Commercial Vehicles"
+    assert DEEPLINK_SCHEMES["volkswagen_commercial"] == "weconnect://"

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -33,7 +33,10 @@ class TestModels:
     def test_brand_configs_all_present(self):
         from custom_components.vag_connect.cariad.models import BRANDS
         assert set(BRANDS.keys()) == {
-            "volkswagen", "audi", "skoda", "seat", "cupra",
+            "volkswagen",
+            # #1316 — VW Commercial Vehicles (Nutzfahrzeuge): separate EU-DA realm.
+            "volkswagen_commercial",
+            "audi", "skoda", "seat", "cupra",
             "volkswagen_na", "porsche",
             # v2.14.11 — Bentley wired (Audi IDK tenant; login+read).
             "bentley",

--- a/tests/test_data_act_state_order.py
+++ b/tests/test_data_act_state_order.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``_build_state`` must emit ``{country}__{language}__{brand}``.
+
+The EU Data Act portal decodes the COUNTRY first, then the language — confirmed
+against a live portal authorize (2026-09-02): with ``datahubConfig`` country=de /
+language=en the portal produced ``state=de__en__…``, and the portal's
+``validLocales`` are all ``{country}/{language}``. The active reader
+``EUDataActConnector`` already builds this order (its ``se__sv`` / ``ch__de`` tests
+pin it); a v2.10.2 change had left the secondary ``DataActPortalAuth._build_state``
+helper on the inverted ``{language}__{country}`` order, invisible because it is only
+ever constructed with the symmetric DE/de defaults. This guards the corrected order
+so the two implementations can't drift again.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._data_act_portal import _build_state
+
+
+def test_symmetric_locale_country_then_language():
+    assert _build_state("volkswagen", "de", "de") == "de__de__VOLKSWAGEN_PASSENGER_CARS"
+
+
+def test_asymmetric_locale_puts_country_first():
+    # the exact regression this guards: {language}__{country} would give "en__de"
+    assert _build_state("volkswagen", "de", "en") == "de__en__VOLKSWAGEN_PASSENGER_CARS"
+    assert _build_state("volkswagen", "ch", "de") == "ch__de__VOLKSWAGEN_PASSENGER_CARS"
+    assert _build_state("volkswagen", "at", "de") == "at__de__VOLKSWAGEN_PASSENGER_CARS"
+
+
+def test_brand_suffix_and_case_folding():
+    assert _build_state("AUDI", "DE", "DE") == "de__de__AUDI"
+    assert _build_state("skoda", "de", "de") == "de__de__SKODA"
+
+
+def test_unknown_brand_falls_back_to_passenger_cars():
+    assert _build_state("nope", "de", "de") == "de__de__VOLKSWAGEN_PASSENGER_CARS"

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -323,6 +323,15 @@ def test_brand_config_resolution() -> None:
     assert seat._client_id.startswith("f85e5b69")
     assert seat._state == "de__de__SEAT"
 
+    # #1316 — VW Commercial Vehicles (Nutzfahrzeuge): same portal client as
+    # passenger VW, but the state_brand MUST be the explicit, live-confirmed
+    # "VOLKSWAGEN_COMMERCIAL_VEHICLES" — NOT the unknown-brand fallback
+    # "VOLKSWAGEN_COMMERCIAL" (brand.upper()), which drops the "_VEHICLES" suffix
+    # and silently handshakes with the wrong realm.
+    vwc = EUDataActConnector(object(), brand="volkswagen_commercial")  # type: ignore[arg-type]
+    assert vwc._client_id.startswith("9b58543e")
+    assert vwc._state == "de__de__VOLKSWAGEN_COMMERCIAL_VEHICLES"
+
     # Unknown brand → VW client with a derived state suffix (graceful).
     porsche = EUDataActConnector(object(), brand="porsche")  # type: ignore[arg-type]
     assert porsche._client_id.startswith("9b58543e")


### PR DESCRIPTION
Part of the 4.7.0b6 beta line — merging without a tag; more fixes to follow before the release is cut.

**Added**
- **Volkswagen Commercial Vehicles (Nutzfahrzeuge) as its own brand.** VW runs Passenger Cars and Commercial Vehicles as separate EU Data Act data-controllers, so a T6.1 / Transporter / Crafter under the commercial realm never delivered through the passenger "Volkswagen EU" setup. New brand `volkswagen_commercial` — same portal client as passenger VW, only the OIDC state_brand differs (`VOLKSWAGEN_COMMERCIAL_VEHICLES`, live-confirmed). Read-only via the EU Data Act portal. (#1316)

**Fixed**
- EU Data Act portal login: corrected the dormant `_build_state` locale order to `{country}__{language}` (the active reader was already correct, so no behaviour change for the de_DE majority) + a regression guard.

Full test suite: 5715 passed, 15 skipped. A discovery pass plus the suite's brand-registry completeness tests together verified every brand-enumeration site the new brand touches (two — the registry-keys assertion and DECLARED_CAPABILITIES — were caught and covered).
