### PR TITLE
fix: auth resilience — transient invalid_client + passwordless reauth (v4.7.0b10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,28 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b10] - 2026-09-04 — Auth resilience (preventive)
+
+### Fixed
+- **A brief VW sign-in server hiccup no longer forces a full re-login.** When the VW
+  identity server rejected a token refresh with a transient `invalid_client` (a known
+  wobble that clears itself), the integration used to bounce you straight to a re-login
+  prompt on the very first hit. It now treats that as transient and simply retries on the
+  next poll — exactly the way the QR and durable-MBB login paths already did. A genuinely
+  dead session still asks you to re-authenticate. Grounded against the cooperating
+  audi_connect project, which saw the same recurring server-side wobble.
+- **QR / passwordless logins can finally re-authenticate without deleting the car.** A
+  passwordless entry (browser-QR or durable-MBB) sent to the re-login prompt used to land
+  on a password form it could never satisfy — the only way out was removing and re-adding
+  the integration. Re-login now re-runs the QR sign-in and refreshes the existing car in
+  place.
+
+### Added
+- **A manual-entry fallback link on the browser-login screen.** VW's pre-filled sign-in
+  link occasionally shows an error page ("Provided request is invalid" or a 500); the
+  login notification now also gives you the plain sign-in URL to open and type the code
+  by hand.
+
 ## [4.7.0b9] - 2026-09-04 — Regression fix + portal reliability
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -36,6 +36,7 @@ from ..exceptions import (
     TwoFactorRequiredError,
     RateLimitError,
     TokenExpiredError,
+    TokenRefreshRetryError,
     UpstreamUnavailableError,
 )
 from ..models import BrandConfig, TokenSet
@@ -1372,7 +1373,25 @@ class IDKAuth:
             # prompting for re-login.
             if resp.status in _TRANSIENT_TOKEN_STATUSES:
                 raise UpstreamUnavailableError(resp.status, self._brand.name)
+            if resp.status == 401:
+                # b10 — a 401 on the refresh endpoint is ``invalid_client`` (RFC
+                # 6749 §5.2), i.e. a transient client-auth wobble on the shared
+                # identity.vwgroup.io IDP — NOT a dead user grant (that comes
+                # back as 400 → TokenExpiredError above). audi_connect saw exactly
+                # this as a recurring "late-August VW token wobble" (#835/#840/
+                # #843) where a hard reauth was a MISCLASSIFICATION — the token
+                # had usually already rotated. Our own device-grant + MBB refresh
+                # paths already treat invalid_client as retryable; harmonise the
+                # IDK path so one blip self-heals next poll instead of bouncing
+                # the user into reauth. A persistent 401 still reaches reauth via
+                # the 3/hour token-refresh storm guard (base._refresh_tokens).
+                raise TokenRefreshRetryError(
+                    f"Token refresh returned HTTP {resp.status} "
+                    "(invalid_client) — transient, retrying next poll"
+                )
             if resp.status != 200:
+                # 403 / other non-200 stay a genuine auth failure (unchanged from
+                # #438): only 401 invalid_client is the evidenced-transient case.
                 raise AuthenticationError(f"Token refresh returned HTTP {resp.status}")
             payload: dict[str, Any] = await resp.json()
 
@@ -1398,6 +1417,14 @@ class IDKAuth:
             # v2.12.4 (#438) — transient 5xx → upstream-unavailable, not auth.
             if resp.status in _TRANSIENT_TOKEN_STATUSES:
                 raise UpstreamUnavailableError(resp.status, self._brand.name)
+            if resp.status == 401:
+                # b10 — same as the CARIAD refresh above: a 401 on the mysmob
+                # refresh endpoint is a transient client-auth wobble, not a dead
+                # token (which is 400 → TokenExpiredError). Retry next poll.
+                raise TokenRefreshRetryError(
+                    f"Škoda token refresh HTTP {resp.status} "
+                    "(invalid_client) — transient, retrying next poll"
+                )
             if resp.status != 200:
                 raise AuthenticationError(f"Škoda token refresh HTTP {resp.status}")
             payload: dict[str, Any] = await resp.json()

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -371,6 +371,16 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         # Populated by Phase 1, displayed during Phase 2.
         self._dag_user_code: str = ""
         self._dag_verification_uri: str = ""
