### PR TITLE
chore: HA-near clean-up (llm prefix, parallel-updates, device-lookup deprecation, 401 diagnostic) — v4.7.0b13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,26 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b13] - 2026-09-04 — HA-near clean-up (quality + deprecations + a diagnostic)
+
 ### Fixed
 - **The "portal session not authorised" repair no longer appears twice.** A b12 change
   registered that repair through two code paths with mirrored ids (one of them mislabelled
   as a generic authentication failure); it now registers exactly once, with the correct
   brand-aware text. Thanks @cyrano330 (#1340).
+
+### Changed
+- **Quieter and more future-proof under the hood** (no user-visible change): the
+  conversation-agent tools are now namespaced (`vag_connect__…`) the way Home Assistant
+  2026.9 requires; the deprecated device-registry lookup was swapped for the entry-scoped
+  one (Home Assistant 2026.8+, with a fallback for older cores); and the "parallel updates"
+  quality rule is now declared where Home Assistant actually reads it.
+
+### Added
+- **A redacted portal-401 diagnostic** (debug-log only): when the EU Data Act portal rejects
+  the vehicle list after a successful login, turning on debug logging now records — names and
+  flags only, never any secret — whether the request went out authenticated or anonymous, to
+  help pin down the cause. Thanks @cyrano330 (#1340).
 
 ## [4.7.0b12] - 2026-09-04 — Repair message + diagnostics fixes (EU Audi)
 

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -959,6 +959,12 @@ _DATA_PRESENT_REQUIRED: frozenset[str] = frozenset({
 })
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/button.py
+++ b/custom_components/vag_connect/button.py
@@ -24,6 +24,12 @@ from .entity_base import VagConnectEntity, register_dynamic_spawner
 #   command-id mapping in CAPABILITY_MAP".
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/calendar.py
+++ b/custom_components/vag_connect/calendar.py
@@ -63,6 +63,12 @@ def _parse_date(val: Any) -> date | None:
         return None
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001
     entry: ConfigEntry,

--- a/custom_components/vag_connect/cariad/auth/_device_grant.py
+++ b/custom_components/vag_connect/cariad/auth/_device_grant.py
@@ -494,10 +494,14 @@ DAG_ENABLED_BRANDS = frozenset({"audi", "seat", "cupra", "audi_na"})
 
 # v2.19.0 — Audi US/CA (audi_na) drives the SAME RFC-8628 flow against the NA IDP
 # instead of the EU one (endpoints mirror EU on identity.na.vwgroup.io, from the
-# live US myAudi market-config / NA OIDC discovery). LIVE-GATED / UNCONFIRMED,
-# needs a real US-Audi tester: (1) whether the NA IDP exposes
-# /oidc/v1/device_authorization at all, (2) whether client 7c6b4634 is
-# device-code-capable, (3) whether a device-grant token then reads na.bff.
+# live US myAudi market-config / NA OIDC discovery).
+# b13 UPDATE — two of the three open questions are now confirmed by a standalone
+# live probe (@cyrano330, #1340, 2026-09-04): (1) the NA IDP DOES expose
+# /oidc/v1/device_authorization (HTTP 200, RFC-8628 response, expires_in=300,
+# interval=1; verification URI identity.na.vwgroup.io/oidc/device/aoa), and
+# (2) client 7c6b4634 (US Android live) IS device-code-capable there (also the
+# US iOS 61755a4f and Watch c07d4b3a clients returned 200). STILL OPEN: (3)
+# whether a device-grant token then READS na.bff — needs a real US account.
 # NOTE: the community "Audi Connect" project reads NA Audi data via the
 # PASSWORD/authorization-code path (no attestation on the reads); this DAG path
 # is the preferred clean-auth alternative — wired here, but its read-capability

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -3938,6 +3938,40 @@ class EUDataActConnector:
             "EU Data Act portal: login succeeded (read-only, ~15min cadence)"
         )
 
+    def _debug_dump_auth_state_on_401(
+        self, url: str, sent_headers: dict[str, str], resp: Any
+    ) -> None:
+        """b13 (#1340 @cyrano330) — on a hard 401 from a proxy_api call, log a
+        REDACTED snapshot of HOW the request was authenticated, so a tester's
+        debug capture answers the open question behind the persistent portal 401:
+        did the GET go out authenticated-but-refused, or anonymous/stale?
+
+        Names + flags ONLY — never a token or cookie value. Fires only when debug
+        logging is on, and can never break the request flow.
+        """
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        try:
+            mode = "bearer" if self._bearer else "cookie"
+            sent_authorization = "Authorization" in sent_headers
+            cookies: list[str] = []
+            try:
+                for cookie in self._session.cookie_jar:
+                    cookies.append(f"{cookie.key}@{cookie.get('domain') or '?'}")
+            except Exception:  # noqa: BLE001
+                cookies = ["<cookie jar unreadable>"]
+            resp_hdrs = getattr(resp, "headers", {})
+            www_auth = str(resp_hdrs.get("WWW-Authenticate", ""))
+            _LOGGER.debug(
+                "EU Data Act 401 auth-state on %s: mode=%s sent_authorization=%s "
+                "session_cookies=%s resp_www_authenticate=%r resp_set_cookie=%s "
+                "(#1340 diagnostic — names/flags only, no secret values)",
+                url.split("?")[0], mode, sent_authorization, cookies or "<none>",
+                www_auth[:80], "Set-Cookie" in resp_hdrs,
+            )
+        except Exception:  # noqa: BLE001 — diagnostics must never break the flow
+            _LOGGER.debug("EU Data Act 401 auth-state dump failed", exc_info=True)
+
     async def _get_json(
         self,
         url: str,
@@ -3993,6 +4027,10 @@ class EUDataActConnector:
                             # portal outage (portal_error).
                             self._last_soft_status = resp.status
                             return None
+                        if resp.status == 401:
+                            self._debug_dump_auth_state_on_401(
+                                url, eff_headers, resp
+                            )
                         raise AuthenticationError(
                             f"EU Data Act GET {url} → HTTP {resp.status}"
                         )

--- a/custom_components/vag_connect/climate.py
+++ b/custom_components/vag_connect/climate.py
@@ -21,6 +21,12 @@ MAX_TEMP = 30.0
 TEMP_STEP = 0.5
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -4439,6 +4439,23 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Truly unavailable — past tolerance and stale-cache window.
         return False
 
+    def _lookup_own_device(
+        self, registry: dr.DeviceRegistry, vin: str
+    ) -> dr.DeviceEntry | None:
+        """Look up our own vehicle device by VIN, entry-scoped.
+
+        b13 — ``device_registry.async_get_device(identifiers=...)`` is deprecated
+        (HA 2026.9, breaks 2027.8) because identifiers are no longer unique across
+        config entries. ``async_get_device_by_identifier((domain, vin), entry_id)``
+        (HA 2026.8+) scopes to THIS entry — strictly correct for our own device.
+        getattr-guarded so pre-2026.8 cores fall back to the old method.
+        """
+        getter = getattr(registry, "async_get_device_by_identifier", None)
+        if getter is not None:
+            found: dr.DeviceEntry | None = getter((DOMAIN, vin), self.entry.entry_id)
+            return found
+        return registry.async_get_device(identifiers={(DOMAIN, vin)})
+
     def _active_vins(self, vins: list[str]) -> list[str]:
         """Drop VINs whose HA device *the user* disabled, so a deactivated
         vehicle stops being polled and stops consuming the daily request budget.
@@ -4463,7 +4480,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         active = [
             vin
             for vin in vins
-            if (dev := registry.async_get_device(identifiers={(DOMAIN, vin)})) is None
+            if (dev := self._lookup_own_device(registry, vin)) is None
             or dev.disabled_by != dr.DeviceEntryDisabler.USER
         ]
         if len(active) != len(vins):
@@ -5682,9 +5699,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         previous_vins = set(self.data.keys()) - {"_meta"}
 
         for stale_vin in previous_vins - current_vins:
-            device_entry = device_reg.async_get_device(
-                identifiers={(DOMAIN, stale_vin)}
-            )
+            device_entry = self._lookup_own_device(device_reg, stale_vin)
             if device_entry is not None:
                 _LOGGER.warning(
                     "VW Group Connect: vehicle %s removed from account — "

--- a/custom_components/vag_connect/device_tracker.py
+++ b/custom_components/vag_connect/device_tracker.py
@@ -28,6 +28,12 @@ from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001
     entry: ConfigEntry,

--- a/custom_components/vag_connect/entity_base.py
+++ b/custom_components/vag_connect/entity_base.py
@@ -56,8 +56,10 @@ _CONNECTION_STATUS_KEYS = frozenset({
 class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
     """Base entity shared by all VW Group Connect platforms.
 
-    parallel_updates=0: the coordinator's background poll loop owns all API
-    calls.  HA entities never initiate requests directly.
+    Parallel updates: the coordinator's background poll loop owns all API
+    calls, so entity updates need no throttling. HA reads that from a
+    MODULE-level ``PARALLEL_UPDATES = 0`` in each platform file (an entity
+    attribute is a no-op), so it is declared there, not here.
 
     available: per-VIN — entity is unavailable when its vehicle's last poll
     failed, even if other vehicles in the same account succeeded.
@@ -73,7 +75,6 @@ class VagConnectEntity(CoordinatorEntity[VagConnectCoordinator]):
     """
 
     _attr_has_entity_name = True
-    _attr_parallel_updates = 0  # coordinator owns all API requests
     # v1.9.1 — set on subclasses that map 1:1 to a coordinator command.
     # ``None`` means "not a command-bound entity, never use Phase-2 gating".
     _command_id: str | None = None

--- a/custom_components/vag_connect/event.py
+++ b/custom_components/vag_connect/event.py
@@ -60,6 +60,12 @@ _BRAND_EVENT_TYPES: dict[str, list[str]] = {
 PUSH_CAPABLE_BRANDS = frozenset(_BRAND_EVENT_TYPES)
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001
     entry: ConfigEntry,

--- a/custom_components/vag_connect/image.py
+++ b/custom_components/vag_connect/image.py
@@ -133,6 +133,12 @@ def _has_image_data(vehicle: dict) -> bool:
     )
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/llm.py
+++ b/custom_components/vag_connect/llm.py
@@ -10,7 +10,7 @@ Generative AI, Ollama — consumes that identical list through the shared
 ``voluptuous_openapi.convert(..., custom_serializer=llm.selector_serializer)``).
 The dict a tool returns is fed back to the model as the tool result — which is
 exactly what lets an agent read Laura's ``summary`` and then call
-``skoda_send_destination`` with the chosen stop.
+``vag_connect__skoda_send_destination`` with the chosen stop.
 
 Two entry points share one ``_TOOL_CLASSES`` list:
 
@@ -36,13 +36,18 @@ from homeassistant.helpers import config_validation as cv, llm
 
 from .const import DOMAIN
 
+# b13 — HA 2026.9 requires llm tool names to be prefixed with "{domain}__"
+# (warns 2026.9, hard-breaks 2027.3 for the async_get_tools/Assist path). The
+# tool names AND every in-prompt/in-description cross-reference use the prefixed
+# form so the model's tool-chaining hints still match the registered names.
 _PROMPT = (
     "This home has a Škoda vehicle. For Škoda EV route or charging planning, or "
-    "MyŠkoda product questions, use skoda_ask_assistant (the in-car AI 'Laura') — "
-    "it returns a text summary you can act on. If Laura or the user settles on a "
-    "destination, push it to the car with skoda_send_destination. To set a "
-    "location-specific charge target, use skoda_set_location_target_soc. Always "
-    "pass the vehicle's VIN."
+    "MyŠkoda product questions, use vag_connect__skoda_ask_assistant (the in-car "
+    "AI 'Laura') — it returns a text summary you can act on. If Laura or the user "
+    "settles on a destination, push it to the car with "
+    "vag_connect__skoda_send_destination. To set a location-specific charge "
+    "target, use vag_connect__skoda_set_location_target_soc. Always pass the "
+    "vehicle's VIN."
 )
 
 
@@ -71,13 +76,13 @@ class _ServiceTool(llm.Tool):
 class AskAssistantTool(_ServiceTool):
     """Laura — the MyŠkoda in-car AI assistant (read-only advisory)."""
 
-    name = "skoda_ask_assistant"
+    name = "vag_connect__skoda_ask_assistant"
     description = (
         "Ask the MyŠkoda in-car AI assistant 'Laura' about EV route/charging "
         "planning or Škoda product questions for one vehicle. Read-only advisory "
         "— it cannot control the car. Returns a text 'summary' you can act on "
-        "(e.g. then call skoda_send_destination) plus a 'session_id'; pass that "
-        "session_id back to continue the same conversation."
+        "(e.g. then call vag_connect__skoda_send_destination) plus a 'session_id'; "
+        "pass that session_id back to continue the same conversation."
     )
     parameters = vol.Schema(
         {
@@ -94,7 +99,7 @@ class AskAssistantTool(_ServiceTool):
 class SendDestinationTool(_ServiceTool):
     """Push a navigation destination to the Škoda infotainment."""
 
-    name = "skoda_send_destination"
+    name = "vag_connect__skoda_send_destination"
     description = (
         "Send a navigation destination (coordinates + name) to the car's "
         "infotainment so it appears as the next destination."
@@ -113,7 +118,7 @@ class SendDestinationTool(_ServiceTool):
 class SetLocationTargetSocTool(_ServiceTool):
     """Set the target state of charge for one charging profile (per-location)."""
 
-    name = "skoda_set_location_target_soc"
+    name = "vag_connect__skoda_set_location_target_soc"
     description = (
         "Set the target charge level (percent) for a specific charging profile — "
         "e.g. the profile active at the car's current location. profile_id comes "

--- a/custom_components/vag_connect/lock.py
+++ b/custom_components/vag_connect/lock.py
@@ -13,6 +13,12 @@ from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity, register_dynamic_spawner
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b12"
+  "version": "4.7.0b13"
 }

--- a/custom_components/vag_connect/number.py
+++ b/custom_components/vag_connect/number.py
@@ -162,6 +162,12 @@ NUMBER_DESCRIPTIONS: tuple[VagNumberDescription, ...] = (
 )
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/select.py
+++ b/custom_components/vag_connect/select.py
@@ -129,6 +129,12 @@ def _normalise_raw_mode(raw: object) -> str | None:
     return _RAW_TO_CANONICAL.get(key)
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -4101,6 +4101,12 @@ class VagWindowPositionSensor(VagConnectEntity, SensorEntity):
         return val if isinstance(val, (int, float)) and not isinstance(val, bool) else None
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/switch.py
+++ b/custom_components/vag_connect/switch.py
@@ -11,6 +11,12 @@ from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity, register_dynamic_spawner
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/time.py
+++ b/custom_components/vag_connect/time.py
@@ -32,6 +32,12 @@ from .coordinator import VagConnectCoordinator
 from .entity_base import VagConnectEntity, register_dynamic_spawner
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/vag_connect/update.py
+++ b/custom_components/vag_connect/update.py
@@ -41,6 +41,12 @@ _IN_PROGRESS_STATES = frozenset({
 })
 
 
+# b13 — platinum parallel-updates rule: the coordinator's background poll
+# loop owns every API request, so entity updates need no throttling. HA reads
+# this MODULE-level constant (an entity attr is a no-op).
+PARALLEL_UPDATES = 0
+
+
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001
     entry: ConfigEntry,

--- a/tests/test_active_vins_poll_optout.py
+++ b/tests/test_active_vins_poll_optout.py
@@ -24,6 +24,7 @@ def _coord():
 
     c = VagConnectCoordinator.__new__(VagConnectCoordinator)
     c.hass = MagicMock()
+    c.entry = MagicMock()  # b13 — _lookup_own_device reads self.entry.entry_id
     return c
 
 
@@ -32,8 +33,10 @@ def _registry(disabled: set[str], missing: set[str] = frozenset()):
 
     reg = MagicMock()
 
-    def _get(identifiers):
-        (_domain, vin), = identifiers
+    # b13 — coordinator now looks up via the entry-scoped
+    # async_get_device_by_identifier(identifier_tuple, config_entry_id).
+    def _get(identifier, _entry_id):
+        _domain, vin = identifier
         if vin in missing:
             return None
         dev = MagicMock()
@@ -42,7 +45,7 @@ def _registry(disabled: set[str], missing: set[str] = frozenset()):
         dev.disabled_by = dr.DeviceEntryDisabler.USER if vin in disabled else None
         return dev
 
-    reg.async_get_device.side_effect = _get
+    reg.async_get_device_by_identifier.side_effect = _get
     return reg
 
 
@@ -84,8 +87,8 @@ def test_system_disabled_device_is_still_polled():
 
     reg = MagicMock()
 
-    def _get(identifiers):
-        (_domain, vin), = identifiers
+    def _get(identifier, _entry_id):
+        _domain, vin = identifier
         dev = MagicMock()
         dev.disabled_by = {
             "VIN_USER": dr.DeviceEntryDisabler.USER,
@@ -94,7 +97,7 @@ def test_system_disabled_device_is_still_polled():
         }.get(vin)
         return dev
 
-    reg.async_get_device.side_effect = _get
+    reg.async_get_device_by_identifier.side_effect = _get
     c = _coord()
     with patch(f"{_MOD}.dr.async_get", return_value=reg):
         # only the user-disabled one drops; integration/config-entry keep polling

--- a/tests/test_b13_cleanup.py
+++ b/tests/test_b13_cleanup.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b13 — HA-near clean-up: PARALLEL_UPDATES, device-lookup deprecation guard,
+and the redacted 401 auth-state debug capture (#1340).
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.vag_connect.const import DOMAIN
+
+
+# ── platinum parallel-updates rule is declared at MODULE level on every platform
+
+_PLATFORMS = [
+    "binary_sensor", "button", "calendar", "climate", "device_tracker", "event",
+    "image", "lock", "number", "select", "sensor", "switch", "time", "update",
+]
+
+
+@pytest.mark.parametrize("platform", _PLATFORMS)
+def test_platform_declares_module_level_parallel_updates(platform: str) -> None:
+    # HA reads PARALLEL_UPDATES as a MODULE attribute; an entity attr is a no-op.
+    # Guards the platinum quality-scale rule being actually in effect.
+    mod = importlib.import_module(f"custom_components.vag_connect.{platform}")
+    assert getattr(mod, "PARALLEL_UPDATES", None) == 0
+
+
+# ── device lookup uses the non-deprecated entry-scoped API when available ─────
+
+class _Coord:
+    """Bind the real coordinator method onto a tiny stub carrying self.entry."""
+
+    def __init__(self) -> None:
+        from custom_components.vag_connect.coordinator import VagConnectCoordinator
+        self._lookup = VagConnectCoordinator._lookup_own_device.__get__(self)
+        self.entry = MagicMock()
+        self.entry.entry_id = "e1"
+
+
+def test_lookup_uses_by_identifier_when_present() -> None:
+    coord = _Coord()
+    registry = MagicMock(spec=["async_get_device_by_identifier"])
+    registry.async_get_device_by_identifier.return_value = "DEV"
+    out = coord._lookup(registry, "WVWZZZ1KZAM000001")
+    # entry-scoped call: single TUPLE identifier + the config entry id
+    registry.async_get_device_by_identifier.assert_called_once_with(
+        (DOMAIN, "WVWZZZ1KZAM000001"), "e1"
+    )
+    assert out == "DEV"
+
+
+def test_lookup_falls_back_on_old_core() -> None:
+    coord = _Coord()
+    # a pre-2026.8 core has no async_get_device_by_identifier
+    registry = MagicMock(spec=["async_get_device"])
+    registry.async_get_device.return_value = "OLD"
+    out = coord._lookup(registry, "WVWZZZ1KZAM000001")
+    registry.async_get_device.assert_called_once_with(
+        identifiers={(DOMAIN, "WVWZZZ1KZAM000001")}
+    )
+    assert out == "OLD"
+
+
+# ── the 401 auth-state debug capture is safe + redacted ───────────────────────
+
+class _Cookie:
+    def __init__(self, key: str, domain: str, value: str) -> None:
+        self.key = key
+        self.value = value
+        self._d = {"domain": domain}
+
+    def get(self, k: str, default=None):
+        return self._d.get(k, default)
+
+
+def _connector(cookies, bearer):
+    from custom_components.vag_connect.cariad.auth._eu_data_act import (
+        EUDataActConnector,
+    )
+    c = EUDataActConnector.__new__(EUDataActConnector)
+    c._bearer = bearer  # type: ignore[attr-defined]
+    sess = MagicMock()
+    sess.cookie_jar = cookies
+    c._session = sess  # type: ignore[attr-defined]
+    return c
+
+
+def test_401_dump_noop_when_debug_off(monkeypatch) -> None:
+    from custom_components.vag_connect.cariad.auth import _eu_data_act
+    # debug off → no-op. monkeypatch (auto-restored) instead of mutating the
+    # module logger's level globally, which would pollute other tests' caplog.
+    monkeypatch.setattr(_eu_data_act._LOGGER, "isEnabledFor", lambda _lvl: False)
+    # a cookie jar that WOULD raise if touched — proves the guard returns early
+    sess = MagicMock()
+    type(sess).cookie_jar = property(
+        lambda self: (_ for _ in ()).throw(AssertionError("touched jar"))
+    )
+    c = _eu_data_act.EUDataActConnector.__new__(_eu_data_act.EUDataActConnector)
+    c._bearer = "tok"  # type: ignore[attr-defined]
+    c._session = sess  # type: ignore[attr-defined]
+    resp = MagicMock()
+    resp.headers = {"WWW-Authenticate": "Bearer"}
+    # must not raise (and must not read the cookie jar)
+    c._debug_dump_auth_state_on_401("https://p/proxy_api/x?y=1", {"Authorization": "x"}, resp)
+
+
+def test_401_dump_logs_redacted_at_debug(caplog) -> None:
+    from custom_components.vag_connect.cariad.auth import _eu_data_act
+    c = _connector([_Cookie("SESSID", "portal.example", "SUPERSECRET")], bearer="tok")
+    resp = MagicMock()
+    resp.headers = {"WWW-Authenticate": "Bearer realm=x", "Set-Cookie": "a=b"}
+    with caplog.at_level(logging.DEBUG, logger=_eu_data_act._LOGGER.name):
+        c._debug_dump_auth_state_on_401(
+            "https://p/proxy_api/consent/me/vehicles?viewPosition=FRONT_LEFT",
+            {"Authorization": "Bearer tok"},
+            resp,
+        )
+    blob = caplog.text
+    assert "mode=bearer" in blob
+    assert "sent_authorization=True" in blob
+    assert "SESSID@portal.example" in blob     # cookie NAME + domain surfaced
+    assert "SUPERSECRET" not in blob           # cookie VALUE never leaked
+    assert "resp_set_cookie=True" in blob
+    # the query string is stripped from the logged URL
+    assert "viewPosition" not in blob

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -3705,6 +3705,9 @@ class TestStaleDevices:
         mock_device = MagicMock()
         mock_device.id = "device_old"
         mock_reg = MagicMock()
+        # b13 — coordinator now looks up via the entry-scoped
+        # async_get_device_by_identifier (with a getattr fallback to the old one).
+        mock_reg.async_get_device_by_identifier = MagicMock(return_value=mock_device)
         mock_reg.async_get_device = MagicMock(return_value=mock_device)
         mock_reg.async_remove_device = MagicMock()
 
@@ -3731,6 +3734,7 @@ class TestStaleDevices:
         coord.data = {"VIN_OLD": {}}
 
         mock_reg = MagicMock()
+        mock_reg.async_get_device_by_identifier = MagicMock(return_value=None)
         mock_reg.async_get_device = MagicMock(return_value=None)  # not found
 
         with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_reg):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -135,8 +135,10 @@ class TestEntityBase:
         assert e._attr_unique_id == "VIN123_key_test"
 
     def test_parallel_updates_is_zero(self):
-        from custom_components.vag_connect.entity_base import VagConnectEntity
-        assert VagConnectEntity._attr_parallel_updates == 0
+        # b13 — HA reads PARALLEL_UPDATES as a MODULE-level constant on each
+        # platform (an entity attr is a no-op), so assert it there.
+        import custom_components.vag_connect.sensor as sensor_mod
+        assert sensor_mod.PARALLEL_UPDATES == 0
 
     def test_has_entity_name_true(self):
         from custom_components.vag_connect.entity_base import VagConnectEntity

--- a/tests/test_skoda_llm_tools.py
+++ b/tests/test_skoda_llm_tools.py
@@ -48,9 +48,9 @@ def _hass(service_result: dict | None = None) -> MagicMock:
 def test_tool_classes_names_and_services() -> None:
     names = {c.name: c._service for c in vag_llm._TOOL_CLASSES}
     assert names == {
-        "skoda_ask_assistant": "ask_assistant",
-        "skoda_send_destination": "send_destination",
-        "skoda_set_location_target_soc": "set_location_target_soc",
+        "vag_connect__skoda_ask_assistant": "ask_assistant",
+        "vag_connect__skoda_send_destination": "send_destination",
+        "vag_connect__skoda_set_location_target_soc": "set_location_target_soc",
     }
     # only the advisory tool asks for a response payload
     ask = vag_llm.AskAssistantTool
@@ -104,15 +104,15 @@ async def test_custom_api_instance_exposes_all_tools() -> None:
     api = vag_llm.VagConnectLLMAPI(hass=MagicMock(), id=DOMAIN, name="VW Group Connect")
     inst = await api.async_get_api_instance(_ctx())
     assert {t.name for t in inst.tools} == {
-        "skoda_ask_assistant",
-        "skoda_send_destination",
-        "skoda_set_location_target_soc",
+        "vag_connect__skoda_ask_assistant",
+        "vag_connect__skoda_send_destination",
+        "vag_connect__skoda_set_location_target_soc",
     }
     expected = getattr(llm, "selector_serializer", None) or getattr(
         llm, "_selector_serializer", None
     )
     assert inst.custom_serializer == expected
-    assert "skoda_ask_assistant" in inst.api_prompt
+    assert "vag_connect__skoda_ask_assistant" in inst.api_prompt
 
 
 def test_platform_hook_is_inert_for_non_assist_api() -> None:


### PR DESCRIPTION
## What

An "HA-near" clean-up pass (v4.7.0b13) — no new user features; it tightens quality, clears two deprecations before they bite, and adds one diagnostic. Bundles the already-merged duplicate-repair fix.

### Fixed
- **The "portal session not authorised" repair no longer appears twice** (already on main): a b12 change registered it through two code paths with mirrored ids, one mislabelled as a generic auth failure. Thanks @cyrano330 (report #1340).

### Changed (no user-visible behaviour change)
- **llm tool namespacing** — the conversation-agent tools are now `vag_connect__…`, as the Assist-folded `async_get_tools` path requires in HA 2026.9 (warns 2026.9, breaks 2027.3). Every in-prompt/in-description cross-reference updated to match; the custom-API path is unaffected.
- **PARALLEL_UPDATES** — declared at MODULE level on all 14 platforms (HA reads the module constant; the `_attr_parallel_updates` we had was a no-op). Makes the platinum `parallel_updates` rule actually take effect.
- **device-registry lookup** — swapped the deprecated `async_get_device(identifiers=…)` (HA 2026.9 deprecation, breaks 2027.8) for the entry-scoped `async_get_device_by_identifier` (HA 2026.8+), getattr-guarded so pre-2026.8 cores fall back cleanly. Strictly correct for our own device.

### Added
- **Redacted portal-401 diagnostic** (debug-log only) — when the EU Data Act portal 401s the vehicle list after a successful login, debug logging now records cookie names/flags and whether an `Authorization` header went out (never a secret value), to distinguish authenticated-but-refused from anonymous. Thanks @cyrano330 (report #1340).
- Recorded @cyrano330's live confirmation that the NA IDP exposes `device_authorization` and `7c6b4634` is device-code-capable (audi_na code comment; report #1340).

## Tests
- New `test_b13_cleanup.py`; updated the affected llm / entity / device-lookup tests.
- Full suite: **5800 passed / 0 failed** · ruff clean · mypy strict clean.

## Deferred (own follow-up)
A UX tip for the `data_act_no_data` repair (delete an existing portal request first — @cyrano330's finding) is deliberately held for a careful 12-language i18n pass rather than rushed here.
