### PR TITLE
b8: last-trip duration sensor + audi_acpp trip stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b8] - 2026-09-03 — Last-trip travel-time sensor
+
+### Added
+- **Last-trip travel-time sensor.** Every trip already carried its duration in the data,
+  but there was no entity for it — now a **Last Trip Duration** sensor (minutes) sits
+  alongside the last-trip distance and average-speed sensors. Thanks @indigomejor for the
+  request (#1310).
+- **Trip sensors now also spawn on the Audi plug&play (OBD-dongle) setup.** The plug&play
+  channel fills last-trip distance and duration, but they were being hidden by the trip
+  brand gate; they now appear like on the other brands.
+
 ## [4.7.0b7] - 2026-09-03 — Grounded audit sweep: safer commands, fewer false readings, fuller Škoda official channel
 
 Every fix below was cross-checked against how the leading open-source VW / Škoda

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b7"
+  "version": "4.7.0b8"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1495,6 +1495,21 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         icon="mdi:speedometer",
         suggested_display_precision=0,
     ),
+    # b8 (#1310, indigomejor) — last-trip travel time. Already parsed into
+    # last_trip_duration_min (minutes) by every trip-capable brand but had no entity.
+    # Per-trip → MEASUREMENT (resets each ignition cycle; NOT the cumulative
+    # TOTAL_INCREASING the lifetime_travel_time_min sibling uses). myskoda +
+    # volkswagencarnet both expose it as DURATION / minutes / MEASUREMENT.
+    VagSensorDescription(
+        key="last_trip_duration_min",
+        translation_key="last_trip_duration_min",
+        data_key="last_trip_duration_min",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:map-clock-outline",
+        suggested_display_precision=0,
+    ),
     # b10 — EU Data Act portal long-tail trip/maintenance sensors.
     VagSensorDescription(
         key="lifetime_avg_speed_kmh",
@@ -4009,6 +4024,7 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
 _TRIP_STATS_KEYS: frozenset[str] = frozenset({
     "last_trip_distance_km",
     "last_trip_avg_speed_kmh",
+    "last_trip_duration_min",
     "last_trip_avg_fuel_consumption_l_100km",
     "last_trip_avg_electric_consumption_kwh_100km",
     # v2.0.0 (Big-Bang) — long-term aggregates. Audi/VW EU ONLY: the CARIAD-BFF
@@ -4033,8 +4049,13 @@ _TRIP_STATS_KEYS: frozenset[str] = frozenset({
 # two active brands. The hide-empty guard below still suppresses any lifetime_* field
 # they leave None; command_trip_stats stays unknown (not False) for them, so the
 # secondary gate does not re-hide.
+# b8 (trip-sweep finding 7) — audi_acpp (plug&play OBD dongle) fills
+# last_trip_distance_km + last_trip_duration_min (plugandplay.py) but was omitted here,
+# so its trip sensors were hidden. Add it as a spawn-gate brand; hide-empty still
+# suppresses the avg_*/lifetime_* keys it doesn't fill, and the CARIAD-BFF FETCH gate
+# (coordinator._TRIP_STATS_BRANDS) stays audi/volkswagen only so no wrong call fires.
 _TRIP_STATS_BRANDS: frozenset[str] = frozenset(
-    {"audi", "volkswagen", "skoda", "seat", "cupra"}
+    {"audi", "volkswagen", "skoda", "seat", "cupra", "audi_acpp"}
 )
 
 # Per-window opening position (% open), from the EU-DA window-lifter positions

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -590,6 +590,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Last Trip Average Speed"
       },
+      "last_trip_duration_min": {
+        "name": "Last Trip Duration"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Last Trip Average Fuel Consumption"
       },

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -470,6 +470,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Poslední Jízda — Prům. Rychlost"
       },
+      "last_trip_duration_min": {
+        "name": "Poslední Jízda — Doba jízdy"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Poslední Jízda — Prům. Spotřeba Paliva"
       },

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -476,6 +476,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Seneste tur — gennemsnitshastighed"
       },
+      "last_trip_duration_min": {
+        "name": "Seneste tur — køretid"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Seneste tur — gennemsnitligt brændstofforbrug"
       },

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -485,6 +485,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Letzte Fahrt — Ø Geschwindigkeit"
       },
+      "last_trip_duration_min": {
+        "name": "Letzte Fahrt — Fahrzeit"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Letzte Fahrt — Ø Kraftstoffverbrauch"
       },

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -476,6 +476,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Last Trip Average Speed"
       },
+      "last_trip_duration_min": {
+        "name": "Last Trip Duration"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Last Trip Average Fuel Consumption"
       },

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -470,6 +470,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Último Viaje — Velocidad Media"
       },
+      "last_trip_duration_min": {
+        "name": "Último Viaje — Duración"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Último Viaje — Consumo Medio Combustible"
       },

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -476,6 +476,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Viimeisen matkan keskinopeus"
       },
+      "last_trip_duration_min": {
+        "name": "Viimeisen matkan kesto"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Viimeisen matkan keskimääräinen polttoaineenkulutus"
       },

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -470,6 +470,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Dernier Trajet — Vitesse Moyenne"
       },
