### PR TITLE
b7: grounded audit sweep + Škoda official channel expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,55 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b7] - 2026-09-03 — Grounded audit sweep: safer commands, fewer false readings, fuller Škoda official channel
+
+Every fix below was cross-checked against how the leading open-source VW / Škoda
+libraries handle the same code path before it shipped.
+
+### Fixed
+- **Climate no longer shows "off" while the car is actively heating or cooling.** On
+  VW / SEAT / CUPRA the climate entity read Off during pre-conditioning (so a
+  `heat_cool` automation never fired) because the backend sends the state in
+  lowercase and the entity compared case-sensitively. It now matches the
+  climatisation switch exactly.
+- **A remote command can no longer be sent to the car twice.** On a multi-vehicle /
+  portal account a slow refresh could blow the 60-second command lock, after which
+  the physical command (charging / unlock / aux-heating) was re-sent **unlocked**.
+  The lock now guards only acquiring the turn and never re-sends on timeout, and the
+  follow-up refresh runs outside the command so a portal hiccup can't be reported as
+  a failed button press.
+- **Parked location stops going stale on Škoda / SEAT / CUPRA.** The 24-hour guard
+  against showing an ancient parked position was silently skipped for these brands, so
+  a location could read as "current" indefinitely once the backend stopped serving it.
+- **Aux-heating now honours your duration / temperature sliders** instead of always
+  falling back to 30 min / 21 °C.
+- **The Škoda official channel can no longer push the odometer backwards.** A staler
+  rate-limited reading could overwrite a fresher mileage; it now never regresses.
+- **No more false red tyre-pressure warning.** A car reporting an
+  "unavailable / unknown / not-supported" tyre status lit the tyre problem sensor red
+  with no actual fault. Absent-telemetry statuses no longer trigger a warning; a real
+  low-pressure fault still does.
+- **Škoda "charged energy" total no longer spikes the Energy Dashboard.** The lifetime
+  figure could drop and be read as a meter reset (phantom kWh). It is now clamped so it
+  never goes backwards. Interim — a true lifetime total is coming.
+
+### Added
+- **SEAT / CUPRA trip-statistics sensors now appear.** Last-trip distance, average
+  speed and consumption, and lifetime distance were already fetched every poll but
+  never shown for these two brands. Thanks @indigomejor for flagging the trip-stats
+  gap (#1309 / #1310).
+- **The Škoda official public-API channel now surfaces much more.** When the official
+  channel is your source it now also shows charge rate / type / completion time,
+  battery-care and plug auto-unlock state, climate-ready time and window heating,
+  lights / sunroof / bonnet, AdBlue range, the secondary engine on plug-in hybrids,
+  and the car image — plus the auxiliary-heating status and active-ventilation state
+  that previously read "unknown" on Škoda.
+
+### Security
+- **Parking city no longer leaks in a diagnostics download.** The diagnostics file (the
+  one you are steered to attach to a GitHub issue) redacted the parking address but left
+  the parking *city* in cleartext. It is now redacted with the rest of the location data.
+
 ## [4.7.0b6] - 2026-09-03 — Volkswagen Commercial Vehicles (Nutzfahrzeuge) + issue-sweep fixes
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/skoda_official.py
+++ b/custom_components/vag_connect/cariad/api/skoda_official.py
@@ -26,10 +26,12 @@ spin)`` signature without a new arg, the VIN(s) ride the ``email`` slot
 from __future__ import annotations
 
 import time
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from aiohttp import ClientSession, ClientTimeout
 
+from .._util import drop_charge_sentinel, safe_int
 from ..exceptions import APIError, AuthenticationError
 from ..models import VehicleData
 
@@ -47,6 +49,22 @@ def _to_bool_open(value: Any) -> bool | None:
         return True
     if v in ("CLOSED", "LOCKED", "NO", "OFF", "UNSUPPORTED"):
         return False
+    return None
+
+
+def _open_strict(value: Any) -> bool | None:
+    """OPEN→True / CLOSED→False / anything else (incl. UNSUPPORTED)→None.
+
+    For optional body parts (sunroof, bonnet) where UNSUPPORTED must stay None so a
+    car without the part doesn't spawn a phantom "closed" binary sensor — unlike
+    ``_to_bool_open`` which maps UNSUPPORTED→False (fine for the universal trunk).
+    """
+    if isinstance(value, str):
+        up = value.strip().upper()
+        if up == "OPEN":
+            return True
+        if up == "CLOSED":
+            return False
     return None
 
 
@@ -190,6 +208,9 @@ class SkodaOfficialClient:
         d.model = v.get("name") or d.model
         if isinstance(v.get("licensePlate"), str):
             d.license_plate = v["licensePlate"]
+        # b7 — the render image URL rides the same response; the image entity reads it.
+        if isinstance(v.get("renderUrl"), str) and v["renderUrl"]:
+            d.render_url = v["renderUrl"]
 
         # -- opening / lock status (overall + detail) -------------------------
         status = v.get("status") or {}
@@ -212,6 +233,20 @@ class SkodaOfficialClient:
         _trunk = _to_bool_open(detail.get("trunk"))
         if _trunk is not None:
             d.trunk_open = _trunk
+        # b7 — status fields the official parser was dropping (all in the response).
+        _lights = overall.get("lights")
+        if isinstance(_lights, str):
+            _lu = _lights.strip().upper()
+            if _lu == "ON":
+                d.lights_on = True
+            elif _lu == "OFF":
+                d.lights_on = False
+        _sun = _open_strict(detail.get("sunroof"))
+        if _sun is not None:
+            d.sunroof_open = _sun
+        _bon = _open_strict(detail.get("bonnet"))  # official "bonnet" → our "hood"
+        if _bon is not None:
+            d.hood_open = _bon
         if isinstance(status.get("carCapturedTimestamp"), str):
             d.last_seen_at = status["carCapturedTimestamp"]
 
