### PR TITLE
fix: Škoda charge-current select fallback + quieter EU-DA/Porsche logs (v4.7.0b11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,28 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b11] - 2026-09-04 — Škoda charge-current fix + quieter logs
+
+### Fixed
+- **Škoda "Max. charge current" no longer shows Unknown on cars without charging
+  profiles.** Some Škoda plug-in hybrids (e.g. an older Superb iV) report the max
+  charge current only as a plain MAXIMUM/REDUCED setting rather than via a charging
+  profile — and the dropdown only ever read the profile, so it sat at Unknown. It now
+  falls back to that plain setting. Thanks @n300home (#1343).
+
+### Changed
+- **The EU Data Act request kickoff no longer logs a scary "no data feed will start"
+  warning when a feed is actually live.** On accounts where the portal keeps the
+  session anonymous, the kickoff can't read its own request back and used to warn on
+  every restart even while data was flowing. That case is now a quiet INFO note; a
+  genuine request rejection (4xx) still warns. Nothing about the feed itself changed —
+  only the false alarm is gone. Thanks @steemandavid (#1273).
+- **The Porsche login now writes a redacted step-by-step debug trace.** Turning on
+  debug logging previously showed nothing at all for Porsche sign-in; it now logs each
+  redirect hop (host + status only — never the URL, code or credentials), so a failed
+  login capture actually reveals where it stops, which is usually Porsche's
+  captcha/consent page. Thanks @Hollywoodchaos (#1337).
+
 ## [4.7.0b10] - 2026-09-04 — Auth resilience (preventive)
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -1478,6 +1478,13 @@ class SkodaClient(CariadBaseClient):
             _mca = v(settings, "maxChargeCurrentAcAmpere")
             if isinstance(_mca, (int, float)) and not isinstance(_mca, bool):
                 d.max_charge_current = float(_mca)
+            # b11 (#1343 n300home) — also capture the plain MAXIMUM/REDUCED enum
+            # so the Skoda charge-current SELECT still shows a value on cars that
+            # return no charging-profiles (its usual source stays empty then).
+            # The numeric sensor keeps using the ampere value above.
+            _mce = v(settings, "maxChargeCurrentAc")
+            if isinstance(_mce, str) and _mce.strip():
+                d.max_charge_current_enum = _mce
             # v1.26.0 Welle-6 (#173, scouts #143/#133) — cross-brand alias.
             # Skoda's autoUnlockPlugWhenCharged or AC-suffix variant.
             au_raw = v(settings, "autoUnlockPlugWhenCharged") or v(settings, "autoUnlockPlugWhenChargedAC")

--- a/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
@@ -1197,10 +1197,16 @@ class DataActScraper:
                                 duration, resp.status, attempts[index + 1][0],
                             )
                             continue
-                        _LOGGER.warning(
+                        # b11 (#1273 steemandavid) — on an anonymous-AEM portal
+                        # session the active-request readback false-negatives even
+                        # when a feed is (or will be) live, so this is not reliably
+                        # an error. INFO, not WARNING, to avoid a false "no data
+                        # feed will start" alarm on accounts that are actually fine.
+                        _LOGGER.info(
                             "kickoff_custom_data_request: created (HTTP %s) but no "
-                            "active request appeared for VIN %s — no data feed will "
-                            "start until this is resolved.",
+                            "active request appeared on readback for VIN %s "
+                            "(expected on anonymous-portal sessions; a live feed "
+                            "may still deliver).",
                             resp.status, _mask_vin(vin),
                         )
                         return None
@@ -1213,15 +1219,28 @@ class DataActScraper:
                             body_text[:200],
                         )
                         continue
-                    # WARNING, not INFO: a non-2xx here means the portal rejected
-                    # the request (e.g. a changed request format) → the car gets
-                    # NO data feed, silently. It must be visible so the next
+                    # b11 (#1273) — split severity by status. A 4xx is a genuine
+                    # request rejection (e.g. a changed request format) → the car
+                    # gets NO data feed, silently; keep it WARNING so the next
                     # portal-side format change doesn't go unnoticed for months.
-                    _LOGGER.warning(
-                        "kickoff_custom_data_request HTTP %s for VIN %s — no data "
-                        "feed will start until this is resolved: %s",
-                        resp.status, _mask_vin(vin), body_text[:300],
-                    )
+                    # A 5xx is usually the portal's one-active-request rule firing
+                    # when a request already exists but isn't readable back on an
+                    # anonymous-AEM session — not an actionable error, and it must
+                    # not cry "no data feed will start" on a live feed.
+                    if 400 <= resp.status < 500:
+                        _LOGGER.warning(
+                            "kickoff_custom_data_request HTTP %s for VIN %s — no "
+                            "data feed will start until this is resolved: %s",
+                            resp.status, _mask_vin(vin), body_text[:300],
+                        )
+                    else:
+                        _LOGGER.info(
+                            "kickoff_custom_data_request HTTP %s for VIN %s — a "
+                            "request likely already exists and isn't readable back "
+                            "on this portal session; a live feed may still "
+                            "deliver: %s",
+                            resp.status, _mask_vin(vin), body_text[:300],
+                        )
                     return None
             except DataActSessionExpiredError:
                 raise

--- a/custom_components/vag_connect/cariad/auth/porsche.py
+++ b/custom_components/vag_connect/cariad/auth/porsche.py
@@ -61,7 +61,7 @@ import hashlib
 import logging
 import os
 import re
-from urllib.parse import parse_qs, urljoin
+from urllib.parse import parse_qs, urljoin, urlsplit
 
 from aiohttp import ClientTimeout, ClientSession
 
@@ -173,6 +173,17 @@ class PorscheAuth:
             allow_redirects=False,
         ) as resp:
             location = resp.headers.get("Location", "")
+        # b11 (#1337 Hollywoodchaos) — the Porsche auth path emitted zero log
+        # lines, so a user's debug capture showed nothing but the final warning.
+        # Log status + whether a redirect was handed back (hostnames/statuses
+        # only — never the URL query, code, state, e-mail or password).
+        _LOGGER.debug(
+            "Porsche auth: password POST → HTTP %s, %s",
+            resp.status,
+            "redirect handed back" if location
+            else "NO Location header (Auth0 rendered a page — likely a "
+                 "captcha/consent step the headless flow can't clear)",
+        )
 
         # Step 4: follow the Auth0 redirect chain to the code.
         #
@@ -220,9 +231,22 @@ class PorscheAuth:
                 headers={"User-Agent": _USER_AGENT},
                 allow_redirects=False,
             ) as resp:
+                # b11 (#1337) — trace each hop by host + status only (never the
+                # full URL, which carries state/code).
+                _LOGGER.debug(
+                    "Porsche auth: redirect hop → host=%s HTTP %s",
+                    urlsplit(target).hostname or "?", resp.status,
+                )
                 # A 200 here means Auth0 rendered a page instead of redirecting
                 # — typically the captcha/consent screen — so there is no code.
                 if resp.status not in (301, 302, 303, 307, 308):
+                    _LOGGER.debug(
+                        "Porsche auth: hop returned HTTP %s (a rendered page, not "
+                        "a redirect) — no authorization code. This is typically "
+                        "the captcha/consent screen the Porsche One migration "
+                        "requires, which the headless login cannot clear.",
+                        resp.status,
+                    )
                     return None
                 current_base = target
                 location = resp.headers.get("Location", "")

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -550,6 +550,13 @@ class VehicleData:
     charging_type: str | None = None
     target_soc: int | None = None
     max_charge_current: float | None = None
+    # b11 (#1343 n300home) — Skoda cars that return no charging-profiles never
+    # populate ``max_charging_current`` (the select's usual source), yet the
+    # plain charging settings still carry the MAXIMUM/REDUCED enum. Kept separate
+    # from the numeric ``max_charge_current`` (device_class current) and from the
+    # EU-DA diagnostic sensor ``max_charge_current_ac``; the Skoda charge-current
+    # select falls back to this when no profile is present.
+    max_charge_current_enum: str | None = None
     min_soc: int | None = None  # Minimum SoC for departure timer (PHEV)
     auto_unlock_charge: bool | None = None
     connector_locked: bool | None = None

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b10"
+  "version": "4.7.0b11"
 }

