### PR TITLE
b9: b7 climate regression fix + portal reliability (#1340, #1273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,32 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b9] - 2026-09-04 — Regression fix + portal reliability
+
+### Fixed
+- **Climate no longer stays "on" after pre-conditioning has finished.** A b7 change
+  made the climate entity and the climatisation switch read "on" for terminal states
+  (Škoda `completed`/`unknown`, SEAT/CUPRA `unsupported`) where they should read off.
+  Both now derive from the same "is climatising" flag, so they always agree and turn
+  off once a session ends.
+- **A parked car no longer loses its map location after a day.** The last-known parked
+  position now stays visible past the 24-hour freshness window (a parked car really is
+  still there) but is flagged stale via a `position_is_stale` attribute, instead of
+  disappearing. A follow-up to the b7 stale-position change.
+- **The "sign-in failed" repair no longer shows a blank message** on an EU Audi whose
+  post-login vehicle list is rejected. Thanks @cyrano330 (#1340).
+
+### Added
+- **`cancel_historical_export` service.** Stops an accidentally-triggered one-time
+  EU Data Act historical export from re-attempting every ~30 minutes until its
+  deadline. A live continuous data request is untouched. Thanks @steemandavid (#1273).
+
+### Changed
+- **The EU Data Act request kickoff no longer re-hammers the portal on every restart.**
+  When a valid data request already exists for a car, the integration trusts it for a
+  day before re-checking, instead of re-requesting it — which the portal rejects with a
+  500 and could storm on each reload. Thanks @steemandavid (#1273).
+
 ## [4.7.0b8] - 2026-09-03 — Last-trip travel-time sensor
 
 ### Added

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -503,6 +503,12 @@ def _register_services(hass: HomeAssistant) -> None:
             call.data["vin"], call.data["file"]
         )
 
+    async def _handle_cancel_historical_export(call: ServiceCall) -> None:
+        # #1273 — off-switch for an accidentally-triggered one-time export.
+        await _coord(call.data["vin"]).async_cancel_historical_export(
+            call.data["vin"]
+        )
+
     async def _handle_set_departure_timer(call: ServiceCall) -> None:
         # v2.0.0 (Big-Bang) — accept optional ``recurring_on`` weekday
         # list (e.g. ``["MONDAY","TUESDAY","FRIDAY"]``). Forwarded to
@@ -703,6 +709,7 @@ def _register_services(hass: HomeAssistant) -> None:
         ("request_historical_export",      _handle_request_historical_export, SERVICE_VIN_SCHEMA),
         ("import_historical_export",       _handle_import_historical_export,  SERVICE_VIN_SCHEMA),
         ("import_export_file",             _handle_import_export_file,        SERVICE_IMPORT_FILE_SCHEMA),
+        ("cancel_historical_export",       _handle_cancel_historical_export,  SERVICE_VIN_SCHEMA),
         ("refresh_vehicle",                _handle_refresh,             vol.Schema({})),
         # v1.13.0 (#63 Phase 3) — explicit semantic-clear alias.
         ("refresh_cloud_cache",            _handle_refresh_cloud_cache, vol.Schema({})),

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -815,6 +815,10 @@ class VehicleData:
     # carry-forward TTL in ``vehicle_cache.reconcile`` measures against, and what
     # the device_tracker exposes so the age is visible rather than implied.
     position_captured_at: str | None = None
+    # b9 — set True by reconcile when the last-known position is carried past the
+    # 24h freshness window (kept visible on the device_tracker, but flagged so a
+    # day-old pin isn't mistaken for a fresh fix). Absent/None = current.
+    position_is_stale: bool | None = None
 
     # Status
     vehicle_state: str | None = None

--- a/custom_components/vag_connect/cariad/vehicle_cache.py
+++ b/custom_components/vag_connect/cariad/vehicle_cache.py
@@ -335,15 +335,21 @@ def reconcile(
     # coordinates, which is worse than showing no address.
     if merged.get("latitude") is None and merged.get("longitude") is None:
         age = position_age_seconds(previous)
+        # b9 (regression fix) — a parked car really is still where it was, so keep
+        # the last-known pin VISIBLE even past the 24h freshness window, but flag it
+        # stale so the map / automations can tell a fresh fix from a day-old one.
+        # (b7 P1-2 dropped it entirely once the age became computable for the
+        # datetime-stamp brands, so a car parked >24h — an airport, a holiday —
+        # lost its device_tracker location.)
+        for field in (*POSITION_FIELDS, "position_captured_at"):
+            if merged.get(field) is None and previous.get(field) is not None:
+                merged[field] = previous[field]
         if age is not None and age > POSITION_MAX_AGE_S:
+            merged["position_is_stale"] = True
             notes.append(
                 f"recorded position is {age / 3600:.0f}h old "
-                f"(limit {POSITION_MAX_AGE_S // 3600}h); dropped, not carried"
+                f"(limit {POSITION_MAX_AGE_S // 3600}h); kept but flagged stale"
             )
-        else:
-            for field in (*POSITION_FIELDS, "position_captured_at"):
-                if merged.get(field) is None and previous.get(field) is not None:
-                    merged[field] = previous[field]
     # Contested readings: the export delivered one field twice under a single
     # capture time with different values, so the parser could only pick by
     # position in the array. That is not evidence, and it is what makes a

--- a/custom_components/vag_connect/climate.py
+++ b/custom_components/vag_connect/climate.py
@@ -72,14 +72,19 @@ class VagClimate(VagConnectEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         # b7 (grounded audit P0-1) — the VW-EU/SEAT/CUPRA parsers store
-        # climatisation_state as the raw LOWERCASE backend string ("heating",
-        # "cooling"); only Škoda stores UPPERCASE. A case-sensitive membership
-        # test against an uppercase active-set therefore read OFF while a
-        # VW/SEAT/CUPRA was actively pre-conditioning, and the uppercase-only test
-        # fixture masked it. Mirror the sibling climatisation switch (switch.py
-        # is_on) EXACTLY — inactive-set exclusion, case-folded — so the climate
-        # entity and the switch can never contradict, and a future active
-        # sub-state (heatingAuxiliary…) isn't silently dropped by a fixed set.
+        # b9 regression fix — derive from the parser-computed
+        # ``climatisation_active`` boolean, the single source of truth every brand
+        # sets alongside ``climatisation_state`` (with full knowledge of that
+        # brand's state vocabulary). The b7 case-folded deny-list
+        # (``state not in ("off","stopped","")``) read HEAT_COOL for TERMINAL /
+        # no-data states — Škoda-official ``COMPLETED``/``UNKNOWN``, SEAT/CUPRA
+        # ``unsupported`` — where the binary sensor + switch correctly read off,
+        # re-introducing the exact climate↔switch contradiction b7 set out to
+        # remove. Prefer the boolean; fall back to the state deny-list only if a
+        # channel ever leaves ``climatisation_active`` unset.
+        active = self._vehicle.get("climatisation_active")
+        if active is not None:
+            return HVACMode.HEAT_COOL if active else HVACMode.OFF
         state = self._vehicle.get("climatisation_state")
         if state and str(state).lower() not in ("off", "stopped", ""):
             return HVACMode.HEAT_COOL

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -235,6 +235,13 @@ HISTORICAL_EXPORT_DEADLINE_S = 72 * 3600
 # service + kickoff abort). The machinery stays intact; nothing else changes.
 ONETIME_EXPORT_DISABLED = False
 CONF_DATA_ACT_IDENTIFIERS     = "data_act_identifiers"
+# b9 (#1273) — sibling map {vin: iso-timestamp} of the last kickoff attempt. We
+# back off re-POSTing a Custom Data Request (the portal 500s on a 2nd active request
+# per VIN, and the anonymous probe false-negatives) when a cached Identifier was
+# re-verified within KICKOFF_REVERIFY_S. Kept SEPARATE from the identifier map so
+# that value stays a plain string (diagnostics redaction + the spawn-gate rely on it).
+CONF_DATA_ACT_KICKOFF_TS      = "data_act_kickoff_ts"
+KICKOFF_REVERIFY_S            = 24 * 3600
 
 # v2.14.0 — OPT-IN, BETA. When set on a Volkswagen entry, the integration
 # authenticates + reads via the volkswagen.de website authproxy (a confidential

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2181,6 +2181,25 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         s = self._historical_state().get(vin)
         return s.get("state", "idle") if isinstance(s, dict) else "idle"
 
+    async def async_cancel_historical_export(self, vin: str) -> bool:
+        """#1273 — user off-switch for a pending one-time historical export.
+
+        Clears the pending state for *vin* so the poll loop stops re-attempting the
+        import (which otherwise retries ~every 30 min until the deadline) and clears
+        the paired timeout repair. A live *continuous* data request is untouched
+        (different state). Returns True if a pending export existed.
+        """
+        st = self._historical_state()
+        existed = st.pop(vin, None) is not None
+        if existed:
+            self._persist_historical_state()
+            from .repairs import clear_issue_historical_timeout  # noqa: PLC0415
+            clear_issue_historical_timeout(self.hass, self.entry.entry_id, vin)
+            _LOGGER.info(
+                "Historical export for %s cancelled by user request.", mask_vin(vin)
+            )
+        return existed
+
     async def _advance_historical_exports(self) -> None:
         """Poll-loop step: import a READY one-time export or time out a stuck one.
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1954,6 +1954,19 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         )
         new_map = dict(existing_map)
         changed = False
+        # b9 (#1273) — sibling {vin: iso} map of the last kickoff attempt, so we can
+        # back off re-POSTing (see the guard below). Same options-then-data read as
+        # the identifier map (the update-listener folds options into data).
+        from .const import (  # noqa: PLC0415
+            CONF_DATA_ACT_KICKOFF_TS,
+            KICKOFF_REVERIFY_S,
+        )
+        kickoff_ts = dict(
+            self.entry.options.get(CONF_DATA_ACT_KICKOFF_TS)
+            or self.entry.data.get(CONF_DATA_ACT_KICKOFF_TS)
+            or {}
+        )
+        new_ts = dict(kickoff_ts)
 
         for vin in list(self.vehicles):
             try:
@@ -1969,7 +1982,36 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                             mask_vin(vin), active[:8],
                         )
                     continue
-                # No active request - kick one off.
+                # b9 (#1273) — the anonymous-AEM probe above false-negatives, and the
+                # portal 500s on a 2nd active request per VIN (one-active-request rule),
+                # so a blind re-POST storms on every restart/reload. When we already
+                # hold a cached Identifier that was re-verified within
+                # KICKOFF_REVERIFY_S, trust it and skip the POST; past that window
+                # re-verify once (the portal silently drops a request ~24-36h, so we
+                # can't trust the cache forever).
+                cached = existing_map.get(vin)
+                if cached:
+                    ts_raw = kickoff_ts.get(vin)
+                    kicked_at = None
+                    if isinstance(ts_raw, str):
+                        try:
+                            kicked_at = datetime.fromisoformat(ts_raw)
+                        except ValueError:
+                            kicked_at = None
+                    if kicked_at is not None:
+                        if kicked_at.tzinfo is None:
+                            kicked_at = kicked_at.replace(tzinfo=timezone.utc)
+                        age_s = (
+                            datetime.now(tz=timezone.utc) - kicked_at
+                        ).total_seconds()
+                        if age_s < KICKOFF_REVERIFY_S:
+                            new_map[vin] = cached
+                            continue
+                # No fresh cached request — kick one off. Stamp the attempt FIRST
+                # (and mark changed) so the backoff holds even if this POST fails,
+                # persisted below — an unpersisted stamp wouldn't survive a restart.
+                new_ts[vin] = datetime.now(tz=timezone.utc).isoformat()
+                changed = True
                 new_id = await scraper.kickoff_custom_data_request(vin)
                 if new_id:
                     new_map[vin] = new_id
@@ -1992,7 +2034,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if changed:
             self.hass.config_entries.async_update_entry(
                 self.entry,
-                options={**self.entry.options, CONF_DATA_ACT_IDENTIFIERS: new_map},
+                options={
+                    **self.entry.options,
+                    CONF_DATA_ACT_IDENTIFIERS: new_map,
+                    CONF_DATA_ACT_KICKOFF_TS: new_ts,
+                },
             )
 
     def _notify_data_act_kickoff(self, vin: str) -> None:

--- a/custom_components/vag_connect/device_tracker.py
+++ b/custom_components/vag_connect/device_tracker.py
@@ -149,6 +149,9 @@ class VagConnectTracker(VagConnectEntity, TrackerEntity):
             # user tell a position from a minute ago from one from yesterday
             # instead of having to trust that the marker is current.
             "position_captured_at",
+            # b9 — True only when the pin is a last-known position kept past the
+            # 24h freshness window; lets the map/automations flag a day-old fix.
+            "position_is_stale",
             "vehicle_state",
             "model",
             "model_year",

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -39,6 +39,7 @@ from .const import (
     CONF_ABRP_USER_TOKEN,
     CONF_BRAND,
     CONF_DATA_ACT_IDENTIFIERS,
+    CONF_DATA_ACT_KICKOFF_TS,
     CONF_ENABLE_REVERSE_GEOCODING,
     CONF_PASSWORD,
     CONF_SPIN,
@@ -323,7 +324,11 @@ def _scrub(value: Any, *, gps_round: bool = False) -> Any:
                     scrubbed[sk] = round(float(v), 1)
                 else:
                     scrubbed[sk] = "**REDACTED**"
-            elif k == CONF_DATA_ACT_IDENTIFIERS or k == "skoda_official_keys":
+            elif k in (
+                CONF_DATA_ACT_IDENTIFIERS,
+                CONF_DATA_ACT_KICKOFF_TS,
+                "skoda_official_keys",
+            ):
                 # #923/#1222 — mask the {VIN: portal-identifier} values, which
                 # the string branch below would otherwise pass through.
                 # #1286 — same shape for the Škoda official per-VIN key map
@@ -396,7 +401,7 @@ def _scrub_raw(value: Any) -> Any:
                 out[sk] = "**REDACTED**"
             elif k in _HASH_KEYS and isinstance(v, str):
                 out[sk] = f"sha256:{_stable_hash(v)}" if v else "**REDACTED**"
-            elif k == CONF_DATA_ACT_IDENTIFIERS:
+            elif k in (CONF_DATA_ACT_IDENTIFIERS, CONF_DATA_ACT_KICKOFF_TS):
                 out[sk] = _redact_identifier_map(v)
             else:
                 out[sk] = _scrub_raw(v)

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b8"
+  "version": "4.7.0b9"
 }

--- a/custom_components/vag_connect/services.yaml
+++ b/custom_components/vag_connect/services.yaml
@@ -243,6 +243,20 @@ import_historical_export:
       selector:
         text:
 
+cancel_historical_export:
+  name: Einmaligen Verlaufsexport abbrechen
+  description: >-
+    Bricht einen laufenden einmaligen Verlaufsexport für ein Fahrzeug ab. Nutze
+    das, wenn du den Export versehentlich ausgelöst hast — es stoppt die
+    wiederholten Import-Versuche (~alle 30 Min bis zum Ablauf). Eine bereits
+    laufende kontinuierliche Datenanforderung bleibt unberührt.
+  fields:
+    vin:
+      name: VIN
+      required: true
+      selector:
+        text:
+
 import_export_file:
   name: Export-Datei importieren
   description: >-

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Sign-in failed — {brand}",
+      "description": "Home Assistant couldn't sign in to your {brand} account — usually a wrong or changed password, though a temporary block can look the same.\n\nSettings → Devices & Services → VW Group Connect → ⋮ → Reconfigure to re-enter your credentials."
+    },
     "two_factor_required": {
       "title": "Two-factor authentication required — {brand}",
       "description": "Your {brand} account ({username}) requires an email verification code.\n\n**One-time fix:**\n1. Open the **{brand} app** on your phone\n2. Sign in manually\n3. Confirm the code sent by email\n4. Restart Home Assistant\n\nAfter this one-time step, the integration stores the login token — you won't need to repeat this."

--- a/custom_components/vag_connect/switch.py
+++ b/custom_components/vag_connect/switch.py
@@ -124,6 +124,14 @@ class VagClimatisationSwitch(VagConnectEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool | None:
+        # b9 regression fix — prefer the parser-computed ``climatisation_active``
+        # boolean (correct for terminal/no-data states like COMPLETED / UNKNOWN /
+        # unsupported, where a raw state deny-list wrongly read "on"); fall back to
+        # the state deny-list only when a channel leaves the boolean unset. Keeps
+        # the switch, the climate entity and the binary sensor in agreement.
+        active = self._vehicle.get("climatisation_active")
+        if active is not None:
+            return bool(active)
         state = self._vehicle.get("climatisation_state")
         if state is None:
             return None

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Přihlášení selhalo — {brand}",
+      "description": "Home Assistant se nemohl přihlásit k účtu {brand} — obvykle nesprávné nebo změněné heslo, ale dočasné zablokování může vypadat stejně.\n\nNastavení → Zařízení a služby → VW Group Connect → ⋮ → Překonfigurovat a znovu zadat přihlašovací údaje."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: vypnuto Volkswagenem",
       "description": "Dne 18. 8. 2026 Volkswagen vypnul přihlášení, které kanál VW EU Two-Way (moderní backend CARIAD) používal, takže jeho hodinový token už nelze obnovit a obousměrné příkazy přes tento kanál přestaly fungovat. Jde o změnu na straně Volkswagenu — na vaší straně není nic špatně nastaveno a váš účet není ohrožen (selhání nastává ještě předtím, než se odešle jakékoli heslo).\n\n**Vaše živé čtení dat funguje dál** přes portál EU Data Act, takže vaše senzory to nijak neovlivní.\n\n**Pro obousměrné příkazy (zamknout/odemknout, klimatizace, nabíjení):** trvalá náhrada přes klasický backend Car-Net (MBB) — který Volkswagen NEVYPNUL — je nyní v betě. Postup, jak ji zapnout a otestovat, najdete v issue #584.\n\nNyní neaktivní kanál můžete kdykoli odebrat v nastavení integrace (VW EU Two-Way → odebrat). Tato zpráva je pouze informativní; integrace běží dál přes vaše čtecí kanály.\n\n**Tip:** pro daný vůz mějte současně zapnutou vždy jen JEDNU obousměrnou integraci. VW omezuje počet požadavků a může dočasně zablokovat účet, na který několik aplikací útočí najednou — když k tomu dojde, nedokáže vůz ovládat ani oficiální aplikace VW, což je signál, že jde o zablokování účtu, nikoli o chybu této integrace."

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Login mislykkedes — {brand}",
+      "description": "Home Assistant kunne ikke logge ind på din {brand}-konto — normalt en forkert eller ændret adgangskode, men en midlertidig blokering kan se ens ud.\n\nIndstillinger → Enheder og tjenester → VW Group Connect → ⋮ → Rekonfigurer for at indtaste dine loginoplysninger igen."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU To-vejs: slået fra af Volkswagen",
       "description": "Den 2026-08-18 slog Volkswagen det login fra, som kanalen VW EU To-vejs (det moderne CARIAD-backend) brugte, så dens token på 1 time ikke længere kan fornyes, og to-vejs-kommandoer via den kanal er stoppet. Dette er en ændring på Volkswagens side — der er ikke noget forkert konfigureret hos dig, og din konto er ikke i fare (fejlen sker, før nogen adgangskode sendes).\n\n**Dine live-aflæsninger virker fortsat** via EU Data Act-portalen, så dine sensorer er upåvirkede.\n\n**Til to-vejs-kommandoer (lås/lås op, klima, opladning):** en vedvarende erstatning via det klassiske Car-Net (MBB)-backend — som Volkswagen IKKE har slået fra — er nu i beta. Se issue #584 for, hvordan du aktiverer og tester den.\n\nDu kan når som helst fjerne den nu inaktive kanal under integrationens indstillinger (VW EU To-vejs → fjern). Denne besked er kun til orientering; integrationen kører videre på dine læsekanaler.\n\n**Tip:** aktivér kun ÉN to-vejs-integration for en given bil ad gangen. VW har hastighedsgrænser og kan midlertidigt spærre en konto, som flere apps hamrer på samtidig — når det sker, kan selv den officielle VW-app ikke styre bilen, hvilket er tegnet på, at det er en kontospærring og ikke denne integration."

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Anmeldung fehlgeschlagen — {brand}",
+      "description": "Home Assistant konnte sich nicht bei deinem {brand}-Konto anmelden — meist ein falsches oder geändertes Passwort, aber eine vorübergehende Sperre kann gleich aussehen.\n\nEinstellungen → Geräte & Dienste → VW Group Connect → ⋮ → Neu konfigurieren, um die Zugangsdaten erneut einzugeben."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: von Volkswagen abgeschaltet",
       "description": "Am 18.08.2026 hat Volkswagen den Login abgeschaltet, den der VW-EU-Two-Way (modernes CARIAD-Backend) nutzte — der 1-Stunden-Token kann nicht mehr erneuert werden, die Befehle über diesen Kanal sind gestoppt. Das ist eine Volkswagen-seitige Änderung — bei dir ist nichts falsch konfiguriert, und dein Konto ist nicht gefährdet (der Fehler passiert, bevor überhaupt ein Passwort gesendet wird).\n\n**Deine Live-Daten laufen weiter** über das EU-Data-Act-Portal, deine Sensoren sind also nicht betroffen.\n\n**Für Zwei-Wege-Befehle (Ver-/Entriegeln, Klima, Laden):** ein dauerhafter Ersatz über das klassische Car-Net-(MBB-)Backend — das Volkswagen NICHT abgeschaltet hat — ist jetzt in der Beta. Wie du ihn aktivierst und testest, steht in Issue #584.\n\nDen inaktiven Kanal kannst du jederzeit in den Integrations-Optionen entfernen (VW EU Two-Way → entfernen). Diese Meldung ist rein informativ; die Integration läuft auf deinen Lese-Kanälen weiter.\n\n**Tipp:** aktiviere pro Auto immer nur EINEN Two-Way-Zugang gleichzeitig. VW drosselt und sperrt Konten zeitweise, wenn mehrere Apps es gleichzeitig bombardieren — dann kann selbst die offizielle VW-App das Auto nicht steuern, und genau das ist das Zeichen für eine Konto-Sperre, nicht die Integration."

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Sign-in failed — {brand}",
+      "description": "Home Assistant couldn't sign in to your {brand} account — usually a wrong or changed password, though a temporary block can look the same.\n\nSettings → Devices & Services → VW Group Connect → ⋮ → Reconfigure to re-enter your credentials."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: disabled by Volkswagen",
       "description": "On 2026-08-18 Volkswagen disabled the login that the VW EU Two-Way (modern CARIAD backend) channel used, so its 1-hour token can no longer be renewed and two-way commands via that channel have stopped. This is a Volkswagen-side change — nothing is misconfigured on your side, and your account is not at risk (the failure happens before any password is sent).\n\n**Your live reads keep working** through the EU Data Act portal, so your sensors are unaffected.\n\n**For two-way commands (lock/unlock, climate, charging):** a durable replacement via the classic Car-Net (MBB) backend — which Volkswagen has NOT disabled — is now in beta. See issue #584 for how to enable and test it.\n\nYou can remove the now-inactive channel any time under the integration's options (VW EU Two-Way → remove). This message is informational; the integration keeps running on your read channels.\n\n**Tip:** enable only ONE two-way integration for a given car at a time. VW rate-limits and can temporarily lock an account that several apps hammer at once — when that happens even the official VW app can't control the car, which is the tell that it's an account lockout, not this integration."

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Error de inicio de sesión — {brand}",
+      "description": "Home Assistant no pudo iniciar sesión en tu cuenta de {brand} — normalmente una contraseña incorrecta o cambiada, aunque un bloqueo temporal puede parecer igual.\n\nAjustes → Dispositivos y servicios → VW Group Connect → ⋮ → Reconfigurar para volver a introducir tus credenciales."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU bidireccional: desactivado por Volkswagen",
       "description": "El 18 de agosto de 2026 Volkswagen desactivó el inicio de sesión que usaba el canal VW EU bidireccional (backend moderno CARIAD), por lo que su token de 1 hora ya no puede renovarse y los comandos bidireccionales a través de ese canal han dejado de funcionar. Se trata de un cambio del lado de Volkswagen — no hay nada mal configurado por tu parte y tu cuenta no corre ningún riesgo (el fallo ocurre antes de que se envíe ninguna contraseña).\n\n**Tus lecturas en vivo siguen funcionando** a través del portal EU Data Act, por lo que tus sensores no se ven afectados.\n\n**Para los comandos bidireccionales (bloqueo/desbloqueo, climatización, carga):** ya está en beta un reemplazo duradero a través del backend clásico Car-Net (MBB), que Volkswagen NO ha desactivado. Consulta la incidencia #584 para saber cómo activarlo y probarlo.\n\nPuedes eliminar el canal ahora inactivo en cualquier momento en las opciones de la integración (VW EU bidireccional → eliminar). Este mensaje es solo informativo; la integración sigue funcionando con tus canales de lectura.\n\n**Consejo:** activa solo UNA integración bidireccional para un mismo coche a la vez. VW aplica límites de frecuencia y puede bloquear temporalmente una cuenta que varias apps saturan a la vez — cuando eso ocurre, ni siquiera la app oficial de VW puede controlar el coche, que es la señal de que se trata de un bloqueo de cuenta y no de un problema de esta integración."

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Kirjautuminen epäonnistui — {brand}",
+      "description": "Home Assistant ei voinut kirjautua {brand}-tilillesi — yleensä väärä tai muutettu salasana, mutta tilapäinen esto voi näyttää samalta.\n\nAsetukset → Laitteet ja palvelut → VW Group Connect → ⋮ → Määritä uudelleen ja anna kirjautumistiedot uudelleen."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: Volkswagen poisti käytöstä",
       "description": "Volkswagen poisti 18.8.2026 käytöstä kirjautumisen, jota VW EU Two-Way (moderni CARIAD-taustajärjestelmä) -kanava käytti, joten sen 1 tunnin tunnistetta ei voi enää uusia ja kaksisuuntaiset komennot tämän kanavan kautta ovat lakanneet toimimasta. Tämä on Volkswagenin puolella tehty muutos — mitään ei ole määritetty väärin sinun puolellasi, eikä tilisi ole vaarassa (virhe tapahtuu ennen kuin mitään salasanaa lähetetään).\n\n**Live-lukemasi toimivat edelleen** EU Data Act -portaalin kautta, joten tämä ei vaikuta antureihisi.\n\n**Kaksisuuntaisiin komentoihin (lukitus/avaus, ilmastointi, lataus):** pysyvä korvaaja klassisen Car-Net (MBB) -taustajärjestelmän kautta — jota Volkswagen EI ole poistanut käytöstä — on nyt betavaiheessa. Katso issue #584, miten se otetaan käyttöön ja testataan.\n\nVoit poistaa nyt käytöstä poistuneen kanavan milloin tahansa integraation asetuksista (VW EU Two-Way → poista). Tämä viesti on vain tiedoksi; integraatio jatkaa toimintaansa lukukanavillasi.\n\n**Vinkki:** ota käyttöön vain YKSI kaksisuuntainen integraatio kutakin autoa kohti kerrallaan. VW rajoittaa pyyntötahtia ja voi tilapäisesti lukita tilin, jota useat sovellukset kuormittavat yhtä aikaa — kun näin käy, edes virallinen VW-sovellus ei pysty ohjaamaan autoa, mikä on merkki tilin lukituksesta eikä tästä integraatiosta."

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Échec de la connexion — {brand}",
+      "description": "Home Assistant n'a pas pu se connecter à votre compte {brand} — généralement un mot de passe incorrect ou modifié, mais un blocage temporaire peut y ressembler.\n\nParamètres → Appareils et services → VW Group Connect → ⋮ → Reconfigurer pour saisir à nouveau vos identifiants."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU bidirectionnel : désactivé par Volkswagen",
       "description": "Le 18 août 2026, Volkswagen a désactivé la connexion qu'utilisait le canal VW EU bidirectionnel (backend CARIAD moderne) ; son jeton d'une heure ne peut donc plus être renouvelé et les commandes bidirectionnelles via ce canal ont cessé de fonctionner. Il s'agit d'un changement côté Volkswagen — rien n'est mal configuré chez vous, et votre compte n'est pas en danger (l'échec se produit avant l'envoi de tout mot de passe).\n\n**Vos lectures en direct continuent de fonctionner** via le portail EU Data Act, vos capteurs ne sont donc pas affectés.\n\n**Pour les commandes bidirectionnelles (verrouillage/déverrouillage, climatisation, charge) :** un remplacement durable via l'ancien backend Car-Net (MBB) — que Volkswagen n'a PAS désactivé — est désormais en bêta. Voir le ticket #584 pour savoir comment l'activer et le tester.\n\nVous pouvez supprimer à tout moment le canal désormais inactif dans les options de l'intégration (VW EU bidirectionnel → supprimer). Ce message est purement informatif ; l'intégration continue de fonctionner sur vos canaux de lecture.\n\n**Conseil :** n'activez qu'UNE seule intégration bidirectionnelle à la fois pour une même voiture. VW limite le nombre de requêtes et peut verrouiller temporairement un compte que plusieurs applications sollicitent en même temps — quand cela arrive, même l'application officielle VW ne peut plus contrôler la voiture, ce qui est le signe d'un verrouillage de compte, et non d'un problème de cette intégration."

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Accesso non riuscito — {brand}",
+      "description": "Home Assistant non è riuscito ad accedere al tuo account {brand} — di solito una password errata o modificata, anche se un blocco temporaneo può sembrare uguale.\n\nImpostazioni → Dispositivi e servizi → VW Group Connect → ⋮ → Riconfigura per reinserire le credenziali."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: disattivato da Volkswagen",
       "description": "Il 18/08/2026 Volkswagen ha disattivato il login usato dal canale VW EU Two-Way (backend moderno CARIAD), quindi il suo token di 1 ora non può più essere rinnovato e i comandi bidirezionali tramite quel canale si sono interrotti. Si tratta di una modifica lato Volkswagen — non c'è nulla di configurato male dalla tua parte, e il tuo account non è a rischio (l'errore si verifica prima che venga inviata qualsiasi password).\n\n**Le tue letture in tempo reale continuano a funzionare** tramite il portale EU Data Act, quindi i tuoi sensori non ne risentono.\n\n**Per i comandi bidirezionali (blocca/sblocca, clima, ricarica):** un sostituto durevole tramite il backend classico Car-Net (MBB) — che Volkswagen NON ha disattivato — è ora in beta. Vedi la issue #584 per sapere come attivarlo e testarlo.\n\nPuoi rimuovere il canale ora inattivo in qualsiasi momento dalle opzioni dell'integrazione (VW EU Two-Way → rimuovi). Questo messaggio è puramente informativo; l'integrazione continua a funzionare sui tuoi canali di lettura.\n\n**Suggerimento:** attiva UNA sola integrazione bidirezionale per una data auto alla volta. VW applica limiti di frequenza e può bloccare temporaneamente un account tempestato di richieste da più app contemporaneamente — quando succede, nemmeno l'app ufficiale VW riesce a controllare l'auto, ed è questo il segnale che si tratta di un blocco dell'account e non di questa integrazione."

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Innlogging mislyktes — {brand}",
+      "description": "Home Assistant kunne ikke logge inn på {brand}-kontoen din — vanligvis feil eller endret passord, men en midlertidig blokkering kan se lik ut.\n\nInnstillinger → Enheter og tjenester → VW Group Connect → ⋮ → Rekonfigurer for å oppgi påloggingsinformasjonen på nytt."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: deaktivert av Volkswagen",
       "description": "Den 2026-08-18 slo Volkswagen av påloggingen som VW EU Two-Way-kanalen (det moderne CARIAD-baksystemet) brukte, så tokenet som er gyldig i én time kan ikke lenger fornyes, og toveiskommandoer via den kanalen har sluttet å fungere. Dette er en endring på Volkswagens side — ingenting er feilkonfigurert hos deg, og kontoen din er ikke i fare (feilen skjer før noe passord sendes).\n\n**Sanntidsavlesningene dine fungerer fortsatt** via EU Data Act-portalen, så sensorene dine påvirkes ikke.\n\n**For toveiskommandoer (lås/lås opp, klima, lading):** en varig erstatning via det klassiske Car-Net (MBB)-baksystemet — som Volkswagen IKKE har slått av — er nå i beta. Se issue #584 for hvordan du aktiverer og tester den.\n\nDu kan når som helst fjerne den nå inaktive kanalen under integrasjonens innstillinger (VW EU Two-Way → fjern). Denne meldingen er kun til informasjon; integrasjonen fortsetter å kjøre på lesekanalene dine.\n\n**Tips:** aktiver kun ÉN toveisintegrasjon for én og samme bil om gangen. VW har hastighetsbegrensninger og kan midlertidig sperre en konto som flere apper bombarderer samtidig — når det skjer, kan selv den offisielle VW-appen ikke styre bilen, og det er tegnet på at det er en kontosperre og ikke denne integrasjonen."

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Aanmelden mislukt — {brand}",
+      "description": "Home Assistant kon niet inloggen op je {brand}-account — meestal een onjuist of gewijzigd wachtwoord, al kan een tijdelijke blokkade er hetzelfde uitzien.\n\nInstellingen → Apparaten en diensten → VW Group Connect → ⋮ → Herconfigureren om je inloggegevens opnieuw in te voeren."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: uitgeschakeld door Volkswagen",
       "description": "Op 2026-08-18 heeft Volkswagen de login uitgeschakeld die het VW EU Two-Way-kanaal (moderne CARIAD-backend) gebruikte, waardoor het token van 1 uur niet meer kan worden vernieuwd en tweerichtingscommando's via dat kanaal zijn gestopt. Dit is een wijziging aan de kant van Volkswagen — er is bij jou niets verkeerd geconfigureerd en je account loopt geen risico (de fout treedt op vóórdat er een wachtwoord wordt verzonden).\n\n**Je live uitlezingen blijven werken** via het EU Data Act-portaal, dus je sensoren worden niet beïnvloed.\n\n**Voor tweerichtingscommando's (vergrendelen/ontgrendelen, klimaat, laden):** een duurzame vervanging via de klassieke Car-Net (MBB)-backend — die Volkswagen NIET heeft uitgeschakeld — is nu in bèta. Zie issue #584 voor hoe je het inschakelt en test.\n\nJe kunt het nu inactieve kanaal op elk moment verwijderen via de opties van de integratie (VW EU Two-Way → verwijderen). Dit bericht is alleen ter informatie; de integratie blijft draaien op je leeskanalen.\n\n**Tip:** schakel per auto slechts ÉÉN tweerichtingsintegratie tegelijk in. VW beperkt het aantal verzoeken en kan een account tijdelijk blokkeren wanneer meerdere apps het tegelijk bestoken — als dat gebeurt, kan zelfs de officiële VW-app de auto niet meer bedienen, en dát is het teken dat het om een accountblokkering gaat en niet om deze integratie."

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Logowanie nie powiodło się — {brand}",
+      "description": "Home Assistant nie mógł zalogować się do konta {brand} — zwykle błędne lub zmienione hasło, ale tymczasowa blokada może wyglądać tak samo.\n\nUstawienia → Urządzenia i usługi → VW Group Connect → ⋮ → Rekonfiguruj, aby ponownie wprowadzić dane logowania."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: wyłączone przez Volkswagena",
       "description": "18.08.2026 Volkswagen wyłączył logowanie, z którego korzystał kanał VW EU Two-Way (nowoczesny backend CARIAD), więc jego godzinny token nie może już być odnawiany, a polecenia dwukierunkowe przez ten kanał przestały działać. To zmiana po stronie Volkswagena — nic nie jest źle skonfigurowane u Ciebie, a Twoje konto nie jest zagrożone (błąd występuje, zanim jakiekolwiek hasło zostanie wysłane).\n\n**Twoje odczyty na żywo nadal działają** przez portal EU Data Act, więc Twoje czujniki pozostają bez zmian.\n\n**Dla poleceń dwukierunkowych (ryglowanie/odryglowanie, klimatyzacja, ładowanie):** trwały zamiennik przez klasyczny backend Car-Net (MBB) — którego Volkswagen NIE wyłączył — jest teraz w wersji beta. Zobacz zgłoszenie #584, aby dowiedzieć się, jak go włączyć i przetestować.\n\nNieaktywny już kanał możesz w każdej chwili usunąć w opcjach integracji (VW EU Two-Way → usuń). To komunikat informacyjny; integracja nadal działa na Twoich kanałach odczytu.\n\n**Wskazówka:** dla danego auta włączaj tylko JEDNĄ integrację dwukierunkową naraz. VW ogranicza liczbę żądań i może tymczasowo zablokować konto, które kilka aplikacji odpytuje jednocześnie — gdy tak się stanie, nawet oficjalna aplikacja VW nie może sterować autem, co jest sygnałem, że to blokada konta, a nie ta integracja."

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1940,6 +1940,10 @@
     }
   },
   "issues": {
+    "invalid_credentials": {
+      "title": "Inloggning misslyckades — {brand}",
+      "description": "Home Assistant kunde inte logga in på ditt {brand}-konto — vanligtvis fel eller ändrat lösenord, men en tillfällig spärr kan se likadan ut.\n\nInställningar → Enheter och tjänster → VW Group Connect → ⋮ → Konfigurera om för att ange dina inloggningsuppgifter igen."
+    },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: inaktiverad av Volkswagen",
       "description": "Den 2026-08-18 inaktiverade Volkswagen den inloggning som kanalen VW EU Two-Way (moderna CARIAD-backendet) använde, så dess 1-timmestoken kan inte längre förnyas och tvåvägskommandon via den kanalen har slutat fungera. Detta är en ändring på Volkswagens sida — inget är felkonfigurerat hos dig, och ditt konto är inte i fara (felet inträffar innan något lösenord skickas).\n\n**Dina live-avläsningar fungerar fortfarande** via EU Data Act-portalen, så dina sensorer påverkas inte.\n\n**För tvåvägskommandon (lås/lås upp, klimat, laddning):** en varaktig ersättning via det klassiska Car-Net-backendet (MBB) — som Volkswagen INTE har inaktiverat — är nu i beta. Se issue #584 för hur du aktiverar och testar den.\n\nDu kan ta bort den nu inaktiva kanalen när som helst under integrationens inställningar (VW EU Two-Way → ta bort). Det här meddelandet är endast informativt; integrationen fortsätter att köras på dina läskanaler.\n\n**Tips:** aktivera bara EN tvåvägsintegration för en och samma bil åt gången. VW har hastighetsbegränsningar och kan tillfälligt låsa ett konto som flera appar hamrar på samtidigt — när det händer kan inte ens den officiella VW-appen styra bilen, vilket är tecknet på att det är en kontospärr, inte den här integrationen."

--- a/tests/test_b9_cancel_export.py
+++ b/tests/test_b9_cancel_export.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1273 (steemandavid) — cancel_historical_export off-switch.
+
+An accidentally-triggered one-time export otherwise re-attempts its import every
+~30 min until the 72h deadline, with no way to stop it. The new service clears the
+pending state so the poll loop stops, and clears the paired timeout repair.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+
+def _hist_coord(state: dict) -> object:
+    import custom_components.vag_connect.coordinator as cm
+
+    c = cm.VagConnectCoordinator.__new__(cm.VagConnectCoordinator)
+    c._historical_export_state = dict(state)
+    c.hass = MagicMock()
+    c.entry = MagicMock(entry_id="e1")
+    c.entry.data = {}
+    return c
+
+
+def test_cancel_clears_pending_and_returns_true() -> None:
+    c = _hist_coord({"VINX": {"state": "pending", "submitted_at": "2026-09-04T00:00:00Z"}})
+    assert asyncio.run(c.async_cancel_historical_export("VINX")) is True
+    # the poll loop keys off this state — must be gone so it stops re-attempting
+    assert c.historical_export_state("VINX") == "idle"
+
+
+def test_cancel_returns_false_when_nothing_pending() -> None:
+    c = _hist_coord({})
+    assert asyncio.run(c.async_cancel_historical_export("VINX")) is False
+
+
+def test_cancel_leaves_other_vins_untouched() -> None:
+    c = _hist_coord({
+        "VINX": {"state": "pending", "submitted_at": "2026-09-04T00:00:00Z"},
+        "VINY": {"state": "pending", "submitted_at": "2026-09-04T00:00:00Z"},
+    })
+    assert asyncio.run(c.async_cancel_historical_export("VINX")) is True
+    assert c.historical_export_state("VINX") == "idle"
+    assert c.historical_export_state("VINY") == "pending"

--- a/tests/test_b9_kickoff_backoff.py
+++ b/tests/test_b9_kickoff_backoff.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1273 (steemandavid) — EU-DA kickoff re-POST backoff.
+
+The anonymous-AEM active-request probe false-negatives, and the portal 500s on a
+2nd active Custom Data Request per VIN, so a blind re-POST storms on every restart.
+When a cached Identifier was re-verified within KICKOFF_REVERIFY_S the kickoff must
+be SKIPPED; past that window it re-verifies once. The attempt timestamp is persisted
+so the backoff survives a restart.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.vag_connect.cariad.models import TokenSet
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+_SCRAPER = "custom_components.vag_connect.cariad.auth._data_act_scraper.DataActScraper"
+_SESS = "homeassistant.helpers.aiohttp_client.async_get_clientsession"
+_VIN = "WVWZZZAUZFW805377"
+
+
+def _stub(identifiers: dict, kickoff_ts: dict) -> Any:
+    stub = type("S", (), {})()
+    stub.entry = MagicMock()
+    stub.entry.options = {
+        "eu_data_act_auto_kickoff": True,
+        "data_act_identifiers": dict(identifiers),
+        "data_act_kickoff_ts": dict(kickoff_ts),
+    }
+    stub.entry.data = {"brand": "volkswagen", "eu_data_act_auto_kickoff": True}
+    client = MagicMock()
+    client._tokens = TokenSet(
+        access_token="a", refresh_token="r", id_token="i", strategy="data_act_portal",
+    )
+    stub._cariad_client = client
+    stub.vehicles = {_VIN: {}}
+    stub.hass = MagicMock()
+    return stub
+
+
+def _run(stub, active_return, kickoff_return="NEWID"):
+    scraper = MagicMock()
+    scraper.get_active_custom_request_identifier = AsyncMock(return_value=active_return)
+    scraper.kickoff_custom_data_request = AsyncMock(return_value=kickoff_return)
+    with patch(_SCRAPER, return_value=scraper), patch(_SESS, return_value=MagicMock()):
+        asyncio.run(
+            VagConnectCoordinator._ensure_data_act_custom_request_kickoff(stub)
+        )
+    return scraper
+
+
+def _iso(**kw) -> str:
+    return (datetime.now(tz=timezone.utc) - timedelta(**kw)).isoformat()
+
+
+def test_skips_repost_when_cached_and_recently_verified() -> None:
+    # the storm-stopper: cached id + a probe false-negative + recent stamp → no POST.
+    stub = _stub({_VIN: "CACHEDID"}, {_VIN: _iso(hours=1)})
+    scraper = _run(stub, active_return=None)
+    scraper.kickoff_custom_data_request.assert_not_awaited()
+    # nothing changed → no entry write
+    stub.hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_reverifies_when_cached_stamp_is_stale() -> None:
+    # past the 24h window, a false-negative probe must re-POST once.
+    stub = _stub({_VIN: "CACHEDID"}, {_VIN: _iso(hours=30)})
+    scraper = _run(stub, active_return=None)
+    scraper.kickoff_custom_data_request.assert_awaited_once()
+
+
+def test_posts_and_stamps_when_no_cached_request() -> None:
+    stub = _stub({}, {})
+    scraper = _run(stub, active_return=None)
+    scraper.kickoff_custom_data_request.assert_awaited_once()
+    # the attempt is persisted (stamp + identifier) so the backoff survives a restart
+    stub.hass.config_entries.async_update_entry.assert_called_once()
+    opts = stub.hass.config_entries.async_update_entry.call_args.kwargs["options"]
+    assert opts["data_act_identifiers"][_VIN] == "NEWID"
+    assert _VIN in opts["data_act_kickoff_ts"]
+
+
+def test_adopting_an_active_request_still_works() -> None:
+    # unchanged behaviour: a live active id is adopted (no POST needed).
+    stub = _stub({}, {})
+    scraper = _run(stub, active_return="LIVEID")
+    scraper.kickoff_custom_data_request.assert_not_awaited()
+    opts = stub.hass.config_entries.async_update_entry.call_args.kwargs["options"]
+    assert opts["data_act_identifiers"][_VIN] == "LIVEID"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -379,6 +379,7 @@ class TestSwitch:
         coord = _make_coordinator()
         vin = list(coord.data.keys())[0]
         coord.data[vin]["climatisation_state"] = "HEATING"
+        coord.data[vin]["climatisation_active"] = True
         s = VagClimatisationSwitch(coord, vin)
         assert s.is_on is True
 
@@ -586,26 +587,45 @@ class TestClimate:
         assert c.hvac_mode == HVACMode.OFF
 
     def test_hvac_mode_heat(self):
-        # b7 (P0-1) — VW-EU/SEAT/CUPRA emit the raw LOWERCASE backend string; the
-        # entity must read it as active. The uppercase-only fixture masked the bug.
+        # b9 — hvac_mode derives from the parser-set climatisation_active boolean,
+        # so an actively pre-conditioning car reads HEAT_COOL regardless of raw
+        # state casing (VW/SEAT/CUPRA lowercase, Škoda uppercase).
         from custom_components.vag_connect.climate import VagClimate
         from homeassistant.components.climate import HVACMode
         coord = _make_coordinator()
         vin = list(coord.data.keys())[0]
         coord.data[vin]["climatisation_state"] = "heating"
+        coord.data[vin]["climatisation_active"] = True
         c = VagClimate(coord, vin)
         assert c.hvac_mode == HVACMode.HEAT_COOL
 
     def test_hvac_mode_heat_uppercase(self):
-        # b7 (P0-1) — Škoda emits UPPERCASE; both casings must map to HEAT_COOL so
-        # the climate entity can never contradict the climatisation switch.
         from custom_components.vag_connect.climate import VagClimate
         from homeassistant.components.climate import HVACMode
         coord = _make_coordinator()
         vin = list(coord.data.keys())[0]
         coord.data[vin]["climatisation_state"] = "COOLING"
+        coord.data[vin]["climatisation_active"] = True
         c = VagClimate(coord, vin)
         assert c.hvac_mode == HVACMode.HEAT_COOL
+
+    def test_hvac_mode_terminal_state_is_off(self):
+        # b9 regression guard — a terminal / no-data climatisation_state (Škoda
+        # COMPLETED/UNKNOWN, SEAT/CUPRA unsupported) has climatisation_active=False,
+        # so the climate entity must read OFF and MUST agree with the switch. The
+        # b7 state deny-list wrongly read HEAT_COOL/on for these.
+        from custom_components.vag_connect.climate import VagClimate
+        from custom_components.vag_connect.switch import VagClimatisationSwitch
+        from homeassistant.components.climate import HVACMode
+        for state in ("COMPLETED", "UNKNOWN", "unsupported"):
+            coord = _make_coordinator()
+            vin = list(coord.data.keys())[0]
+            coord.data[vin]["climatisation_state"] = state
+            coord.data[vin]["climatisation_active"] = False
+            c = VagClimate(coord, vin)
+            s = VagClimatisationSwitch(coord, vin)
+            assert c.hvac_mode == HVACMode.OFF, state
+            assert s.is_on is False, state  # climate and switch agree
 
     def test_current_temperature(self):
         from custom_components.vag_connect.climate import VagClimate
@@ -1093,10 +1113,13 @@ class TestSwitchRemaining:
         coord.async_stop_climatisation.assert_called_once_with(vin)
 
     def test_climatisation_is_none_when_state_none(self):
+        # b9 — with neither the climatisation_active boolean nor a state present,
+        # is_on stays unknown (None), not a misleading Off.
         from custom_components.vag_connect.switch import VagClimatisationSwitch
         coord = _make_coordinator()
         vin = list(coord.data.keys())[0]
         coord.data[vin]["climatisation_state"] = None
+        coord.data[vin]["climatisation_active"] = None
         s = VagClimatisationSwitch(coord, vin)
         assert s.is_on is None
 

--- a/tests/test_v2241_setup_data_loss_and_position_ttl.py
+++ b/tests/test_v2241_setup_data_loss_and_position_ttl.py
@@ -187,16 +187,30 @@ class TestPositionTTL:
         assert merged["parking_address"] == "Bünzweg 16"
         assert not notes
 
-    def test_a_stale_position_is_dropped_not_carried(self) -> None:
+    def test_a_stale_position_is_kept_but_flagged(self) -> None:
+        # b9 — a parked car is still where it was, so the last-known pin is KEPT
+        # visible on the device_tracker (b7 dropped it, so a car parked >24h lost
+        # its location) but flagged stale so a day-old fix isn't read as fresh.
         previous = {
             "latitude": 47.39, "longitude": 8.05,
             "parking_address": "Bünzweg 16",
             "position_captured_at": _ago(days=9),
         }
         merged, notes = reconcile(previous, {"vin": "X"})
-        assert merged.get("latitude") is None, "a 9-day-old position read as current"
-        assert merged.get("parking_address") is None
-        assert any("dropped" in n for n in notes)
+        assert merged["latitude"] == 47.39
+        assert merged["parking_address"] == "Bünzweg 16"
+        assert merged.get("position_is_stale") is True
+        assert any("stale" in n for n in notes)
+
+    def test_a_recent_position_is_not_flagged_stale(self) -> None:
+        previous = {
+            "latitude": 47.39, "longitude": 8.05,
+            "position_captured_at": _ago(hours=2),
+        }
+        merged, notes = reconcile(previous, {"vin": "X"})
+        assert merged["latitude"] == 47.39
+        assert merged.get("position_is_stale") is None  # current → not flagged
+        assert not notes
 
     def test_unknown_age_is_not_treated_as_expired(self) -> None:
         """Brands that never send a timestamp must not lose their position."""
@@ -205,14 +219,18 @@ class TestPositionTTL:
         assert merged["latitude"] == 47.39
 
     def test_last_seen_at_is_the_fallback_clock(self) -> None:
+        # b9 — last_seen_at still drives the age, but a stale position is now KEPT
+        # and flagged (not dropped).
         old = {"latitude": 1.0, "longitude": 2.0, "last_seen_at": _ago(days=5)}
         merged, notes = reconcile(old, {"vin": "X"})
-        assert merged.get("latitude") is None
-        assert any("dropped" in n for n in notes)
+        assert merged["latitude"] == 1.0
+        assert merged.get("position_is_stale") is True
+        assert any("stale" in n for n in notes)
 
         recent = {"latitude": 1.0, "longitude": 2.0, "last_seen_at": _ago(hours=1)}
         merged2, _ = reconcile(recent, {"vin": "X"})
         assert merged2["latitude"] == 1.0
+        assert merged2.get("position_is_stale") is None
 
     def test_a_fresh_position_never_inherits_the_old_address(self) -> None:
         """The subtle one: topping fresh coordinates up with a previous address


### PR DESCRIPTION
Regression fix from the audit sweep plus two grounded reliability fixes. Every change was cross-checked against our own code and the competitor libraries before shipping.

## Fixed
- **Climate/switch b7 regression** — b7's case-folded state deny-list read "on" for terminal states (Škoda `completed`/`unknown`, SEAT/CUPRA `unsupported`) where the binary sensor + switch correctly read off. Both now derive from the parser-computed `climatisation_active` boolean, so they always agree and read off once a session ends.
- **Parked position keep-and-flag** — b7 P1-2 dropped a parked position older than 24h for the datetime-stamp brands, so a car parked >24h lost its device_tracker pin. It's now kept visible past the window but flagged stale (`position_is_stale`).
- **invalid_credentials repair renders** — `repairs.py` raised an `invalid_credentials` Repair with no matching `issues` translation in any of the 13 i18n files, so it showed blank. Added it (title + description). Thanks @cyrano330 (#1340).

## Added
- **`cancel_historical_export` service** — off-switch for an accidentally-triggered one-time export (steemandavid, #1273).

## Changed
- **EU-DA kickoff backoff** — trust a cached data-request Identifier for 24h before re-verifying, instead of re-POSTing every restart (the portal 500s on a 2nd active request per VIN). Persisted so it survives a restart (steemandavid, #1273).

## Verification
Full suite 5759 passed, ruff + mypy strict clean. Regression tests added for each. The audit also cleared the energy-clamp interim and the command-lock refactor as non-regressions, and confirmed a set of competitor "adopt" items we already do or are structurally immune to (403 isolation, 429 handling, ConfigEntryNotReady, gps_accuracy, lenient enums, MY27 lock, rate-limit) — no change needed.