@@ -262,6 +297,17 @@ class SkodaOfficialClient:
             d.is_electric = True
         elif "ELECTRIC" in types and len(types) > 1:
             d.is_hybrid = True
+        # b7 — AdBlue + the whole secondary engine (a PHEV loses its second engine on
+        # an official-only cycle without these). All already in the response.
+        if isinstance(fuel.get("adBlueRange"), (int, float)):
+            d.adblue_range_km = int(fuel["adBlueRange"])
+        _sec_type = sec.get("engineType")
+        if isinstance(_sec_type, str):
+            d.secondary_engine_type = _sec_type
+        if isinstance(sec.get("currentFuelLevelInPercent"), (int, float)):
+            d.secondary_engine_fuel_level_pct = int(sec["currentFuelLevelInPercent"])
+        if isinstance(sec.get("remainingRangeInKm"), (int, float)):
+            d.secondary_engine_range_km = int(sec["remainingRangeInKm"])
 
         # -- charging ---------------------------------------------------------
         charging = v.get("charging") or {}
@@ -276,6 +322,7 @@ class SkodaOfficialClient:
         batt = cstat.get("battery") or {}
         if isinstance(batt.get("stateOfChargeInPercent"), (int, float)):
             d.battery_soc = int(batt["stateOfChargeInPercent"])
