### PR TITLE
fix: post-login portal 401 → session-expired repair + diagnostics setup_error guard (v4.7.0b12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,20 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b12] - 2026-09-04 — Repair message + diagnostics fixes (EU Audi)
+
+### Fixed
+- **A post-login portal error no longer tells you to fix a correct password.** When an
+  EU Audi's login succeeds but the EU Data Act portal then rejects the vehicle list (a
+  401 *after* sign-in), the repair now says the portal session needs re-establishing —
+  instead of the misleading "invalid credentials". A genuine wrong password is still
+  reported as such. Thanks @cyrano330 (#1340).
+- **Downloading diagnostics no longer fails with a 500 when setup didn't complete.**
+  Exactly when the download is most useful — an entry stuck in `setup_error` — the
+  diagnostics handler used to error out. It now returns the redacted config plus a note
+  about the incomplete setup, so a failed setup can actually be triaged. Thanks
+  @cyrano330 (#1340).
+
 ## [4.7.0b11] - 2026-09-04 — Škoda charge-current fix + quieter logs
 
 ### Fixed

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -125,6 +125,15 @@ _SETUP_ERRORS: dict[str, str] = {
     "invalid_credentials": (
         "Invalid credentials. Check email and password in the app."
     ),
+    # b12 (#1340 @cyrano330) — login succeeded but the EU Data Act portal returned
+    # 401 on enumeration. NOT a credential problem; a Repair (data_act_session_
+    # expired) explains the re-login. Kept OUT of _HARD_AUTH_SETUP_ERRORS so it
+    # retries (ConfigEntryNotReady) — the portal session may recover on its own.
+    "data_act_session_expired": (
+        "The EU Data Act portal signed you in but then refused the vehicle list "
+        "(session not authorised). Re-establish the portal session — see the "
+        "repair notice. This is not a wrong-password problem."
+    ),
 }
 
 # #909 (2026-07, Audi e-tron GT — Lagaff86) — setup reasons that CANNOT clear on

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -25,6 +25,7 @@ from .._util import (
 from ..exceptions import (
     APIError,
     AuthenticationError,
+    PortalSessionExpiredError,
     SpinError,
     VehicleCommandError,
 )
@@ -356,7 +357,17 @@ class VWEUClient(CariadBaseClient):
                     await self._refresh_tokens()
                 else:
                     await portal.login(self._email, self._password)
-                vins = await portal.list_vehicle_vins()
+                # b12 (#1340 @cyrano330) — a 401 on the SECOND enumeration, after
+                # we already refreshed/re-logged-in, means the portal refuses to
+                # authorise an otherwise-valid session (the IDK + portal logins
+                # both succeeded). Mark it distinctly so the coordinator surfaces
+                # the session-expired repair instead of "wrong password". A
+                # genuinely bad credential fails at portal.login() above and never
+                # reaches here.
+                try:
+                    vins = await portal.list_vehicle_vins()
+                except AuthenticationError as err2:
+                    raise PortalSessionExpiredError(str(err2)) from err2
             # Best-effort nickname enrichment from the relation endpoint.
             self._vehicle_metadata: dict[str, dict[str, Any]] = {}
             for pvin in vins:

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -372,6 +372,32 @@ class PortalInteractionRequiredError(AuthenticationError):
         self.reason = reason
 
 
+class PortalSessionExpiredError(AuthenticationError):
+    """b12 (#1340 @cyrano330) — the IDK login AND the EU Data Act portal login
+    both succeeded, but the portal then returned 401 on the vehicle enumeration
+    even after a fresh re-login/refresh — i.e. the portal won't authorise an
+    otherwise-valid session.
+
+    Distinct from ``AuthenticationError`` so the coordinator surfaces the
+    ``data_act_session_expired`` repair (re-login via the OptionsFlow) instead of
+    the credential catch-all — the password is provably fine (the login returned
+    an auth code), so telling the user to re-type it is wrong. Only raised on the
+    SECOND enumeration 401, which is reachable only after a successful login.
+    """
+
+    def __init__(self, reason: str = "") -> None:
+        msg = (
+            "EU Data Act portal returned 401 on vehicle enumeration after a "
+            "successful login"
+        )
+        if reason:
+            msg += f" ({reason})"
+        msg += ". This is NOT a wrong-password problem — the portal session "
+        msg += "needs re-establishing."
+        super().__init__(msg)
+        self.reason = reason
+
+
 class RateLimitError(CariadError):
     """Account temporarily blocked by VAG rate limiter."""
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1091,6 +1091,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             AuthenticationError,
             EmailTwoFactorRequiredError,
             PortalInteractionRequiredError,
+            PortalSessionExpiredError,
             TermsAndConditionsError,
             MarketingConsentError,
             TwoFactorRequiredError,
@@ -1732,6 +1733,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # get told to fix their password.
         except PortalInteractionRequiredError as err:
             raise ValueError("portal_interaction_required") from err
+        except PortalSessionExpiredError as err:
+            # b12 (#1340 @cyrano330) — login succeeded but the portal returned 401
+            # on enumeration even after a re-login: the password is fine, so raise
+            # the session-expired repair (re-login via OptionsFlow) instead of the
+            # credential catch-all. Soft reason (not in _HARD_AUTH_SETUP_ERRORS) →
+            # ConfigEntryNotReady retries, and the portal session may recover.
+            self._raise_data_act_session_expired_repair()
+            raise ValueError("data_act_session_expired") from err
         except AuthenticationError as err:
             raise ValueError("invalid_credentials") from err
         except Exception as err:  # noqa: BLE001

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -451,7 +451,24 @@ async def async_get_config_entry_diagnostics(
     surfaces 1-decimal-rounded coords (~11 km bucket — useful for
     debug, still privacy-safe). Otherwise full removal.
     """
-    coordinator: VagConnectCoordinator = entry.runtime_data
+    # b12 (#1340 @cyrano330) — on setup_error the entry never reached LOADED, so
+    # entry.runtime_data is still None. Every coordinator.* deref below (first:
+    # coordinator.vehicles.items()) would AttributeError → the diagnostics HTTP
+    # view turns that into a 500, exactly when the download is most useful for
+    # triaging a failed setup. Return the redacted config + a note instead.
+    coordinator: VagConnectCoordinator | None = getattr(entry, "runtime_data", None)
+    if coordinator is None:
+        return {
+            "note": (
+                "Setup did not complete for this config entry: the coordinator "
+                "(entry.runtime_data) is unavailable, so only the redacted config "
+                "and options are included. See Settings > Devices & Services for "
+                "the exact setup error / reauth prompt."
+            ),
+            "entry_state": str(getattr(entry, "state", "unknown")),
+            "config": _scrub(dict(entry.data), gps_round=False),
+            "options": _scrub(dict(entry.options), gps_round=False),
+        }
 
     # GPS-rounding opt-in — same signal as the reverse-geocoding toggle.
     gps_round = bool(

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b11"
+  "version": "4.7.0b12"
 }

--- a/tests/test_b12_cyrano_followup.py
+++ b/tests/test_b12_cyrano_followup.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b12 — #1340 (@cyrano330) follow-up fixes.
+
+1. Repair-routing: an EU Audi whose IDK + portal logins BOTH succeed but whose
+   portal then 401s on vehicle enumeration (even after a re-login) must surface
+   the ``data_act_session_expired`` repair, NOT ``invalid_credentials`` — the
+   password is provably fine. A distinct ``PortalSessionExpiredError`` carries
+   that case; it is raised only on the SECOND enumeration 401 (reachable only
+   after a successful login), and routed as a soft (retrying) setup error.
+
+2. Diagnostics no longer 500 when the entry is in setup_error: the handler
+   dereferenced the coordinator (entry.runtime_data), which is None before setup
+   completes — exactly when the download is most useful. It now returns a
+   redacted partial (config + note) instead.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.exceptions import (
+    AuthenticationError,
+    PortalSessionExpiredError,
+)
+from custom_components.vag_connect.cariad.models import TokenSet
+
+
+# ── the distinct exception ───────────────────────────────────────────────────
+
+def test_session_expired_is_subclass_of_auth_error() -> None:
+    # MUST stay a subclass so existing `except AuthenticationError` still catches
+    # it (backward compatible); only the coordinator's dedicated branch treats it
+    # specially, and it must be caught BEFORE the credential catch-all.
+    assert issubclass(PortalSessionExpiredError, AuthenticationError)
+    e = PortalSessionExpiredError("portal 401")
+    assert e.reason == "portal 401"
+    assert "wrong-password problem" in str(e).lower() or "not a wrong-password" in str(e).lower()
+
+
+# ── the reason is a SOFT setup error (retries), not HARD (reauth-hard) ────────
+
+def test_session_expired_reason_is_soft_retry() -> None:
+    from custom_components.vag_connect import (
+        _HARD_AUTH_SETUP_ERRORS,
+        _SETUP_ERRORS,
+    )
+    assert "data_act_session_expired" in _SETUP_ERRORS
+    assert "data_act_session_expired" not in _HARD_AUTH_SETUP_ERRORS
+    # contrast: a genuine credential failure stays HARD
+    assert "invalid_credentials" in _HARD_AUTH_SETUP_ERRORS
+
+
+# ── vw_eu enumeration retry raises the distinct exception on the 2nd 401 ──────
+
+class TestVwEuEnumerationRetry:
+    def _client(self, portal: MagicMock):
+        from custom_components.vag_connect.cariad.api.vw_eu import VWEUClient
+        c = VWEUClient.__new__(VWEUClient)
+        c._eu_portal = portal
+        c._email = "me@example.com"
+        c._password = "secret"
+        # non-device_grant_portal → takes the portal.login() retry branch
+        c._tokens = TokenSet("a", "r", "i", 0.0, "data_act_portal")
+        return c
+
+    def test_second_401_after_relogin_is_session_expired(self) -> None:
+        portal = MagicMock()
+        # 401 on both the first and the post-login retry enumeration
+        portal.list_vehicle_vins = AsyncMock(side_effect=AuthenticationError("401"))
+        portal.login = AsyncMock()
+        c = self._client(portal)
+        with pytest.raises(PortalSessionExpiredError):
+            asyncio.run(c.get_vehicles())
+        portal.login.assert_awaited_once()  # the one re-login happened
+
+    def test_first_401_then_success_is_not_flagged(self) -> None:
+        # a transient first 401 that recovers after re-login must NOT be surfaced
+        # as session-expired — data flows normally.
+        portal = MagicMock()
+        portal.list_vehicle_vins = AsyncMock(
+            side_effect=[AuthenticationError("401"), ["WVWZZZ1KZAM000001"]]
+        )
+        portal.login = AsyncMock()
+        portal.get_relation_nickname = AsyncMock(return_value=None)
+        c = self._client(portal)
+        vins = asyncio.run(c.get_vehicles())
+        assert vins == ["WVWZZZ1KZAM000001"]
+
+
+# ── diagnostics guard on setup_error (runtime_data is None) ───────────────────
+
+def test_diagnostics_returns_partial_when_setup_incomplete() -> None:
+    from custom_components.vag_connect.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.runtime_data = None  # setup never completed
+    entry.data = {"brand": "audi", "username": "me@example.com", "password": "secret"}
+    entry.options = {}
+    entry.state = "setup_error"
+
+    result = asyncio.run(async_get_config_entry_diagnostics(hass, entry))
+
+    assert "note" in result
+    assert "config" in result
+    assert result["entry_state"] == "setup_error"
+    # secrets stay redacted even on the partial path (reuses _scrub)
+    assert result["config"].get("password") != "secret"


### PR DESCRIPTION
## What

Two grounded fixes for @cyrano330's b11 retest (report #1340), v4.7.0b12. Both leave the issue open — the underlying Audi-EU 401 is still unsolved; these improve only the *messaging* and *diagnosability* around it.

### Fixed
- **Post-login portal 401 → session-expired repair, not "invalid credentials".** An EU Audi whose IDK login *and* EU Data Act portal login both succeed, but whose portal then 401s on the vehicle enumeration even after a re-login, was shown `invalid_credentials` — telling the user to re-type a provably-correct password. A new `PortalSessionExpiredError` (subclass of `AuthenticationError`, so existing handlers still catch it) is raised **only on the 2nd enumeration 401** (reachable only after a successful login — a genuine bad credential fails at `portal.login()` first), and the coordinator routes it to the existing `data_act_session_expired` repair as a soft/retrying setup error.
- **Diagnostics no longer 500 on `setup_error`.** `entry.runtime_data` (the coordinator) is `None` until setup completes, and the handler dereferenced it (`coordinator.vehicles.items()`) → AttributeError → HTTP 500, exactly when the download is most useful. It now early-returns a redacted partial (config + options + a note + entry_state) via the existing `_scrub()`.

## Tests
- New: `test_b12_cyrano_followup.py` (5) — exception subclass, soft-vs-hard reason routing, the vw_eu 2nd-401 retry, and the diagnostics partial.
- Full suite: **5782 passed / 0 failed** · ruff clean · mypy strict clean
