### PR TITLE
fix: stop registering the session-expired repair twice on setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **The "portal session not authorised" repair no longer appears twice.** A b12 change
+  registered that repair through two code paths with mirrored ids (one of them mislabelled
+  as a generic authentication failure); it now registers exactly once, with the correct
+  brand-aware text. Thanks @cyrano330 (#1340).
+
 ## [4.7.0b12] - 2026-09-04 — Repair message + diagnostics fixes (EU Audi)
 
 ### Fixed

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -125,15 +125,6 @@ _SETUP_ERRORS: dict[str, str] = {
     "invalid_credentials": (
         "Invalid credentials. Check email and password in the app."
     ),
-    # b12 (#1340 @cyrano330) — login succeeded but the EU Data Act portal returned
-    # 401 on enumeration. NOT a credential problem; a Repair (data_act_session_
-    # expired) explains the re-login. Kept OUT of _HARD_AUTH_SETUP_ERRORS so it
-    # retries (ConfigEntryNotReady) — the portal session may recover on its own.
-    "data_act_session_expired": (
-        "The EU Data Act portal signed you in but then refused the vehicle list "
-        "(session not authorised). Re-establish the portal session — see the "
-        "repair notice. This is not a wrong-password problem."
-    ),
 }
 
 # #909 (2026-07, Audi e-tron GT — Lagaff86) — setup reasons that CANNOT clear on

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1736,11 +1736,23 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         except PortalSessionExpiredError as err:
             # b12 (#1340 @cyrano330) — login succeeded but the portal returned 401
             # on enumeration even after a re-login: the password is fine, so raise
-            # the session-expired repair (re-login via OptionsFlow) instead of the
-            # credential catch-all. Soft reason (not in _HARD_AUTH_SETUP_ERRORS) →
-            # ConfigEntryNotReady retries, and the portal session may recover.
+            # the brand-aware session-expired repair (re-login via OptionsFlow),
+            # the same one the runtime poll paths use, instead of the credential
+            # catch-all. Raise ConfigEntryNotReady DIRECTLY (soft, retrying — the
+            # portal session may recover) rather than ValueError: routing via
+            # ValueError would ALSO fire __init__.raise_issue_auth_required, which
+            # has no mapping for this reason and would register a SECOND, generic
+            # "auth_failed" repair with a mirrored id — the user then sees the
+            # repair twice (b12b, spotted by @cyrano330).
+            from homeassistant.exceptions import (  # noqa: PLC0415
+                ConfigEntryNotReady,
+            )
+
             self._raise_data_act_session_expired_repair()
-            raise ValueError("data_act_session_expired") from err
+            raise ConfigEntryNotReady(
+                "The EU Data Act portal signed you in but then refused the "
+                "vehicle list (session not authorised) — see the repair notice."
+            ) from err
         except AuthenticationError as err:
             raise ValueError("invalid_credentials") from err
         except Exception as err:  # noqa: BLE001

--- a/tests/test_b12_cyrano_followup.py
+++ b/tests/test_b12_cyrano_followup.py
@@ -40,16 +40,22 @@ def test_session_expired_is_subclass_of_auth_error() -> None:
     assert "wrong-password problem" in str(e).lower() or "not a wrong-password" in str(e).lower()
 
 
-# ── the reason is a SOFT setup error (retries), not HARD (reauth-hard) ────────
+# ── the session-expired case bypasses the generic ValueError repair route ────
 
-def test_session_expired_reason_is_soft_retry() -> None:
+def test_session_expired_bypasses_generic_setup_routing() -> None:
+    # b12b (@cyrano330 duplicate-repair): the coordinator raises ConfigEntryNotReady
+    # DIRECTLY and creates only the dedicated brand-aware repair. It must NOT route
+    # through the generic ValueError → raise_issue_auth_required path — that has no
+    # mapping for this reason and would register a SECOND generic "auth_failed"
+    # repair with a mirrored id (the duplicate the user saw). Guard against a
+    # regression that re-introduces that route.
     from custom_components.vag_connect import (
         _HARD_AUTH_SETUP_ERRORS,
         _SETUP_ERRORS,
     )
-    assert "data_act_session_expired" in _SETUP_ERRORS
+    assert "data_act_session_expired" not in _SETUP_ERRORS
     assert "data_act_session_expired" not in _HARD_AUTH_SETUP_ERRORS
-    # contrast: a genuine credential failure stays HARD
+    # a genuine credential failure still routes hard, unchanged
     assert "invalid_credentials" in _HARD_AUTH_SETUP_ERRORS
 
 


### PR DESCRIPTION
## What

Fixes a b12 regression @cyrano330 caught on report #1340: the session-expired repair was registered **twice** on setup.

The b12 setup catch created the `data_act_session_expired` repair via the dedicated brand-aware helper (`data_act_session_expired_<id>`) **and** routed through `ValueError → raise_issue_auth_required`, which has no mapping for that reason and registered a **second, generic `auth_failed` repair** with a mirrored id (`<id>_data_act_session_expired`), created in the same millisecond. The user saw the repair twice, one of them mislabelled.

The setup catch now raises `ConfigEntryNotReady` **directly** (still soft/retrying) and creates only the one dedicated, brand-aware repair — matching the runtime poll paths. Removes the now-unused `_SETUP_ERRORS` entry; the b12 test now regression-guards against re-introducing the generic route.

No version bump / no release here — the fix lands on main to be tagged later.

## Tests
- `test_b12_cyrano_followup.py` (5) green · ruff clean · mypy strict clean