+            d.has_battery = True
         if isinstance(batt.get("remainingCruisingRangeInMeters"), (int, float)):
             d.electric_range_km = int(batt["remainingCruisingRangeInMeters"] // 1000)
         if isinstance(cset.get("targetStateOfChargeInPercent"), (int, float)):
@@ -286,6 +333,45 @@ class SkodaOfficialClient:
             d.preferred_charge_mode = cset["preferredChargeMode"]
         if isinstance(cset.get("maxChargeCurrentAcAmpere"), (int, float)):
             d.max_charge_current = float(cset["maxChargeCurrentAcAmpere"])
+        # b7 — charging status/settings the official parser was dropping (all in the
+        # response; on an official-only cycle these entities otherwise go dark).
+        _saved = charging.get("isVehicleInSavedLocation")
+        if isinstance(_saved, bool):
+            d.vehicle_at_saved_location = _saved
+        if isinstance(cstat.get("chargingRateInKilometersPerHour"), (int, float)):
+            d.charging_rate_kmh = float(cstat["chargingRateInKilometersPerHour"])
+        _ctype = drop_charge_sentinel(cstat.get("chargeType"))  # AC/DC, #1104 sentinel
+        if isinstance(_ctype, str) and _ctype:
+            d.charging_type = _ctype
+        _fully = cstat.get("fullyChargedAt")
+        if isinstance(_fully, str) and _fully:
+            try:
+                d.charge_complete_eta = datetime.fromisoformat(
+                    _fully.replace("Z", "+00:00"))
+            except ValueError:
+                pass
+        if not d.charge_complete_eta:
+            _rem = safe_int(cstat.get("remainingTimeToFullyChargedInMinutes"))
+            if _rem:
+                d.charge_complete_eta = datetime.now(tz=timezone.utc) + timedelta(
+                    minutes=_rem)
+        _care = cset.get("chargingCareMode")
+        if isinstance(_care, str):
+            _cu = _care.strip().upper()
+            if _cu in ("ACTIVATED", "ACTIVE", "ON", "TRUE"):
+                d.battery_care_enabled = True
+            elif _cu in ("DEACTIVATED", "INACTIVE", "OFF", "FALSE"):
+                d.battery_care_enabled = False
+        _autolock = cset.get("autoUnlockPlugWhenCharged")
+        if isinstance(_autolock, str):
+            _au = _autolock.strip().upper()
+            if _au in ("ON", "PERMANENT", "TRUE", "YES"):
+                d.auto_unlock_when_charged = True
+            elif _au in ("OFF", "FALSE", "NO"):
+                d.auto_unlock_when_charged = False
+        _modes = cset.get("availableChargeModes")
+        if isinstance(_modes, list) and _modes:
+            d.available_charge_modes = [str(m) for m in _modes if m is not None]
 
         # -- air conditioning / climate --------------------------------------
         ac = v.get("airConditioning") or {}
@@ -295,6 +381,11 @@ class SkodaOfficialClient:
             # COMPLETED | UNKNOWN — active only while it's actually conditioning.
             d.climatisation_active = ac["state"].strip().upper() in (
                 "COOLING", "HEATING", "HEATING_AUXILIARY", "VENTILATION",
+            )
+            # b7 — coarse aux-heating flag from the AC enum (mirrors mysmob); the
+            # dedicated auxiliaryHeating block below refines it when present.
+            d.aux_heating_active = (
+                ac["state"].strip().upper() == "HEATING_AUXILIARY"
             )
         tt = ac.get("targetTemperature") or {}
         if isinstance(tt.get("value"), (int, float)):
@@ -306,6 +397,39 @@ class SkodaOfficialClient:
         _whr = _to_bool_open(wh.get("rear"))
         if _whr is not None:
             d.window_heating_back = _whr
+        # b7 — climate booleans/timestamps the official parser was dropping.
+        _whenabled = wh.get("enabled")
+        if isinstance(_whenabled, bool):
+            d.window_heating_enabled = _whenabled
+        _reach = ac.get("estimatedReachOfTargetTemperatureAt")
+        if isinstance(_reach, str) and _reach:
+            d.climate_ready_at = _reach
+        _noext = ac.get("airConditioningWithoutExternalPower")
+        if isinstance(_noext, bool):
+            d.air_conditioning_without_external_power = _noext
+        _atunlock = ac.get("airConditioningAtUnlock")
+        if isinstance(_atunlock, bool):
+            d.climate_at_unlock = _atunlock
+
+        # -- auxiliary heating / active ventilation (Škoda product gaps) -----
+        # Both blocks arrive in the same GET response but the parser dropped them, so
+        # the dedicated auxiliary_heating_status sensor and the active-ventilation
+        # state/switch read "unknown" on Škoda (they were vw_eu-only). Parse them.
+        aux = v.get("auxiliaryHeating") or {}
+        _aux_state = aux.get("state")
+        if isinstance(_aux_state, str) and _aux_state:
+            d.auxiliary_heating_status = _aux_state
+            d.aux_heating_active = _aux_state.strip().lower() in (
+                "heating", "on", "active", "started", "heatingon",
+                "heating_auxiliary",
+            )
+        vent = v.get("activeVentilation") or {}
+        _vent_state = vent.get("state")
+        if isinstance(_vent_state, str) and _vent_state:
+            d.active_ventilation_state = _vent_state
+        _vent_dur = vent.get("durationInSeconds")
+        if isinstance(_vent_dur, (int, float)) and not isinstance(_vent_dur, bool):
+            d.active_ventilation_remaining_time_min = int(_vent_dur // 60)
 
         # -- parking position (the GPS the EU-DA channel can't get) ----------
         pos = v.get("parkingPosition") or {}
@@ -315,6 +439,10 @@ class SkodaOfficialClient:
         ):
             d.latitude = float(gps["latitude"])
             d.longitude = float(gps["longitude"])
+        # b7 — the human-readable parking address rides the same block (redacted in
+        # diagnostics via _REDACT_KEYS; surfaced as the device_tracker attribute).
+        if isinstance(pos.get("formattedAddress"), str) and pos["formattedAddress"]:
+            d.parking_address = pos["formattedAddress"]
         return d
 
     # -- commands -------------------------------------------------------------

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -4701,9 +4701,25 @@ class VWEUClient(CariadBaseClient):
                     d.tire_pressure_rear_right_bar = round(bar_value, 2)
             warning_raw = tyre_value.get("overallStatus") or tyre_value.get("warningLight")
             if isinstance(warning_raw, str):
-                d.tire_pressure_warning = warning_raw.lower() not in (
-                    "ok", "normal", "off", "false",
-                )
+                lowered = warning_raw.lower()
+                # b7 (grounded audit P1-6, INTERIM) — this branch used allow-list-GOOD
+                # polarity (anything not in {ok,normal,off,false} → warning=True), so a
+                # telemetry-ABSENT status (unavailable/unknown/notSupported/…) lit the
+                # tyre PROBLEM sensor RED on a fault-free car. Demote the known "no data"
+                # tokens out of the True path (leave the bool None, mirroring the oil
+                # parser above — "don't render a fake OK") while any other non-OK token
+                # still fires as a real fault. The full explicit-BAD polarity flip waits
+                # on a byte capture of the tyrePressure overallStatus vocabulary.
+                if lowered in ("ok", "normal", "off", "false", "none"):
+                    d.tire_pressure_warning = False
+                elif lowered in (
+                    "unavailable", "unknown", "notsupported", "not_supported",
+                    "unsupported", "invalid", "na", "n/a", "notavailable",
+                    "not_available",
+                ):
+                    d.tire_pressure_warning = None
+                else:
+                    d.tire_pressure_warning = True
             elif isinstance(warning_raw, bool):
                 d.tire_pressure_warning = warning_raw
 

--- a/custom_components/vag_connect/cariad/vehicle_cache.py
+++ b/custom_components/vag_connect/cariad/vehicle_cache.py
@@ -124,7 +124,13 @@ def position_age_seconds(previous: dict[str, Any]) -> float | None:
     supply a timestamp would otherwise lose a working position entirely.
     """
     for key in ("position_captured_at", "last_seen_at"):
-        stamp = _parse_iso(previous.get(key))
+        # b7 (grounded audit P1-2) — use _as_aware_dt, NOT _parse_iso. Škoda/SEAT/
+        # CUPRA set last_seen_at as a datetime object (compute_connection_state) and
+        # never set position_captured_at; _parse_iso is string-only, so it returned
+        # None for both → age None → the POSITION_MAX_AGE_S expiry was skipped and a
+        # stale parked position was carried forward indefinitely for those brands
+        # (the correct coercer already exists and is used elsewhere in this module).
+        stamp = _as_aware_dt(previous.get(key))
         if stamp is not None:
             return (datetime.now(tz=timezone.utc) - stamp).total_seconds()
     return None
@@ -132,7 +138,20 @@ def position_age_seconds(previous: dict[str, Any]) -> float | None:
 # Fields that physically only ever increase. A fresh value below the recorded
 # one is a bad reading (the portal occasionally serves a stale / zero odometer)
 # — keep the recorded value so the "km" sensor never jumps backwards.
-MONOTONIC_INCREASING_FIELDS: tuple[str, ...] = ("odometer_km",)
+# b7 (grounded audit P1-5, INTERIM) — total_charged_energy_kwh is exposed as a
+# TOTAL_INCREASING energy sensor but is summed from a trailing 50-session window
+# (skoda.py get_charging_history has no nextCursor paging), so once a car has >50
+# lifetime sessions an old session is evicted, the summed "total" DROPS, and HA
+# reads the drop as a meter reset → phantom kWh spike in the Energy Dashboard.
+# Clamping it here kills the spike (a no-op for cars under 50 sessions, where the
+# window IS the true total). STOPGAP, not the real fix: for high-session cars the
+# clamped value freezes near its peak rather than tracking a true lifetime total —
+# the real fix (page nextCursor to a real cumulative, or import per-session HA
+# long-term statistics) is staged pending a live Škoda charging-statistics fixture.
+MONOTONIC_INCREASING_FIELDS: tuple[str, ...] = (
+    "odometer_km",
+    "total_charged_energy_kwh",
+)
 
 # Raw portal field name -> the entity attribute it fills, for the contested
 # reading resolver below. Deliberately explicit and NUMERIC-only: comparing a

--- a/custom_components/vag_connect/climate.py
+++ b/custom_components/vag_connect/climate.py
@@ -20,9 +20,6 @@ MIN_TEMP = 16.0
 MAX_TEMP = 30.0
 TEMP_STEP = 0.5
 
-# Climatisation state values that mean "active"
-_ACTIVE_STATES = {"HEATING", "COOLING", "VENTILATION"}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -74,8 +71,17 @@ class VagClimate(VagConnectEntity, ClimateEntity):
 
     @property
     def hvac_mode(self) -> HVACMode:
+        # b7 (grounded audit P0-1) — the VW-EU/SEAT/CUPRA parsers store
+        # climatisation_state as the raw LOWERCASE backend string ("heating",
+        # "cooling"); only Škoda stores UPPERCASE. A case-sensitive membership
+        # test against an uppercase active-set therefore read OFF while a
+        # VW/SEAT/CUPRA was actively pre-conditioning, and the uppercase-only test
+        # fixture masked it. Mirror the sibling climatisation switch (switch.py
+        # is_on) EXACTLY — inactive-set exclusion, case-folded — so the climate
+        # entity and the switch can never contradict, and a future active
+        # sub-state (heatingAuxiliary…) isn't silently dropped by a fixed set.
         state = self._vehicle.get("climatisation_state")
-        if state and state in _ACTIVE_STATES:
+        if state and str(state).lower() not in ("off", "stopped", ""):
             return HVACMode.HEAT_COOL
         return HVACMode.OFF
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -3339,6 +3339,16 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if not isinstance(field_sources, dict):
             field_sources = {}
             enriched["field_sources"] = field_sources
+        # b7 (grounded audit P1-4) — the official read is rate-limited/cached (20/h),
+        # so it can carry a STALER value than the just-reconciled primary. The primary
+        # poll was already monotonic-guarded by reconcile(), but this overlay runs
+        # AFTER reconcile and raw-overwrote every differing field — so a lower cached
+        # odometer jumped the km sensor backwards and persisted. Never let the official
+        # overlay regress a physically-monotonic field; reuse the same field set the
+        # rest of the pipeline enforces (reconcile / _channel_merge exclusion).
+        from .cariad.vehicle_cache import (  # noqa: PLC0415
+            MONOTONIC_INCREASING_FIELDS,
+        )
         merged = 0
         for key, val in od.items():
             if key in ("vin", "field_sources", "source_channel"):
@@ -3350,6 +3360,17 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             if key == "last_seen_at":
                 # advance-only: skip if the primary already carries a timestamp.
                 if enriched.get(key):
+                    continue
+            if key in MONOTONIC_INCREASING_FIELDS:
+                # never regress a monotonic field (e.g. odometer_km): a staler cached
+                # official reading must not overwrite a fresher, higher primary value.
+                # Gap-fill (existing None) and advance (>=) are fine; a decrease is not.
+                existing = enriched.get(key)
+                if (
+                    isinstance(existing, (int, float))
+                    and isinstance(val, (int, float))
+                    and val < existing
+                ):
                     continue
             enriched[key] = val
             field_sources[key] = "skoda_official"
@@ -6733,10 +6754,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
 
         When the caller does not pass ``duration_min`` / ``target_c``
         the integration reads the per-config ``auxheat_duration`` /
-        ``auxheat_target_temp`` numbers stored under ``entry.options``
-        (written by the new v2.8.0 ``VagConnectNumber`` sliders). If
-        those are absent we fall back to the spec defaults (30 min,
-        21 C), matching the numbers the Audi + VW phone apps preselect.
+        ``auxheat_target_temp`` numbers written by the v2.8.0
+        ``VagConnectNumber`` sliders (options, folded into ``entry.data``
+        by the update-listener — read options-then-data). If those are
+        absent we fall back to the spec defaults (30 min, 21 C), matching
+        the numbers the Audi + VW phone apps preselect.
         """
         brand = str(self.entry.data.get(CONF_BRAND, "")).lower()
         cariad_brand = brand in {"volkswagen", "audi"}
@@ -6754,15 +6776,26 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             await self._cariad_cmd(vin, "command_start_aux_heating", spin=spin)
             return
 
+        # b7 (grounded audit P1-3) — read options THEN data. The options
+        # update-listener folds options into entry.data and blanks entry.options
+        # (__init__.py), so by read time the slider values live in entry.data;
+        # reading options alone always fell through to the 30 min / 21 C spec
+        # defaults right after the user moved the slider. Mirrors _spin_from_entry
+        # (below) and number.native_value.
         options = dict(getattr(self.entry, "options", None) or {})
+        data = dict(getattr(self.entry, "data", None) or {})
         if duration_min is None:
-            opt_dur = options.get("auxheat_duration") if isinstance(options, dict) else None
+            opt_dur = options.get("auxheat_duration")
+            if opt_dur is None:
+                opt_dur = data.get("auxheat_duration")
             try:
                 duration_min = int(opt_dur) if opt_dur is not None else 30
             except (TypeError, ValueError):
                 duration_min = 30
         if target_c is None:
-            opt_temp = options.get("auxheat_target_temp") if isinstance(options, dict) else None
+            opt_temp = options.get("auxheat_target_temp")
+            if opt_temp is None:
+                opt_temp = data.get("auxheat_target_temp")
             try:
                 target_c = float(opt_temp) if opt_temp is not None else 21.0
             except (TypeError, ValueError):
@@ -7568,16 +7601,45 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # releases the lock — after 60s we proceed anyway.
         cmd_class = self._COMMAND_CLASS.get(method, method)
         lock = self._get_command_lock(vin, cmd_class)
+        # b7 (grounded audit P1-1) — time only LOCK ACQUISITION, never command
+        # execution. The old code wrapped the whole dispatch (which included a full
+        # multi-VIN async_request_refresh) in a 60s timeout, so a slow / multi-VIN /
+        # portal account blew the budget and then RE-DISPATCHED the physical command
+        # UNLOCKED → a non-idempotent charge/unlock/aux-heat was sent to the car
+        # TWICE. No competitor re-issues on timeout. On a contended lock we now
+        # surface a soft "busy" error and never re-send; the refresh moved out of
+        # the locked/timed section entirely (see below).
         try:
-            async with asyncio.timeout(_COMMAND_LOCK_TIMEOUT):
-                async with lock:
-                    await self._dispatch_cmd_locked(vin, method, **kwargs)
+            await asyncio.wait_for(lock.acquire(), _COMMAND_LOCK_TIMEOUT)
         except TimeoutError:
             _LOGGER.warning(
-                "VW Group Connect: %s(%s) lock timeout (%ss) — proceeding without lock",
+                "VW Group Connect: %s(%s) skipped — another same-class command is "
+                "still running after %ss",
                 method, mask_vin(vin), _COMMAND_LOCK_TIMEOUT,
             )
+            raise HomeAssistantError(
+                f"{method} skipped: another command for this vehicle is still "
+                "in progress"
+            ) from None
+        try:
             await self._dispatch_cmd_locked(vin, method, **kwargs)
+        finally:
+            lock.release()
+        # b7 — refresh AFTER the command completes, OUTSIDE the lock and the
+        # command's own error scope. A refresh/portal error must never be recorded as
+        # a command failure (P2-twin) nor surfaced as a failed button press, and the
+        # heavy multi-VIN refresh must not count against the command-lock budget (that
+        # coupling is what used to trip the 60 s timeout). Awaited so callers still see
+        # fresh state on return, but in its own guard so it can't masquerade as a
+        # command error. Only reached on success — a failed dispatch re-raises out of
+        # the finally above, exactly as before.
+        try:
+            await self.async_request_refresh()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "VW Group Connect: post-command refresh failed for %s(%s)",
+                method, mask_vin(vin), exc_info=True,
+            )
 
     async def _dispatch_cmd_locked(self, vin: str, method: str, **kwargs: Any) -> None:
         """Inner dispatch — assumes per-VIN-per-class lock already held.
@@ -7589,7 +7651,10 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         try:
             fn = getattr(self._cariad_client, method)
             await fn(vin, **kwargs)
-            await self.async_request_refresh()
+            # b7 (grounded audit P1-1 / P2-twin) — the post-command refresh moved to
+            # the caller (_cariad_cmd), OUTSIDE this try and the command lock, so a
+            # refresh/portal error is no longer misclassified as a command failure
+            # and the multi-VIN refresh no longer eats the command-lock budget.
             try:
                 self.record_command_success(vin, method)
             except Exception:  # noqa: BLE001
@@ -7618,7 +7683,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             if fb is not None:
                 try:
                     await getattr(fb, method)(vin, **kwargs)
-                    await self.async_request_refresh()
+                    # b7 — refresh moved to the caller (_cariad_cmd); keep it out of
+                    # this try so a refresh error isn't misread as a fallback failure.
                     try:
                         self.record_command_success(vin, method)
                     except Exception:  # noqa: BLE001

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -72,6 +72,14 @@ _REDACT_KEYS = frozenset({
     "vin",
     "address",
     "parking_address",
+    # b7 (grounded audit P0-2a) — parking_address is redacted but its sibling
+    # parking_city carried a CLEARTEXT city name straight into the diagnostics
+    # download (the file owners attach to public GitHub issues). A plain city hits
+    # only the generic string branch, which masks e-mail/VIN/latitude=&longitude=
+    # but nothing matches a bare city name. myskoda treats the whole address block
+    # as one PII unit for exactly this reason (their #477 was this leak class).
+    # Redact it by key so it can't fall through regardless of the value form.
+    "parking_city",
     "user_id",
     "account_id",
     # D#1231 — the volkswagen.de profile block is personal: the number plate

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b6"
+  "version": "4.7.0b7"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -4027,7 +4027,15 @@ _TRIP_STATS_KEYS: frozenset[str] = frozenset({
 # longer mapped (odometer_km carries the true total). The CARIAD-BFF FETCH gate
 # stays audi/volkswagen only (coordinator._TRIP_STATS_BRANDS) because Škoda already
 # has the per-trip data inline — no wrong BFF call fires for Škoda.
-_TRIP_STATS_BRANDS: frozenset[str] = frozenset({"audi", "volkswagen", "skoda"})
+# b7 (grounded audit P1-7) — SEAT/CUPRA populate last_trip_* / lifetime_distance_km
+# every get_status (seat_cupra.py driving-data/SHORT, corrected in #392) and declare
+# trip_statistics=True, but were omitted here so the trip sensors never spawned for
+# two active brands. The hide-empty guard below still suppresses any lifetime_* field
+# they leave None; command_trip_stats stays unknown (not False) for them, so the
+# secondary gate does not re-hide.
+_TRIP_STATS_BRANDS: frozenset[str] = frozenset(
+    {"audi", "volkswagen", "skoda", "seat", "cupra"}
+)
 
 # Per-window opening position (% open), from the EU-DA window-lifter positions
 # (``position_*_door_window_lifter``). Parsed into ``windows_position`` — a slot
@@ -4146,7 +4154,13 @@ async def async_setup_entry(
             if desc.key in _TRIP_STATS_KEYS:
                 if not trip_stats_supported:
                     continue
-                if (
+                # b7 (grounded audit P1-7) — the tripStatistics capability gate only
+                # applies to brands that FETCH trips from the CARIAD-BFF
+                # /tripstatistics endpoint (audi/volkswagen). Škoda/SEAT/CUPRA get
+                # trip data inline from their own get_status parse, so a missing
+                # tripStatistics cap must NOT hide their sensors; the hide-empty guard
+                # below already suppresses any field they don't fill.
+                if brand in ("audi", "volkswagen") and (
                     coordinator.command_capability_supported(vin, "command_trip_stats")
                     is False
                 ):

--- a/tests/test_b7_audit_fixes.py
+++ b/tests/test_b7_audit_fixes.py
@@ -1,0 +1,231 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b7 — grounded-audit regression fixes.
+
+One test module per finding from the competitor-grounded audit sweep. Each pins the
+exact behaviour the fix changed so it can't silently regress:
+
+* P0-2a — parking_city redacted in diagnostics (cleartext city leak).
+* P1-2  — parked-GPS TTL honours a datetime last_seen_at (Škoda/SEAT/CUPRA).
+* P1-4  — the Škoda-official merge overlay never regresses the odometer.
+* P1-5  — total_charged_energy_kwh clamped monotonic (Energy-Dashboard spike).
+* P1-6  — tyre-pressure warning: telemetry-absent status never lights a fake red.
+* P1-7  — SEAT/CUPRA trip-statistics sensors are allowed to spawn.
+* Commit I — the Škoda-official parser reads the ~20 fields it used to drop plus the
+  aux-heating / active-ventilation blocks.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+
+# ── P0-2a — parking_city redaction ──────────────────────────────────────────
+
+def test_parking_city_is_redacted():
+    from custom_components.vag_connect.diagnostics import _REDACT_KEYS
+    # parking_address was redacted but its sibling cleartext city was not.
+    assert "parking_city" in _REDACT_KEYS
+    assert "parking_address" in _REDACT_KEYS
+
+
+# ── P1-2 — position TTL accepts a datetime stamp ────────────────────────────
+
+class TestPositionAgeDatetime:
+    def test_datetime_stamp_yields_a_real_age(self):
+        from custom_components.vag_connect.cariad.vehicle_cache import (
+            POSITION_MAX_AGE_S,
+            position_age_seconds,
+        )
+        now = datetime.now(tz=timezone.utc)
+        # Škoda/SEAT/CUPRA set last_seen_at as a datetime object — previously
+        # _parse_iso rejected it and the age came back None (TTL disabled).
+        stale = position_age_seconds({"last_seen_at": now - timedelta(hours=30)})
+        assert stale is not None
+        assert stale > POSITION_MAX_AGE_S
+        fresh = position_age_seconds({"last_seen_at": now - timedelta(hours=1)})
+        assert fresh is not None
+        assert fresh < POSITION_MAX_AGE_S
+
+    def test_iso_string_stamp_still_works(self):
+        from custom_components.vag_connect.cariad.vehicle_cache import (
+            position_age_seconds,
+        )
+        iso = (datetime.now(tz=timezone.utc) - timedelta(hours=2)).isoformat()
+        age = position_age_seconds({"last_seen_at": iso})
+        assert age is not None and age > 3600
+
+
+# ── P1-4 — official merge never regresses the odometer ──────────────────────
+
+class TestOfficialMergeOdometerGuard:
+    def _coord_with_official(self, official_odo):
+        import custom_components.vag_connect.coordinator as coord_mod
+        from custom_components.vag_connect.cariad.models import VehicleData
+        coord = coord_mod.VagConnectCoordinator.__new__(coord_mod.VagConnectCoordinator)
+        official = VehicleData(vin="VINX")
+        official.odometer_km = official_odo
+        client = MagicMock()
+        client.official_live_read = AsyncMock(return_value=official)
+        coord._cariad_client = client
+        return coord
+
+    def test_staler_official_odometer_does_not_regress(self):
+        import asyncio
+        coord = self._coord_with_official(45000)  # staler / lower
+        enriched = {"odometer_km": 45010, "field_sources": {}}  # fresher / higher
+        asyncio.run(coord._merge_official_live("VINX", enriched))
+        assert enriched["odometer_km"] == 45010  # kept, not jumped backwards
+
+    def test_official_fills_odometer_gap(self):
+        import asyncio
+        coord = self._coord_with_official(45000)
+        enriched = {"field_sources": {}}  # primary had no odometer
+        asyncio.run(coord._merge_official_live("VINX", enriched))
+        assert enriched["odometer_km"] == 45000  # gap-filled
+
+
+# ── P1-5 — charged-energy totalizer clamped monotonic ───────────────────────
+
+class TestChargedEnergyMonotonic:
+    def test_field_is_monotonic(self):
+        from custom_components.vag_connect.cariad.vehicle_cache import (
+            MONOTONIC_INCREASING_FIELDS,
+        )
+        assert "total_charged_energy_kwh" in MONOTONIC_INCREASING_FIELDS
+
+    def test_reconcile_clamps_a_window_eviction_drop(self):
+        from custom_components.vag_connect.cariad.vehicle_cache import reconcile
+        prev = {"total_charged_energy_kwh": 500.0}
+        fresh = {"total_charged_energy_kwh": 480.0}  # old session left the window
+        out, _disc = reconcile(prev, fresh)
+        assert out["total_charged_energy_kwh"] == 500.0  # no fake meter reset
+
+    def test_reconcile_allows_a_real_increase(self):
+        from custom_components.vag_connect.cariad.vehicle_cache import reconcile
+        prev = {"total_charged_energy_kwh": 500.0}
+        fresh = {"total_charged_energy_kwh": 520.0}
+        out, _disc = reconcile(prev, fresh)
+        assert out["total_charged_energy_kwh"] == 520.0
+
+
+# ── P1-6 — tyre-pressure warning polarity ───────────────────────────────────
+
+def _tyre_warning(status: str):
+    from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+    client = VWEUClient.__new__(VWEUClient)
+    client._vehicle_metadata = {}
+    client._tokens = None
+    client._spin = ""
+    raw = {"tyrePressure": {"tyrePressureStatus": {"value": {"overallStatus": status}}}}
+    return client._parse_status("VINX", raw, parking={}).tire_pressure_warning
+
+
+class TestTyrePressurePolarity:
+    def test_absent_telemetry_never_lights_red(self):
+        # the bug: any non-allowlisted token → True → fake red on a fault-free car.
+        for status in ("unavailable", "unknown", "notSupported", "invalid", "na"):
+            assert _tyre_warning(status) is not True, status
+
+    def test_ok_states_are_false(self):
+        assert _tyre_warning("ok") is False
+        assert _tyre_warning("normal") is False
+
+    def test_real_fault_is_true(self):
+        assert _tyre_warning("warning") is True
+        assert _tyre_warning("alert") is True
+
+
+# ── P1-7 — SEAT/CUPRA trip statistics ───────────────────────────────────────
+
+def test_trip_stats_brands_includes_seat_cupra():
+    from custom_components.vag_connect.sensor import _TRIP_STATS_BRANDS
+    assert {"seat", "cupra"} <= _TRIP_STATS_BRANDS
+    # regression guard: the brands that already had it stay.
+    assert {"audi", "volkswagen", "skoda"} <= _TRIP_STATS_BRANDS
+
+
+# ── Commit I — Škoda-official parser expansion ──────────────────────────────
+
+def _official(v: dict):
+    from custom_components.vag_connect.cariad.api.skoda_official import (
+        SkodaOfficialClient,
+    )
+    return SkodaOfficialClient._parse_vehicle("VINX", v)
+
+
+class TestSkodaOfficialExpandedParse:
+    def test_aux_heating_and_active_ventilation(self):
+        d = _official({
+            "auxiliaryHeating": {"state": "HEATING", "durationInSeconds": 1200},
+            "activeVentilation": {"state": "VENTILATION", "durationInSeconds": 900},
+        })
+        assert d.auxiliary_heating_status == "HEATING"
+        assert d.aux_heating_active is True
+        assert d.active_ventilation_state == "VENTILATION"
+        assert d.active_ventilation_remaining_time_min == 15
+
+    def test_charging_extras(self):
+        d = _official({"charging": {
+            "isVehicleInSavedLocation": True,
+            "status": {
+                "chargingRateInKilometersPerHour": 22.0,
+                "chargeType": "AC",
+                "remainingTimeToFullyChargedInMinutes": 30,
+            },
+            "settings": {
+                "chargingCareMode": "ACTIVATED",
+                "autoUnlockPlugWhenCharged": "PERMANENT",
+                "availableChargeModes": ["MANUAL", "TIMER"],
+            },
+        }})
+        assert d.vehicle_at_saved_location is True
+        assert d.charging_rate_kmh == 22.0
+        assert d.charging_type == "AC"
+        assert d.charge_complete_eta is not None
+        assert d.battery_care_enabled is True
+        assert d.auto_unlock_when_charged is True
+        assert d.available_charge_modes == ["MANUAL", "TIMER"]
+
+    def test_status_climate_and_fuel_extras(self):
+        d = _official({
+            "renderUrl": "https://img.example/car.png",
+            "status": {
+                "overall": {"lights": "ON"},
+                "detail": {"sunroof": "OPEN", "bonnet": "CLOSED"},
+            },
+            "airConditioning": {
+                "estimatedReachOfTargetTemperatureAt": "2026-09-03T08:00:00Z",
+                "airConditioningWithoutExternalPower": True,
+                "airConditioningAtUnlock": False,
+                "windowHeating": {"enabled": True},
+            },
+            "parkingPosition": {"formattedAddress": "Bahnhofstrasse 1"},
+            "fuelStatus": {
+                "adBlueRange": 4200,
+                "secondaryEngineRange": {
+                    "engineType": "GASOLINE",
+                    "currentFuelLevelInPercent": 55,
+                    "remainingRangeInKm": 480,
+                },
+            },
+        })
+        assert d.render_url == "https://img.example/car.png"
+        assert d.lights_on is True
+        assert d.sunroof_open is True
+        assert d.hood_open is False
+        assert d.climate_ready_at == "2026-09-03T08:00:00Z"
+        assert d.air_conditioning_without_external_power is True
+        assert d.climate_at_unlock is False
+        assert d.window_heating_enabled is True
+        assert d.parking_address == "Bahnhofstrasse 1"
+        assert d.adblue_range_km == 4200
+        assert d.secondary_engine_type == "GASOLINE"
+        assert d.secondary_engine_fuel_level_pct == 55
+        assert d.secondary_engine_range_km == 480
+
+    def test_unsupported_sunroof_stays_none(self):
+        # a car without a sunroof reports UNSUPPORTED — must not spawn a phantom
+        # "closed" reading (unlike the universal trunk).
+        d = _official({"status": {"detail": {"sunroof": "UNSUPPORTED"}}})
+        assert d.sunroof_open is None

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -586,11 +586,24 @@ class TestClimate:
         assert c.hvac_mode == HVACMode.OFF
 
     def test_hvac_mode_heat(self):
+        # b7 (P0-1) — VW-EU/SEAT/CUPRA emit the raw LOWERCASE backend string; the
+        # entity must read it as active. The uppercase-only fixture masked the bug.
         from custom_components.vag_connect.climate import VagClimate
         from homeassistant.components.climate import HVACMode
         coord = _make_coordinator()
         vin = list(coord.data.keys())[0]
-        coord.data[vin]["climatisation_state"] = "HEATING"
+        coord.data[vin]["climatisation_state"] = "heating"
+        c = VagClimate(coord, vin)
+        assert c.hvac_mode == HVACMode.HEAT_COOL
+
+    def test_hvac_mode_heat_uppercase(self):
+        # b7 (P0-1) — Škoda emits UPPERCASE; both casings must map to HEAT_COOL so
+        # the climate entity can never contradict the climatisation switch.
+        from custom_components.vag_connect.climate import VagClimate
+        from homeassistant.components.climate import HVACMode
+        coord = _make_coordinator()
+        vin = list(coord.data.keys())[0]
+        coord.data[vin]["climatisation_state"] = "COOLING"
         c = VagClimate(coord, vin)
         assert c.hvac_mode == HVACMode.HEAT_COOL
 

--- a/tests/test_v2180_command_error_surfacing.py
+++ b/tests/test_v2180_command_error_surfacing.py
@@ -96,4 +96,9 @@ async def test_success_path_untouched() -> None:
     c._cariad_client.command_wake = AsyncMock(return_value=None)
     await VagConnectCoordinator._dispatch_cmd_locked(c, VIN, "command_wake")
     c.record_command_success.assert_called_once()
-    c.async_request_refresh.assert_awaited_once()
+    # b7 (P1-1 / P2-twin) — the post-command refresh moved OUT of the inner dispatch
+    # to the caller (_cariad_cmd), outside the command lock + error scope, so a
+    # refresh/portal error can't masquerade as a command failure. The inner dispatch
+    # no longer refreshes; the caller-level refresh is covered in test_entities
+    # (test_set_departure_timer_calls_cariad).
+    c.async_request_refresh.assert_not_awaited()

--- a/tests/test_v280_auxheat.py
+++ b/tests/test_v280_auxheat.py
@@ -206,6 +206,27 @@ class TestCoordinatorAuxHeatingStart:
             target_c=22.5,
         )
 
+    def test_audi_reads_data_fallback(self):
+        # b7 (P1-3) — the options update-listener folds options into entry.data and
+        # blanks entry.options, so by read time the slider values live in entry.data.
+        # Reading options-only used to fall through to the 30 min / 21 C defaults.
+        coord = _coord("audi")
+        coord.entry.options = {}
+        coord.entry.data = {
+            "brand": "audi",
+            "auxheat_duration": 45,
+            "auxheat_target_temp": 22.5,
+        }
+        asyncio.run(
+            coord.async_start_aux_heating("VINX")
+        )
+        coord._cariad_cmd.assert_awaited_once_with(
+            "VINX",
+            "command_start_aux_heating",
+            duration_min=45,
+            target_c=22.5,
+        )
+
     def test_caller_kwargs_win_over_options(self):
         coord = _coord(
             "volkswagen",


### PR DESCRIPTION
Ten commits — nine grounded-audit fixes plus the Škoda official-channel parser expansion. Every fix was cross-checked against how the leading open-source VW / Škoda libraries handle the same code path before it shipped.

## Fixes
- **Climate case-fold (P0)** — VW / SEAT / CUPRA read "off" while actively pre-conditioning because the backend sends the state lowercase; now matches the climatisation switch exactly (case-folded inactive-set), so the two entities can't contradict.
- **Command-lock safety (P0-severity)** — a slow refresh could blow the 60 s command lock, after which the physical command (charge / unlock / aux-heat) was re-sent **unlocked**. The lock now guards only acquiring the turn and never re-sends on timeout; the post-command refresh runs outside the lock and the command's error scope, so a portal error is no longer recorded as a failed button press.
- **Diagnostics: parking_city (P0 security)** — the cleartext parking city leaked into the diagnostics download (the file users attach to public issues); now redacted by key.
- **Parked-GPS TTL** — the 24 h stale-position guard was skipped for the datetime-stamped brands (Škoda / SEAT / CUPRA); now honoured.
- **Aux-heating** honours the configured duration / temperature instead of hardcoded 30 min / 21 °C (options-then-data).
- **Official-merge odometer guard** — a staler rate-limited official reading can no longer push the mileage backwards.
- **Tyre-pressure warning** — an absent / unknown status no longer lights a false red; a real fault still does. Interim.
- **Škoda charged-energy total** clamped monotonic so a trailing-window drop no longer reads as a meter reset. Interim.
- **SEAT / CUPRA trip-statistics sensors** now spawn (fetched every poll but never shown). Thanks @indigomejor (#1309 / #1310).

## Škoda official channel
`_parse_vehicle` now reads the ~20 fields the official reader already fetched but dropped (charge rate / type / ETA, care-mode, plug auto-unlock, available modes, saved-location, climate booleans + estimated-reach, window heating, lights / sunroof / bonnet, AdBlue, secondary engine, render URL, parking address) plus the auxiliaryHeating and activeVentilation blocks — pure parse additions, no extra request / rate-limit cost.

## Verification
Full suite 5748 passed, ruff + mypy strict clean. Regression tests in `test_b7_audit_fixes.py` pin each fix.

Deferred pending a live / byte re-check: the full Škoda lifetime-energy total and the full tyre-pressure polarity flip (safe interims ship here).