+        # b10 (#835) — the plain verification_uri (no ``?user_code=`` prefill).
+        # VW's prefilled ``verification_uri_complete`` intermittently 500s /
+        # returns INVALID_REQUEST; the plain page keeps working, so we surface it
+        # as a manual-entry fallback in the login notification.
+        self._dag_verification_uri_plain: str = ""
+        # b10 (#845/#835) — passwordless (device_grant / durable-MBB) reauth:
+        # when set, the shared QR finish updates the EXISTING entry's tokens
+        # in place instead of creating a new entry.
+        self._reauth_qr: bool = False
+        self._reauth_qr_entry_id: str = ""
         self._dag_device_code: str = ""
         self._dag_poll_interval: int = 5
         self._dag_expires_in: int = 300
@@ -1395,6 +1405,19 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             f"**4. Go back to Settings > Devices & Services** and "
             f"click Submit / Weiter in the VW Group Connect dialog."
         )
+        # b10 (#835) — manual-entry fallback: VW's prefilled link above
+        # intermittently returns an error page ("Provided request is invalid" /
+        # HTTP 500). The plain sign-in page keeps working, so offer it with the
+        # code to type by hand.
+        if (
+            self._dag_verification_uri_plain
+            and self._dag_verification_uri_plain != self._dag_verification_uri
+        ):
+            message += (
+                f"\n\n_If the link above shows an error page, open_ "
+                f"{self._dag_verification_uri_plain} _and enter the code_ "
+                f"`{self._dag_user_code}` _by hand._"
+            )
         pn_create(
             self.hass,
             message,
@@ -1498,6 +1521,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             self._dag_device_code = code.device_code
             self._dag_user_code = code.user_code
             self._dag_verification_uri = code.verification_uri_complete
+            self._dag_verification_uri_plain = code.verification_uri
             self._dag_poll_interval = code.interval
             self._dag_expires_in = code.expires_in
             _LOGGER.debug(
@@ -1606,6 +1630,12 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         if self._dag_tokens is None:
             # Shouldn't happen if step routing is correct, but defensive.
             return self.async_abort(reason="dag_no_tokens")
+
+        # b10 (#845/#835) — passwordless reauth: the QR was re-run to refresh an
+        # EXISTING entry's tokens. Update it in place and stop here, BEFORE any of
+        # the create/dedup branches below (which stay untouched for fresh setup).
+        if self._reauth_qr:
+            return await self._finish_reauth_qr()
 
         # b15 — device-grant Audi command FALLBACK: the MBB QR just minted the
         # durable Car-Net bearer; attach it to an EXISTING device-grant Audi entry
@@ -1813,6 +1843,17 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             self.context["entry_id"]
         )
 
+        # b10 (#845/#835) — passwordless (device_grant / durable-MBB) entries have
+        # no stored password (username is the BrandID `sub`), so the credential
+        # form below can never succeed for them and leaves the user stuck. Route
+        # them to re-run the QR sign-in, which updates the entry's tokens in place.
+        if (
+            reauth_entry is not None
+            and reauth_entry.data.get("dag_initial_tokens")
+            and not reauth_entry.data.get(CONF_PASSWORD)
+        ):
+            return await self.async_step_reauth_qr()
+
         if user_input is not None and reauth_entry is not None:
             brand    = reauth_entry.data[CONF_BRAND]
             username = reauth_entry.data[CONF_USERNAME]
@@ -1849,6 +1890,109 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 "username": reauth_entry.data.get(CONF_USERNAME, "") if reauth_entry else "",
             },
         )