+      "last_trip_duration_min": {
+        "name": "Dernier Trajet — Durée"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Dernier Trajet — Conso. Carburant Moyenne"
       },

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -476,6 +476,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Velocità media ultimo viaggio"
       },
+      "last_trip_duration_min": {
+        "name": "Durata ultimo viaggio"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Consumo medio carburante ultimo viaggio"
       },

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -476,6 +476,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Siste tur, gjennomsnittsfart"
       },
+      "last_trip_duration_min": {
+        "name": "Siste tur, kjøretid"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Siste tur, gjennomsnittlig drivstofforbruk"
       },

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -470,6 +470,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Laatste Rit — Gem. Snelheid"
       },
+      "last_trip_duration_min": {
+        "name": "Laatste Rit — Ritduur"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Laatste Rit — Gem. Brandstofverbruik"
       },

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -470,6 +470,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Ostatnia Trasa — Średnia Prędkość"
       },
+      "last_trip_duration_min": {
+        "name": "Ostatnia Trasa — Czas jazdy"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Ostatnia Trasa — Średnie Zużycie Paliwa"
       },

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -470,6 +470,9 @@
       "last_trip_avg_speed_kmh": {
         "name": "Senaste Resa — Medel-Hastighet"
       },
+      "last_trip_duration_min": {
+        "name": "Senaste Resa — Restid"
+      },
       "last_trip_avg_fuel_consumption_l_100km": {
         "name": "Senaste Resa — Medel-Bränsleförbrukning"
       },

--- a/tests/test_b8_last_trip_duration.py
+++ b/tests/test_b8_last_trip_duration.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b8 (#1310, indigomejor) — last-trip travel-time sensor (last_trip_duration_min).
+
+The value was already parsed into ``last_trip_duration_min`` (minutes) by every
+trip-capable brand but had no entity. These pin the descriptor's shape (per-trip
+DURATION / minutes / MEASUREMENT — NOT the cumulative TOTAL_INCREASING the lifetime
+sibling uses), its gating, and its presence across every i18n file.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+
+
+def test_last_trip_duration_descriptor():
+    from homeassistant.components.sensor import (
+        SensorDeviceClass,
+        SensorStateClass,
+    )
+    from homeassistant.const import UnitOfTime
+
+    from custom_components.vag_connect.sensor import (
+        SENSOR_DESCRIPTIONS,
+        _TRIP_STATS_BRANDS,
+        _TRIP_STATS_KEYS,
+    )
+
+    d = next(x for x in SENSOR_DESCRIPTIONS if x.key == "last_trip_duration_min")
+    assert d.data_key == "last_trip_duration_min"
+    assert d.device_class == SensorDeviceClass.DURATION
+    assert d.native_unit_of_measurement == UnitOfTime.MINUTES
+    # per-trip value resets each ignition cycle → MEASUREMENT, never TOTAL_INCREASING
+    assert d.state_class == SensorStateClass.MEASUREMENT
+    assert d.entity_category is None  # primary, like its last_trip_* siblings
+    # gated with the other per-trip keys, and audi_acpp added (trip-sweep finding 7)
+    assert "last_trip_duration_min" in _TRIP_STATS_KEYS
+    assert "audi_acpp" in _TRIP_STATS_BRANDS
+
+
+def test_last_trip_duration_i18n_present_in_all_files():
+    base = os.path.join(
+        os.path.dirname(__file__), "..", "custom_components", "vag_connect"
+    )
+    files = [os.path.join(base, "strings.json")] + glob.glob(
+        os.path.join(base, "translations", "*.json")
+    )
+    assert len(files) >= 13, files
+    for f in files:
+        with open(f, encoding="utf-8") as fh:
+            data = json.load(fh)
+        sensor = data["entity"]["sensor"]
+        assert "last_trip_duration_min" in sensor, f
+        name = sensor["last_trip_duration_min"]["name"]
+        assert isinstance(name, str) and name.strip(), f


### PR DESCRIPTION
Adds the last-trip travel-time sensor (#1310) and fixes audi_acpp trip-stats gating, from a deep-sweep of the trip-statistics subsystem.

## Added
- **Last Trip Duration sensor** — the per-trip travel time was already parsed into `last_trip_duration_min` (minutes) by every trip-capable brand but had no entity. `DURATION` / minutes / `MEASUREMENT` (a per-trip value, not the cumulative `TOTAL_INCREASING` the `lifetime_travel_time_min` sibling uses); myskoda and volkswagencarnet both expose it the same way. Gated with the other `last_trip_*` keys; name added to all 13 i18n files. Requested by @indigomejor (#1310).
- **Trip sensors now spawn on the Audi plug&play (OBD-dongle) setup** — the plug&play channel fills last-trip distance and duration but they were being hidden by the trip brand gate.

## Verification
Full suite 5750 passed, ruff + mypy strict clean. Regression test in `test_b8_last_trip_duration.py`.

The deep-sweep also flagged four trip-parse items (BFF-side lifetime fields, a dual-parser dead-read for `last_trip_reset_at`/totals, an electric-consumption key divergence, SEAT/CUPRA consumption scaling) that each need a live/byte capture before any change — deliberately not touched here.
