### PR TITLE
v4.7.0b6 sweep fixes — Reconfigure crash, lifetime carry-forward, no-legacy gate, TPMS + Škoda update sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
-## [4.7.0b6] - 2026-09-03 — Volkswagen Commercial Vehicles (Nutzfahrzeuge)
+## [4.7.0b6] - 2026-09-03 — Volkswagen Commercial Vehicles (Nutzfahrzeuge) + issue-sweep fixes
 
 ### Added
 - **Volkswagen Commercial Vehicles is now its own brand.** VW runs Passenger Cars and
@@ -52,8 +52,26 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   **Volkswagen Commercial Vehicles** at setup — or add it as a second entry alongside your
   passenger VW — and its portal feed comes through. Read-only via the EU Data Act portal,
   same as passenger VW. Thanks @EcksteinU for the clear ID.3 + T6.1 report (#1316).
+- **Tyre pressure monitoring type sensor.** Cars with an indirect (ABS-based) TPMS never
+  report per-wheel pressures, so they showed no tyre entities at all. A new diagnostic
+  "Tyre pressure monitoring" sensor now says whether your car measures per-wheel pressures
+  or uses an indirect system (#528, #538).
+- **Škoda: software update status sensor.** Surfaces the software-update lifecycle the
+  readiness endpoint reports (e.g. "update in progress"). Thanks to the Vehicle Data Scout
+  on the Elroq (#1333).
 
 ### Fixed
+- **Lifetime trip totals no longer go blank between deliveries.** The cumulative lifetime_*
+  sensors (distance, avg speed, avg consumption, …) dropped to "unknown" on any poll that
+  didn't re-send the block — annoying in history and automations. They now keep their last
+  value until a fresh one arrives (a genuine reset still lands). Thanks @indigomejor (#1310).
+- **Reconfigure no longer crashes the background poll.** A Reconfigure could null the client
+  mid-cycle and the next poll raised "NoneType has no attribute get_status". The poll loop
+  now captures the client up front and skips the cycle cleanly if it's gone (#584).
+- **VW: "no legacy Car-Net" cars stop offering dead command buttons.** When a car's MBB
+  command channel definitively has no legacy enrolment, its command controls are now hidden
+  (instead of failing on every press) and the integration stops re-poking the gateway for it
+  each poll — and the diagnostics now report it correctly (#1150, #584).
 - **EU Data Act portal login: the state locale order is now correct for non-matching
   country/language.** The portal expects `{country}__{language}` (a German account viewing in
   English is `de__en`); a secondary login helper had the two halves reversed. The active

--- a/custom_components/vag_connect/cariad/_unexpected_keys.py
+++ b/custom_components/vag_connect/cariad/_unexpected_keys.py
@@ -338,6 +338,9 @@ EXPECTED_KEYS: dict[str, dict[str, set[str]]] = {
             # for "car is being driven" / "12V critical" automations.
             "ignitionOn",
             "batteryProtectionLimitOn",
+            # #1333 — readiness software-update lifecycle (Scout, Elroq); now mapped
+            # to readiness_software_update_status, so stop re-flagging it.
+            "softwareUpdateStatus",
         },
         # v1.20.0 (Bundle 2 Phase A) — myskoda PR #557 widget endpoint
         # for lightweight per-tick polling. Schema verified against

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -74,6 +74,20 @@ def _is_driving_from_readiness(readiness: Any) -> bool:
     return isinstance(readiness, dict) and readiness.get("inMotion") is True
 
 
+def _software_update_from_readiness(readiness: Any) -> str | None:
+    """#1333 — the readiness block's software-update lifecycle value, verbatim.
+
+    Returns the raw enum string (e.g. ``"UPDATE_IN_PROGRESS"``) stripped, or None
+    when the block/field is absent or blank. Kept RAW (not enum-normalized) so a
+    plain string sensor surfaces any value we haven't catalogued yet rather than an
+    ENUM dropping it — the Scout "never suppress" policy. Pure + total for a unit
+    test that pins the extraction (mirrors ``_is_driving_from_readiness``)."""
+    if not isinstance(readiness, dict):
+        return None
+    val = readiness.get("softwareUpdateStatus")
+    return val.strip() if isinstance(val, str) and val.strip() else None
+
+
 def _primary_soc_or_none(
     soc_i: int | None, fuel_i: int | None, engine_type: Any
 ) -> int | None:
@@ -1955,6 +1969,12 @@ class SkodaClient(CariadBaseClient):
             bplim = v(readiness, "batteryProtectionLimitOn")
             if isinstance(bplim, bool):
                 d.battery_protection_limit_on = bplim
+            # #1333 (Scout, Elroq) — readiness software-update lifecycle, verbatim
+            # (raw enum string) for a plain string sensor. Via the pure helper so a
+            # unit test can pin the extraction (mirrors is_driving).
+            d.readiness_software_update_status = _software_update_from_readiness(
+                readiness
+            )
 
         # ── carCapturedTimestamp → connection_state (v1.8.12 refactor) ────
         # v1.8.11 introduced this logic Skoda-only; v1.8.12 extracted the

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -3119,6 +3119,31 @@ def map_dataset_to_vehicle_data(
         if _tpr is not None:
             setattr(d, _attr, _tpr)
 
+    # E'''. #528/#538 — TPMS system-type. Classify the RAW actual-pressure family
+    # via ``fields.get`` (read-only — does NOT touch the ``used`` set, so the
+    # sentinel-consume bookkeeping the E' loop already did is untouched, and the
+    # "1"s stay Scout-silent). ``first()`` can't be used here: it drops the "1"
+    # sentinel to None. Any corner >1 is a genuine reading ("measured"); else any
+    # corner ==1 is an indirect/no-numeric TPMS ("indirect"); all-0/absent → None
+    # so no phantom entity spawns.
+    _tpms_present = [
+        _v for _v in (
+            _to_int(fields.get(_n))
+            for _n in (
+                "tyre_pressure_actual_front_left",
+                "tyre_pressure_actual_front_right",
+                "tyre_pressure_actual_rear_left",
+                "tyre_pressure_actual_rear_right",
+                "tyre_pressure_actual_spare_tyre",
+            )
+        ) if _v is not None
+    ]
+    if _tpms_present:
+        if any(_v > 1 for _v in _tpms_present):
+            d.tpms_status = "measured"
+        elif any(_v == 1 for _v in _tpms_present):
+            d.tpms_status = "indirect"
+
     # F. Lights / energy / misc.
     # parking_lights (plural enum): 0=unsup 1=invalid 2=off 3=left 4=right 5=both.
     _plights = _to_int(first("parking_lights"))

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1450,6 +1450,13 @@ class VehicleData:
     software_update_status: str | None = None
     ota_update_available: bool | None = None
     ota_release_notes_url: str | None = None
+    # #1333 (Scout, Elroq) — Škoda ``readiness.softwareUpdateStatus`` (e.g.
+    # "UPDATE_IN_PROGRESS"). A SEPARATE source from ``software_update_status`` above
+    # (that is the /software-version/update-status endpoint). Surfaced as a plain
+    # string diagnostic sensor (not an ENUM) so a value we haven't seen yet is shown
+    # verbatim, never suppressed — the Scout "never suppress" policy. Škoda-only;
+    # other brands leave it None → no phantom entity (gated by _DATA_PRESENT_REQUIRED).
+    readiness_software_update_status: str | None = None
 
     # v2.0.0 (Big-Bang) — Skoda driving-score (efficiency metric 0-100).
     # Endpoint ``GET /api/v2/vehicle-status/{vin}/driving-score`` on mysmob

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1786,6 +1786,13 @@ class VehicleData:
     tyre_pressure_required_rl: int | None = None
     tyre_pressure_required_rr: int | None = None
     tyre_pressure_required_spare: int | None = None
+    # #528/#538 — TPMS system-type. Indirect/ABS-based TPMS ships the whole
+    # actual-pressure family as "1" (dict 1=invalid: system present, no numeric
+    # bar), which the sentinel filter drops — so the per-wheel pressure sensors
+    # never spawn and the fact the car HAS a (indirect) TPMS is otherwise invisible.
+    # "measured" = at least one corner reports a real >1 reading; "indirect" =
+    # the family is present but all-"1". ENUM sensor, diagnostic, off by default.
+    tpms_status: str | None = None
     # F. Lights / energy / misc.
     # Parking lights state (parking_lights enum → off/left/right/both). sensor.
     parking_lights_state: str | None = None

--- a/custom_components/vag_connect/cariad/vehicle_cache.py
+++ b/custom_components/vag_connect/cariad/vehicle_cache.py
@@ -55,6 +55,21 @@ CARRY_FORWARD_FIELDS: frozenset[str] = frozenset({
     # (an implausibly old account session is dropped), and carrying them forward
     # would resurrect exactly the suppressed stale reading we just removed.
     "equipment_count",
+    # #1310 (indigomejor) — lifetime_* are cumulative long-term aggregates the
+    # source re-sends whole when it has data (EU Data Act portal for Škoda; the
+    # 1h-cached trip-stats refresh for Audi/VW). A poll that omits the block used to
+    # blank them to "unknown" between deliveries, making them useless in
+    # history/automations. Carry the last value forward ("old but visible"); a
+    # genuine owner reset ships a fresh non-None value that still wins in reconcile.
+    # Never per-poll-suppressed (unlike primary_engine_soc_pct / last_refuel_*), so
+    # the carry-forward trap above does not apply.
+    "lifetime_distance_km", "lifetime_avg_speed_kmh", "lifetime_travel_time_min",
+    "lifetime_avg_fuel_consumption_l_100km",
+    "lifetime_avg_electric_consumption_kwh_100km",
+    "lifetime_avg_recuperation_kwh_100km", "lifetime_trip_distance_km",
+    "lifetime_trip_start_odometer_km", "lifetime_avg_aux_consumption_kwh_100km",
+    "lifetime_avg_gas_consumption_kg_100km", "lifetime_range_gain_km",
+    "lifetime_zero_emission_km",
 })
 
 # #923 — the parked position belongs in the "old but visible" class too: a

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -424,6 +424,14 @@ def _mbb_command_capability(
     cmd = _mbb_command_channel_client(coord)
     if cmd is None:
         return None
+    # #584/#1150 — this VIN's operationList returned the definitive
+    # ``gw.error.authentication`` verdict (no legacy Car-Net enrolment), so the MBB
+    # command channel can never work for it. Hide the control (False) instead of
+    # leaving it visible to fail on every press. NOT triggered by a VSR 403
+    # XID_APP_VW — that is the HEALTHY durable-MBB state (commands work, only the
+    # data-read plane is closed) and is deliberately never added to the set.
+    if vin in getattr(cmd, "mbb_no_legacy_vins", ()):
+        return False
     if command_id not in _MBB_COMMAND_SERVICE:
         # A command we don't route via MBB — leave it to the BFF gate rather
         # than risk hiding a legitimate non-MBB control.
@@ -4690,6 +4698,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 vins = list(self.vehicles.keys())
         for vin in vins:
             if not vin:
+                continue
+            # #584/#1150 — a VIN with the definitive no-legacy verdict can never use
+            # the MBB command channel, so stop re-hitting the gateway warm-up for it
+            # every poll. (The 12h per-VIN cache already suppresses the HTTP call
+            # within a session; this makes the skip explicit and covers a cache reset.)
+            if vin in getattr(cmd, "mbb_no_legacy_vins", ()):
                 continue
             try:
                 await getter(vin, for_command=True)

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -3427,9 +3427,20 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 # until a restart. update_interval is None here, so this loop —
                 # not _async_update_data — is the periodic path. No-op non-MBB.
                 await self._refresh_mbb_command_capabilities()
-                self._push_official_mode()  # #1286 — official_only routing before read
+                # #584 — capture the client up front. A Reconfigure unload nulls
+                # self._cariad_client, and any await above (sleep / watchdog /
+                # capability refresh) yields long enough for that to land mid-cycle;
+                # the gather below would then raise "'NoneType' object has no
+                # attribute 'get_status'". _async_update_data already guards this
+                # way; the background poll loop needs the same. Skip this cycle
+                # cleanly if the client is gone — the next cycle re-reads it, or the
+                # loop exits on _started=False.
+                _client = self._cariad_client
+                if _client is None:
+                    continue
+                self._push_official_mode(_client)  # #1286 — official_only routing
                 results = await asyncio.gather(
-                    *[self._cariad_client.get_status(vin) for vin in vins],
+                    *[_client.get_status(vin) for vin in vins],
                     return_exceptions=True,
                 )
                 fresh: dict[str, Any] = {}

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -559,10 +559,24 @@ async def async_get_config_entry_diagnostics(
     # commands are unavailable — so a #584-class report is triageable straight
     # from the diagnostics instead of asking the reporter for a debug log.
     mbb_no_legacy: list[str] = []
-    _nl = getattr(client, "mbb_no_legacy_vins", None) if client is not None else None
-    if _nl:
+    # #1150 — the verdict is recorded on WHICHEVER VWEUClient ran the operationList.
+    # On the #584 read-only-primary shape (VW-EU portal/vw.de primary + an armed MBB
+    # command channel) it lands on the ``_mbb_command`` sub-connector, not the
+    # parent — so reading only the parent exported an empty list even several polls
+    # after the verdict was set. Union the parent with both sub-connectors so the
+    # export reflects the real state regardless of which instance recorded it.
+    _nl_union: set[str] = set()
+    for _obj in (
+        client,
+        getattr(client, "_mbb_command", None) if client is not None else None,
+        getattr(client, "_mbb_fallback", None) if client is not None else None,
+    ):
+        _s = getattr(_obj, "mbb_no_legacy_vins", None) if _obj is not None else None
+        if _s:
+            _nl_union.update(_s)
+    if _nl_union:
         try:
-            mbb_no_legacy = sorted(mask_vin(v) for v in _nl)
+            mbb_no_legacy = sorted(mask_vin(v) for v in _nl_union)
         except Exception:  # noqa: BLE001
             mbb_no_legacy = []
 

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -2783,6 +2783,20 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
+    # #528/#538 — TPMS system-type. On an indirect/ABS-based TPMS car the whole
+    # actual-pressure family is "1" (dropped), so this is the ONLY tyre signal that
+    # car gets: "measured" (per-wheel numeric) vs "indirect" (present, no values).
+    # ENUM so HA localizes it; diagnostic + off by default (matches the tyre family).
+    VagSensorDescription(
+        key="tpms_status",
+        translation_key="tpms_status",
+        data_key="tpms_status",
+        icon="mdi:car-tire-alert",
+        device_class=SensorDeviceClass.ENUM,
+        options=["measured", "indirect"],
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
     # F. Lights / energy / misc.
     VagSensorDescription(
         key="parking_lights_state",
@@ -3946,6 +3960,7 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     "tyre_pressure_required_rl",
     "tyre_pressure_required_rr",
     "tyre_pressure_required_spare",
+    "tpms_status",  # #528/#538 — only spawns when the actual-pressure family shipped
     # v2.15.5 (#541) — V2G / bidirectional-charging charge-level limits.
     # EU-Data-Act dialect only; vehicles/channels without the field stay None.
     "bidi_max_charge_level_pct",

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1208,6 +1208,19 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:chip",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # #1333 (Scout, Elroq) — Škoda readiness software-update lifecycle. Plain
+    # STRING sensor (no device_class/options) on purpose: an ENUM would drop any
+    # value we haven't catalogued, and we only have one confirmed token so far —
+    # a string surfaces every value verbatim (Scout "never suppress" policy).
+    # Škoda-only; gated via _DATA_PRESENT_REQUIRED so other brands + older firmware
+    # get no phantom "unknown" entity.
+    VagSensorDescription(
+        key="readiness_software_update_status",
+        translation_key="readiness_software_update_status",
+        data_key="readiness_software_update_status",
+        icon="mdi:cellphone-arrow-down",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     # v1.15.0 (#35) — Skoda Charging History → HA Energy Dashboard.
     # ``total_charged_energy_kwh`` with TOTAL_INCREASING is THE long-
     # term-statistics signal users want for kWh-tracking dashboards.
@@ -3601,6 +3614,7 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
     # Cross-brand support deferred — CARIAD-BFF + OLA don't expose an
     # equivalent endpoint yet (Research 2026-05-02).
     "software_version",
+    "readiness_software_update_status",  # #1333 — Škoda-only readiness signal
     # v1.15.0 (#35) — Skoda-only charging history. Cross-brand deferred
     # (CARIAD-BFF/OLA equivalent endpoints unverified).
     "total_charged_energy_kwh",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1457,6 +1457,9 @@
           "measured": "Measured (per-wheel)",
           "indirect": "Indirect (no pressure values)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Software update status"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1450,6 +1450,13 @@
       },
       "no_data_count": {
         "name": "No-data polls"
+      },
+      "tpms_status": {
+        "name": "Tyre pressure monitoring",
+        "state": {
+          "measured": "Measured (per-wheel)",
+          "indirect": "Indirect (no pressure values)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1424,6 +1424,9 @@
           "measured": "Měřeno (na kolo)",
           "indirect": "Nepřímé (bez hodnot tlaku)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Stav aktualizace softwaru"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Dotazy bez dat"
+      },
+      "tpms_status": {
+        "name": "Kontrola tlaku v pneumatikách",
+        "state": {
+          "measured": "Měřeno (na kolo)",
+          "indirect": "Nepřímé (bez hodnot tlaku)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1424,6 +1424,9 @@
           "measured": "Målt (pr. hjul)",
           "indirect": "Indirekte (ingen trykværdier)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Softwareopdateringsstatus"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Forespørgsler uden data"
+      },
+      "tpms_status": {
+        "name": "Dæktrykovervågning",
+        "state": {
+          "measured": "Målt (pr. hjul)",
+          "indirect": "Indirekte (ingen trykværdier)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1424,6 +1424,9 @@
           "measured": "Gemessen (pro Rad)",
           "indirect": "Indirekt (keine Druckwerte)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Software-Update-Status"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Abfragen ohne Daten"
+      },
+      "tpms_status": {
+        "name": "Reifendruckkontrolle",
+        "state": {
+          "measured": "Gemessen (pro Rad)",
+          "indirect": "Indirekt (keine Druckwerte)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "No-data polls"
+      },
+      "tpms_status": {
+        "name": "Tyre pressure monitoring",
+        "state": {
+          "measured": "Measured (per-wheel)",
+          "indirect": "Indirect (no pressure values)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1424,6 +1424,9 @@
           "measured": "Measured (per-wheel)",
           "indirect": "Indirect (no pressure values)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Software update status"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Consultas sin datos"
+      },
+      "tpms_status": {
+        "name": "Control de presión de neumáticos",
+        "state": {
+          "measured": "Medido (por rueda)",
+          "indirect": "Indirecto (sin valores de presión)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1424,6 +1424,9 @@
           "measured": "Medido (por rueda)",
           "indirect": "Indirecto (sin valores de presión)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Estado de actualización de software"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Kyselyt ilman dataa"
+      },
+      "tpms_status": {
+        "name": "Rengaspaineen valvonta",
+        "state": {
+          "measured": "Mitattu (per pyörä)",
+          "indirect": "Epäsuora (ei painearvoja)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1424,6 +1424,9 @@
           "measured": "Mitattu (per pyörä)",
           "indirect": "Epäsuora (ei painearvoja)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Ohjelmistopäivityksen tila"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1424,6 +1424,9 @@
           "measured": "Mesurée (par roue)",
           "indirect": "Indirecte (sans valeurs de pression)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "État de la mise à jour logicielle"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Interrogations sans données"
+      },
+      "tpms_status": {
+        "name": "Surveillance de la pression des pneus",
+        "state": {
+          "measured": "Mesurée (par roue)",
+          "indirect": "Indirecte (sans valeurs de pression)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1424,6 +1424,9 @@
           "measured": "Misurata (per ruota)",
           "indirect": "Indiretto (nessun valore di pressione)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Stato aggiornamento software"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Sondaggi senza dati"
+      },
+      "tpms_status": {
+        "name": "Monitoraggio pressione pneumatici",
+        "state": {
+          "measured": "Misurata (per ruota)",
+          "indirect": "Indiretto (nessun valore di pressione)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1424,6 +1424,9 @@
           "measured": "Målt (per hjul)",
           "indirect": "Indirekte (ingen trykkverdier)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Status for programvareoppdatering"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Spørringer uten data"
+      },
+      "tpms_status": {
+        "name": "Dekktrykkovervåking",
+        "state": {
+          "measured": "Målt (per hjul)",
+          "indirect": "Indirekte (ingen trykkverdier)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1424,6 +1424,9 @@
           "measured": "Gemeten (per wiel)",
           "indirect": "Indirect (geen drukwaarden)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Status software-update"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Pollingen zonder gegevens"
+      },
+      "tpms_status": {
+        "name": "Bandenspanningscontrole",
+        "state": {
+          "measured": "Gemeten (per wiel)",
+          "indirect": "Indirect (geen drukwaarden)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1424,6 +1424,9 @@
           "measured": "Mierzone (na koło)",
           "indirect": "Pośrednie (brak wartości ciśnienia)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Stan aktualizacji oprogramowania"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Odpytania bez danych"
+      },
+      "tpms_status": {
+        "name": "Kontrola ciśnienia w oponach",
+        "state": {
+          "measured": "Mierzone (na koło)",
+          "indirect": "Pośrednie (brak wartości ciśnienia)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1417,6 +1417,13 @@
       },
       "no_data_count": {
         "name": "Förfrågningar utan data"
+      },
+      "tpms_status": {
+        "name": "Däcktrycksövervakning",
+        "state": {
+          "measured": "Uppmätt (per hjul)",
+          "indirect": "Indirekt (inga tryckvärden)"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1424,6 +1424,9 @@
           "measured": "Uppmätt (per hjul)",
           "indirect": "Indirekt (inga tryckvärden)"
         }
+      },
+      "readiness_software_update_status": {
+        "name": "Status för programuppdatering"
       }
     },
     "binary_sensor": {

--- a/tests/test_1150_no_legacy_command_gate.py
+++ b/tests/test_1150_no_legacy_command_gate.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1150 / #584 — the "no legacy MBB enrolment" verdict must hide the command.
+
+When a car's MBB operationList returns the definitive ``gw.error.authentication``
+401, the MBB command channel can never work for that VIN, so the command controls
+must be hidden (not left to fail on every press). This guards the gate in
+``_mbb_command_capability``. (The diagnostics-visibility half of #1150 — unioning
+the parent client with its ``_mbb_command`` / ``_mbb_fallback`` sub-connectors —
+is exercised by the diagnostics suite.)
+
+Critically, a VSR 403 ``XID_APP_VW`` must NOT trigger this: that is the HEALTHY
+durable-MBB state (commands work, only the data-read plane is closed), and the
+recorder deliberately never adds it to the set — see test_584_no_legacy_verdict.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.vag_connect.coordinator import _mbb_command_capability
+
+
+def _coord(no_legacy: set[str]) -> SimpleNamespace:
+    # MBB-primary shape: _mbb_command_channel_client returns the client itself
+    # (strategy == "mbb"), which is where the verdict set lives.
+    client = SimpleNamespace(
+        _tokens=SimpleNamespace(strategy="mbb"),
+        mbb_no_legacy_vins=set(no_legacy),
+        _mbb_oplist_cache={},
+    )
+    return SimpleNamespace(_cariad_client=client)
+
+
+def test_no_legacy_vin_hides_the_mbb_command():
+    coord = _coord({"NOLEGACYVIN"})
+    # any MBB-routed command → hidden (False), before the oplist-cache path
+    assert _mbb_command_capability(coord, "NOLEGACYVIN", "lock") is False
+    assert _mbb_command_capability(coord, "NOLEGACYVIN", "start_charging") is False
+
+
+def test_other_vin_is_not_hidden_by_the_no_legacy_gate():
+    coord = _coord({"NOLEGACYVIN"})
+    # a VIN NOT in the set falls through to the normal path (empty oplist cache →
+    # None / permissive BFF gate); it must never be forced to the no-legacy False.
+    assert _mbb_command_capability(coord, "OTHERVIN", "lock") is not False
+
+
+def test_empty_set_leaves_the_gate_inactive():
+    coord = _coord(set())
+    assert _mbb_command_capability(coord, "ANYVIN", "lock") is not False

--- a/tests/test_1310_data_quality.py
+++ b/tests/test_1310_data_quality.py
@@ -104,3 +104,33 @@ def test_reconcile_holds_equipment_count_but_not_fill_up() -> None:
     assert out["equipment_count"] == 9  # held, not blanked to unknown
     # the fill-up is NOT resurrected — carry-forward must not defeat staleness
     assert out.get("last_refuel_at") is None
+
+
+def test_lifetime_fields_are_carried_forward() -> None:
+    # #1310 — the full lifetime_* aggregate set is cumulative long-term telemetry.
+    for k in (
+        "lifetime_distance_km", "lifetime_avg_speed_kmh", "lifetime_travel_time_min",
+        "lifetime_avg_fuel_consumption_l_100km",
+        "lifetime_avg_electric_consumption_kwh_100km",
+        "lifetime_zero_emission_km",
+    ):
+        assert k in CARRY_FORWARD_FIELDS
+
+
+def test_reconcile_holds_lifetime_when_a_poll_omits_it() -> None:
+    # a partial poll (e.g. a Škoda EU-DA drop without the aggregate block) must not
+    # blank the lifetime sensors to "unknown".
+    prev = {"lifetime_distance_km": 42000.0, "lifetime_avg_speed_kmh": 48.0}
+    fresh = {"battery_soc": 80}
+    out, _disc = reconcile(prev, fresh)
+    assert out["lifetime_distance_km"] == 42000.0
+    assert out["lifetime_avg_speed_kmh"] == 48.0
+
+
+def test_reconcile_lets_a_lifetime_reset_through() -> None:
+    # a genuine owner reset ships a fresh non-None (lower/zero) value, which must
+    # win over the carried one — carry-forward only fills a None.
+    prev = {"lifetime_distance_km": 42000.0}
+    fresh = {"lifetime_distance_km": 0.0}
+    out, _disc = reconcile(prev, fresh)
+    assert out["lifetime_distance_km"] == 0.0

--- a/tests/test_1333_skoda_software_update.py
+++ b/tests/test_1333_skoda_software_update.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1333 (Scout, Elroq) — Škoda readiness ``softwareUpdateStatus`` mapping.
+
+The readiness endpoint gained a software-update lifecycle field (e.g.
+``UPDATE_IN_PROGRESS``). It is surfaced verbatim through a plain STRING sensor (not
+an ENUM) so a value we haven't catalogued yet is shown as-is rather than dropped —
+the Scout "never suppress" policy. These pin the pure extraction helper + its
+call-site (mirrors the is_driving pattern) so it can't regress back inline.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.api.skoda import (
+    _software_update_from_readiness,
+)
+
+
+def test_extracts_raw_value_verbatim() -> None:
+    assert (
+        _software_update_from_readiness({"softwareUpdateStatus": "UPDATE_IN_PROGRESS"})
+        == "UPDATE_IN_PROGRESS"
+    )
+
+
+def test_strips_whitespace() -> None:
+    assert (
+        _software_update_from_readiness({"softwareUpdateStatus": "  UPDATE_SUCCESSFUL  "})
+        == "UPDATE_SUCCESSFUL"
+    )
+
+
+def test_none_when_absent_or_blank() -> None:
+    assert _software_update_from_readiness({"inMotion": True}) is None
+    assert _software_update_from_readiness({"softwareUpdateStatus": ""}) is None
+    assert _software_update_from_readiness({"softwareUpdateStatus": "   "}) is None
+
+
+def test_none_for_non_dict() -> None:
+    assert _software_update_from_readiness(None) is None
+    assert _software_update_from_readiness("garbage") is None
+
+
+def test_get_status_routes_through_the_helper() -> None:
+    import inspect
+
+    from custom_components.vag_connect.cariad.api import skoda as skoda_mod
+
+    src = inspect.getsource(skoda_mod.SkodaClient.get_status)
+    # the assignment must route through the helper (may wrap across lines for
+    # line-length), so the readiness extraction can't silently regress back inline
+    assert "_software_update_from_readiness" in src
+    assert "d.readiness_software_update_status = _software_update_from_readiness" in src

--- a/tests/test_tpms_status.py
+++ b/tests/test_tpms_status.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#528/#538 — TPMS system-type (tpms_status) from the EU Data Act actual-pressure family.
+
+Indirect/ABS-based TPMS ships the whole actual-pressure family as the "1" sentinel,
+which the parser drops — so the per-wheel sensors never spawn and the fact the car
+HAS a TPMS was invisible. tpms_status surfaces it: "measured" when a corner reports
+a real >1 reading, "indirect" when the family is present but all-"1". Read from the
+RAW ``fields`` (read-only), so the sentinel-consume bookkeeping is untouched.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+_ACTUAL = (
+    "tyre_pressure_actual_front_left",
+    "tyre_pressure_actual_front_right",
+    "tyre_pressure_actual_rear_left",
+    "tyre_pressure_actual_rear_right",
+)
+
+
+def _map(fields: dict[str, str]) -> VehicleData:
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_indirect_when_the_actual_family_is_all_one() -> None:
+    d = _map({k: "1" for k in _ACTUAL})
+    assert d.tpms_status == "indirect"
+    # the per-wheel pressure targets still drop (regression guard on the sentinel)
+    assert d.tyre_pressure_actual_fl is None
+    assert d.tyre_pressure_actual_rr is None
+
+
+def test_measured_when_any_corner_reports_a_real_reading() -> None:
+    d = _map({
+        "tyre_pressure_actual_front_left": "230",
+        "tyre_pressure_actual_front_right": "1",  # one faulty/invalid corner
+    })
+    assert d.tpms_status == "measured"
+    assert d.tyre_pressure_actual_fl == 230  # the real reading still maps
+
+
+def test_none_when_absent_or_all_unsupported() -> None:
+    assert _map({}).tpms_status is None
+    # 0 = unsupported → no TPMS signal, no phantom entity
+    assert _map({"tyre_pressure_actual_front_left": "0"}).tpms_status is None
+
+
+def test_spare_only_indirect_still_classifies() -> None:
+    d = _map({"tyre_pressure_actual_spare_tyre": "1"})
+    assert d.tpms_status == "indirect"


### PR DESCRIPTION
The rest of the 4.7.0b6 beta line — issue-sweep fixes on top of the Volkswagen Commercial Vehicles brand already on main. Tag v4.7.0b6 after merge.

**Added**
- **Tyre pressure monitoring type sensor** (`tpms_status`): indirect (ABS-based) TPMS cars showed no tyre entities at all; a diagnostic sensor now reports *measured* (per-wheel) vs *indirect* (#528, #538).
- **Škoda: software update status sensor** from the readiness endpoint — surfaced verbatim as a string sensor so an uncatalogued state is never dropped (#1333).

**Fixed**
- **Lifetime trip totals no longer blank between deliveries** — the cumulative `lifetime_*` sensors are carried forward like other slow telemetry, a genuine reset still wins (#1310, thanks @indigomejor).
- **Reconfigure no longer crashes the background poll** with "NoneType has no attribute get_status" — the poll loop captures the client up front and skips the cycle cleanly if it's gone (#584).
- **VW "no legacy Car-Net" cars**: the command controls are hidden (not left to fail on every press), the gateway isn't re-poked each poll, and the diagnostics now report it correctly — a VSR 403 XID_APP_VW is deliberately NOT treated as no-legacy (that is the healthy two-way state) (#1150, #584).

Full test suite: 5730 passed, 15 skipped. Three swept items were verified already-done/infeasible and deliberately not rebuilt: #1165 (shipped), #13 (infeasible + an issue-number mismatch in the ask), and the #465 stale-data notification (already shipped in v3.1.0).