+
+    async def async_step_reauth_qr(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """b10 (#845/#835) — passwordless reauth via the QR device grant.
+
+        A device_grant / durable-MBB entry has no stored password, so reauth
+        re-runs the same QR sign-in machinery as setup. ``_reauth_qr`` makes the
+        shared finish step update THIS entry's tokens in place (see
+        ``_finish_reauth_qr``) instead of creating a second entry.
+        """
+        reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        if reauth_entry is None:
+            return self.async_abort(reason="reconfigure_failed")
+        strategy = (reauth_entry.data.get("dag_initial_tokens") or {}).get(
+            "strategy", "device_grant"
+        )
+        # Mirror the state async_step_browser_login / async_step_mbb_login set
+        # before handing off to the shared pending → approve → finish steps.
+        self._reauth_qr = True
+        self._reauth_qr_entry_id = reauth_entry.entry_id
+        self._dag_mbb = strategy == "mbb"
+        self._dag_mbb_fallback = False
+        self._dag_mbb_command = False
+        self._dag_brand = reauth_entry.data.get(CONF_BRAND, "")
+        self._dag_user_input = dict(reauth_entry.data)
+        self._dag_request_task = None
+        self._dag_poll_task = None
+        self._dag_user_code = ""
+        self._dag_verification_uri = ""
+        self._dag_device_code = ""
+        self._dag_tokens = None
+        self._dag_mbb_tokens = None
+        self._dag_mbb_client_id = ""
+        self._dag_mbb_ineligible = False
+        self._dag_user_id = ""
+        self._dag_error = ""
+        return await self.async_step_browser_login_pending()
+
+    async def _finish_reauth_qr(self) -> config_entries.ConfigFlowResult:
+        """b10 — write the freshly-minted QR tokens onto the existing entry.
+
+        The coordinator prefers the persisted token store over
+        ``dag_initial_tokens`` (it only reads dag_initial_tokens when the store is
+        empty), so a reauth MUST overwrite the persisted store — otherwise the
+        reload would re-load the dead tokens and the reauth would no-op. Overwrite
+        both the store and dag_initial_tokens, then reload the entry.
+        """
+        from homeassistant.helpers.storage import Store  # noqa: PLC0415
+
+        from .cariad.auth._token_storage import (  # noqa: PLC0415
+            _STORAGE_VERSION,
+            TokenStorage,
+            storage_key_for_entry,
+        )
+        from .cariad.models import TokenSet  # noqa: PLC0415
+
+        entry = self.hass.config_entries.async_get_entry(
+            self._reauth_qr_entry_id or ""
+        )
+        if entry is None:
+            return self.async_abort(reason="reconfigure_failed")
+        if self._dag_tokens is None:
+            return self.async_abort(reason="dag_no_tokens")
+        if self._dag_mbb:
+            if self._dag_mbb_tokens is None:
+                return self.async_abort(reason="mbb_not_eligible")
+            fresh = TokenSet(
+                access_token=self._dag_mbb_tokens.access_token,
+                refresh_token=self._dag_mbb_tokens.refresh_token,
+                id_token=self._dag_tokens.id_token,
+                expires_at=self._dag_mbb_tokens.expires_at,
+                strategy="mbb",
+            )
+        else:
+            fresh = TokenSet(
+                access_token=self._dag_tokens.access_token,
+                refresh_token=self._dag_tokens.refresh_token,
+                id_token=self._dag_tokens.id_token,
+                expires_at=self._dag_tokens.expires_at,
+                strategy="device_grant",
+            )
+        store: Store[dict[str, Any]] = Store(
+            self.hass, _STORAGE_VERSION, storage_key_for_entry(entry.entry_id)
+        )
+        await TokenStorage(store).save(fresh)
+        new_data = {
+            **entry.data,
+            "dag_initial_tokens": {
+                "access_token": fresh.access_token,
+                "refresh_token": fresh.refresh_token,
+                "id_token": fresh.id_token,
+                "expires_at": fresh.expires_at,
+                "strategy": fresh.strategy,
+            },
+        }
+        if self._dag_mbb and self._dag_mbb_client_id:
+            new_data["mbb_client_id"] = self._dag_mbb_client_id
+        self.hass.config_entries.async_update_entry(entry, data=new_data)
+        await self.hass.config_entries.async_reload(entry.entry_id)
+        return self.async_abort(reason="reauth_successful")
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b9"
+  "version": "4.7.0b10"
 }