--- a/custom_components/vag_connect/select.py
+++ b/custom_components/vag_connect/select.py
@@ -217,7 +217,13 @@ class VagSkodaChargeCurrentSelect(VagConnectEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the current max-charging-current as a canonical key."""
-        return _normalise_skoda_current(self._vehicle.get("max_charging_current"))
+        # b11 (#1343) — profiles cars populate ``max_charging_current``; cars
+        # without any charging-profile fall back to the plain MAXIMUM/REDUCED
+        # enum captured from the charging-settings block.
+        return _normalise_skoda_current(
+            self._vehicle.get("max_charging_current")
+            or self._vehicle.get("max_charge_current_enum")
+        )
 
     async def async_select_option(self, option: str) -> None:
         """Set AC max charging current — maps canonical key to API enum."""

--- a/tests/test_b11_newest_sweep_fixes.py
+++ b/tests/test_b11_newest_sweep_fixes.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b11 — fixes from the newest-comments deep sweep.
+
+#1343 (@n300home) — Skoda cars that return NO charging-profiles never populate
+``max_charging_current`` (the charge-current select's usual source), so the
+"Max. Ladestrom" select showed Unknown even though the plain charging settings
+carry the MAXIMUM/REDUCED enum (``maxChargeCurrentAc``). The select now falls
+back to that enum, captured into ``VehicleData.max_charge_current_enum``.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+# ── #1343: the new field is real and is emitted into the vehicle dict ────────
+
+def test_vehicledata_carries_enum_field_and_emits_it() -> None:
+    d = VehicleData(vin="VINX", max_charge_current_enum="MAXIMUM")
+    assert d.max_charge_current_enum == "MAXIMUM"
+    # to_dict()/asdict emits every field → the select can read it off the dict.
+    assert asdict(d)["max_charge_current_enum"] == "MAXIMUM"
+
+
+def test_vehicledata_enum_defaults_none() -> None:
+    assert VehicleData(vin="VINX").max_charge_current_enum is None
+
+
+# ── #1343: the Skoda select falls back to the enum when no profiles exist ────
+
+class TestSkodaChargeCurrentEnumFallback:
+    def _entity(self, vehicle: dict):
+        from custom_components.vag_connect.select import VagSkodaChargeCurrentSelect
+        coord = MagicMock()
+        coord.data = {"VINX": vehicle}
+        coord.vehicles = {"VINX": vehicle}
+        e = VagSkodaChargeCurrentSelect.__new__(VagSkodaChargeCurrentSelect)
+        e.coordinator = coord
+        e._vin = "VINX"
+        return e
+
+    def test_enum_fallback_when_no_profiles(self) -> None:
+        # the #1343 case: no profiles → max_charging_current unset, only the enum
+        e = self._entity({"vin": "VINX", "max_charge_current_enum": "MAXIMUM"})
+        assert e.current_option == "maximum"
+
+    def test_enum_fallback_reduced_casefold(self) -> None:
+        e = self._entity({"vin": "VINX", "max_charge_current_enum": "REDUCED"})
+        assert e.current_option == "reduced"
+
+    def test_profiles_value_wins_over_enum(self) -> None:
+        # a profiles car keeps its profile-derived value even if the enum differs
+        e = self._entity({
+            "vin": "VINX",
+            "max_charging_current": "REDUCED",
+            "max_charge_current_enum": "MAXIMUM",
+        })
+        assert e.current_option == "reduced"
+
+    def test_neither_present_is_none(self) -> None:
+        assert self._entity({"vin": "VINX"}).current_option is None
+
+    def test_unknown_enum_value_is_none(self) -> None:
+        e = self._entity({"vin": "VINX", "max_charge_current_enum": "WEIRD"})
+        assert e.current_option is None


### PR DESCRIPTION
## What

Three fixes from the newest-comments deep sweep (v4.7.0b11). Each is grounded against code + tests. None auto-closes its issue — all three are partial or awaiting user confirmation.

### Fixed
- **#1343 (@n300home) — Škoda "max charge current" select showed Unknown on cars with no charging profiles.** The select only read `max_charging_current` (populated from the charging-profiles endpoint). Cars that return no profiles still carry the plain `maxChargeCurrentAc` MAXIMUM/REDUCED enum, which the Škoda path mapped nowhere. Added a `max_charge_current_enum` field (fed on the mysmob path) + a select fallback. The working profiles path is untouched.

### Changed
- **#1273 (@steemandavid) — the EU Data Act kickoff logged a false "no data feed will start" WARNING** on anonymous-portal sessions where the request can't be read back, even while a feed was live. Split severity: a genuine 4xx rejection stays WARNING; the anonymous-session 5xx / empty-readback drops to INFO. Log-severity only — feed behaviour unchanged.
- **#1337 (@Hollywoodchaos) — Porsche login emitted zero log lines**, so debug captures showed nothing. Added a redacted per-hop trace (host + status only — never the URL, code or credentials), so a failed-login capture reveals where it stops (usually the captcha/consent hop).

## Tests
- New: `test_b11_newest_sweep_fixes.py` (7)
- Full suite: **5777 passed / 0 failed** · ruff clean · mypy strict clean