--- a/tests/test_b10_preventive_reauth.py
+++ b/tests/test_b10_preventive_reauth.py
@@ -1,0 +1,222 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b10 preventive fixes (grounded in audi_connect #835/#845).
+
+P2a — the browser-login notification offers the PLAIN verification_uri as a
+manual-entry fallback, because VW's prefilled ``verification_uri_complete``
+intermittently 500s / returns INVALID_REQUEST (#835).
+
+P2b — a passwordless (device_grant / durable-MBB) entry sent to reauth must NOT
+land on the credential form (it has no stored password → dead end). It re-runs
+the QR sign-in and updates the EXISTING entry in place. Crucially the reauth
+finish overwrites the PERSISTED token store, not just ``dag_initial_tokens`` —
+the coordinator prefers the store when both exist, so a dag-only update would be
+a silent no-op.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.vag_connect.cariad.models import TokenSet
+from custom_components.vag_connect.config_flow import VagConnectConfigFlow
+from custom_components.vag_connect.const import CONF_BRAND, CONF_PASSWORD, DOMAIN
+
+
+def _flow() -> VagConnectConfigFlow:
+    flow = VagConnectConfigFlow()
+    flow.hass = MagicMock()
+    flow.context = {"entry_id": "e1"}
+    flow.handler = DOMAIN
+    flow.flow_id = "test"
+    return flow
+
+
+def _entry(data: dict) -> MagicMock:
+    entry = MagicMock()
+    entry.entry_id = "e1"
+    entry.data = data
+    return entry
+
+
+# ── P2a — plain-URL fallback in the login notification ───────────────────────
+
+def test_notification_includes_plain_url_fallback() -> None:
+    flow = _flow()
+    flow._dag_verification_uri = "https://idp/oidc/device?user_code=ABCD-1234"
+    flow._dag_verification_uri_plain = "https://idp/oidc/device"
+    flow._dag_user_code = "ABCD-1234"
+    with patch(
+        "homeassistant.components.persistent_notification.async_create"
+    ) as pn:
+        flow._fire_dag_persistent_notification()
+    msg = pn.call_args.args[1]
+    assert "https://idp/oidc/device" in msg
+    assert "by hand" in msg  # the fallback sentence is present
+
+
+def test_notification_omits_fallback_when_no_distinct_plain_url() -> None:
+    flow = _flow()
+    flow._dag_verification_uri = "https://idp/oidc/device?user_code=ABCD-1234"
+    flow._dag_verification_uri_plain = ""  # not captured / same
+    flow._dag_user_code = "ABCD-1234"
+    with patch(
+        "homeassistant.components.persistent_notification.async_create"
+    ) as pn:
+        flow._fire_dag_persistent_notification()
+    assert "by hand" not in pn.call_args.args[1]
+
+
+# ── P2b — passwordless reauth routes to QR, not the credential form ──────────
+
+def test_reauth_confirm_routes_passwordless_entry_to_qr() -> None:
+    flow = _flow()
+    flow.hass.config_entries.async_get_entry = MagicMock(
+        return_value=_entry({
+            CONF_BRAND: "audi",
+            "dag_initial_tokens": {"strategy": "device_grant"},
+            CONF_PASSWORD: "",
+        })
+    )
+    flow.async_step_reauth_qr = AsyncMock(return_value={"type": "sentinel"})
+    result = asyncio.run(flow.async_step_reauth_confirm(None))
+    flow.async_step_reauth_qr.assert_awaited_once()
+    assert result == {"type": "sentinel"}
+
+
+def test_reauth_confirm_password_entry_still_shows_form() -> None:
+    # regression: a normal email+password entry must NOT be rerouted.
+    flow = _flow()
+    flow.hass.config_entries.async_get_entry = MagicMock(
+        return_value=_entry({
+            CONF_BRAND: "audi",
+            "username": "me@example.com",
+            CONF_PASSWORD: "secret",
+        })
+    )
+    flow.async_step_reauth_qr = AsyncMock()
+    result = asyncio.run(flow.async_step_reauth_confirm(None))
+    flow.async_step_reauth_qr.assert_not_awaited()
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+
+def test_reauth_qr_sets_device_grant_state_and_routes_to_pending() -> None:
+    flow = _flow()
+    flow.hass.config_entries.async_get_entry = MagicMock(
+        return_value=_entry({
+            CONF_BRAND: "audi",
+            "dag_initial_tokens": {"strategy": "device_grant"},
+            CONF_PASSWORD: "",
+        })
+    )
+    flow.async_step_browser_login_pending = AsyncMock(return_value={"type": "s"})
+    asyncio.run(flow.async_step_reauth_qr(None))
+    flow.async_step_browser_login_pending.assert_awaited_once()
+    assert flow._reauth_qr is True
+    assert flow._reauth_qr_entry_id == "e1"
+    assert flow._dag_mbb is False
+    assert flow._dag_brand == "audi"
+
+
+def test_reauth_qr_mbb_strategy_sets_mbb_flag() -> None:
+    flow = _flow()
+    flow.hass.config_entries.async_get_entry = MagicMock(
+        return_value=_entry({
+            CONF_BRAND: "volkswagen",
+            "dag_initial_tokens": {"strategy": "mbb"},
+            CONF_PASSWORD: "",
+        })
+    )
+    flow.async_step_browser_login_pending = AsyncMock(return_value={"type": "s"})
+    asyncio.run(flow.async_step_reauth_qr(None))
+    assert flow._dag_mbb is True
+
+
+def test_browser_login_finish_reauth_guard_diverts_to_reauth_finish() -> None:
+    # With _reauth_qr set, finish must divert BEFORE any create/dedup branch.
+    flow = _flow()
+    flow._dag_tokens = TokenSet("a", "r", "i", 0.0, "device_grant")
+    flow._reauth_qr = True
+    flow._finish_reauth_qr = AsyncMock(return_value={"type": "abort"})
+    # async_create_entry / set_unique_id would be the create path — make them
+    # explode so the test fails loudly if the guard doesn't divert.
+    flow.async_create_entry = MagicMock(side_effect=AssertionError("create path taken"))
+    flow.async_set_unique_id = AsyncMock(side_effect=AssertionError("dedup path taken"))
+    asyncio.run(flow.async_step_browser_login_finish(None))
+    flow._finish_reauth_qr.assert_awaited_once()
+
+
+def test_finish_reauth_qr_overwrites_store_and_entry_device_grant() -> None:
+    # The load-bearing invariant: reauth overwrites the PERSISTED token store
+    # (not just dag_initial_tokens), else the coordinator reloads dead tokens.
+    flow = _flow()
+    flow._reauth_qr_entry_id = "e1"
+    flow._dag_mbb = False
+    flow._dag_tokens = TokenSet("newAT", "newRT", "newID", 123.0, "device_grant")
+    entry = _entry({CONF_BRAND: "audi", "dag_initial_tokens": {"strategy": "device_grant"}})
+    flow.hass.config_entries.async_get_entry = MagicMock(return_value=entry)
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+
+    saved = {}
+    storage = MagicMock()
+
+    async def _save(ts):
+        saved["ts"] = ts
+    storage.save = _save
+
+    with patch(
+        "custom_components.vag_connect.cariad.auth._token_storage.TokenStorage",
+        return_value=storage,
+    ), patch(
+        "custom_components.vag_connect.cariad.auth._token_storage.storage_key_for_entry",
+        return_value="vag_connect_e1",
+    ), patch("homeassistant.helpers.storage.Store", return_value=MagicMock()):
+        result = asyncio.run(flow._finish_reauth_qr())
+
+    # persisted store overwritten with the fresh device_grant tokens
+    assert saved["ts"].access_token == "newAT"
+    assert saved["ts"].strategy == "device_grant"
+    # entry's dag_initial_tokens also refreshed + reloaded
+    new_data = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert new_data["dag_initial_tokens"]["refresh_token"] == "newRT"
+    flow.hass.config_entries.async_reload.assert_awaited_once_with("e1")
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+
+
+def test_finish_reauth_qr_mbb_uses_mbb_tokens() -> None:
+    flow = _flow()
+    flow._reauth_qr_entry_id = "e1"
+    flow._dag_mbb = True
+    flow._dag_tokens = TokenSet("oidcAT", "oidcRT", "theIDtoken", 1.0, "device_grant")
+    flow._dag_mbb_tokens = TokenSet("mbbAT", "mbbRT", "", 456.0, "mbb")
+    flow._dag_mbb_client_id = "XID123"
+    entry = _entry({CONF_BRAND: "volkswagen", "dag_initial_tokens": {"strategy": "mbb"}})
+    flow.hass.config_entries.async_get_entry = MagicMock(return_value=entry)
+    flow.hass.config_entries.async_update_entry = MagicMock()
+    flow.hass.config_entries.async_reload = AsyncMock()
+
+    saved = {}
+    storage = MagicMock()
+
+    async def _save(ts):
+        saved["ts"] = ts
+    storage.save = _save
+
+    with patch(
+        "custom_components.vag_connect.cariad.auth._token_storage.TokenStorage",
+        return_value=storage,
+    ), patch(
+        "custom_components.vag_connect.cariad.auth._token_storage.storage_key_for_entry",
+        return_value="vag_connect_e1",
+    ), patch("homeassistant.helpers.storage.Store", return_value=MagicMock()):
+        asyncio.run(flow._finish_reauth_qr())
+
+    # MBB bearer stored, but the id_token is carried from the OIDC token set
+    assert saved["ts"].access_token == "mbbAT"
+    assert saved["ts"].id_token == "theIDtoken"
+    assert saved["ts"].strategy == "mbb"
+    new_data = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert new_data["mbb_client_id"] == "XID123"

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -3014,11 +3014,17 @@ class TestIDKAuthAdditional:
         with pytest.raises(UpstreamUnavailableError, match="503"):
             asyncio.run(auth.refresh("old_token"))
 
-    def test_refresh_non_200_non_5xx_raises_auth(self):
-        """A non-200 that is neither 400 nor a 5xx (e.g. 401) is still a genuine
-        auth failure and must raise AuthenticationError."""
+    def test_refresh_401_is_retryable_not_auth(self):
+        """b10 — a 401 ``invalid_client`` on refresh is a transient client-auth
+        wobble, NOT a dead grant (that is 400 → TokenExpiredError). It must raise
+        TokenRefreshRetryError so the coordinator self-heals next poll instead of
+        hard-bouncing the user into reauth — matching our device-grant/MBB refresh
+        siblings and the audi_connect #835/#840/#843 finding. A 403 still raises
+        AuthenticationError (see below); only 401 is the evidenced-transient case."""
         from custom_components.vag_connect.cariad.auth.idk import IDKAuth
-        from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+        from custom_components.vag_connect.cariad.exceptions import (
+            TokenRefreshRetryError,
+        )
         from custom_components.vag_connect.cariad.models import BRAND_SKODA
 
         oidc = self._resp(200, json_data={"token_endpoint": "https://idp/token"})
@@ -3027,7 +3033,23 @@ class TestIDKAuthAdditional:
         session.get = MagicMock(return_value=oidc)
         session.post = MagicMock(return_value=bad)
         auth = IDKAuth(session, BRAND_SKODA)
-        with pytest.raises(AuthenticationError, match="401"):
+        with pytest.raises(TokenRefreshRetryError):
+            asyncio.run(auth.refresh("old_token"))
+
+    def test_refresh_403_still_raises_auth(self):
+        """b10 — only 401 flips to transient; 403 (and any other non-200) stays a
+        genuine AuthenticationError, unchanged from #438."""
+        from custom_components.vag_connect.cariad.auth.idk import IDKAuth
+        from custom_components.vag_connect.cariad.exceptions import AuthenticationError
+        from custom_components.vag_connect.cariad.models import BRAND_SKODA
+
+        oidc = self._resp(200, json_data={"token_endpoint": "https://idp/token"})
+        bad = self._resp(403, text="Forbidden")
+        session = MagicMock()
+        session.get = MagicMock(return_value=oidc)
+        session.post = MagicMock(return_value=bad)
+        auth = IDKAuth(session, BRAND_SKODA)
+        with pytest.raises(AuthenticationError, match="403"):
             asyncio.run(auth.refresh("old_token"))
 
     def test_idk_auth_hmac_extraction_from_js(self):

--- a/tests/test_v2124_token_refresh_transient.py
+++ b/tests/test_v2124_token_refresh_transient.py
@@ -9,7 +9,17 @@ spammed Error-Reporter issues (#435–#439) for a server-side blip.
 
 ``refresh()`` now raises ``UpstreamUnavailableError`` (a non-auth transient
 the coordinator tolerates) on 5xx. A 400 still means a genuinely rejected
-refresh token (→ full re-login), and 401/403 still raise ``AuthenticationError``.
+refresh token (→ full re-login).
+
+b10 update: a **401** on the refresh endpoint is ``invalid_client`` (RFC 6749
+§5.2) — a transient client-auth wobble on the shared identity.vwgroup.io IDP,
+NOT a dead user grant (which is the 400 above). audi_connect saw exactly this
+recurring "late-August VW token wobble" (#835/#840/#843) where a hard reauth was
+a misclassification, and our own device-grant + MBB refresh paths already treat
+invalid_client as retryable — so the IDK/mysmob path now raises
+``TokenRefreshRetryError`` on 401 too, and it self-heals next poll (a persistent
+401 still reaches reauth via the storm guard). A **403** (and any other non-200)
+still raises ``AuthenticationError`` — only 401 is the evidenced-transient case.
 """
 
 from __future__ import annotations
@@ -22,6 +32,7 @@ from custom_components.vag_connect.cariad.auth.idk import IDKAuth
 from custom_components.vag_connect.cariad.exceptions import (
     AuthenticationError,
     TokenExpiredError,
+    TokenRefreshRetryError,
     UpstreamUnavailableError,
 )
 
@@ -86,11 +97,21 @@ async def test_cariad_refresh_400_is_token_expired() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status", [401, 403])
-async def test_cariad_refresh_auth_statuses_still_raise_auth(status: int) -> None:
-    """401/403 are genuine auth failures and must still raise (unchanged)."""
+async def test_cariad_refresh_401_is_retryable() -> None:
+    """b10 — 401 invalid_client is a transient wobble, not a hard auth failure.
+
+    Must be a ``TokenRefreshRetryError`` (sibling of AuthenticationError) so the
+    coordinator self-heals next poll instead of hard-bouncing into reauth.
+    """
+    with pytest.raises(TokenRefreshRetryError):
+        await _auth("volkswagen", 401).refresh("rt")
+
+
+@pytest.mark.asyncio
+async def test_cariad_refresh_403_still_raises_auth() -> None:
+    """403 (and any other non-200) stays a genuine auth failure — only 401 flips."""
     with pytest.raises(AuthenticationError):
-        await _auth("volkswagen", status).refresh("rt")
+        await _auth("volkswagen", 403).refresh("rt")
 
 
 @pytest.mark.asyncio
@@ -104,3 +125,10 @@ async def test_skoda_refresh_5xx_is_upstream_unavailable() -> None:
 async def test_skoda_refresh_400_is_token_expired() -> None:
     with pytest.raises(TokenExpiredError):
         await _auth("skoda", 400).refresh("rt")
+
+
+@pytest.mark.asyncio
+async def test_skoda_refresh_401_is_retryable() -> None:
+    """b10 — same 401→transient classification on the mysmob refresh endpoint."""
+    with pytest.raises(TokenRefreshRetryError):
+        await _auth("skoda", 401).refresh("rt")


### PR DESCRIPTION
## What

Three grounded, **preventive** auth-resilience fixes (v4.7.0b10). None of these fixes a currently-open report — they harden latent failure modes surfaced while cross-checking the cooperating audi_connect project's auth threads.

### Fixed
- **Transient `invalid_client` (401) on token refresh is now retryable, not a hard reauth.** The IDK / mysmob refresh path used to raise `AuthenticationError` on the first 401 → an immediate re-login prompt. It now raises `TokenRefreshRetryError` (self-heals on the next poll), matching what the device-grant and durable-MBB refresh paths already do. A dead token (400) and 403/other non-200 still hard-fail; a persistent 401 still reaches reauth via the token-refresh storm guard.
- **Passwordless (device_grant / durable-MBB) entries can re-authenticate via QR.** They previously landed on a password form they could never satisfy (the username is the BrandID `sub`, no stored password). Reauth now re-runs the QR sign-in and updates the existing entry in place — overwriting both the persisted token store and `dag_initial_tokens` (a store-only update would otherwise no-op, since the coordinator prefers the store), then reloading. Isolated path: the setup/create flow is byte-for-byte unchanged.

### Added
- **Plain-URL manual-entry fallback in the browser-login notification** for when VW's prefilled sign-in link errors (500 / "Provided request is invalid").

## Invariant note
This reverses the older assertion that a 401/403 on refresh must raise `AuthenticationError` — but only for 401 (`invalid_client`), on the evidence it is a transient wobble and to match our own sibling refresh paths. 403 stays a hard auth failure. The affected tests were updated with that rationale spelled out, not silently rewritten.

## Tests
- New: `test_b10_preventive_reauth.py` (9)
- Updated: `test_v2124_token_refresh_transient.py` (401→retry / 403→auth split + Škoda 401), `test_cariad.py` (split the hidden invariant test)
- Full suite: **5770 passed / 0 failed** · ruff clean · mypy strict clean
