### PR TITLE
b14: per-brand EU Data Act portal client + automation triggers/conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,35 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b14] - 2026-09-05 — Audi/Škoda/Bentley EU Data Act fix + experimental automation triggers
+
+### Fixed
+- **Audi, Škoda and Bentley now actually read from the EU Data Act portal.** They were signing in
+  with the Volkswagen portal login, so the sign-in *looked* like it worked but the session stayed
+  anonymous and every data request came back empty (a hidden 401). Each brand now uses its own
+  portal login — the one the portal's per-brand sign-in actually expects — on both the cookie and
+  the token channel. Huge thanks to @cyrano330 for the root-cause trace (#1340).
+
+### Added
+- **Automations can now react to your car directly (experimental, opt-in).** New named
+  triggers — started/stopped charging, plugged in/unplugged, locked/unlocked, started/stopped
+  preconditioning, and charge target reached — plus matching conditions (is charging, is
+  plugged in, is locked, is preconditioning, charge target reached). They're derived purely
+  from data the integration already polls, so they add no extra API calls. This rides a Home
+  Assistant platform its own developers still flag as "may change without notice", so treat it
+  as a preview: it only registers on cores new enough to support it and quietly does nothing on
+  older ones.
+
+### Changed
+- **Clearer, safer "no data yet" portal help.** The EU Data Act repair guide now explains that the
+  portal keeps one active request *per car*: delete an older request only for the **same** vehicle,
+  and on a mixed passenger + commercial account keep each car's request under its own brand view
+  instead of deleting the other car's. In all 12 supported languages. Thanks @cyrano330 (#1340).
+- **Tidier, safer portal debug log.** The redacted 401 auth-state line (debug only) now masks the
+  UUID inside session-cookie names, logs once per setup instead of repeating, and adds a
+  portal-domain-cookies field that shows at a glance whether a failing request went out anonymous
+  or authenticated-but-refused. Thanks @cyrano330 (#1340).
+
 ## [4.7.0b13] - 2026-09-04 — HA-near clean-up (quality + deprecations + a diagnostic)
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_data_act_portal.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_portal.py
@@ -102,6 +102,26 @@ _BRAND_STATE_FRAGMENTS = {
     "bentley": "BENTLEY",
 }
 
+# #1340 — each brand authenticates against the portal with its OWN OIDC client;
+# the shared VW client leaves the session anonymous (login lands on the portal but
+# every data read 401s). Same ids as ``_eu_data_act._EUDA_BRANDS`` (kept in lock-
+# step — see test_1340_portal_client_ids), grounded from each brand's portal login
+# redirect. Brands not listed keep the VW client. The authorize call and the token
+# exchange MUST use the same one.
+_CUPRA_SEAT_CLIENT_ID = "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com"
+_BRAND_CLIENT_IDS = {
+    "audi": "cc29b87a-5e9a-4362-aecf-5adea6b01bbb@apps_vw-dilab_com",
+    "skoda": "3ea88bf9-1d4e-4a68-b3ad-4098c1f1d246@apps_vw-dilab_com",
+    "bentley": "d38aac0f-3d89-4a63-8538-b75b31322c7b@apps_vw-dilab_com",
+    "cupra": _CUPRA_SEAT_CLIENT_ID,
+    "seat": _CUPRA_SEAT_CLIENT_ID,
+}
+
+
+def _brand_client_id(brand_name: str) -> str:
+    """Portal OIDC client_id for *brand_name* (VW client for anything unlisted)."""
+    return _BRAND_CLIENT_IDS.get(brand_name.lower(), _PORTAL_OIDC_CLIENT_ID)
+
 _DEFAULT_COUNTRY = "DE"
 _DEFAULT_LANGUAGE = "de"
 _PORTAL_REQUEST_TIMEOUT_S = 30
@@ -223,7 +243,7 @@ class DataActPortalAuth:
         # the IDP for this specific client_id and caused the
         # "unexpected landing URL" symptom users reported on #388/#393.
         authorize_params = {
-            "client_id": _PORTAL_OIDC_CLIENT_ID,
+            "client_id": _brand_client_id(self._brand_name),
             "redirect_uri": _PORTAL_OIDC_REDIRECT_URI,
             "response_type": "code",
             "scope": _PORTAL_OIDC_SCOPE,
@@ -1115,7 +1135,7 @@ class DataActPortalAuth:
             "grant_type": "authorization_code",
             "code": auth_code,
             "redirect_uri": _PORTAL_OIDC_REDIRECT_URI,
-            "client_id": _PORTAL_OIDC_CLIENT_ID,
+            "client_id": _brand_client_id(self._brand_name),
             "code_verifier": pkce_verifier,
         }
         try:

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -86,6 +86,15 @@ _EUDA_CUPRA_SEAT = {
     "client_id": "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com",
     "scope": "openid profile cars",
 }
+# #1340 (@cyrano330) — Audi, Škoda and Bentley each have their OWN EU Data Act
+# portal OIDC client. Reusing the VW client made login "succeed" (it lands on the
+# portal host) while leaving the session ANONYMOUS, so every proxy_api data read
+# 401'd. Each id is grounded from the portal's per-brand login redirect — the
+# authorize call for that brand 302s to identity.vwgroup.io/signin-service/<id> —
+# and is the same id every other EU-Data-Act reader uses.
+_EUDA_AUDI_CLIENT_ID = "cc29b87a-5e9a-4362-aecf-5adea6b01bbb@apps_vw-dilab_com"
+_EUDA_SKODA_CLIENT_ID = "3ea88bf9-1d4e-4a68-b3ad-4098c1f1d246@apps_vw-dilab_com"
+_EUDA_BENTLEY_CLIENT_ID = "d38aac0f-3d89-4a63-8538-b75b31322c7b@apps_vw-dilab_com"
 _EUDA_BRANDS: dict[str, dict[str, str]] = {
     "volkswagen": _EUDA_VW,
     # #1316 — VW Commercial Vehicles (Nutzfahrzeuge): SAME portal client as
@@ -95,8 +104,9 @@ _EUDA_BRANDS: dict[str, dict[str, str]] = {
     "volkswagen_commercial": {**_EUDA_VW, "state_brand": "VOLKSWAGEN_COMMERCIAL_VEHICLES"},
     "cupra": {**_EUDA_CUPRA_SEAT, "state_brand": "CUPRA"},
     "seat": {**_EUDA_CUPRA_SEAT, "state_brand": "SEAT"},
-    "skoda": {**_EUDA_VW, "state_brand": "SKODA"},
-    "audi": {**_EUDA_VW, "state_brand": "AUDI"},
+    "skoda": {**_EUDA_VW, "client_id": _EUDA_SKODA_CLIENT_ID, "state_brand": "SKODA"},
+    "audi": {**_EUDA_VW, "client_id": _EUDA_AUDI_CLIENT_ID, "state_brand": "AUDI"},
+    "bentley": {**_EUDA_VW, "client_id": _EUDA_BENTLEY_CLIENT_ID, "state_brand": "BENTLEY"},
 }
 
 _VEHICLES_PATH = "/proxy_api/consent/me/vehicles"
@@ -1375,6 +1385,12 @@ _ENVELOPE_NOISE_LEAVES: frozenset[str] = frozenset({
 })
 _ENVELOPE_UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+# Unanchored — masks a UUID embedded ANYWHERE in a string (e.g. the IDP session
+# cookies literally NAMED ``s_<uuid>`` / ``d_<uuid>``, where the UUID is in the
+# name itself). Used by the redacted 401 auth-state dump (#1340).
+_EMBEDDED_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
 )
 
 
@@ -3946,29 +3962,48 @@ class EUDataActConnector:
         debug capture answers the open question behind the persistent portal 401:
         did the GET go out authenticated-but-refused, or anonymous/stale?
 
-        Names + flags ONLY — never a token or cookie value. Fires only when debug
-        logging is on, and can never break the request flow.
+        Names + flags ONLY — never a token or cookie value; and the cookie NAME
+        itself is UUID-masked, because the IDP session cookies are named
+        ``s_<uuid>`` / ``d_<uuid>`` (the UUID lives in the name). Fires only when
+        debug logging is on, once per connector instance, and can never break the
+        request flow.
         """
         if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        if getattr(self, "_logged_401_auth_state", False):
+            # One VW-EU setup hits the portal from ~3 call sites; log the snapshot
+            # once so a pasted debug log stays readable (#1340 @cyrano330).
             return
         try:
             mode = "bearer" if self._bearer else "cookie"
             sent_authorization = "Authorization" in sent_headers
             cookies: list[str] = []
+            # Derived fork-answer (#1340 @cyrano330): the cookies whose domain is
+            # the PORTAL host. ['affinity'] only = anonymous session (our bug);
+            # an auth cookie ('ath'/'access_token'/…) = authenticated-but-refused
+            # (a real portal-side problem). One field decides which.
+            portal_cookies: list[str] = []
+            portal_host = urlparse(_PORTAL_BASE).netloc
             try:
                 for cookie in self._session.cookie_jar:
-                    cookies.append(f"{cookie.key}@{cookie.get('domain') or '?'}")
+                    name = _EMBEDDED_UUID_RE.sub("<uuid>", cookie.key)
+                    dom = cookie.get("domain") or "?"
+                    cookies.append(f"{name}@{dom}")
+                    if portal_host in dom:
+                        portal_cookies.append(name)
             except Exception:  # noqa: BLE001
                 cookies = ["<cookie jar unreadable>"]
             resp_hdrs = getattr(resp, "headers", {})
             www_auth = str(resp_hdrs.get("WWW-Authenticate", ""))
             _LOGGER.debug(
                 "EU Data Act 401 auth-state on %s: mode=%s sent_authorization=%s "
-                "session_cookies=%s resp_www_authenticate=%r resp_set_cookie=%s "
+                "session_cookies=%s portal_domain_cookies=%s "
+                "resp_www_authenticate=%r resp_set_cookie=%s "
                 "(#1340 diagnostic — names/flags only, no secret values)",
                 url.split("?")[0], mode, sent_authorization, cookies or "<none>",
-                www_auth[:80], "Set-Cookie" in resp_hdrs,
+                portal_cookies or "<none>", www_auth[:80], "Set-Cookie" in resp_hdrs,
             )
+            self._logged_401_auth_state = True
         except Exception:  # noqa: BLE001 — diagnostics must never break the flow
             _LOGGER.debug("EU Data Act 401 auth-state dump failed", exc_info=True)
 

--- a/custom_components/vag_connect/condition.py
+++ b/custom_components/vag_connect/condition.py
@@ -13,13 +13,26 @@ calls. Per-vehicle targeting is a future enhancement.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.condition import Condition
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
+
+# The named-condition platform only exists on HA 2026.7+ (upstream-flagged "do not
+# use yet by integrations"). Import it defensively so the module stays importable
+# — and static-analysable against an older HA baseline — on cores that don't have
+# it yet; there, async_get_conditions simply registers nothing.
+if TYPE_CHECKING:
+    from homeassistant.helpers.condition import (  # type: ignore[attr-defined]
+        Condition,
+    )
+else:
+    try:
+        from homeassistant.helpers.condition import Condition
+    except ImportError:  # HA < 2026.7 — platform not available
+        Condition = object
 
 # condition id (is_* per HA naming rules) → the vehicle-dict boolean field it maps.
 _BOOL_CONDITIONS: dict[str, str] = {

--- a/custom_components/vag_connect/condition.py
+++ b/custom_components/vag_connect/condition.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b14 (EXPERIMENTAL) — integration-registered named conditions for VW Group
+Connect vehicles (HA 2026.7+ named-condition platform).
+
+Same experimental caveat as ``trigger.py``: the developer API is upstream-flagged
+"do not use yet by integrations" and may change without a deprecation notice, so
+this is opt-in and modeled on ``homeassistant/components/sun/condition.py``.
+
+v1 tests whether ANY of the account's vehicles is in the given state (e.g.
+"a vehicle is charging") — read purely from the state we already poll, no new API
+calls. Per-vehicle targeting is a future enhancement.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.condition import Condition
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+# condition id (is_* per HA naming rules) → the vehicle-dict boolean field it maps.
+_BOOL_CONDITIONS: dict[str, str] = {
+    "is_charging": "is_charging",
+    "is_plugged_in": "plug_connected",
+    "is_locked": "doors_locked",
+    "is_preconditioning": "climatisation_active",
+}
+_CONDITION_KEYS: tuple[str, ...] = (*_BOOL_CONDITIONS, "is_charge_target_reached")
+
+
+def _coordinators(hass: HomeAssistant) -> list[Any]:
+    out: list[Any] = []
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        coord = getattr(entry, "runtime_data", None)
+        if coord is not None and getattr(coord, "vehicles", None) is not None:
+            out.append(coord)
+    return out
+
+
+def _vehicle_matches(condition_key: str, veh: dict[str, Any]) -> bool:
+    field = _BOOL_CONDITIONS.get(condition_key)
+    if field is not None:
+        return veh.get(field) is True
+    if condition_key == "is_charge_target_reached":
+        soc, tgt = veh.get("battery_soc"), veh.get("target_soc")
+        return (
+            isinstance(soc, int) and isinstance(tgt, int)
+            and not isinstance(soc, bool) and not isinstance(tgt, bool)
+            and soc >= tgt
+        )
+    return False
+
+
+def _any_vehicle_matches(hass: HomeAssistant, condition_key: str) -> bool:
+    for coord in _coordinators(hass):
+        for vin, veh in (coord.vehicles or {}).items():
+            if str(vin).startswith("_") or not isinstance(veh, dict):
+                continue
+            if _vehicle_matches(condition_key, veh):
+                return True
+    return False
+
+
+class _VagVehicleCondition(Condition):
+    """Base for a single 'any vehicle is <state>' condition."""
+
+    _condition_key: str = ""
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        return config
+
+    def __init__(self, hass: HomeAssistant, config: Any) -> None:
+        super().__init__(hass, config)
+        self._hass = hass
+
+    def _async_check(self, **kwargs: Any) -> bool:
+        return _any_vehicle_matches(self._hass, self._condition_key)
+
+
+def _make_condition(condition_key: str) -> type[Condition]:
+    class _C(_VagVehicleCondition):
+        _condition_key = condition_key
+
+    _C.__name__ = f"VagVehicle_{condition_key}_Condition"
+    _C.__qualname__ = _C.__name__
+    return _C
+
+
+CONDITIONS: dict[str, type[Condition]] = {
+    key: _make_condition(key) for key in _CONDITION_KEYS
+}
+
+
+async def async_get_conditions(hass: HomeAssistant) -> dict[str, type[Condition]]:
+    """HA named-condition platform hook — expose our vehicle conditions.
+
+    Only concrete classes are registered, so an experimental-API change degrades
+    to registering nothing rather than a class HA cannot instantiate.
+    """
+    return {
+        key: cls
+        for key, cls in CONDITIONS.items()
+        if not getattr(cls, "__abstractmethods__", frozenset())
+    }

--- a/custom_components/vag_connect/conditions.yaml
+++ b/custom_components/vag_connect/conditions.yaml
@@ -1,0 +1,9 @@
+# Named conditions exposed by VW Group Connect (experimental, HA 2026.7+).
+# Human-readable names + descriptions live in strings.json / translations; these
+# conditions take no fields in v1 (each tests whether any of the account's
+# vehicles is currently in the given state).
+is_charging:
+is_plugged_in:
+is_locked:
+is_preconditioning:
+is_charge_target_reached:

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -12,6 +12,7 @@ Thread safety:
 """
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
@@ -1072,6 +1073,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # and the diagnostics export size stay predictable.
         self.error_buffer: ErrorRingBuffer = ErrorRingBuffer()
 
+        # b14 (experimental) — state-transition detector feeding the named-trigger
+        # platform (trigger.py). No-op until a trigger subscribes; fed ONLY on the
+        # real data push (async_set_updated_data(data), not the optimistic echoes).
+        from .trigger_detect import VehicleTransitionDetector  # noqa: PLC0415
+
+        self._transition_detector = VehicleTransitionDetector()
+
         # update_interval=None: no HA-level polling
         # Updates arrive reactively via _on_cc_update → async_set_updated_data
         super().__init__(
@@ -1082,6 +1090,16 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             update_interval=None,
         )
 
+    def register_transition_listener(
+        self,
+        event_key: str,
+        vin: str | None,
+        callback: Callable[[dict[str, Any]], None],
+    ) -> Callable[[], None]:
+        """b14 (experimental) — subscribe to a vehicle state-transition event
+        (e.g. ``started_charging``), optionally scoped to one VIN. Used by the
+        named-trigger platform; returns an unsubscribe callable."""
+        return self._transition_detector.register(event_key, vin, callback)
 
     async def async_setup(self) -> bool:
         """Authenticate and fetch initial vehicle data via own CARIAD client."""
@@ -5662,6 +5680,16 @@ class VagConnectCoordinator(DataUpdateCoordinator):
 
             # Remove devices for VINs no longer present in the account
             await self._async_remove_stale_devices(set(data.keys()))
+
+            # b14 (experimental) — feed the state-transition detector ONLY here,
+            # on a real data push. The 5 optimistic-echo async_set_updated_data(
+            # dict(self.vehicles)) calls must NOT feed it (they'd fire phantom
+            # transitions on a command echo). No-op unless a trigger subscribed.
+            # getattr-guarded: the hook is purely additive, so a coordinator built
+            # without __init__ (test __new__ path) simply skips it.
+            _detector = getattr(self, "_transition_detector", None)
+            if _detector is not None:
+                _detector.feed(data)
 
             self.async_set_updated_data(data)
             _LOGGER.debug("VW Group Connect: pushed %d vehicle(s) to HA", len(data))

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b13"
+  "version": "4.7.0b14"
 }

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -2010,7 +2010,7 @@
     },
     "data_act_no_data": {
       "title": "EU Data Act portal: no vehicle data yet ({brand})",
-      "description": "The EU Data Act portal signed in for {brand} but isn't returning any vehicle data yet.\n\nThe integration tries to create the continuous data request for you automatically, but on some accounts the portal keeps the browser session anonymous — and then the automatic request (and the in-app \"Create EU Data Act data request\" button) can't complete, so you have to create the request yourself in the portal. The usual causes of an empty feed:\n\n1. **Ownership/usership not confirmed for this car.** The portal must show your vehicle's ownership (or usership) as confirmed. If it isn't, confirm it there first — necessary, though not always sufficient on its own.\n2. **Data-sharing consent not granted for this car.** You grant the EU Data Act data-sharing consent per vehicle, once. Until you do, the request stays empty.\n3. **No continuous request exists yet.** If the automatic creation didn't take, create it yourself: in the portal, add a Custom Data Request with all clusters ticked at a 15-minute frequency. The integration picks it up on the next poll — no restart needed.\n4. **The car hasn't sent anything new yet.** A fresh dataset is only published after the car has been driven, charged, or locked/unlocked, so a new request can take 15-60 minutes (or a short drive) to start filling.\n5. **A VW-side outage.** VW reported an all-brands EU Data Act portal outage from late May 2026; while it lasts the portal returns empty data for every tool, recovering brand by brand.\n6. **Or add the volkswagen.de website read channel.** In the integration's options you can add the read-only volkswagen.de website channel as an alternative source: it signs in on the volkswagen.de website (not the app backend that blocks the headless login), and for some cars returns fields the portal feed doesn't. It needs your Volkswagen ID to be the vehicle's confirmed primary user.\n\n**Quickest check:** open `eu-data-act.drivesomethinggreater.com`, sign in, and confirm (a) ownership/usership is confirmed, (b) the data-sharing consent is granted for this car, and (c) there is an active continuous (15-minute) data request with all clusters ticked — creating it yourself if none exists. If you see no data there either, it's the VW side — nothing this integration can do until VW restores it.\n\nThis is the read-only portal beta — the warning clears by itself once data arrives."
+      "description": "The EU Data Act portal signed in for {brand} but isn't returning any vehicle data yet.\n\nThe integration tries to create the continuous data request for you automatically, but on some accounts the portal keeps the browser session anonymous — and then the automatic request (and the in-app \"Create EU Data Act data request\" button) can't complete, so you have to create the request yourself in the portal. The usual causes of an empty feed:\n\n1. **Ownership/usership not confirmed for this car.** The portal must show your vehicle's ownership (or usership) as confirmed. If it isn't, confirm it there first — necessary, though not always sufficient on its own.\n2. **Data-sharing consent not granted for this car.** You grant the EU Data Act data-sharing consent per vehicle, once. Until you do, the request stays empty.\n3. **No continuous request exists yet.** If the automatic creation didn't take, create it yourself: in the portal, add a Custom Data Request with all clusters ticked at a 15-minute frequency. **First delete any older request for this same car** — the portal allows only one active request per vehicle, so an older one (for example a monthly request) for this car blocks the new one. Don't delete another car's request: on a mixed passenger + commercial account each car keeps its own request under its own realm (passenger cars under Volkswagen Personenkraftwagen, vans under Volkswagen Nutzfahrzeuge). The integration picks it up on the next poll — no restart needed.\n4. **The car hasn't sent anything new yet.** A fresh dataset is only published after the car has been driven, charged, or locked/unlocked, so a new request can take 15-60 minutes (or a short drive) to start filling.\n5. **A VW-side outage.** VW reported an all-brands EU Data Act portal outage from late May 2026; while it lasts the portal returns empty data for every tool, recovering brand by brand.\n6. **Or add the volkswagen.de website read channel.** In the integration's options you can add the read-only volkswagen.de website channel as an alternative source: it signs in on the volkswagen.de website (not the app backend that blocks the headless login), and for some cars returns fields the portal feed doesn't. It needs your Volkswagen ID to be the vehicle's confirmed primary user.\n\n**Quickest check:** open `eu-data-act.drivesomethinggreater.com`, sign in, and confirm (a) ownership/usership is confirmed, (b) the data-sharing consent is granted for this car, and (c) there is an active continuous (15-minute) data request with all clusters ticked — creating it yourself if none exists. If you see no data there either, it's the VW side — nothing this integration can do until VW restores it.\n\nThis is the read-only portal beta — the warning clears by itself once data arrives."
     },
     "vweu_twoway_disabled": {
       "title": "VW EU Two-Way: disabled by Volkswagen",
@@ -2306,6 +2306,66 @@
     },
     "historical_wedge_blocked": {
       "message": "A one-time historical export is already in progress for this car. The portal handles one request of this kind at a time, so wait for the current one to finish (or time out) before requesting another."
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Vehicle started charging",
+      "description": "Triggers when a vehicle starts charging."
+    },
+    "stopped_charging": {
+      "name": "Vehicle stopped charging",
+      "description": "Triggers when a vehicle stops charging."
+    },
+    "plugged_in": {
+      "name": "Vehicle plugged in",
+      "description": "Triggers when a vehicle's charging cable is connected."
+    },
+    "unplugged": {
+      "name": "Vehicle unplugged",
+      "description": "Triggers when a vehicle's charging cable is disconnected."
+    },
+    "locked": {
+      "name": "Vehicle locked",
+      "description": "Triggers when a vehicle becomes locked."
+    },
+    "unlocked": {
+      "name": "Vehicle unlocked",
+      "description": "Triggers when a vehicle becomes unlocked."
+    },
+    "started_preconditioning": {
+      "name": "Vehicle started preconditioning",
+      "description": "Triggers when a vehicle starts climate preconditioning."
+    },
+    "stopped_preconditioning": {
+      "name": "Vehicle stopped preconditioning",
+      "description": "Triggers when a vehicle stops climate preconditioning."
+    },
+    "charge_target_reached": {
+      "name": "Vehicle reached its charge target",
+      "description": "Triggers when a vehicle's charge level reaches its target."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "A vehicle is charging",
+      "description": "Tests whether any vehicle is currently charging."
+    },
+    "is_plugged_in": {
+      "name": "A vehicle is plugged in",
+      "description": "Tests whether any vehicle's charging cable is connected."
+    },
+    "is_locked": {
+      "name": "A vehicle is locked",
+      "description": "Tests whether any vehicle is locked."
+    },
+    "is_preconditioning": {
+      "name": "A vehicle is preconditioning",
+      "description": "Tests whether any vehicle is running climate preconditioning."
+    },
+    "is_charge_target_reached": {
+      "name": "A vehicle reached its charge target",
+      "description": "Tests whether any vehicle's charge level is at or above its target."
     }
   }
 }

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "Portál EU Data Act: zatím žádná data vozidla ({brand})",
-      "description": "Portál EU Data Act se přihlásil pro {brand}, ale zatím nevrací žádná data vozidla.\n\nIntegrace se za vás pokouší souvislý požadavek na data vytvořit automaticky, ale u některých účtů portál ponechá relaci prohlížeče anonymní — a pak se automatický požadavek (a tlačítko „Vytvořit požadavek na data podle EU Data Act\" v aplikaci) nemůže dokončit, takže si musíte požadavek v portálu vytvořit sami. Obvyklé příčiny prázdného přísunu dat:\n\n1. **Vlastnictví/užívání není pro toto vozidlo potvrzeno.** Portál musí u vašeho vozidla zobrazovat vlastnictví (nebo užívání) jako potvrzené. Pokud tomu tak není, potvrďte je tam nejdřív — nutné, i když samo o sobě ne vždy dostačující.\n2. **Souhlas se sdílením dat není pro toto vozidlo udělen.** Souhlas se sdílením dat podle EU Data Act udělujete pro každé vozidlo jednou. Dokud to neuděláte, požadavek zůstane prázdný.\n3. **Zatím neexistuje žádný souvislý požadavek.** Pokud automatické vytvoření neproběhlo, vytvořte jej sami: v portálu přidejte Vlastní požadavek na data (Custom Data Request) se všemi skupinami zaškrtnutými a s frekvencí 15 minut. Integrace jej převezme při dalším dotazu — restart není potřeba.\n4. **Vozidlo zatím neodeslalo nic nového.** Nová datová sada se zveřejní až poté, co bylo vozidlo řízeno, nabito nebo zamčeno/odemčeno, takže než se nový požadavek začne plnit, může to trvat 15–60 minut (nebo krátkou jízdu).\n5. **Výpadek na straně VW.** VW ohlásil výpadek portálu EU Data Act pro všechny značky od konce května 2026; dokud trvá, portál vrací prázdná data pro každý nástroj a zotavuje se značka po značce.\n6. **Nebo přidejte čtecí kanál webu volkswagen.de.** V možnostech integrace můžete jako alternativní zdroj přidat čtecí (read-only) kanál webu volkswagen.de: přihlásí se na webu volkswagen.de (ne do backendu aplikace, který blokuje bezhlavé přihlášení) a u některých vozidel vrací pole, která přísun z portálu nevrací. Vyžaduje, aby vaše Volkswagen ID bylo potvrzeným hlavním uživatelem vozidla.\n\n**Nejrychlejší kontrola:** otevřete `eu-data-act.drivesomethinggreater.com`, přihlaste se a ověřte, že (a) je potvrzeno vlastnictví/užívání, (b) je pro toto vozidlo udělen souhlas se sdílením dat a (c) existuje aktivní souvislý (15minutový) požadavek na data se všemi skupinami zaškrtnutými — pokud žádný neexistuje, vytvořte jej sami. Pokud ani tam nevidíte žádná data, je to na straně VW — tato integrace s tím nic nezmůže, dokud to VW neobnoví.\n\nToto je beta verze portálu jen pro čtení — jakmile data dorazí, upozornění samo zmizí."
+      "description": "Portál EU Data Act se přihlásil pro {brand}, ale zatím nevrací žádná data vozidla.\n\nIntegrace se za vás pokouší souvislý požadavek na data vytvořit automaticky, ale u některých účtů portál ponechá relaci prohlížeče anonymní — a pak se automatický požadavek (a tlačítko „Vytvořit požadavek na data podle EU Data Act\" v aplikaci) nemůže dokončit, takže si musíte požadavek v portálu vytvořit sami. Obvyklé příčiny prázdného přísunu dat:\n\n1. **Vlastnictví/užívání není pro toto vozidlo potvrzeno.** Portál musí u vašeho vozidla zobrazovat vlastnictví (nebo užívání) jako potvrzené. Pokud tomu tak není, potvrďte je tam nejdřív — nutné, i když samo o sobě ne vždy dostačující.\n2. **Souhlas se sdílením dat není pro toto vozidlo udělen.** Souhlas se sdílením dat podle EU Data Act udělujete pro každé vozidlo jednou. Dokud to neuděláte, požadavek zůstane prázdný.\n3. **Zatím neexistuje žádný souvislý požadavek.** Pokud automatické vytvoření neproběhlo, vytvořte jej sami: v portálu přidejte Vlastní požadavek na data (Custom Data Request) se všemi skupinami zaškrtnutými a s frekvencí 15 minut. **Nejprve smažte jakýkoli starší požadavek pro právě toto vozidlo** — portál povoluje jen jeden aktivní požadavek na vozidlo, takže starší (například měsíční) požadavek pro toto vozidlo blokuje nový. Nemažte požadavek jiného vozidla: u smíšeného účtu s osobními i užitkovými vozy si každé vozidlo zachovává svůj vlastní požadavek ve své vlastní sekci (osobní vozy pod Volkswagen Personenkraftwagen, dodávky pod Volkswagen Nutzfahrzeuge). Integrace jej převezme při dalším dotazu — restart není potřeba.\n4. **Vozidlo zatím neodeslalo nic nového.** Nová datová sada se zveřejní až poté, co bylo vozidlo řízeno, nabito nebo zamčeno/odemčeno, takže než se nový požadavek začne plnit, může to trvat 15–60 minut (nebo krátkou jízdu).\n5. **Výpadek na straně VW.** VW ohlásil výpadek portálu EU Data Act pro všechny značky od konce května 2026; dokud trvá, portál vrací prázdná data pro každý nástroj a zotavuje se značka po značce.\n6. **Nebo přidejte čtecí kanál webu volkswagen.de.** V možnostech integrace můžete jako alternativní zdroj přidat čtecí (read-only) kanál webu volkswagen.de: přihlásí se na webu volkswagen.de (ne do backendu aplikace, který blokuje bezhlavé přihlášení) a u některých vozidel vrací pole, která přísun z portálu nevrací. Vyžaduje, aby vaše Volkswagen ID bylo potvrzeným hlavním uživatelem vozidla.\n\n**Nejrychlejší kontrola:** otevřete `eu-data-act.drivesomethinggreater.com`, přihlaste se a ověřte, že (a) je potvrzeno vlastnictví/užívání, (b) je pro toto vozidlo udělen souhlas se sdílením dat a (c) existuje aktivní souvislý (15minutový) požadavek na data se všemi skupinami zaškrtnutými — pokud žádný neexistuje, vytvořte jej sami. Pokud ani tam nevidíte žádná data, je to na straně VW — tato integrace s tím nic nezmůže, dokud to VW neobnoví.\n\nToto je beta verze portálu jen pro čtení — jakmile data dorazí, upozornění samo zmizí."
     },
     "data_act_browser_missing": {
       "description": "Zapnul jsi zálohu přes headless prohlížeč pro portál EU Data Act, ale balíček Pythonu `playwright` není v tvém kontejneru Home Assistant nainstalovaný.\n\n**Instalace:** otevři shell kontejneru HA (Doplňky → Terminal & SSH, nebo `docker exec` pro ruční instalaci) a spusť:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nStahování chromia je velké (kolem 100 MB), proto je tato závislost volitelná a není součástí integrace. Po instalaci restartuj Home Assistant.\n\nPřípadně vypni přepínač v Nastavení → Zařízení a služby → VW Group Connect → Konfigurovat → 'Portál EU Data Act: záloha přes headless prohlížeč'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Pouze oficiální API",
         "mysmob_only": "Pouze standardní kanál"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Vozidlo zahájilo nabíjení",
+      "description": "Spustí se, když vozidlo zahájí nabíjení."
+    },
+    "stopped_charging": {
+      "name": "Vozidlo ukončilo nabíjení",
+      "description": "Spustí se, když vozidlo ukončí nabíjení."
+    },
+    "plugged_in": {
+      "name": "Vozidlo připojeno",
+      "description": "Spustí se, když je připojen nabíjecí kabel vozidla."
+    },
+    "unplugged": {
+      "name": "Vozidlo odpojeno",
+      "description": "Spustí se, když je odpojen nabíjecí kabel vozidla."
+    },
+    "locked": {
+      "name": "Vozidlo uzamčeno",
+      "description": "Spustí se, když se vozidlo uzamkne."
+    },
+    "unlocked": {
+      "name": "Vozidlo odemčeno",
+      "description": "Spustí se, když se vozidlo odemkne."
+    },
+    "started_preconditioning": {
+      "name": "Vozidlo zahájilo předklimatizaci",
+      "description": "Spustí se, když vozidlo zahájí předklimatizaci."
+    },
+    "stopped_preconditioning": {
+      "name": "Vozidlo ukončilo předklimatizaci",
+      "description": "Spustí se, když vozidlo ukončí předklimatizaci."
+    },
+    "charge_target_reached": {
+      "name": "Vozidlo dosáhlo cíle nabití",
+      "description": "Spustí se, když úroveň nabití vozidla dosáhne cílové hodnoty."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Vozidlo nabíjí",
+      "description": "Zjišťuje, zda některé vozidlo právě nabíjí."
+    },
+    "is_plugged_in": {
+      "name": "Vozidlo je připojeno",
+      "description": "Zjišťuje, zda je připojen nabíjecí kabel některého vozidla."
+    },
+    "is_locked": {
+      "name": "Vozidlo je uzamčeno",
+      "description": "Zjišťuje, zda je některé vozidlo uzamčeno."
+    },
+    "is_preconditioning": {
+      "name": "Vozidlo předklimatizuje",
+      "description": "Zjišťuje, zda některé vozidlo právě předklimatizuje."
+    },
+    "is_charge_target_reached": {
+      "name": "Vozidlo dosáhlo cíle nabití",
+      "description": "Zjišťuje, zda úroveň nabití některého vozidla dosáhla cílové hodnoty nebo ji překročila."
     }
   }
 }

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "EU Data Act-portal: ingen køretøjsdata endnu ({brand})",
-      "description": "EU Data Act-portalen loggede ind for {brand}, men returnerer endnu ingen køretøjsdata.\n\nIntegrationen forsøger at oprette den kontinuerlige dataanmodning for dig automatisk, men på nogle konti holder portalen browsersessionen anonym — og så kan den automatiske anmodning (og knappen \"Opret EU Data Act-dataanmodning\" i appen) ikke fuldføres, så du er nødt til at oprette anmodningen selv i portalen. De sædvanlige årsager til et tomt feed:\n\n1. **Ejerskab/brugsret ikke bekræftet for denne bil.** Portalen skal vise dit køretøjs ejerskab (eller brugsret) som bekræftet. Hvis den ikke gør det, så bekræft det der først — nødvendigt, men ikke altid tilstrækkeligt i sig selv.\n2. **Samtykke til datadeling ikke givet for denne bil.** Du giver samtykket til datadeling under EU Data Act pr. køretøj, én gang. Indtil du gør det, forbliver anmodningen tom.\n3. **Der findes endnu ingen kontinuerlig anmodning.** Hvis den automatiske oprettelse ikke lykkedes, så opret den selv: tilføj i portalen en Custom Data Request med alle clusters markeret og en frekvens på 15 minutter. Integrationen opfanger den ved næste poll — ingen genstart nødvendig.\n4. **Bilen har endnu ikke sendt noget nyt.** Et nyt datasæt offentliggøres først, når bilen er blevet kørt, opladet eller låst/låst op, så en ny anmodning kan tage 15-60 minutter (eller en kort køretur) om at begynde at blive fyldt.\n5. **Et nedbrud på VW's side.** VW har rapporteret et nedbrud i EU Data Act-portalen for alle mærker fra slutningen af maj 2026; så længe det varer, returnerer portalen tomme data for alle værktøjer og kommer sig mærke for mærke.\n6. **Eller tilføj læsekanalen for volkswagen.de-webstedet.** I integrationens indstillinger kan du tilføje den skrivebeskyttede volkswagen.de-webstedskanal som en alternativ kilde: den logger ind på volkswagen.de-webstedet (ikke app-backenden, der blokerer det headless-login) og returnerer for nogle biler felter, som portal-feedet ikke gør. Den kræver, at dit Volkswagen ID er køretøjets bekræftede primære bruger.\n\n**Hurtigste tjek:** åbn `eu-data-act.drivesomethinggreater.com`, log ind, og bekræft (a) at ejerskab/brugsret er bekræftet, (b) at samtykket til datadeling er givet for denne bil, og (c) at der findes en aktiv kontinuerlig (15-minutters) dataanmodning med alle clusters markeret — opret den selv, hvis der ikke findes nogen. Hvis du heller ikke ser nogen data der, er det VW's side — der er ikke noget, denne integration kan gøre, før VW genopretter det.\n\nDette er den skrivebeskyttede portal-beta — advarslen forsvinder af sig selv, når der ankommer data."
+      "description": "EU Data Act-portalen loggede ind for {brand}, men returnerer endnu ingen køretøjsdata.\n\nIntegrationen forsøger at oprette den kontinuerlige dataanmodning for dig automatisk, men på nogle konti holder portalen browsersessionen anonym — og så kan den automatiske anmodning (og knappen \"Opret EU Data Act-dataanmodning\" i appen) ikke fuldføres, så du er nødt til at oprette anmodningen selv i portalen. De sædvanlige årsager til et tomt feed:\n\n1. **Ejerskab/brugsret ikke bekræftet for denne bil.** Portalen skal vise dit køretøjs ejerskab (eller brugsret) som bekræftet. Hvis den ikke gør det, så bekræft det der først — nødvendigt, men ikke altid tilstrækkeligt i sig selv.\n2. **Samtykke til datadeling ikke givet for denne bil.** Du giver samtykket til datadeling under EU Data Act pr. køretøj, én gang. Indtil du gør det, forbliver anmodningen tom.\n3. **Der findes endnu ingen kontinuerlig anmodning.** Hvis den automatiske oprettelse ikke lykkedes, så opret den selv: tilføj i portalen en Custom Data Request med alle clusters markeret og en frekvens på 15 minutter. **Slet først enhver ældre anmodning for netop denne bil** — portalen tillader kun én aktiv anmodning pr. køretøj, så en ældre (for eksempel en månedlig) anmodning for denne bil blokerer den nye. Slet ikke en anden bils anmodning: på en blandet konto med person- og erhvervskøretøjer beholder hver bil sin egen anmodning under sit eget område (personbiler under Volkswagen Personenkraftwagen, varevogne under Volkswagen Nutzfahrzeuge). Integrationen opfanger den ved næste poll — ingen genstart nødvendig.\n4. **Bilen har endnu ikke sendt noget nyt.** Et nyt datasæt offentliggøres først, når bilen er blevet kørt, opladet eller låst/låst op, så en ny anmodning kan tage 15-60 minutter (eller en kort køretur) om at begynde at blive fyldt.\n5. **Et nedbrud på VW's side.** VW har rapporteret et nedbrud i EU Data Act-portalen for alle mærker fra slutningen af maj 2026; så længe det varer, returnerer portalen tomme data for alle værktøjer og kommer sig mærke for mærke.\n6. **Eller tilføj læsekanalen for volkswagen.de-webstedet.** I integrationens indstillinger kan du tilføje den skrivebeskyttede volkswagen.de-webstedskanal som en alternativ kilde: den logger ind på volkswagen.de-webstedet (ikke app-backenden, der blokerer det headless-login) og returnerer for nogle biler felter, som portal-feedet ikke gør. Den kræver, at dit Volkswagen ID er køretøjets bekræftede primære bruger.\n\n**Hurtigste tjek:** åbn `eu-data-act.drivesomethinggreater.com`, log ind, og bekræft (a) at ejerskab/brugsret er bekræftet, (b) at samtykket til datadeling er givet for denne bil, og (c) at der findes en aktiv kontinuerlig (15-minutters) dataanmodning med alle clusters markeret — opret den selv, hvis der ikke findes nogen. Hvis du heller ikke ser nogen data der, er det VW's side — der er ikke noget, denne integration kan gøre, før VW genopretter det.\n\nDette er den skrivebeskyttede portal-beta — advarslen forsvinder af sig selv, når der ankommer data."
     },
     "data_act_browser_missing": {
       "description": "Du aktiverede headless-browser-fallbacken til EU Data Act-portalen, men Python-pakken `playwright` er ikke installeret i din Home Assistant-container.\n\n**Sådan installeres den:** åbn HA-containerens shell (Add-ons → Terminal & SSH, eller `docker exec` til en manuel installation), og kør:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nChromium-downloadet er stort (omkring 100 MB), hvilket er grunden til, at denne afhængighed er et tilvalg i stedet for at være bundtet med integrationen. Efter installationen skal du genstarte Home Assistant.\n\nAlternativt kan du deaktivere kontakten under Indstillinger → Enheder & tjenester → VW Group Connect → Konfigurer → 'EU Data Act-portal: headless-browser-fallback'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Kun officielt API",
         "mysmob_only": "Kun standardkanal"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Køretøj startede opladning",
+      "description": "Udløses, når et køretøj begynder at oplade."
+    },
+    "stopped_charging": {
+      "name": "Køretøj stoppede opladning",
+      "description": "Udløses, når et køretøj stopper med at oplade."
+    },
+    "plugged_in": {
+      "name": "Køretøj tilsluttet",
+      "description": "Udløses, når et køretøjs ladekabel tilsluttes."
+    },
+    "unplugged": {
+      "name": "Køretøj frakoblet",
+      "description": "Udløses, når et køretøjs ladekabel frakobles."
+    },
+    "locked": {
+      "name": "Køretøj låst",
+      "description": "Udløses, når et køretøj bliver låst."
+    },
+    "unlocked": {
+      "name": "Køretøj oplåst",
+      "description": "Udløses, når et køretøj bliver låst op."
+    },
+    "started_preconditioning": {
+      "name": "Køretøj startede forkonditionering",
+      "description": "Udløses, når et køretøj starter klimaforkonditionering."
+    },
+    "stopped_preconditioning": {
+      "name": "Køretøj stoppede forkonditionering",
+      "description": "Udløses, når et køretøj stopper klimaforkonditionering."
+    },
+    "charge_target_reached": {
+      "name": "Køretøj nåede sit opladningsmål",
+      "description": "Udløses, når et køretøjs ladeniveau når sit mål."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Et køretøj oplader",
+      "description": "Tester, om et køretøj oplader lige nu."
+    },
+    "is_plugged_in": {
+      "name": "Et køretøj er tilsluttet",
+      "description": "Tester, om et køretøjs ladekabel er tilsluttet."
+    },
+    "is_locked": {
+      "name": "Et køretøj er låst",
+      "description": "Tester, om et køretøj er låst."
+    },
+    "is_preconditioning": {
+      "name": "Et køretøj forkonditionerer",
+      "description": "Tester, om et køretøj kører klimaforkonditionering."
+    },
+    "is_charge_target_reached": {
+      "name": "Et køretøj nåede sit opladningsmål",
+      "description": "Tester, om et køretøjs ladeniveau er på eller over sit mål."
     }
   }
 }

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1998,7 +1998,7 @@
     },
     "data_act_no_data": {
       "title": "EU-Data-Act-Portal: noch keine Fahrzeugdaten ({brand})",
-      "description": "Das EU-Data-Act-Portal hat sich für {brand} angemeldet, liefert aber noch keine Fahrzeugdaten.\n\nDie Integration versucht, die fortlaufende Datenanfrage automatisch für dich zu erstellen, aber bei manchen Konten hält das Portal die Browser-Sitzung anonym — und dann kann die automatische Anfrage (und der In-App-Button „EU-Data-Act-Datenanfrage erstellen\") nicht abgeschlossen werden, sodass du die Anfrage selbst im Portal erstellen musst. Die üblichen Ursachen für einen leeren Feed:\n\n1. **Eigentümerschaft/Nutzerschaft für dieses Auto nicht bestätigt.** Das Portal muss die Eigentümerschaft (oder Nutzerschaft) deines Fahrzeugs als bestätigt anzeigen. Falls nicht, bestätige sie dort zuerst — notwendig, aber allein nicht immer ausreichend.\n2. **Einwilligung zur Datenfreigabe für dieses Auto nicht erteilt.** Du erteilst die EU-Data-Act-Einwilligung zur Datenfreigabe einmalig pro Fahrzeug. Bis du das tust, bleibt die Anfrage leer.\n3. **Es existiert noch keine fortlaufende Anfrage.** Falls die automatische Erstellung nicht funktioniert hat, erstelle sie selbst: Füge im Portal eine benutzerdefinierte Datenanfrage (Custom Data Request) mit allen angehakten Clustern und einer Frequenz von 15 Minuten hinzu. Die Integration übernimmt sie beim nächsten Abruf — kein Neustart nötig.\n4. **Das Auto hat noch nichts Neues gesendet.** Ein neuer Datensatz wird erst veröffentlicht, nachdem das Auto gefahren, geladen oder ver-/entriegelt wurde, daher kann es 15-60 Minuten (oder eine kurze Fahrt) dauern, bis sich eine neue Anfrage zu füllen beginnt.\n5. **Eine Störung auf VW-Seite.** VW hat eine markenübergreifende Störung des EU-Data-Act-Portals seit Ende Mai 2026 gemeldet; solange sie anhält, liefert das Portal für jedes Tool leere Daten und erholt sich Marke für Marke.\n6. **Oder füge den Lesekanal der volkswagen.de-Website hinzu.** In den Optionen der Integration kannst du den schreibgeschützten volkswagen.de-Website-Kanal als alternative Quelle hinzufügen: Er meldet sich auf der volkswagen.de-Website an (nicht am App-Backend, das den Headless-Login blockiert) und liefert für manche Autos Felder, die der Portal-Feed nicht hat. Dafür muss deine Volkswagen ID der bestätigte Hauptnutzer des Fahrzeugs sein.\n\n**Schnellste Prüfung:** Öffne `eu-data-act.drivesomethinggreater.com`, melde dich an und stelle sicher, dass (a) die Eigentümerschaft/Nutzerschaft bestätigt ist, (b) die Einwilligung zur Datenfreigabe für dieses Auto erteilt ist und (c) eine aktive fortlaufende (15-Minuten-)Datenanfrage mit allen angehakten Clustern existiert — erstelle sie selbst, falls keine vorhanden ist. Wenn du auch dort keine Daten siehst, liegt es an der VW-Seite — diese Integration kann nichts tun, bis VW es wiederherstellt.\n\nDies ist die schreibgeschützte Portal-Beta — die Warnung verschwindet von selbst, sobald Daten eintreffen."
+      "description": "Das EU-Data-Act-Portal hat sich für {brand} angemeldet, liefert aber noch keine Fahrzeugdaten.\n\nDie Integration versucht, die fortlaufende Datenanfrage automatisch für dich zu erstellen, aber bei manchen Konten hält das Portal die Browser-Sitzung anonym — und dann kann die automatische Anfrage (und der In-App-Button „EU-Data-Act-Datenanfrage erstellen\") nicht abgeschlossen werden, sodass du die Anfrage selbst im Portal erstellen musst. Die üblichen Ursachen für einen leeren Feed:\n\n1. **Eigentümerschaft/Nutzerschaft für dieses Auto nicht bestätigt.** Das Portal muss die Eigentümerschaft (oder Nutzerschaft) deines Fahrzeugs als bestätigt anzeigen. Falls nicht, bestätige sie dort zuerst — notwendig, aber allein nicht immer ausreichend.\n2. **Einwilligung zur Datenfreigabe für dieses Auto nicht erteilt.** Du erteilst die EU-Data-Act-Einwilligung zur Datenfreigabe einmalig pro Fahrzeug. Bis du das tust, bleibt die Anfrage leer.\n3. **Es existiert noch keine fortlaufende Anfrage.** Falls die automatische Erstellung nicht funktioniert hat, erstelle sie selbst: Füge im Portal eine benutzerdefinierte Datenanfrage (Custom Data Request) mit allen angehakten Clustern und einer Frequenz von 15 Minuten hinzu. **Lösche zuerst jede ältere Anfrage für genau dieses Auto** — das Portal erlaubt nur eine aktive Anfrage pro Fahrzeug, sodass eine ältere (z. B. eine monatliche) für dieses Auto die neue blockiert. Lösche nicht die Anfrage eines anderen Autos: Bei einem gemischten Konto aus Pkw und Nutzfahrzeugen behält jedes Auto seine eigene Anfrage in seinem eigenen Bereich (Pkw unter Volkswagen Personenkraftwagen, Transporter unter Volkswagen Nutzfahrzeuge). Die Integration übernimmt sie beim nächsten Abruf — kein Neustart nötig.\n4. **Das Auto hat noch nichts Neues gesendet.** Ein neuer Datensatz wird erst veröffentlicht, nachdem das Auto gefahren, geladen oder ver-/entriegelt wurde, daher kann es 15-60 Minuten (oder eine kurze Fahrt) dauern, bis sich eine neue Anfrage zu füllen beginnt.\n5. **Eine Störung auf VW-Seite.** VW hat eine markenübergreifende Störung des EU-Data-Act-Portals seit Ende Mai 2026 gemeldet; solange sie anhält, liefert das Portal für jedes Tool leere Daten und erholt sich Marke für Marke.\n6. **Oder füge den Lesekanal der volkswagen.de-Website hinzu.** In den Optionen der Integration kannst du den schreibgeschützten volkswagen.de-Website-Kanal als alternative Quelle hinzufügen: Er meldet sich auf der volkswagen.de-Website an (nicht am App-Backend, das den Headless-Login blockiert) und liefert für manche Autos Felder, die der Portal-Feed nicht hat. Dafür muss deine Volkswagen ID der bestätigte Hauptnutzer des Fahrzeugs sein.\n\n**Schnellste Prüfung:** Öffne `eu-data-act.drivesomethinggreater.com`, melde dich an und stelle sicher, dass (a) die Eigentümerschaft/Nutzerschaft bestätigt ist, (b) die Einwilligung zur Datenfreigabe für dieses Auto erteilt ist und (c) eine aktive fortlaufende (15-Minuten-)Datenanfrage mit allen angehakten Clustern existiert — erstelle sie selbst, falls keine vorhanden ist. Wenn du auch dort keine Daten siehst, liegt es an der VW-Seite — diese Integration kann nichts tun, bis VW es wiederherstellt.\n\nDies ist die schreibgeschützte Portal-Beta — die Warnung verschwindet von selbst, sobald Daten eintreffen."
     },
     "data_act_session_expired": {
       "description": "Das {brand}-Portal unter `eu-data-act.drivesomethinggreater.com` hat einen API-Aufruf für eine Custom Data Request mit HTTP 401 beantwortet – das bedeutet, die Sitzungs-Cookies sind abgelaufen. Das Portal unterstützt keine Token-Aktualisierung im Hintergrund, daher kann Home Assistant das nicht automatisch beheben.\n\n**Was zu tun ist:** Einstellungen → Geräte & Dienste → VW Group Connect → 3-Punkte-Menü → Neu konfigurieren → Zugangsdaten erneut eingeben. Beim nächsten Einrichtungsdurchlauf wird die Portal-Sitzung neu geöffnet und die Integration nimmt das Abfragen der aktiven Custom Data Request wieder auf.\n\nDiese Warnung verschwindet von selbst, sobald der nächste API-Aufruf des Portals erfolgreich ist.",
@@ -2306,6 +2306,66 @@
     },
     "historical_wedge_blocked": {
       "message": "Für dieses Fahrzeug läuft bereits ein einmaliger Verlaufsexport. Das Portal bearbeitet immer nur eine solche Anfrage gleichzeitig – warte deshalb, bis die aktuelle abgeschlossen ist (oder das Zeitlimit abläuft), bevor du eine neue anforderst."
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Fahrzeug hat Ladevorgang gestartet",
+      "description": "Wird ausgelöst, wenn ein Fahrzeug den Ladevorgang startet."
+    },
+    "stopped_charging": {
+      "name": "Fahrzeug hat Ladevorgang beendet",
+      "description": "Wird ausgelöst, wenn ein Fahrzeug den Ladevorgang beendet."
+    },
+    "plugged_in": {
+      "name": "Fahrzeug eingesteckt",
+      "description": "Wird ausgelöst, wenn das Ladekabel eines Fahrzeugs angeschlossen wird."
+    },
+    "unplugged": {
+      "name": "Fahrzeug ausgesteckt",
+      "description": "Wird ausgelöst, wenn das Ladekabel eines Fahrzeugs getrennt wird."
+    },
+    "locked": {
+      "name": "Fahrzeug verriegelt",
+      "description": "Wird ausgelöst, wenn ein Fahrzeug verriegelt wird."
+    },
+    "unlocked": {
+      "name": "Fahrzeug entriegelt",
+      "description": "Wird ausgelöst, wenn ein Fahrzeug entriegelt wird."
+    },
+    "started_preconditioning": {
+      "name": "Fahrzeug-Vorklimatisierung gestartet",
+      "description": "Wird ausgelöst, wenn ein Fahrzeug die Vorklimatisierung startet."
+    },
+    "stopped_preconditioning": {
+      "name": "Fahrzeug-Vorklimatisierung beendet",
+      "description": "Wird ausgelöst, wenn ein Fahrzeug die Vorklimatisierung beendet."
+    },
+    "charge_target_reached": {
+      "name": "Fahrzeug hat Ladeziel erreicht",
+      "description": "Wird ausgelöst, wenn der Ladestand eines Fahrzeugs sein Ziel erreicht."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Ein Fahrzeug lädt",
+      "description": "Prüft, ob ein Fahrzeug gerade lädt."
+    },
+    "is_plugged_in": {
+      "name": "Ein Fahrzeug ist eingesteckt",
+      "description": "Prüft, ob das Ladekabel eines Fahrzeugs angeschlossen ist."
+    },
+    "is_locked": {
+      "name": "Ein Fahrzeug ist verriegelt",
+      "description": "Prüft, ob ein Fahrzeug verriegelt ist."
+    },
+    "is_preconditioning": {
+      "name": "Ein Fahrzeug klimatisiert vor",
+      "description": "Prüft, ob ein Fahrzeug gerade vorklimatisiert."
+    },
+    "is_charge_target_reached": {
+      "name": "Ein Fahrzeug hat sein Ladeziel erreicht",
+      "description": "Prüft, ob der Ladestand eines Fahrzeugs sein Ziel erreicht hat."
     }
   }
 }

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1998,7 +1998,7 @@
     },
     "data_act_no_data": {
       "title": "EU Data Act portal: no vehicle data yet ({brand})",
-      "description": "The EU Data Act portal signed in for {brand} but isn't returning any vehicle data yet.\n\nThe integration tries to create the continuous data request for you automatically, but on some accounts the portal keeps the browser session anonymous — and then the automatic request (and the in-app \"Create EU Data Act data request\" button) can't complete, so you have to create the request yourself in the portal. The usual causes of an empty feed:\n\n1. **Ownership/usership not confirmed for this car.** The portal must show your vehicle's ownership (or usership) as confirmed. If it isn't, confirm it there first — necessary, though not always sufficient on its own.\n2. **Data-sharing consent not granted for this car.** You grant the EU Data Act data-sharing consent per vehicle, once. Until you do, the request stays empty.\n3. **No continuous request exists yet.** If the automatic creation didn't take, create it yourself: in the portal, add a Custom Data Request with all clusters ticked at a 15-minute frequency. The integration picks it up on the next poll — no restart needed.\n4. **The car hasn't sent anything new yet.** A fresh dataset is only published after the car has been driven, charged, or locked/unlocked, so a new request can take 15-60 minutes (or a short drive) to start filling.\n5. **A VW-side outage.** VW reported an all-brands EU Data Act portal outage from late May 2026; while it lasts the portal returns empty data for every tool, recovering brand by brand.\n6. **Or add the volkswagen.de website read channel.** In the integration's options you can add the read-only volkswagen.de website channel as an alternative source: it signs in on the volkswagen.de website (not the app backend that blocks the headless login), and for some cars returns fields the portal feed doesn't. It needs your Volkswagen ID to be the vehicle's confirmed primary user.\n\n**Quickest check:** open `eu-data-act.drivesomethinggreater.com`, sign in, and confirm (a) ownership/usership is confirmed, (b) the data-sharing consent is granted for this car, and (c) there is an active continuous (15-minute) data request with all clusters ticked — creating it yourself if none exists. If you see no data there either, it's the VW side — nothing this integration can do until VW restores it.\n\nThis is the read-only portal beta — the warning clears by itself once data arrives."
+      "description": "The EU Data Act portal signed in for {brand} but isn't returning any vehicle data yet.\n\nThe integration tries to create the continuous data request for you automatically, but on some accounts the portal keeps the browser session anonymous — and then the automatic request (and the in-app \"Create EU Data Act data request\" button) can't complete, so you have to create the request yourself in the portal. The usual causes of an empty feed:\n\n1. **Ownership/usership not confirmed for this car.** The portal must show your vehicle's ownership (or usership) as confirmed. If it isn't, confirm it there first — necessary, though not always sufficient on its own.\n2. **Data-sharing consent not granted for this car.** You grant the EU Data Act data-sharing consent per vehicle, once. Until you do, the request stays empty.\n3. **No continuous request exists yet.** If the automatic creation didn't take, create it yourself: in the portal, add a Custom Data Request with all clusters ticked at a 15-minute frequency. **First delete any older request for this same car** — the portal allows only one active request per vehicle, so an older one (for example a monthly request) for this car blocks the new one. Don't delete another car's request: on a mixed passenger + commercial account each car keeps its own request under its own realm (passenger cars under Volkswagen Personenkraftwagen, vans under Volkswagen Nutzfahrzeuge). The integration picks it up on the next poll — no restart needed.\n4. **The car hasn't sent anything new yet.** A fresh dataset is only published after the car has been driven, charged, or locked/unlocked, so a new request can take 15-60 minutes (or a short drive) to start filling.\n5. **A VW-side outage.** VW reported an all-brands EU Data Act portal outage from late May 2026; while it lasts the portal returns empty data for every tool, recovering brand by brand.\n6. **Or add the volkswagen.de website read channel.** In the integration's options you can add the read-only volkswagen.de website channel as an alternative source: it signs in on the volkswagen.de website (not the app backend that blocks the headless login), and for some cars returns fields the portal feed doesn't. It needs your Volkswagen ID to be the vehicle's confirmed primary user.\n\n**Quickest check:** open `eu-data-act.drivesomethinggreater.com`, sign in, and confirm (a) ownership/usership is confirmed, (b) the data-sharing consent is granted for this car, and (c) there is an active continuous (15-minute) data request with all clusters ticked — creating it yourself if none exists. If you see no data there either, it's the VW side — nothing this integration can do until VW restores it.\n\nThis is the read-only portal beta — the warning clears by itself once data arrives."
     },
     "data_act_browser_missing": {
       "description": "You enabled the headless-browser fallback for the EU Data Act portal but the `playwright` Python package is not installed in your Home Assistant container.\n\n**To install:** open the HA container shell (Add-ons → Terminal & SSH, or `docker exec` for a manual install) and run:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nThe chromium download is large (around 100 MB), which is why this dependency is opt-in instead of bundled with the integration. After installing, restart Home Assistant.\n\nAlternatively, disable the toggle under Settings → Devices & Services → VW Group Connect → Configure → 'EU Data Act portal: headless-browser fallback'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Official API only",
         "mysmob_only": "Standard channel only"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Vehicle started charging",
+      "description": "Triggers when a vehicle starts charging."
+    },
+    "stopped_charging": {
+      "name": "Vehicle stopped charging",
+      "description": "Triggers when a vehicle stops charging."
+    },
+    "plugged_in": {
+      "name": "Vehicle plugged in",
+      "description": "Triggers when a vehicle's charging cable is connected."
+    },
+    "unplugged": {
+      "name": "Vehicle unplugged",
+      "description": "Triggers when a vehicle's charging cable is disconnected."
+    },
+    "locked": {
+      "name": "Vehicle locked",
+      "description": "Triggers when a vehicle becomes locked."
+    },
+    "unlocked": {
+      "name": "Vehicle unlocked",
+      "description": "Triggers when a vehicle becomes unlocked."
+    },
+    "started_preconditioning": {
+      "name": "Vehicle started preconditioning",
+      "description": "Triggers when a vehicle starts climate preconditioning."
+    },
+    "stopped_preconditioning": {
+      "name": "Vehicle stopped preconditioning",
+      "description": "Triggers when a vehicle stops climate preconditioning."
+    },
+    "charge_target_reached": {
+      "name": "Vehicle reached its charge target",
+      "description": "Triggers when a vehicle's charge level reaches its target."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "A vehicle is charging",
+      "description": "Tests whether any vehicle is currently charging."
+    },
+    "is_plugged_in": {
+      "name": "A vehicle is plugged in",
+      "description": "Tests whether any vehicle's charging cable is connected."
+    },
+    "is_locked": {
+      "name": "A vehicle is locked",
+      "description": "Tests whether any vehicle is locked."
+    },
+    "is_preconditioning": {
+      "name": "A vehicle is preconditioning",
+      "description": "Tests whether any vehicle is running climate preconditioning."
+    },
+    "is_charge_target_reached": {
+      "name": "A vehicle reached its charge target",
+      "description": "Tests whether any vehicle's charge level is at or above its target."
     }
   }
 }

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "Portal EU Data Act: aún no hay datos del vehículo ({brand})",
-      "description": "El portal de la Ley de Datos de la UE inició sesión para {brand} pero todavía no devuelve ningún dato del vehículo.\n\nLa integración intenta crear la solicitud de datos continua por ti automáticamente, pero en algunas cuentas el portal mantiene la sesión del navegador anónima — y entonces la solicitud automática (y el botón \"Crear solicitud de datos de la Ley de Datos de la UE\" dentro de la app) no puede completarse, por lo que tienes que crear la solicitud tú mismo en el portal. Las causas habituales de un feed vacío:\n\n1. **Propiedad/uso no confirmado para este coche.** El portal debe mostrar la propiedad (o el uso) de tu vehículo como confirmada. Si no lo está, confírmala allí primero — necesario, aunque no siempre suficiente por sí solo.\n2. **Consentimiento de intercambio de datos no otorgado para este coche.** El consentimiento de intercambio de datos de la Ley de Datos de la UE se otorga por vehículo, una sola vez. Hasta que lo hagas, la solicitud permanece vacía.\n3. **Todavía no existe ninguna solicitud continua.** Si la creación automática no funcionó, créala tú mismo: en el portal, añade una Solicitud de Datos Personalizada con todos los clústeres marcados a una frecuencia de 15 minutos. La integración la detecta en el siguiente sondeo — sin necesidad de reiniciar.\n4. **El coche todavía no ha enviado nada nuevo.** Solo se publica un conjunto de datos nuevo después de que el coche se haya conducido, cargado o bloqueado/desbloqueado, por lo que una solicitud nueva puede tardar entre 15 y 60 minutos (o un trayecto corto) en empezar a llenarse.\n5. **Una interrupción del lado de VW.** VW informó de una interrupción del portal de la Ley de Datos de la UE para todas las marcas desde finales de mayo de 2026; mientras dure, el portal devuelve datos vacíos para todas las herramientas, recuperándose marca por marca.\n6. **O añade el canal de lectura del sitio web volkswagen.de.** En las opciones de la integración puedes añadir el canal de solo lectura del sitio web volkswagen.de como fuente alternativa: inicia sesión en el sitio web volkswagen.de (no en el backend de la app que bloquea el inicio de sesión headless) y, para algunos coches, devuelve campos que el feed del portal no ofrece. Necesita que tu Volkswagen ID sea el usuario principal confirmado del vehículo.\n\n**Comprobación más rápida:** abre `eu-data-act.drivesomethinggreater.com`, inicia sesión y confirma (a) que la propiedad/uso está confirmada, (b) que el consentimiento de intercambio de datos está otorgado para este coche, y (c) que existe una solicitud de datos continua (de 15 minutos) activa con todos los clústeres marcados — creándola tú mismo si no existe ninguna. Si tampoco ves datos ahí, es el lado de VW — nada que esta integración pueda hacer hasta que VW lo restablezca.\n\nEsta es la beta del portal de solo lectura — la advertencia desaparece por sí sola en cuanto llegan los datos."
+      "description": "El portal de la Ley de Datos de la UE inició sesión para {brand} pero todavía no devuelve ningún dato del vehículo.\n\nLa integración intenta crear la solicitud de datos continua por ti automáticamente, pero en algunas cuentas el portal mantiene la sesión del navegador anónima — y entonces la solicitud automática (y el botón \"Crear solicitud de datos de la Ley de Datos de la UE\" dentro de la app) no puede completarse, por lo que tienes que crear la solicitud tú mismo en el portal. Las causas habituales de un feed vacío:\n\n1. **Propiedad/uso no confirmado para este coche.** El portal debe mostrar la propiedad (o el uso) de tu vehículo como confirmada. Si no lo está, confírmala allí primero — necesario, aunque no siempre suficiente por sí solo.\n2. **Consentimiento de intercambio de datos no otorgado para este coche.** El consentimiento de intercambio de datos de la Ley de Datos de la UE se otorga por vehículo, una sola vez. Hasta que lo hagas, la solicitud permanece vacía.\n3. **Todavía no existe ninguna solicitud continua.** Si la creación automática no funcionó, créala tú mismo: en el portal, añade una Solicitud de Datos Personalizada con todos los clústeres marcados a una frecuencia de 15 minutos. **Elimina primero cualquier solicitud más antigua de este mismo coche** — el portal solo permite una solicitud activa por vehículo, así que una más antigua (por ejemplo una mensual) de este coche bloquea la nueva. No elimines la solicitud de otro coche: en una cuenta mixta de turismos y vehículos comerciales cada coche conserva su propia solicitud en su propio ámbito (los turismos bajo Volkswagen Personenkraftwagen, las furgonetas bajo Volkswagen Nutzfahrzeuge). La integración la detecta en el siguiente sondeo — sin necesidad de reiniciar.\n4. **El coche todavía no ha enviado nada nuevo.** Solo se publica un conjunto de datos nuevo después de que el coche se haya conducido, cargado o bloqueado/desbloqueado, por lo que una solicitud nueva puede tardar entre 15 y 60 minutos (o un trayecto corto) en empezar a llenarse.\n5. **Una interrupción del lado de VW.** VW informó de una interrupción del portal de la Ley de Datos de la UE para todas las marcas desde finales de mayo de 2026; mientras dure, el portal devuelve datos vacíos para todas las herramientas, recuperándose marca por marca.\n6. **O añade el canal de lectura del sitio web volkswagen.de.** En las opciones de la integración puedes añadir el canal de solo lectura del sitio web volkswagen.de como fuente alternativa: inicia sesión en el sitio web volkswagen.de (no en el backend de la app que bloquea el inicio de sesión headless) y, para algunos coches, devuelve campos que el feed del portal no ofrece. Necesita que tu Volkswagen ID sea el usuario principal confirmado del vehículo.\n\n**Comprobación más rápida:** abre `eu-data-act.drivesomethinggreater.com`, inicia sesión y confirma (a) que la propiedad/uso está confirmada, (b) que el consentimiento de intercambio de datos está otorgado para este coche, y (c) que existe una solicitud de datos continua (de 15 minutos) activa con todos los clústeres marcados — creándola tú mismo si no existe ninguna. Si tampoco ves datos ahí, es el lado de VW — nada que esta integración pueda hacer hasta que VW lo restablezca.\n\nEsta es la beta del portal de solo lectura — la advertencia desaparece por sí sola en cuanto llegan los datos."
     },
     "data_act_browser_missing": {
       "description": "Activaste la alternativa con navegador headless para el portal EU Data Act, pero el paquete de Python `playwright` no está instalado en tu contenedor de Home Assistant.\n\n**Para instalarlo:** abre el shell del contenedor de HA (Complementos → Terminal & SSH, o `docker exec` para una instalación manual) y ejecuta:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nLa descarga de chromium es grande (unos 100 MB), por eso esta dependencia es opcional en lugar de venir incluida en la integración. Reinicia Home Assistant después de instalarla.\n\nComo alternativa, desactiva la opción en Ajustes → Dispositivos y servicios → VW Group Connect → Configurar → 'Portal EU Data Act: alternativa con navegador headless'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Solo API oficial",
         "mysmob_only": "Solo canal estándar"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "El vehículo empezó a cargar",
+      "description": "Se activa cuando un vehículo empieza a cargar."
+    },
+    "stopped_charging": {
+      "name": "El vehículo dejó de cargar",
+      "description": "Se activa cuando un vehículo deja de cargar."
+    },
+    "plugged_in": {
+      "name": "Vehículo conectado",
+      "description": "Se activa cuando se conecta el cable de carga de un vehículo."
+    },
+    "unplugged": {
+      "name": "Vehículo desconectado",
+      "description": "Se activa cuando se desconecta el cable de carga de un vehículo."
+    },
+    "locked": {
+      "name": "Vehículo bloqueado",
+      "description": "Se activa cuando un vehículo se bloquea."
+    },
+    "unlocked": {
+      "name": "Vehículo desbloqueado",
+      "description": "Se activa cuando un vehículo se desbloquea."
+    },
+    "started_preconditioning": {
+      "name": "El vehículo inició el preacondicionamiento",
+      "description": "Se activa cuando un vehículo inicia el preacondicionamiento de la climatización."
+    },
+    "stopped_preconditioning": {
+      "name": "El vehículo detuvo el preacondicionamiento",
+      "description": "Se activa cuando un vehículo detiene el preacondicionamiento de la climatización."
+    },
+    "charge_target_reached": {
+      "name": "El vehículo alcanzó su objetivo de carga",
+      "description": "Se activa cuando el nivel de carga de un vehículo alcanza su objetivo."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Un vehículo está cargando",
+      "description": "Comprueba si algún vehículo está cargando en este momento."
+    },
+    "is_plugged_in": {
+      "name": "Un vehículo está conectado",
+      "description": "Comprueba si el cable de carga de algún vehículo está conectado."
+    },
+    "is_locked": {
+      "name": "Un vehículo está bloqueado",
+      "description": "Comprueba si algún vehículo está bloqueado."
+    },
+    "is_preconditioning": {
+      "name": "Un vehículo está preacondicionando",
+      "description": "Comprueba si algún vehículo está ejecutando el preacondicionamiento de la climatización."
+    },
+    "is_charge_target_reached": {
+      "name": "Un vehículo alcanzó su objetivo de carga",
+      "description": "Comprueba si el nivel de carga de algún vehículo está en su objetivo o por encima."
     }
   }
 }

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "EU Data Act -portaali: ei vielä ajoneuvon tietoja ({brand})",
-      "description": "EU:n datasäädöksen portaaliin kirjauduttiin sisään merkin {brand} osalta, mutta se ei vielä palauta mitään ajoneuvon tietoja.\n\nIntegraatio yrittää luoda jatkuvan datapyynnön puolestasi automaattisesti, mutta joillakin tileillä portaali pitää selainistunnon anonyyminä — jolloin automaattinen pyyntö (ja sovelluksen sisäinen \"Luo EU:n datasäädöksen datapyyntö\" -painike) ei pysty valmistumaan, joten sinun on luotava pyyntö itse portaalissa. Tyhjän tietovirran tavalliset syyt:\n\n1. **Omistajuutta/käyttäjyyttä ei ole vahvistettu tälle autolle.** Portaalin on näytettävä ajoneuvosi omistajuus (tai käyttäjyys) vahvistettuna. Jos näin ei ole, vahvista se siellä ensin — välttämätöntä, vaikkakaan ei aina yksin riittävää.\n2. **Tietojen jakamisen suostumusta ei ole myönnetty tälle autolle.** Myönnät EU:n datasäädöksen tietojenjakosuostumuksen ajoneuvokohtaisesti, kerran. Ennen kuin teet sen, pyyntö pysyy tyhjänä.\n3. **Jatkuvaa pyyntöä ei ole vielä olemassa.** Jos automaattinen luonti ei onnistunut, luo se itse: lisää portaalissa mukautettu datapyyntö (Custom Data Request), jossa kaikki klusterit on rastitettu 15 minuutin taajuudella. Integraatio poimii sen seuraavalla kyselyllä — uudelleenkäynnistystä ei tarvita.\n4. **Auto ei ole vielä lähettänyt mitään uutta.** Uusi tietojoukko julkaistaan vasta, kun autoa on ajettu, ladattu tai lukittu/avattu, joten uuden pyynnön täyttymisen alkaminen voi kestää 15–60 minuuttia (tai lyhyen ajomatkan).\n5. **VW:n puolen käyttökatko.** VW ilmoitti kaikkia merkkejä koskevasta EU:n datasäädöksen portaalin käyttökatkosta toukokuun 2026 lopusta alkaen; katkon ajan portaali palauttaa tyhjää dataa jokaiselle työkalulle ja palautuu merkki kerrallaan.\n6. **Tai lisää volkswagen.de-sivuston lukukanava.** Integraation asetuksissa voit lisätä vain luku -tilaisen volkswagen.de-sivustokanavan vaihtoehtoiseksi lähteeksi: se kirjautuu sisään volkswagen.de-sivustolla (ei sovelluksen taustajärjestelmään, joka estää headless-kirjautumisen), ja palauttaa joillekin autoille kenttiä, joita portaalin tietovirta ei palauta. Se edellyttää, että Volkswagen ID:si on ajoneuvon vahvistettu ensisijainen käyttäjä.\n\n**Nopein tarkistus:** avaa `eu-data-act.drivesomethinggreater.com`, kirjaudu sisään ja varmista, että (a) omistajuus/käyttäjyys on vahvistettu, (b) tietojenjakosuostumus on myönnetty tälle autolle ja (c) aktiivinen jatkuva (15 minuutin) datapyyntö on olemassa, ja siinä on kaikki klusterit rastitettuina — luoden sen itse, jos sellaista ei ole. Jos et näe sielläkään dataa, kyse on VW:n puolesta — tämä integraatio ei voi tehdä mitään ennen kuin VW palauttaa sen toimintaan.\n\nTämä on vain luku -tilaisen portaalin beeta — varoitus poistuu itsestään, kun dataa saapuu."
+      "description": "EU:n datasäädöksen portaaliin kirjauduttiin sisään merkin {brand} osalta, mutta se ei vielä palauta mitään ajoneuvon tietoja.\n\nIntegraatio yrittää luoda jatkuvan datapyynnön puolestasi automaattisesti, mutta joillakin tileillä portaali pitää selainistunnon anonyyminä — jolloin automaattinen pyyntö (ja sovelluksen sisäinen \"Luo EU:n datasäädöksen datapyyntö\" -painike) ei pysty valmistumaan, joten sinun on luotava pyyntö itse portaalissa. Tyhjän tietovirran tavalliset syyt:\n\n1. **Omistajuutta/käyttäjyyttä ei ole vahvistettu tälle autolle.** Portaalin on näytettävä ajoneuvosi omistajuus (tai käyttäjyys) vahvistettuna. Jos näin ei ole, vahvista se siellä ensin — välttämätöntä, vaikkakaan ei aina yksin riittävää.\n2. **Tietojen jakamisen suostumusta ei ole myönnetty tälle autolle.** Myönnät EU:n datasäädöksen tietojenjakosuostumuksen ajoneuvokohtaisesti, kerran. Ennen kuin teet sen, pyyntö pysyy tyhjänä.\n3. **Jatkuvaa pyyntöä ei ole vielä olemassa.** Jos automaattinen luonti ei onnistunut, luo se itse: lisää portaalissa mukautettu datapyyntö (Custom Data Request), jossa kaikki klusterit on rastitettu 15 minuutin taajuudella. **Poista ensin kaikki tätä samaa autoa koskevat vanhemmat pyynnöt** — portaali sallii vain yhden aktiivisen pyynnön ajoneuvoa kohti, joten tätä autoa koskeva vanhempi (esimerkiksi kuukausittainen) pyyntö estää uuden. Älä poista toisen auton pyyntöä: sekatilillä, jolla on sekä henkilö- että hyötyajoneuvoja, jokainen auto säilyttää oman pyyntönsä omassa osiossaan (henkilöautot kohdassa Volkswagen Personenkraftwagen, pakettiautot kohdassa Volkswagen Nutzfahrzeuge). Integraatio poimii sen seuraavalla kyselyllä — uudelleenkäynnistystä ei tarvita.\n4. **Auto ei ole vielä lähettänyt mitään uutta.** Uusi tietojoukko julkaistaan vasta, kun autoa on ajettu, ladattu tai lukittu/avattu, joten uuden pyynnön täyttymisen alkaminen voi kestää 15–60 minuuttia (tai lyhyen ajomatkan).\n5. **VW:n puolen käyttökatko.** VW ilmoitti kaikkia merkkejä koskevasta EU:n datasäädöksen portaalin käyttökatkosta toukokuun 2026 lopusta alkaen; katkon ajan portaali palauttaa tyhjää dataa jokaiselle työkalulle ja palautuu merkki kerrallaan.\n6. **Tai lisää volkswagen.de-sivuston lukukanava.** Integraation asetuksissa voit lisätä vain luku -tilaisen volkswagen.de-sivustokanavan vaihtoehtoiseksi lähteeksi: se kirjautuu sisään volkswagen.de-sivustolla (ei sovelluksen taustajärjestelmään, joka estää headless-kirjautumisen), ja palauttaa joillekin autoille kenttiä, joita portaalin tietovirta ei palauta. Se edellyttää, että Volkswagen ID:si on ajoneuvon vahvistettu ensisijainen käyttäjä.\n\n**Nopein tarkistus:** avaa `eu-data-act.drivesomethinggreater.com`, kirjaudu sisään ja varmista, että (a) omistajuus/käyttäjyys on vahvistettu, (b) tietojenjakosuostumus on myönnetty tälle autolle ja (c) aktiivinen jatkuva (15 minuutin) datapyyntö on olemassa, ja siinä on kaikki klusterit rastitettuina — luoden sen itse, jos sellaista ei ole. Jos et näe sielläkään dataa, kyse on VW:n puolesta — tämä integraatio ei voi tehdä mitään ennen kuin VW palauttaa sen toimintaan.\n\nTämä on vain luku -tilaisen portaalin beeta — varoitus poistuu itsestään, kun dataa saapuu."
     },
     "data_act_browser_missing": {
       "description": "Otit käyttöön selaimettoman varajärjestelmän EU Data Act -portaalille, mutta `playwright` Python-pakettia ei ole asennettu Home Assistant -kontissasi.\n\n**Asennus:** avaa HA-kontin komentokehote (Lisäosat → Terminal & SSH, tai `docker exec` manuaaliseen asennukseen) ja suorita:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nChromium-lataus on suuri (noin 100 Mt), minkä vuoksi tämä riippuvuus on valinnainen sen sijaan, että se olisi niputettu integraation kanssa. Asennuksen jälkeen käynnistä Home Assistant uudelleen.\n\nVaihtoehtoisesti poista kytkin käytöstä kohdassa Asetukset → Laitteet ja palvelut → VW Group Connect → Määritä → 'EU Data Act -portaali: selaimeton varajärjestelmä'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Vain virallinen API",
         "mysmob_only": "Vain vakiokanava"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Ajoneuvo aloitti lataamisen",
+      "description": "Käynnistyy, kun ajoneuvo aloittaa lataamisen."
+    },
+    "stopped_charging": {
+      "name": "Ajoneuvo lopetti lataamisen",
+      "description": "Käynnistyy, kun ajoneuvo lopettaa lataamisen."
+    },
+    "plugged_in": {
+      "name": "Ajoneuvo kytketty",
+      "description": "Käynnistyy, kun ajoneuvon latauskaapeli kytketään."
+    },
+    "unplugged": {
+      "name": "Ajoneuvo irrotettu",
+      "description": "Käynnistyy, kun ajoneuvon latauskaapeli irrotetaan."
+    },
+    "locked": {
+      "name": "Ajoneuvo lukittu",
+      "description": "Käynnistyy, kun ajoneuvo lukitaan."
+    },
+    "unlocked": {
+      "name": "Ajoneuvon lukitus avattu",
+      "description": "Käynnistyy, kun ajoneuvon lukitus avataan."
+    },
+    "started_preconditioning": {
+      "name": "Ajoneuvo aloitti esi-ilmastoinnin",
+      "description": "Käynnistyy, kun ajoneuvo aloittaa esi-ilmastoinnin."
+    },
+    "stopped_preconditioning": {
+      "name": "Ajoneuvo lopetti esi-ilmastoinnin",
+      "description": "Käynnistyy, kun ajoneuvo lopettaa esi-ilmastoinnin."
+    },
+    "charge_target_reached": {
+      "name": "Ajoneuvo saavutti lataustavoitteen",
+      "description": "Käynnistyy, kun ajoneuvon lataustaso saavuttaa tavoitteensa."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Ajoneuvo lataa",
+      "description": "Tarkistaa, lataako jokin ajoneuvo parhaillaan."
+    },
+    "is_plugged_in": {
+      "name": "Ajoneuvo on kytketty",
+      "description": "Tarkistaa, onko jonkin ajoneuvon latauskaapeli kytketty."
+    },
+    "is_locked": {
+      "name": "Ajoneuvo on lukittu",
+      "description": "Tarkistaa, onko jokin ajoneuvo lukittu."
+    },
+    "is_preconditioning": {
+      "name": "Ajoneuvo esi-ilmastoi",
+      "description": "Tarkistaa, käyttääkö jokin ajoneuvo esi-ilmastointia."
+    },
+    "is_charge_target_reached": {
+      "name": "Ajoneuvo saavutti lataustavoitteen",
+      "description": "Tarkistaa, onko jonkin ajoneuvon lataustaso tavoitteessa tai sen yli."
     }
   }
 }

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "Portail EU Data Act : pas encore de données du véhicule ({brand})",
-      "description": "Le portail EU Data Act s'est connecté pour {brand} mais ne renvoie encore aucune donnée du véhicule.\n\nL'intégration essaie de créer automatiquement la demande de données continue à votre place, mais sur certains comptes le portail garde la session du navigateur anonyme — et dans ce cas la demande automatique (et le bouton « Créer une demande de données EU Data Act » dans l'application) ne peut pas aboutir, vous devez donc créer la demande vous-même dans le portail. Les causes habituelles d'un flux vide :\n\n1. **Propriété/droit d'usage non confirmé pour ce véhicule.** Le portail doit indiquer la propriété (ou le droit d'usage) de votre véhicule comme confirmée. Si ce n'est pas le cas, confirmez-la d'abord là-bas — nécessaire, mais pas toujours suffisant à lui seul.\n2. **Consentement au partage des données non accordé pour ce véhicule.** Vous accordez le consentement au partage des données EU Data Act par véhicule, une seule fois. Tant que vous ne l'avez pas fait, la demande reste vide.\n3. **Aucune demande continue n'existe encore.** Si la création automatique n'a pas fonctionné, créez-la vous-même : dans le portail, ajoutez une demande de données personnalisée (Custom Data Request) avec tous les clusters cochés à une fréquence de 15 minutes. L'intégration la récupère lors de la prochaine interrogation — aucun redémarrage nécessaire.\n4. **La voiture n'a encore rien envoyé de nouveau.** Un nouveau jeu de données n'est publié qu'après que la voiture a été conduite, chargée ou verrouillée/déverrouillée ; une nouvelle demande peut donc mettre 15 à 60 minutes (ou un court trajet) avant de commencer à se remplir.\n5. **Une panne du côté de VW.** VW a signalé une panne du portail EU Data Act touchant toutes les marques depuis fin mai 2026 ; tant qu'elle dure, le portail renvoie des données vides pour tous les outils, se rétablissant marque par marque.\n6. **Ou ajoutez le canal de lecture du site web volkswagen.de.** Dans les options de l'intégration, vous pouvez ajouter le canal en lecture seule du site web volkswagen.de comme source alternative : il se connecte sur le site web volkswagen.de (et non sur le backend de l'application qui bloque la connexion sans interface), et pour certaines voitures il renvoie des champs que le flux du portail ne fournit pas. Il faut que votre Volkswagen ID soit l'utilisateur principal confirmé du véhicule.\n\n**Vérification la plus rapide :** ouvrez `eu-data-act.drivesomethinggreater.com`, connectez-vous et vérifiez que (a) la propriété/le droit d'usage est confirmé, (b) le consentement au partage des données est accordé pour ce véhicule, et (c) il existe une demande de données continue (15 minutes) active avec tous les clusters cochés — en la créant vous-même s'il n'y en a aucune. Si vous ne voyez pas non plus de données là-bas, c'est du côté de VW — cette intégration ne peut rien faire tant que VW ne l'a pas rétabli.\n\nIl s'agit de la version bêta du portail en lecture seule — l'avertissement disparaît de lui-même une fois les données arrivées."
+      "description": "Le portail EU Data Act s'est connecté pour {brand} mais ne renvoie encore aucune donnée du véhicule.\n\nL'intégration essaie de créer automatiquement la demande de données continue à votre place, mais sur certains comptes le portail garde la session du navigateur anonyme — et dans ce cas la demande automatique (et le bouton « Créer une demande de données EU Data Act » dans l'application) ne peut pas aboutir, vous devez donc créer la demande vous-même dans le portail. Les causes habituelles d'un flux vide :\n\n1. **Propriété/droit d'usage non confirmé pour ce véhicule.** Le portail doit indiquer la propriété (ou le droit d'usage) de votre véhicule comme confirmée. Si ce n'est pas le cas, confirmez-la d'abord là-bas — nécessaire, mais pas toujours suffisant à lui seul.\n2. **Consentement au partage des données non accordé pour ce véhicule.** Vous accordez le consentement au partage des données EU Data Act par véhicule, une seule fois. Tant que vous ne l'avez pas fait, la demande reste vide.\n3. **Aucune demande continue n'existe encore.** Si la création automatique n'a pas fonctionné, créez-la vous-même : dans le portail, ajoutez une demande de données personnalisée (Custom Data Request) avec tous les clusters cochés à une fréquence de 15 minutes. **Supprimez d'abord toute demande plus ancienne pour ce même véhicule** — le portail n'autorise qu'une seule demande active par véhicule, de sorte qu'une demande plus ancienne (par exemple une demande mensuelle) pour ce véhicule bloque la nouvelle. Ne supprimez pas la demande d'un autre véhicule : sur un compte mixte de véhicules particuliers et utilitaires, chaque véhicule conserve sa propre demande dans son propre domaine (les véhicules particuliers sous Volkswagen Personenkraftwagen, les utilitaires sous Volkswagen Nutzfahrzeuge). L'intégration la récupère lors de la prochaine interrogation — aucun redémarrage nécessaire.\n4. **La voiture n'a encore rien envoyé de nouveau.** Un nouveau jeu de données n'est publié qu'après que la voiture a été conduite, chargée ou verrouillée/déverrouillée ; une nouvelle demande peut donc mettre 15 à 60 minutes (ou un court trajet) avant de commencer à se remplir.\n5. **Une panne du côté de VW.** VW a signalé une panne du portail EU Data Act touchant toutes les marques depuis fin mai 2026 ; tant qu'elle dure, le portail renvoie des données vides pour tous les outils, se rétablissant marque par marque.\n6. **Ou ajoutez le canal de lecture du site web volkswagen.de.** Dans les options de l'intégration, vous pouvez ajouter le canal en lecture seule du site web volkswagen.de comme source alternative : il se connecte sur le site web volkswagen.de (et non sur le backend de l'application qui bloque la connexion sans interface), et pour certaines voitures il renvoie des champs que le flux du portail ne fournit pas. Il faut que votre Volkswagen ID soit l'utilisateur principal confirmé du véhicule.\n\n**Vérification la plus rapide :** ouvrez `eu-data-act.drivesomethinggreater.com`, connectez-vous et vérifiez que (a) la propriété/le droit d'usage est confirmé, (b) le consentement au partage des données est accordé pour ce véhicule, et (c) il existe une demande de données continue (15 minutes) active avec tous les clusters cochés — en la créant vous-même s'il n'y en a aucune. Si vous ne voyez pas non plus de données là-bas, c'est du côté de VW — cette intégration ne peut rien faire tant que VW ne l'a pas rétabli.\n\nIl s'agit de la version bêta du portail en lecture seule — l'avertissement disparaît de lui-même une fois les données arrivées."
     },
     "data_act_browser_missing": {
       "description": "Vous avez activé le repli navigateur headless pour le portail EU Data Act, mais le paquet Python `playwright` n'est pas installé dans votre conteneur Home Assistant.\n\n**Pour l'installer :** ouvrez le shell du conteneur HA (Modules complémentaires → Terminal & SSH, ou `docker exec` pour une installation manuelle) et exécutez :\n\n```\npip install playwright\nplaywright install chromium\n```\n\nLe téléchargement de chromium est volumineux (environ 100 Mo), c'est pourquoi cette dépendance est optionnelle plutôt qu'incluse dans l'intégration. Redémarrez Home Assistant après l'installation.\n\nVous pouvez aussi désactiver l'option dans Paramètres → Appareils et services → VW Group Connect → Configurer → « Portail EU Data Act : repli navigateur headless ».",
@@ -2306,6 +2306,66 @@
         "official_only": "API officielle uniquement",
         "mysmob_only": "Canal standard uniquement"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Le véhicule a commencé à charger",
+      "description": "Se déclenche lorsqu'un véhicule commence à charger."
+    },
+    "stopped_charging": {
+      "name": "Le véhicule a arrêté de charger",
+      "description": "Se déclenche lorsqu'un véhicule arrête de charger."
+    },
+    "plugged_in": {
+      "name": "Véhicule branché",
+      "description": "Se déclenche lorsque le câble de charge d'un véhicule est branché."
+    },
+    "unplugged": {
+      "name": "Véhicule débranché",
+      "description": "Se déclenche lorsque le câble de charge d'un véhicule est débranché."
+    },
+    "locked": {
+      "name": "Véhicule verrouillé",
+      "description": "Se déclenche lorsqu'un véhicule se verrouille."
+    },
+    "unlocked": {
+      "name": "Véhicule déverrouillé",
+      "description": "Se déclenche lorsqu'un véhicule se déverrouille."
+    },
+    "started_preconditioning": {
+      "name": "Le véhicule a démarré le préconditionnement",
+      "description": "Se déclenche lorsqu'un véhicule démarre le préconditionnement de la climatisation."
+    },
+    "stopped_preconditioning": {
+      "name": "Le véhicule a arrêté le préconditionnement",
+      "description": "Se déclenche lorsqu'un véhicule arrête le préconditionnement de la climatisation."
+    },
+    "charge_target_reached": {
+      "name": "Le véhicule a atteint son objectif de charge",
+      "description": "Se déclenche lorsque le niveau de charge d'un véhicule atteint son objectif."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Un véhicule est en charge",
+      "description": "Vérifie si un véhicule est en charge actuellement."
+    },
+    "is_plugged_in": {
+      "name": "Un véhicule est branché",
+      "description": "Vérifie si le câble de charge d'un véhicule est branché."
+    },
+    "is_locked": {
+      "name": "Un véhicule est verrouillé",
+      "description": "Vérifie si un véhicule est verrouillé."
+    },
+    "is_preconditioning": {
+      "name": "Un véhicule est en préconditionnement",
+      "description": "Vérifie si un véhicule exécute le préconditionnement de la climatisation."
+    },
+    "is_charge_target_reached": {
+      "name": "Un véhicule a atteint son objectif de charge",
+      "description": "Vérifie si le niveau de charge d'un véhicule est à son objectif ou au-dessus."
     }
   }
 }

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "Portale EU Data Act: ancora nessun dato del veicolo ({brand})",
-      "description": "Il portale dell'EU Data Act ha effettuato l'accesso per {brand} ma non restituisce ancora alcun dato del veicolo.\n\nL'integrazione tenta di creare automaticamente per te la richiesta di dati continua, ma su alcuni account il portale mantiene anonima la sessione del browser — e in tal caso la richiesta automatica (e il pulsante \"Crea richiesta dati EU Data Act\" nell'app) non riesce a completarsi, quindi devi creare tu stesso la richiesta nel portale. Le cause abituali di un feed vuoto:\n\n1. **Proprietà/utilizzo non confermati per questa auto.** Il portale deve mostrare come confermata la proprietà (o l'utilizzo) del tuo veicolo. Se non lo è, confermala prima lì — necessario, anche se da solo non sempre sufficiente.\n2. **Consenso alla condivisione dei dati non concesso per questa auto.** Il consenso alla condivisione dei dati dell'EU Data Act si concede per veicolo, una volta sola. Finché non lo fai, la richiesta resta vuota.\n3. **Non esiste ancora alcuna richiesta continua.** Se la creazione automatica non ha avuto effetto, creala tu stesso: nel portale, aggiungi una Richiesta dati personalizzata con tutti i cluster selezionati a una frequenza di 15 minuti. L'integrazione la rileva al prossimo polling — nessun riavvio necessario.\n4. **L'auto non ha ancora inviato nulla di nuovo.** Un nuovo set di dati viene pubblicato solo dopo che l'auto è stata guidata, ricaricata o bloccata/sbloccata, quindi una nuova richiesta può impiegare 15-60 minuti (o un breve tragitto) prima di iniziare a riempirsi.\n5. **Un'interruzione lato VW.** VW ha segnalato un'interruzione del portale EU Data Act per tutti i marchi a partire da fine maggio 2026; finché dura, il portale restituisce dati vuoti per ogni strumento, ripristinandosi marchio per marchio.\n6. **Oppure aggiungi il canale di lettura del sito web volkswagen.de.** Nelle opzioni dell'integrazione puoi aggiungere il canale di sola lettura del sito web volkswagen.de come fonte alternativa: effettua l'accesso sul sito web volkswagen.de (non il backend dell'app che blocca il login headless) e per alcune auto restituisce campi che il feed del portale non fornisce. Richiede che il tuo Volkswagen ID sia l'utente primario confermato del veicolo.\n\n**Verifica più rapida:** apri `eu-data-act.drivesomethinggreater.com`, accedi e conferma che (a) la proprietà/l'utilizzo sia confermato, (b) il consenso alla condivisione dei dati sia concesso per questa auto e (c) sia presente una richiesta dati continua (15 minuti) attiva con tutti i cluster selezionati — creandola tu stesso se non ne esiste nessuna. Se anche lì non vedi dati, il problema è lato VW — questa integrazione non può fare nulla finché VW non lo ripristina.\n\nQuesta è la beta del portale in sola lettura — l'avviso scompare da solo una volta arrivati i dati."
+      "description": "Il portale dell'EU Data Act ha effettuato l'accesso per {brand} ma non restituisce ancora alcun dato del veicolo.\n\nL'integrazione tenta di creare automaticamente per te la richiesta di dati continua, ma su alcuni account il portale mantiene anonima la sessione del browser — e in tal caso la richiesta automatica (e il pulsante \"Crea richiesta dati EU Data Act\" nell'app) non riesce a completarsi, quindi devi creare tu stesso la richiesta nel portale. Le cause abituali di un feed vuoto:\n\n1. **Proprietà/utilizzo non confermati per questa auto.** Il portale deve mostrare come confermata la proprietà (o l'utilizzo) del tuo veicolo. Se non lo è, confermala prima lì — necessario, anche se da solo non sempre sufficiente.\n2. **Consenso alla condivisione dei dati non concesso per questa auto.** Il consenso alla condivisione dei dati dell'EU Data Act si concede per veicolo, una volta sola. Finché non lo fai, la richiesta resta vuota.\n3. **Non esiste ancora alcuna richiesta continua.** Se la creazione automatica non ha avuto effetto, creala tu stesso: nel portale, aggiungi una Richiesta dati personalizzata con tutti i cluster selezionati a una frequenza di 15 minuti. **Elimina prima qualsiasi richiesta più vecchia per questa stessa auto** — il portale consente una sola richiesta attiva per veicolo, quindi una più vecchia (ad esempio una mensile) per questa auto blocca quella nuova. Non eliminare la richiesta di un'altra auto: su un account misto di autovetture e veicoli commerciali ogni auto conserva la propria richiesta nel proprio ambito (le autovetture sotto Volkswagen Personenkraftwagen, i furgoni sotto Volkswagen Nutzfahrzeuge). L'integrazione la rileva al prossimo polling — nessun riavvio necessario.\n4. **L'auto non ha ancora inviato nulla di nuovo.** Un nuovo set di dati viene pubblicato solo dopo che l'auto è stata guidata, ricaricata o bloccata/sbloccata, quindi una nuova richiesta può impiegare 15-60 minuti (o un breve tragitto) prima di iniziare a riempirsi.\n5. **Un'interruzione lato VW.** VW ha segnalato un'interruzione del portale EU Data Act per tutti i marchi a partire da fine maggio 2026; finché dura, il portale restituisce dati vuoti per ogni strumento, ripristinandosi marchio per marchio.\n6. **Oppure aggiungi il canale di lettura del sito web volkswagen.de.** Nelle opzioni dell'integrazione puoi aggiungere il canale di sola lettura del sito web volkswagen.de come fonte alternativa: effettua l'accesso sul sito web volkswagen.de (non il backend dell'app che blocca il login headless) e per alcune auto restituisce campi che il feed del portale non fornisce. Richiede che il tuo Volkswagen ID sia l'utente primario confermato del veicolo.\n\n**Verifica più rapida:** apri `eu-data-act.drivesomethinggreater.com`, accedi e conferma che (a) la proprietà/l'utilizzo sia confermato, (b) il consenso alla condivisione dei dati sia concesso per questa auto e (c) sia presente una richiesta dati continua (15 minuti) attiva con tutti i cluster selezionati — creandola tu stesso se non ne esiste nessuna. Se anche lì non vedi dati, il problema è lato VW — questa integrazione non può fare nulla finché VW non lo ripristina.\n\nQuesta è la beta del portale in sola lettura — l'avviso scompare da solo una volta arrivati i dati."
     },
     "data_act_browser_missing": {
       "description": "Hai abilitato il fallback con browser headless per il portale EU Data Act ma il pacchetto Python `playwright` non è installato nel tuo container di Home Assistant.\n\n**Per installarlo:** apri la shell del container HA (Add-on → Terminal & SSH, oppure `docker exec` per un'installazione manuale) ed esegui:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nIl download di Chromium è grande (circa 100 MB), motivo per cui questa dipendenza è opt-in invece di essere inclusa nell'integrazione. Dopo l'installazione, riavvia Home Assistant.\n\nIn alternativa, disabilita l'opzione in Impostazioni → Dispositivi e servizi → VW Group Connect → Configura → 'Portale EU Data Act: fallback con browser headless'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Solo API ufficiale",
         "mysmob_only": "Solo canale standard"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Il veicolo ha iniziato a caricare",
+      "description": "Si attiva quando un veicolo inizia a caricare."
+    },
+    "stopped_charging": {
+      "name": "Il veicolo ha smesso di caricare",
+      "description": "Si attiva quando un veicolo smette di caricare."
+    },
+    "plugged_in": {
+      "name": "Veicolo collegato",
+      "description": "Si attiva quando il cavo di ricarica di un veicolo viene collegato."
+    },
+    "unplugged": {
+      "name": "Veicolo scollegato",
+      "description": "Si attiva quando il cavo di ricarica di un veicolo viene scollegato."
+    },
+    "locked": {
+      "name": "Veicolo bloccato",
+      "description": "Si attiva quando un veicolo viene bloccato."
+    },
+    "unlocked": {
+      "name": "Veicolo sbloccato",
+      "description": "Si attiva quando un veicolo viene sbloccato."
+    },
+    "started_preconditioning": {
+      "name": "Il veicolo ha avviato la preclimatizzazione",
+      "description": "Si attiva quando un veicolo avvia la preclimatizzazione."
+    },
+    "stopped_preconditioning": {
+      "name": "Il veicolo ha interrotto la preclimatizzazione",
+      "description": "Si attiva quando un veicolo interrompe la preclimatizzazione."
+    },
+    "charge_target_reached": {
+      "name": "Il veicolo ha raggiunto l'obiettivo di carica",
+      "description": "Si attiva quando il livello di carica di un veicolo raggiunge il suo obiettivo."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Un veicolo è in carica",
+      "description": "Verifica se un veicolo è in carica in questo momento."
+    },
+    "is_plugged_in": {
+      "name": "Un veicolo è collegato",
+      "description": "Verifica se il cavo di ricarica di un veicolo è collegato."
+    },
+    "is_locked": {
+      "name": "Un veicolo è bloccato",
+      "description": "Verifica se un veicolo è bloccato."
+    },
+    "is_preconditioning": {
+      "name": "Un veicolo è in preclimatizzazione",
+      "description": "Verifica se un veicolo sta eseguendo la preclimatizzazione."
+    },
+    "is_charge_target_reached": {
+      "name": "Un veicolo ha raggiunto l'obiettivo di carica",
+      "description": "Verifica se il livello di carica di un veicolo è pari o superiore al suo obiettivo."
     }
   }
 }

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "EU Data Act-portal: ingen kjøretøydata ennå ({brand})",
-      "description": "EU Data Act-portalen logget inn for {brand}, men returnerer ennå ingen kjøretøydata.\n\nIntegrasjonen prøver å opprette den kontinuerlige dataforespørselen automatisk for deg, men på enkelte kontoer holder portalen nettleserøkten anonym — og da kan ikke den automatiske forespørselen (og den innebygde knappen «Opprett EU Data Act-dataforespørsel») fullføres, så du må opprette forespørselen selv i portalen. De vanlige årsakene til en tom feed:\n\n1. **Eierskap/brukerskap ikke bekreftet for denne bilen.** Portalen må vise eierskapet (eller brukerskapet) for kjøretøyet ditt som bekreftet. Hvis det ikke er det, bekreft det der først — nødvendig, men ikke alltid tilstrekkelig i seg selv.\n2. **Samtykke til datadeling ikke gitt for denne bilen.** Du gir samtykket til datadeling under EU Data Act per kjøretøy, én gang. Inntil du gjør det, forblir forespørselen tom.\n3. **Ingen kontinuerlig forespørsel finnes ennå.** Hvis den automatiske opprettelsen ikke gikk gjennom, opprett den selv: legg til en egendefinert dataforespørsel i portalen med alle klynger avkrysset og 15-minutters frekvens. Integrasjonen fanger den opp ved neste avspørring — ingen omstart nødvendig.\n4. **Bilen har ikke sendt noe nytt ennå.** Et ferskt datasett publiseres først etter at bilen har blitt kjørt, ladet eller låst/låst opp, så en ny forespørsel kan bruke 15–60 minutter (eller en kort kjøretur) på å begynne å fylles.\n5. **Et avbrudd på VW-siden.** VW meldte om et avbrudd i EU Data Act-portalen for alle merker fra slutten av mai 2026; så lenge det varer, returnerer portalen tomme data for alle verktøy, og gjenopprettes merke for merke.\n6. **Eller legg til lesekanalen for nettstedet volkswagen.de.** I integrasjonens innstillinger kan du legge til den skrivebeskyttede volkswagen.de-nettstedkanalen som en alternativ kilde: den logger inn på nettstedet volkswagen.de (ikke app-backenden som blokkerer den hodeløse innloggingen), og returnerer for enkelte biler felter som portal-feeden ikke gir. Den krever at Volkswagen-ID-en din er kjøretøyets bekreftede primærbruker.\n\n**Raskeste sjekk:** åpne `eu-data-act.drivesomethinggreater.com`, logg inn, og bekreft at (a) eierskap/brukerskap er bekreftet, (b) samtykket til datadeling er gitt for denne bilen, og (c) det finnes en aktiv kontinuerlig (15-minutters) dataforespørsel med alle klynger avkrysset — opprett den selv hvis ingen finnes. Hvis du heller ikke ser noen data der, er det VW-siden — ingenting denne integrasjonen kan gjøre før VW gjenoppretter den.\n\nDette er den skrivebeskyttede portal-betaen — advarselen forsvinner av seg selv når data kommer inn."
+      "description": "EU Data Act-portalen logget inn for {brand}, men returnerer ennå ingen kjøretøydata.\n\nIntegrasjonen prøver å opprette den kontinuerlige dataforespørselen automatisk for deg, men på enkelte kontoer holder portalen nettleserøkten anonym — og da kan ikke den automatiske forespørselen (og den innebygde knappen «Opprett EU Data Act-dataforespørsel») fullføres, så du må opprette forespørselen selv i portalen. De vanlige årsakene til en tom feed:\n\n1. **Eierskap/brukerskap ikke bekreftet for denne bilen.** Portalen må vise eierskapet (eller brukerskapet) for kjøretøyet ditt som bekreftet. Hvis det ikke er det, bekreft det der først — nødvendig, men ikke alltid tilstrekkelig i seg selv.\n2. **Samtykke til datadeling ikke gitt for denne bilen.** Du gir samtykket til datadeling under EU Data Act per kjøretøy, én gang. Inntil du gjør det, forblir forespørselen tom.\n3. **Ingen kontinuerlig forespørsel finnes ennå.** Hvis den automatiske opprettelsen ikke gikk gjennom, opprett den selv: legg til en egendefinert dataforespørsel i portalen med alle klynger avkrysset og 15-minutters frekvens. **Slett først enhver eldre forespørsel for nettopp denne bilen** — portalen tillater bare én aktiv forespørsel per kjøretøy, så en eldre (for eksempel en månedlig) forespørsel for denne bilen blokkerer den nye. Ikke slett en annen bils forespørsel: på en blandet konto med person- og nyttekjøretøy beholder hver bil sin egen forespørsel under sitt eget område (personbiler under Volkswagen Personenkraftwagen, varebiler under Volkswagen Nutzfahrzeuge). Integrasjonen fanger den opp ved neste avspørring — ingen omstart nødvendig.\n4. **Bilen har ikke sendt noe nytt ennå.** Et ferskt datasett publiseres først etter at bilen har blitt kjørt, ladet eller låst/låst opp, så en ny forespørsel kan bruke 15–60 minutter (eller en kort kjøretur) på å begynne å fylles.\n5. **Et avbrudd på VW-siden.** VW meldte om et avbrudd i EU Data Act-portalen for alle merker fra slutten av mai 2026; så lenge det varer, returnerer portalen tomme data for alle verktøy, og gjenopprettes merke for merke.\n6. **Eller legg til lesekanalen for nettstedet volkswagen.de.** I integrasjonens innstillinger kan du legge til den skrivebeskyttede volkswagen.de-nettstedkanalen som en alternativ kilde: den logger inn på nettstedet volkswagen.de (ikke app-backenden som blokkerer den hodeløse innloggingen), og returnerer for enkelte biler felter som portal-feeden ikke gir. Den krever at Volkswagen-ID-en din er kjøretøyets bekreftede primærbruker.\n\n**Raskeste sjekk:** åpne `eu-data-act.drivesomethinggreater.com`, logg inn, og bekreft at (a) eierskap/brukerskap er bekreftet, (b) samtykket til datadeling er gitt for denne bilen, og (c) det finnes en aktiv kontinuerlig (15-minutters) dataforespørsel med alle klynger avkrysset — opprett den selv hvis ingen finnes. Hvis du heller ikke ser noen data der, er det VW-siden — ingenting denne integrasjonen kan gjøre før VW gjenoppretter den.\n\nDette er den skrivebeskyttede portal-betaen — advarselen forsvinner av seg selv når data kommer inn."
     },
     "data_act_browser_missing": {
       "description": "Du aktiverte reserveløsningen med nettleser uten grensesnitt for EU Data Act-portalen, men Python-pakken `playwright` er ikke installert i Home Assistant-containeren din.\n\n**Slik installerer du:** åpne HA-containerskallet (Tillegg → Terminal & SSH, eller `docker exec` for en manuell installasjon) og kjør:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nChromium-nedlastingen er stor (rundt 100 MB), som er grunnen til at denne avhengigheten er valgfri i stedet for pakket med integrasjonen. Etter installasjon starter du Home Assistant på nytt.\n\nAlternativt kan du deaktivere bryteren under Innstillinger → Enheter og tjenester → VW Group Connect → Konfigurer → «EU Data Act-portal: reserveløsning med nettleser uten grensesnitt».",
@@ -2306,6 +2306,66 @@
         "official_only": "Kun offisielt API",
         "mysmob_only": "Kun standardkanal"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Kjøretøyet startet lading",
+      "description": "Utløses når et kjøretøy begynner å lade."
+    },
+    "stopped_charging": {
+      "name": "Kjøretøyet stoppet lading",
+      "description": "Utløses når et kjøretøy slutter å lade."
+    },
+    "plugged_in": {
+      "name": "Kjøretøy tilkoblet",
+      "description": "Utløses når et kjøretøys ladekabel kobles til."
+    },
+    "unplugged": {
+      "name": "Kjøretøy frakoblet",
+      "description": "Utløses når et kjøretøys ladekabel kobles fra."
+    },
+    "locked": {
+      "name": "Kjøretøy låst",
+      "description": "Utløses når et kjøretøy blir låst."
+    },
+    "unlocked": {
+      "name": "Kjøretøy låst opp",
+      "description": "Utløses når et kjøretøy blir låst opp."
+    },
+    "started_preconditioning": {
+      "name": "Kjøretøyet startet forhåndsklimatisering",
+      "description": "Utløses når et kjøretøy starter forhåndsklimatisering."
+    },
+    "stopped_preconditioning": {
+      "name": "Kjøretøyet stoppet forhåndsklimatisering",
+      "description": "Utløses når et kjøretøy stopper forhåndsklimatisering."
+    },
+    "charge_target_reached": {
+      "name": "Kjøretøyet nådde lademålet",
+      "description": "Utløses når et kjøretøys ladenivå når målet sitt."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Et kjøretøy lader",
+      "description": "Sjekker om et kjøretøy lader akkurat nå."
+    },
+    "is_plugged_in": {
+      "name": "Et kjøretøy er tilkoblet",
+      "description": "Sjekker om et kjøretøys ladekabel er tilkoblet."
+    },
+    "is_locked": {
+      "name": "Et kjøretøy er låst",
+      "description": "Sjekker om et kjøretøy er låst."
+    },
+    "is_preconditioning": {
+      "name": "Et kjøretøy forhåndsklimatiserer",
+      "description": "Sjekker om et kjøretøy kjører forhåndsklimatisering."
+    },
+    "is_charge_target_reached": {
+      "name": "Et kjøretøy nådde lademålet",
+      "description": "Sjekker om et kjøretøys ladenivå er på eller over målet."
     }
   }
 }

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "EU Data Act-portaal: nog geen voertuiggegevens ({brand})",
-      "description": "Het EU Data Act-portaal is aangemeld voor {brand}, maar levert nog geen voertuiggegevens.\n\nDe integratie probeert het doorlopende gegevensverzoek automatisch voor je aan te maken, maar bij sommige accounts houdt het portaal de browsersessie anoniem — en dan kan het automatische verzoek (en de in-app-knop \"EU Data Act-gegevensverzoek aanmaken\") niet worden voltooid, dus moet je het verzoek zelf in het portaal aanmaken. De gebruikelijke oorzaken van een lege feed:\n\n1. **Eigendom/gebruikersrecht niet bevestigd voor deze auto.** Het portaal moet het eigendom (of gebruikersrecht) van je voertuig als bevestigd tonen. Als dat niet zo is, bevestig het daar dan eerst — noodzakelijk, maar op zichzelf niet altijd voldoende.\n2. **Toestemming voor gegevensdeling niet verleend voor deze auto.** Je verleent de EU Data Act-toestemming voor gegevensdeling één keer per voertuig. Zolang je dat niet doet, blijft het verzoek leeg.\n3. **Er bestaat nog geen doorlopend verzoek.** Als het automatisch aanmaken niet is gelukt, maak het dan zelf aan: voeg in het portaal een Custom Data Request toe met alle clusters aangevinkt op een frequentie van 15 minuten. De integratie pikt het bij de volgende polling op — geen herstart nodig.\n4. **De auto heeft nog niets nieuws verstuurd.** Een nieuwe dataset wordt pas gepubliceerd nadat de auto is gereden, opgeladen of vergrendeld/ontgrendeld, dus een nieuw verzoek kan er 15-60 minuten (of een korte rit) over doen om zich te vullen.\n5. **Een storing aan VW-zijde.** VW meldde een storing van het EU Data Act-portaal voor alle merken vanaf eind mei 2026; zolang die duurt levert het portaal voor elke tool lege gegevens, en herstelt het merk voor merk.\n6. **Of voeg het leeskanaal van de volkswagen.de-website toe.** In de opties van de integratie kun je het alleen-lezen volkswagen.de-websitekanaal als alternatieve bron toevoegen: het meldt zich aan op de volkswagen.de-website (niet de app-backend die de headless login blokkeert), en levert voor sommige auto's velden die de portaalfeed niet levert. Daarvoor moet je Volkswagen ID de bevestigde hoofdgebruiker van het voertuig zijn.\n\n**Snelste controle:** open `eu-data-act.drivesomethinggreater.com`, meld je aan en bevestig (a) dat eigendom/gebruikersrecht is bevestigd, (b) dat de toestemming voor gegevensdeling voor deze auto is verleend, en (c) dat er een actief doorlopend gegevensverzoek (van 15 minuten) is met alle clusters aangevinkt — maak het zelf aan als er geen bestaat. Als je daar ook geen gegevens ziet, ligt het aan de VW-zijde — dan kan deze integratie niets doen totdat VW het herstelt.\n\nDit is de alleen-lezen portaalbèta — de waarschuwing verdwijnt vanzelf zodra er gegevens binnenkomen."
+      "description": "Het EU Data Act-portaal is aangemeld voor {brand}, maar levert nog geen voertuiggegevens.\n\nDe integratie probeert het doorlopende gegevensverzoek automatisch voor je aan te maken, maar bij sommige accounts houdt het portaal de browsersessie anoniem — en dan kan het automatische verzoek (en de in-app-knop \"EU Data Act-gegevensverzoek aanmaken\") niet worden voltooid, dus moet je het verzoek zelf in het portaal aanmaken. De gebruikelijke oorzaken van een lege feed:\n\n1. **Eigendom/gebruikersrecht niet bevestigd voor deze auto.** Het portaal moet het eigendom (of gebruikersrecht) van je voertuig als bevestigd tonen. Als dat niet zo is, bevestig het daar dan eerst — noodzakelijk, maar op zichzelf niet altijd voldoende.\n2. **Toestemming voor gegevensdeling niet verleend voor deze auto.** Je verleent de EU Data Act-toestemming voor gegevensdeling één keer per voertuig. Zolang je dat niet doet, blijft het verzoek leeg.\n3. **Er bestaat nog geen doorlopend verzoek.** Als het automatisch aanmaken niet is gelukt, maak het dan zelf aan: voeg in het portaal een Custom Data Request toe met alle clusters aangevinkt op een frequentie van 15 minuten. **Verwijder eerst elk ouder verzoek voor precies deze auto** — het portaal staat maar één actief verzoek per voertuig toe, dus een ouder verzoek (bijvoorbeeld een maandelijks) voor deze auto blokkeert het nieuwe. Verwijder niet het verzoek van een andere auto: bij een gemengd account met personen- en bedrijfsvoertuigen behoudt elke auto zijn eigen verzoek onder zijn eigen gedeelte (personenauto's onder Volkswagen Personenkraftwagen, bestelwagens onder Volkswagen Nutzfahrzeuge). De integratie pikt het bij de volgende polling op — geen herstart nodig.\n4. **De auto heeft nog niets nieuws verstuurd.** Een nieuwe dataset wordt pas gepubliceerd nadat de auto is gereden, opgeladen of vergrendeld/ontgrendeld, dus een nieuw verzoek kan er 15-60 minuten (of een korte rit) over doen om zich te vullen.\n5. **Een storing aan VW-zijde.** VW meldde een storing van het EU Data Act-portaal voor alle merken vanaf eind mei 2026; zolang die duurt levert het portaal voor elke tool lege gegevens, en herstelt het merk voor merk.\n6. **Of voeg het leeskanaal van de volkswagen.de-website toe.** In de opties van de integratie kun je het alleen-lezen volkswagen.de-websitekanaal als alternatieve bron toevoegen: het meldt zich aan op de volkswagen.de-website (niet de app-backend die de headless login blokkeert), en levert voor sommige auto's velden die de portaalfeed niet levert. Daarvoor moet je Volkswagen ID de bevestigde hoofdgebruiker van het voertuig zijn.\n\n**Snelste controle:** open `eu-data-act.drivesomethinggreater.com`, meld je aan en bevestig (a) dat eigendom/gebruikersrecht is bevestigd, (b) dat de toestemming voor gegevensdeling voor deze auto is verleend, en (c) dat er een actief doorlopend gegevensverzoek (van 15 minuten) is met alle clusters aangevinkt — maak het zelf aan als er geen bestaat. Als je daar ook geen gegevens ziet, ligt het aan de VW-zijde — dan kan deze integratie niets doen totdat VW het herstelt.\n\nDit is de alleen-lezen portaalbèta — de waarschuwing verdwijnt vanzelf zodra er gegevens binnenkomen."
     },
     "data_act_browser_missing": {
       "description": "Je hebt de headless-browser-fallback voor het EU Data Act-portaal ingeschakeld, maar het Python-pakket `playwright` is niet geïnstalleerd in je Home Assistant-container.\n\n**Installeren:** open de shell van de HA-container (Add-ons → Terminal & SSH, of `docker exec` voor een handmatige installatie) en voer uit:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nDe chromium-download is groot (ongeveer 100 MB), daarom is deze afhankelijkheid optioneel in plaats van meegeleverd met de integratie. Herstart Home Assistant na de installatie.\n\nJe kunt de schakelaar ook uitzetten via Instellingen → Apparaten & diensten → VW Group Connect → Configureren → 'EU Data Act-portaal: headless-browser-fallback'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Alleen officiële API",
         "mysmob_only": "Alleen standaardkanaal"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Voertuig is begonnen met laden",
+      "description": "Wordt geactiveerd wanneer een voertuig begint met laden."
+    },
+    "stopped_charging": {
+      "name": "Voertuig is gestopt met laden",
+      "description": "Wordt geactiveerd wanneer een voertuig stopt met laden."
+    },
+    "plugged_in": {
+      "name": "Voertuig aangesloten",
+      "description": "Wordt geactiveerd wanneer de laadkabel van een voertuig wordt aangesloten."
+    },
+    "unplugged": {
+      "name": "Voertuig losgekoppeld",
+      "description": "Wordt geactiveerd wanneer de laadkabel van een voertuig wordt losgekoppeld."
+    },
+    "locked": {
+      "name": "Voertuig vergrendeld",
+      "description": "Wordt geactiveerd wanneer een voertuig wordt vergrendeld."
+    },
+    "unlocked": {
+      "name": "Voertuig ontgrendeld",
+      "description": "Wordt geactiveerd wanneer een voertuig wordt ontgrendeld."
+    },
+    "started_preconditioning": {
+      "name": "Voertuig is begonnen met voorconditioneren",
+      "description": "Wordt geactiveerd wanneer een voertuig begint met het voorconditioneren van het klimaat."
+    },
+    "stopped_preconditioning": {
+      "name": "Voertuig is gestopt met voorconditioneren",
+      "description": "Wordt geactiveerd wanneer een voertuig stopt met het voorconditioneren van het klimaat."
+    },
+    "charge_target_reached": {
+      "name": "Voertuig heeft zijn laaddoel bereikt",
+      "description": "Wordt geactiveerd wanneer het laadniveau van een voertuig zijn doel bereikt."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Een voertuig laadt",
+      "description": "Test of een voertuig op dit moment laadt."
+    },
+    "is_plugged_in": {
+      "name": "Een voertuig is aangesloten",
+      "description": "Test of de laadkabel van een voertuig is aangesloten."
+    },
+    "is_locked": {
+      "name": "Een voertuig is vergrendeld",
+      "description": "Test of een voertuig is vergrendeld."
+    },
+    "is_preconditioning": {
+      "name": "Een voertuig is aan het voorconditioneren",
+      "description": "Test of een voertuig het klimaat aan het voorconditioneren is."
+    },
+    "is_charge_target_reached": {
+      "name": "Een voertuig heeft zijn laaddoel bereikt",
+      "description": "Test of het laadniveau van een voertuig op of boven zijn doel is."
     }
   }
 }

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "Portal EU Data Act: brak danych pojazdu ({brand})",
-      "description": "Portal EU Data Act zalogował się do {brand}, ale nie zwraca jeszcze żadnych danych pojazdu.\n\nIntegracja próbuje automatycznie utworzyć dla Ciebie ciągłe żądanie danych, ale na niektórych kontach portal utrzymuje sesję przeglądarki jako anonimową — i wtedy automatyczne żądanie (oraz przycisk „Utwórz żądanie danych EU Data Act\" w aplikacji) nie może się zakończyć, więc musisz samodzielnie utworzyć żądanie w portalu. Typowe przyczyny pustego strumienia danych:\n\n1. **Nie potwierdzono własności/użytkowania tego samochodu.** Portal musi pokazywać własność (lub użytkowanie) Twojego pojazdu jako potwierdzoną. Jeśli tak nie jest, najpierw potwierdź to tam — konieczne, choć samo w sobie nie zawsze wystarczające.\n2. **Nie udzielono zgody na udostępnianie danych dla tego samochodu.** Zgodę na udostępnianie danych w ramach EU Data Act udzielasz osobno dla każdego pojazdu, jednorazowo. Dopóki tego nie zrobisz, żądanie pozostaje puste.\n3. **Nie istnieje jeszcze żadne ciągłe żądanie.** Jeśli automatyczne utworzenie się nie powiodło, utwórz je samodzielnie: w portalu dodaj niestandardowe żądanie danych (Custom Data Request) z zaznaczonymi wszystkimi klastrami i częstotliwością 15 minut. Integracja odbierze je przy następnym odpytaniu — bez potrzeby restartu.\n4. **Samochód nie wysłał jeszcze nic nowego.** Nowy zestaw danych jest publikowany dopiero po tym, jak samochód był prowadzony, ładowany lub zamknięty/otwarty, więc nowe żądanie może potrzebować 15–60 minut (lub krótkiej jazdy), zanim zacznie się wypełniać.\n5. **Awaria po stronie VW.** VW zgłosił awarię portalu EU Data Act obejmującą wszystkie marki, trwającą od końca maja 2026; dopóki trwa, portal zwraca puste dane dla każdego narzędzia, przywracając działanie marka po marce.\n6. **Albo dodaj kanał odczytu ze strony volkswagen.de.** W opcjach integracji możesz dodać kanał tylko do odczytu ze strony volkswagen.de jako alternatywne źródło: loguje się on na stronie volkswagen.de (a nie w backendzie aplikacji, który blokuje logowanie headless) i dla niektórych samochodów zwraca pola, których strumień z portalu nie udostępnia. Wymaga, aby Twój Volkswagen ID był potwierdzonym głównym użytkownikiem pojazdu.\n\n**Najszybsze sprawdzenie:** otwórz `eu-data-act.drivesomethinggreater.com`, zaloguj się i potwierdź, że (a) własność/użytkowanie jest potwierdzone, (b) zgoda na udostępnianie danych jest udzielona dla tego samochodu oraz (c) istnieje aktywne ciągłe (15-minutowe) żądanie danych z zaznaczonymi wszystkimi klastrami — tworząc je samodzielnie, jeśli żadne nie istnieje. Jeśli i tam nie widzisz żadnych danych, to problem po stronie VW — ta integracja nic nie może zrobić, dopóki VW go nie usunie.\n\nTo jest wersja beta portalu tylko do odczytu — ostrzeżenie zniknie samo, gdy tylko napłyną dane."
+      "description": "Portal EU Data Act zalogował się do {brand}, ale nie zwraca jeszcze żadnych danych pojazdu.\n\nIntegracja próbuje automatycznie utworzyć dla Ciebie ciągłe żądanie danych, ale na niektórych kontach portal utrzymuje sesję przeglądarki jako anonimową — i wtedy automatyczne żądanie (oraz przycisk „Utwórz żądanie danych EU Data Act\" w aplikacji) nie może się zakończyć, więc musisz samodzielnie utworzyć żądanie w portalu. Typowe przyczyny pustego strumienia danych:\n\n1. **Nie potwierdzono własności/użytkowania tego samochodu.** Portal musi pokazywać własność (lub użytkowanie) Twojego pojazdu jako potwierdzoną. Jeśli tak nie jest, najpierw potwierdź to tam — konieczne, choć samo w sobie nie zawsze wystarczające.\n2. **Nie udzielono zgody na udostępnianie danych dla tego samochodu.** Zgodę na udostępnianie danych w ramach EU Data Act udzielasz osobno dla każdego pojazdu, jednorazowo. Dopóki tego nie zrobisz, żądanie pozostaje puste.\n3. **Nie istnieje jeszcze żadne ciągłe żądanie.** Jeśli automatyczne utworzenie się nie powiodło, utwórz je samodzielnie: w portalu dodaj niestandardowe żądanie danych (Custom Data Request) z zaznaczonymi wszystkimi klastrami i częstotliwością 15 minut. **Najpierw usuń wszelkie starsze żądania dla tego samego samochodu** — portal zezwala tylko na jedno aktywne żądanie na pojazd, więc starsze (na przykład miesięczne) żądanie dla tego samochodu blokuje nowe. Nie usuwaj żądania innego samochodu: na koncie mieszanym z samochodami osobowymi i użytkowymi każdy samochód zachowuje własne żądanie w swoim własnym obszarze (samochody osobowe w Volkswagen Personenkraftwagen, samochody dostawcze w Volkswagen Nutzfahrzeuge). Integracja odbierze je przy następnym odpytaniu — bez potrzeby restartu.\n4. **Samochód nie wysłał jeszcze nic nowego.** Nowy zestaw danych jest publikowany dopiero po tym, jak samochód był prowadzony, ładowany lub zamknięty/otwarty, więc nowe żądanie może potrzebować 15–60 minut (lub krótkiej jazdy), zanim zacznie się wypełniać.\n5. **Awaria po stronie VW.** VW zgłosił awarię portalu EU Data Act obejmującą wszystkie marki, trwającą od końca maja 2026; dopóki trwa, portal zwraca puste dane dla każdego narzędzia, przywracając działanie marka po marce.\n6. **Albo dodaj kanał odczytu ze strony volkswagen.de.** W opcjach integracji możesz dodać kanał tylko do odczytu ze strony volkswagen.de jako alternatywne źródło: loguje się on na stronie volkswagen.de (a nie w backendzie aplikacji, który blokuje logowanie headless) i dla niektórych samochodów zwraca pola, których strumień z portalu nie udostępnia. Wymaga, aby Twój Volkswagen ID był potwierdzonym głównym użytkownikiem pojazdu.\n\n**Najszybsze sprawdzenie:** otwórz `eu-data-act.drivesomethinggreater.com`, zaloguj się i potwierdź, że (a) własność/użytkowanie jest potwierdzone, (b) zgoda na udostępnianie danych jest udzielona dla tego samochodu oraz (c) istnieje aktywne ciągłe (15-minutowe) żądanie danych z zaznaczonymi wszystkimi klastrami — tworząc je samodzielnie, jeśli żadne nie istnieje. Jeśli i tam nie widzisz żadnych danych, to problem po stronie VW — ta integracja nic nie może zrobić, dopóki VW go nie usunie.\n\nTo jest wersja beta portalu tylko do odczytu — ostrzeżenie zniknie samo, gdy tylko napłyną dane."
     },
     "data_act_browser_missing": {
       "description": "Włączyłeś rezerwowy tryb przeglądarki headless dla portalu EU Data Act, ale pakiet Pythona `playwright` nie jest zainstalowany w Twoim kontenerze Home Assistant.\n\n**Aby zainstalować:** otwórz powłokę kontenera HA (Dodatki → Terminal & SSH lub `docker exec` przy instalacji ręcznej) i uruchom:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nPobranie chromium jest duże (około 100 MB), dlatego ta zależność jest opcjonalna, a nie dołączona do integracji. Po instalacji uruchom ponownie Home Assistant.\n\nAlternatywnie wyłącz przełącznik w Ustawienia → Urządzenia i usługi → VW Group Connect → Konfiguruj → 'Portal EU Data Act: rezerwowy tryb przeglądarki headless'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Tylko oficjalne API",
         "mysmob_only": "Tylko kanał standardowy"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Pojazd rozpoczął ładowanie",
+      "description": "Wyzwalane, gdy pojazd rozpoczyna ładowanie."
+    },
+    "stopped_charging": {
+      "name": "Pojazd zakończył ładowanie",
+      "description": "Wyzwalane, gdy pojazd kończy ładowanie."
+    },
+    "plugged_in": {
+      "name": "Pojazd podłączony",
+      "description": "Wyzwalane, gdy kabel ładowania pojazdu zostaje podłączony."
+    },
+    "unplugged": {
+      "name": "Pojazd odłączony",
+      "description": "Wyzwalane, gdy kabel ładowania pojazdu zostaje odłączony."
+    },
+    "locked": {
+      "name": "Pojazd zablokowany",
+      "description": "Wyzwalane, gdy pojazd zostaje zablokowany."
+    },
+    "unlocked": {
+      "name": "Pojazd odblokowany",
+      "description": "Wyzwalane, gdy pojazd zostaje odblokowany."
+    },
+    "started_preconditioning": {
+      "name": "Pojazd rozpoczął wstępną klimatyzację",
+      "description": "Wyzwalane, gdy pojazd rozpoczyna wstępną klimatyzację."
+    },
+    "stopped_preconditioning": {
+      "name": "Pojazd zakończył wstępną klimatyzację",
+      "description": "Wyzwalane, gdy pojazd kończy wstępną klimatyzację."
+    },
+    "charge_target_reached": {
+      "name": "Pojazd osiągnął docelowy poziom naładowania",
+      "description": "Wyzwalane, gdy poziom naładowania pojazdu osiąga wartość docelową."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Pojazd się ładuje",
+      "description": "Sprawdza, czy którykolwiek pojazd aktualnie się ładuje."
+    },
+    "is_plugged_in": {
+      "name": "Pojazd jest podłączony",
+      "description": "Sprawdza, czy kabel ładowania któregokolwiek pojazdu jest podłączony."
+    },
+    "is_locked": {
+      "name": "Pojazd jest zablokowany",
+      "description": "Sprawdza, czy którykolwiek pojazd jest zablokowany."
+    },
+    "is_preconditioning": {
+      "name": "Pojazd wstępnie klimatyzuje",
+      "description": "Sprawdza, czy którykolwiek pojazd wykonuje wstępną klimatyzację."
+    },
+    "is_charge_target_reached": {
+      "name": "Pojazd osiągnął docelowy poziom naładowania",
+      "description": "Sprawdza, czy poziom naładowania któregokolwiek pojazdu osiągnął wartość docelową lub ją przekroczył."
     }
   }
 }

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1994,7 +1994,7 @@
     },
     "data_act_no_data": {
       "title": "EU Data Act-portalen: ingen fordonsdata ännu ({brand})",
-      "description": "EU Data Act-portalen loggade in för {brand} men returnerar ännu inga fordonsdata.\n\nIntegrationen försöker skapa den kontinuerliga dataförfrågan åt dig automatiskt, men på vissa konton håller portalen webbläsarsessionen anonym — och då kan den automatiska förfrågan (och knappen \"Skapa dataförfrågan enligt EU:s dataakt\" i appen) inte slutföras, så du måste skapa förfrågan själv i portalen. De vanliga orsakerna till ett tomt flöde:\n\n1. **Ägarskap/nyttjanderätt är inte bekräftat för den här bilen.** Portalen måste visa ditt fordons ägarskap (eller nyttjanderätt) som bekräftat. Om det inte gör det, bekräfta det där först — nödvändigt, men inte alltid tillräckligt i sig.\n2. **Samtycke till datadelning är inte beviljat för den här bilen.** Du beviljar samtycket till datadelning enligt EU:s dataakt per fordon, en gång. Tills du gör det förblir förfrågan tom.\n3. **Ingen kontinuerlig förfrågan finns ännu.** Om den automatiska skapelsen inte gick igenom, skapa den själv: lägg till en anpassad dataförfrågan (Custom Data Request) i portalen med alla kluster ikryssade och en frekvens på 15 minuter. Integrationen plockar upp den vid nästa avläsning — ingen omstart behövs.\n4. **Bilen har inte skickat något nytt ännu.** En ny datamängd publiceras först efter att bilen har körts, laddats eller låsts/låsts upp, så en ny förfrågan kan ta 15–60 minuter (eller en kort körtur) innan den börjar fyllas.\n5. **Ett avbrott på VW:s sida.** VW rapporterade ett avbrott i EU Data Act-portalen för alla varumärken från slutet av maj 2026; så länge det pågår returnerar portalen tomma data för alla verktyg och återhämtar sig varumärke för varumärke.\n6. **Eller lägg till läskanalen för webbplatsen volkswagen.de.** I integrationens inställningar kan du lägga till den skrivskyddade webbplatskanalen volkswagen.de som en alternativ källa: den loggar in på webbplatsen volkswagen.de (inte app-backenden som blockerar den huvudlösa inloggningen), och returnerar för vissa bilar fält som portalflödet inte gör. Det kräver att ditt Volkswagen ID är fordonets bekräftade primära användare.\n\n**Snabbaste kontrollen:** öppna `eu-data-act.drivesomethinggreater.com`, logga in och bekräfta (a) att ägarskap/nyttjanderätt är bekräftat, (b) att samtycket till datadelning är beviljat för den här bilen, och (c) att det finns en aktiv kontinuerlig dataförfrågan (15 minuter) med alla kluster ikryssade — skapa den själv om ingen finns. Om du inte ser några data där heller är det VW:s sida — inget den här integrationen kan göra förrän VW återställer den.\n\nDetta är den skrivskyddade portal-betan — varningen försvinner av sig själv när data kommer in."
+      "description": "EU Data Act-portalen loggade in för {brand} men returnerar ännu inga fordonsdata.\n\nIntegrationen försöker skapa den kontinuerliga dataförfrågan åt dig automatiskt, men på vissa konton håller portalen webbläsarsessionen anonym — och då kan den automatiska förfrågan (och knappen \"Skapa dataförfrågan enligt EU:s dataakt\" i appen) inte slutföras, så du måste skapa förfrågan själv i portalen. De vanliga orsakerna till ett tomt flöde:\n\n1. **Ägarskap/nyttjanderätt är inte bekräftat för den här bilen.** Portalen måste visa ditt fordons ägarskap (eller nyttjanderätt) som bekräftat. Om det inte gör det, bekräfta det där först — nödvändigt, men inte alltid tillräckligt i sig.\n2. **Samtycke till datadelning är inte beviljat för den här bilen.** Du beviljar samtycket till datadelning enligt EU:s dataakt per fordon, en gång. Tills du gör det förblir förfrågan tom.\n3. **Ingen kontinuerlig förfrågan finns ännu.** Om den automatiska skapelsen inte gick igenom, skapa den själv: lägg till en anpassad dataförfrågan (Custom Data Request) i portalen med alla kluster ikryssade och en frekvens på 15 minuter. **Ta först bort alla äldre förfrågningar för just den här bilen** — portalen tillåter bara en aktiv förfrågan per fordon, så en äldre (till exempel en månatlig) förfrågan för den här bilen blockerar den nya. Ta inte bort en annan bils förfrågan: på ett blandat konto med person- och nyttofordon behåller varje bil sin egen förfrågan under sitt eget område (personbilar under Volkswagen Personenkraftwagen, skåpbilar under Volkswagen Nutzfahrzeuge). Integrationen plockar upp den vid nästa avläsning — ingen omstart behövs.\n4. **Bilen har inte skickat något nytt ännu.** En ny datamängd publiceras först efter att bilen har körts, laddats eller låsts/låsts upp, så en ny förfrågan kan ta 15–60 minuter (eller en kort körtur) innan den börjar fyllas.\n5. **Ett avbrott på VW:s sida.** VW rapporterade ett avbrott i EU Data Act-portalen för alla varumärken från slutet av maj 2026; så länge det pågår returnerar portalen tomma data för alla verktyg och återhämtar sig varumärke för varumärke.\n6. **Eller lägg till läskanalen för webbplatsen volkswagen.de.** I integrationens inställningar kan du lägga till den skrivskyddade webbplatskanalen volkswagen.de som en alternativ källa: den loggar in på webbplatsen volkswagen.de (inte app-backenden som blockerar den huvudlösa inloggningen), och returnerar för vissa bilar fält som portalflödet inte gör. Det kräver att ditt Volkswagen ID är fordonets bekräftade primära användare.\n\n**Snabbaste kontrollen:** öppna `eu-data-act.drivesomethinggreater.com`, logga in och bekräfta (a) att ägarskap/nyttjanderätt är bekräftat, (b) att samtycket till datadelning är beviljat för den här bilen, och (c) att det finns en aktiv kontinuerlig dataförfrågan (15 minuter) med alla kluster ikryssade — skapa den själv om ingen finns. Om du inte ser några data där heller är det VW:s sida — inget den här integrationen kan göra förrän VW återställer den.\n\nDetta är den skrivskyddade portal-betan — varningen försvinner av sig själv när data kommer in."
     },
     "data_act_browser_missing": {
       "description": "Du aktiverade headless-webbläsar-fallbacken för EU Data Act-portalen, men Python-paketet `playwright` är inte installerat i din Home Assistant-container.\n\n**För att installera:** öppna HA-containerns skal (Tillägg → Terminal & SSH, eller `docker exec` för en manuell installation) och kör:\n\n```\npip install playwright\nplaywright install chromium\n```\n\nChromium-nedladdningen är stor (runt 100 MB), därför är detta beroende valfritt i stället för inbyggt i integrationen. Starta om Home Assistant efter installationen.\n\nAlternativt kan du stänga av reglaget under Inställningar → Enheter & tjänster → VW Group Connect → Konfigurera → 'EU Data Act-portalen: headless-webbläsar-fallback'.",
@@ -2306,6 +2306,66 @@
         "official_only": "Endast officiellt API",
         "mysmob_only": "Endast standardkanal"
       }
+    }
+  },
+  "triggers": {
+    "started_charging": {
+      "name": "Fordonet började ladda",
+      "description": "Utlöses när ett fordon börjar ladda."
+    },
+    "stopped_charging": {
+      "name": "Fordonet slutade ladda",
+      "description": "Utlöses när ett fordon slutar ladda."
+    },
+    "plugged_in": {
+      "name": "Fordon anslutet",
+      "description": "Utlöses när ett fordons laddkabel ansluts."
+    },
+    "unplugged": {
+      "name": "Fordon frånkopplat",
+      "description": "Utlöses när ett fordons laddkabel kopplas från."
+    },
+    "locked": {
+      "name": "Fordon låst",
+      "description": "Utlöses när ett fordon låses."
+    },
+    "unlocked": {
+      "name": "Fordon upplåst",
+      "description": "Utlöses när ett fordon låses upp."
+    },
+    "started_preconditioning": {
+      "name": "Fordonet startade förkonditionering",
+      "description": "Utlöses när ett fordon startar klimatförkonditionering."
+    },
+    "stopped_preconditioning": {
+      "name": "Fordonet stoppade förkonditionering",
+      "description": "Utlöses när ett fordon stoppar klimatförkonditionering."
+    },
+    "charge_target_reached": {
+      "name": "Fordonet nådde sitt laddmål",
+      "description": "Utlöses när ett fordons laddnivå når sitt mål."
+    }
+  },
+  "conditions": {
+    "is_charging": {
+      "name": "Ett fordon laddar",
+      "description": "Testar om något fordon laddar just nu."
+    },
+    "is_plugged_in": {
+      "name": "Ett fordon är anslutet",
+      "description": "Testar om något fordons laddkabel är ansluten."
+    },
+    "is_locked": {
+      "name": "Ett fordon är låst",
+      "description": "Testar om något fordon är låst."
+    },
+    "is_preconditioning": {
+      "name": "Ett fordon förkonditionerar",
+      "description": "Testar om något fordon kör klimatförkonditionering."
+    },
+    "is_charge_target_reached": {
+      "name": "Ett fordon nådde sitt laddmål",
+      "description": "Testar om något fordons laddnivå är på eller över sitt mål."
     }
   }
 }

--- a/custom_components/vag_connect/trigger.py
+++ b/custom_components/vag_connect/trigger.py
@@ -19,14 +19,30 @@ per-device targeting is a future enhancement.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.helpers.trigger import Trigger, TriggerActionRunner
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 from .trigger_detect import EVENT_KEYS
+
+# The named-trigger platform only exists on HA 2026.7+ (and is upstream-flagged
+# "may change without a deprecation notice"). Import it defensively so the module
+# stays importable — and static-analysable against an older HA baseline — on
+# cores that don't have it yet; there, async_get_triggers simply registers
+# nothing.
+if TYPE_CHECKING:
+    from homeassistant.helpers.trigger import (  # type: ignore[attr-defined]
+        Trigger,
+        TriggerActionRunner,
+    )
+else:
+    try:
+        from homeassistant.helpers.trigger import Trigger, TriggerActionRunner
+    except ImportError:  # HA < 2026.7 — platform not available
+        Trigger = object
+        TriggerActionRunner = object
 
 
 def _coordinators(hass: HomeAssistant) -> list[Any]:

--- a/custom_components/vag_connect/trigger.py
+++ b/custom_components/vag_connect/trigger.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b14 (EXPERIMENTAL) — integration-registered named triggers for VW Group
+Connect vehicles (HA 2026.7+ named-trigger platform).
+
+⚠️ The developer API for this platform is upstream-flagged "still in very active
+development and should not be used yet by integrations. The API may change
+without a deprecation notice" — and it DID change between HA 2026.6 and dev
+(``async_attach_runner`` gained a ``did_not_trigger`` param). So this is opt-in /
+experimental, modeled on ``homeassistant/components/sun/trigger.py``, and its
+signatures must be re-verified at each HA bump. If the platform is absent on an
+older core, ``async_get_triggers`` simply registers nothing.
+
+Each trigger fires when the vehicle state edge is detected on a REAL data update
+(coordinator._transition_detector) — no new API calls, purely derived from state
+we already poll. v1 fires for ANY of the account's vehicles and hands the action
+a payload with the ``vin`` (filter with ``{{ trigger.vin }}`` for one car);
+per-device targeting is a future enhancement.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.trigger import Trigger, TriggerActionRunner
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+from .trigger_detect import EVENT_KEYS
+
+
+def _coordinators(hass: HomeAssistant) -> list[Any]:
+    """Every loaded vag_connect coordinator (one per brand/account entry)."""
+    out: list[Any] = []
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        coord = getattr(entry, "runtime_data", None)
+        if coord is not None and hasattr(coord, "register_transition_listener"):
+            out.append(coord)
+    return out
+
+
+class _VagVehicleTrigger(Trigger):
+    """Base for a single vehicle state-transition trigger.
+
+    Subclasses set ``_event_key`` to one of :data:`trigger_detect.EVENT_KEYS`.
+    """
+
+    _event_key: str = ""
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        return config
+
+    def __init__(self, hass: HomeAssistant, config: Any) -> None:
+        super().__init__(hass, config)
+        self._hass = hass
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: Any = None,
+    ) -> CALLBACK_TYPE:
+        # did_not_trigger is accepted for forward-compat with newer HA cores that
+        # pass it (HA 2026.6 does not); we don't use it.
+        event_key = self._event_key
+
+        def _on_transition(payload: dict[str, Any]) -> None:
+            run_action(payload, f"vehicle {payload.get('event', event_key)}")
+
+        unsubs = [
+            coord.register_transition_listener(event_key, None, _on_transition)
+            for coord in _coordinators(self._hass)
+        ]
+
+        @callback
+        def _remove() -> None:
+            for unsub in unsubs:
+                unsub()
+
+        return _remove
+
+
+def _make_trigger(event_key: str) -> type[Trigger]:
+    """Build a concrete Trigger subclass for one event key."""
+
+    class _T(_VagVehicleTrigger):
+        _event_key = event_key
+
+    _T.__name__ = f"VagVehicle_{event_key}_Trigger"
+    _T.__qualname__ = _T.__name__
+    return _T
+
+
+# Registered trigger names → classes. Keys are the stable snake_case ids the
+# strings.json "triggers" section + triggers.yaml describe.
+TRIGGERS: dict[str, type[Trigger]] = {
+    event_key: _make_trigger(event_key) for event_key in sorted(EVENT_KEYS)
+}
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """HA named-trigger platform hook — expose our vehicle triggers.
+
+    Robust against the experimental API changing: only classes that are actually
+    CONCRETE (all abstractmethods implemented) are registered, so if a future HA
+    adds/renames a required method, we degrade to registering nothing instead of
+    handing HA a class it cannot instantiate.
+    """
+    return {
+        key: cls
+        for key, cls in TRIGGERS.items()
+        if not getattr(cls, "__abstractmethods__", frozenset())
+    }

--- a/custom_components/vag_connect/trigger_detect.py
+++ b/custom_components/vag_connect/trigger_detect.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b14 (experimental) — vehicle state-transition detection for the named-trigger
+platform (``trigger.py``).
+
+Kept OUT of the 8000-line coordinator so the edge logic is unit-testable in
+isolation and HA-version-independent. The coordinator feeds each REAL (push /
+poll) data snapshot into :meth:`VehicleTransitionDetector.feed`; the detector
+compares it against the previous snapshot and fires edge callbacks that the
+trigger platform subscribes to.
+
+Two hard rules the caller must honour (both grounded in the coordinator's own
+documented traps):
+  * feed() ONLY on a real data update — NEVER on the optimistic-echo
+    ``async_set_updated_data(dict(self.vehicles))`` calls, or every button press
+    would fire a phantom "started charging".
+  * the first snapshot of a VIN, and any ``None`` (unknown) → value edge, never
+    fire — otherwise every restart spams events.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# Boolean field → (event on False→True, event on True→False).
+_BOOL_EDGES: dict[str, tuple[str, str]] = {
+    "is_charging": ("started_charging", "stopped_charging"),
+    "plug_connected": ("plugged_in", "unplugged"),
+    "climatisation_active": ("started_preconditioning", "stopped_preconditioning"),
+}
+# doors_locked reads inverted: True→False is "unlocked", False→True is "locked".
+_LOCK_FIELD = "doors_locked"
+
+# Every event key the detector can emit — the trigger platform registers these.
+EVENT_KEYS: frozenset[str] = frozenset(
+    {ev for pair in _BOOL_EDGES.values() for ev in pair}
+    | {"locked", "unlocked", "charge_target_reached"}
+)
+
+# The vehicle-dict fields we snapshot each cycle (keep the baseline tiny).
+_TRACKED_FIELDS: tuple[str, ...] = (
+    "is_charging", "plug_connected", "climatisation_active", "doors_locked",
+    "battery_soc", "target_soc",
+)
+
+_Listener = Callable[[dict[str, Any]], None]
+
+
+class VehicleTransitionDetector:
+    """Detects per-vehicle state edges across successive data snapshots."""
+
+    def __init__(self) -> None:
+        self._prev: dict[str, dict[str, Any]] = {}
+        # event_key → list of (vin_or_None, callback)
+        self._listeners: dict[str, list[tuple[str | None, _Listener]]] = {}
+
+    def register(
+        self, event_key: str, vin: str | None, callback: _Listener
+    ) -> Callable[[], None]:
+        """Subscribe to an event (optionally scoped to one VIN). Returns unsub."""
+        entry = (vin, callback)
+        self._listeners.setdefault(event_key, []).append(entry)
+
+        def _unsub() -> None:
+            lst = self._listeners.get(event_key)
+            if lst is not None and entry in lst:
+                lst.remove(entry)
+
+        return _unsub
+
+    def feed(self, data: dict[str, dict[str, Any]]) -> None:
+        """Compare *data* against the last snapshot and fire edge listeners."""
+        for vin, veh in data.items():
+            if str(vin).startswith("_") or not isinstance(veh, dict):
+                continue
+            prev = self._prev.get(vin)
+            if prev is not None:
+                for event_key in self._detect(prev, veh):
+                    self._fire(event_key, vin)
+            self._prev[vin] = {k: veh.get(k) for k in _TRACKED_FIELDS}
+
+    def _detect(self, prev: dict[str, Any], cur: dict[str, Any]) -> list[str]:
+        events: list[str] = []
+        for field, (on_true, on_false) in _BOOL_EDGES.items():
+            old, new = prev.get(field), cur.get(field)
+            if isinstance(old, bool) and isinstance(new, bool) and old != new:
+                events.append(on_true if new else on_false)
+        old, new = prev.get(_LOCK_FIELD), cur.get(_LOCK_FIELD)
+        if isinstance(old, bool) and isinstance(new, bool) and old != new:
+            events.append("locked" if new else "unlocked")
+        # charge_target_reached — SoC crosses UP to >= target (once, not every
+        # poll while parked at/above target).
+        po, pn, tgt = (
+            prev.get("battery_soc"), cur.get("battery_soc"), cur.get("target_soc")
+        )
+        if (
+            isinstance(po, int) and isinstance(pn, int) and isinstance(tgt, int)
+            and not isinstance(po, bool) and not isinstance(pn, bool)
+            and po < tgt <= pn
+        ):
+            events.append("charge_target_reached")
+        return events
+
+    def _fire(self, event_key: str, vin: str) -> None:
+        payload = {"vin": vin, "event": event_key}
+        for lvin, cb in list(self._listeners.get(event_key, [])):
+            if lvin is None or lvin == vin:
+                try:
+                    cb(payload)
+                except Exception:  # noqa: BLE001 — a listener must never break polling
+                    _LOGGER.debug(
+                        "vehicle transition listener for %s raised", event_key,
+                        exc_info=True,
+                    )

--- a/custom_components/vag_connect/triggers.yaml
+++ b/custom_components/vag_connect/triggers.yaml
@@ -1,0 +1,13 @@
+# Named triggers exposed by VW Group Connect (experimental, HA 2026.7+).
+# Human-readable names + descriptions live in strings.json / translations; these
+# triggers take no fields in v1 (each fires for any of the account's vehicles —
+# filter on the payload's `vin` in the automation).
+started_charging:
+stopped_charging:
+plugged_in:
+unplugged:
+locked:
+unlocked:
+started_preconditioning:
+stopped_preconditioning:
+charge_target_reached:

--- a/tests/test_1340_portal_client_ids.py
+++ b/tests/test_1340_portal_client_ids.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1340 (@cyrano330) — Audi/Škoda/Bentley each authenticate against the EU Data
+Act portal with their OWN OIDC client. Reusing the VW client made login "succeed"
+(it lands on the portal host) while the session stayed ANONYMOUS, so every
+proxy_api data read 401'd. The full ids are grounded from the portal's per-brand
+login redirect (each 302s to identity.vwgroup.io/signin-service/<that id>), match
+every other EU-Data-Act reader, and are verified live 2026-09-05. Both portal-auth
+consumers (the cookie reader and the token/device-grant login) must use them and
+must never drift apart.
+"""
+from __future__ import annotations
+
+# Grounded 2026-09-05: triple-source (independent EU-DA readers) + a live
+# unauthenticated authorize handshake (each id 302 → signin-service/<id>).
+_AUDI = "cc29b87a-5e9a-4362-aecf-5adea6b01bbb@apps_vw-dilab_com"
+_SKODA = "3ea88bf9-1d4e-4a68-b3ad-4098c1f1d246@apps_vw-dilab_com"
+_BENTLEY = "d38aac0f-3d89-4a63-8538-b75b31322c7b@apps_vw-dilab_com"
+_CUPRA_SEAT = "f85e5b69-e3b2-43aa-9c0d-1b7d0e0b576f@apps_vw-dilab_com"
+_VW = "9b58543e-1c15-4193-91d5-8a14145bebb0@apps_vw-dilab_com"
+
+
+def _cookie_client(brand: str) -> str:
+    from custom_components.vag_connect.cariad.auth._eu_data_act import (
+        EUDataActConnector,
+    )
+    return EUDataActConnector(object(), brand=brand)._client_id  # type: ignore[arg-type]
+
+
+def test_cookie_reader_uses_own_client_per_brand() -> None:
+    assert _cookie_client("audi") == _AUDI
+    assert _cookie_client("skoda") == _SKODA
+    assert _cookie_client("bentley") == _BENTLEY
+    # unchanged brands keep their own client
+    assert _cookie_client("volkswagen") == _VW
+    assert _cookie_client("volkswagen_commercial") == _VW
+    assert _cookie_client("cupra") == _CUPRA_SEAT
+    assert _cookie_client("seat") == _CUPRA_SEAT
+    # a genuinely unknown brand still falls back to VW (graceful)
+    assert _cookie_client("porsche") == _VW
+
+
+def test_portal_login_path_uses_own_client_per_brand() -> None:
+    from custom_components.vag_connect.cariad.auth._data_act_portal import (
+        _brand_client_id,
+    )
+    assert _brand_client_id("audi") == _AUDI
+    assert _brand_client_id("skoda") == _SKODA
+    assert _brand_client_id("bentley") == _BENTLEY
+    assert _brand_client_id("cupra") == _CUPRA_SEAT
+    assert _brand_client_id("seat") == _CUPRA_SEAT
+    assert _brand_client_id("volkswagen") == _VW
+    assert _brand_client_id("porsche") == _VW      # unknown → VW fallback
+    assert _brand_client_id("AUDI") == _AUDI        # case-insensitive
+
+
+def test_both_consumers_agree_on_every_brand() -> None:
+    # The cookie reader and the token/device-grant login must never disagree on a
+    # brand's portal client — a drift would make one channel silently anonymous.
+    from custom_components.vag_connect.cariad.auth._data_act_portal import (
+        _brand_client_id,
+    )
+    for brand in (
+        "audi", "skoda", "bentley", "cupra", "seat",
+        "volkswagen", "volkswagen_commercial", "porsche",
+    ):
+        assert _cookie_client(brand) == _brand_client_id(brand), brand

--- a/tests/test_b13_cleanup.py
+++ b/tests/test_b13_cleanup.py
@@ -129,3 +129,42 @@ def test_401_dump_logs_redacted_at_debug(caplog) -> None:
     assert "resp_set_cookie=True" in blob
     # the query string is stripped from the logged URL
     assert "viewPosition" not in blob
+
+
+def test_401_dump_masks_uuid_in_cookie_name(caplog) -> None:
+    # b14 (#1340 @cyrano330): the IDP session cookies are NAMED s_<uuid>/d_<uuid>,
+    # so a "names only" dump must still mask the UUID that lives in the name.
+    from custom_components.vag_connect.cariad.auth import _eu_data_act
+    uid = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    c = _connector(
+        [
+            _Cookie(f"s_{uid}", "identity.vwgroup.io", "v"),
+            _Cookie("affinity", "eu-data-act.drivesomethinggreater.com", "lb"),
+        ],
+        bearer=None,
+    )
+    resp = MagicMock()
+    resp.headers = {}
+    with caplog.at_level(logging.DEBUG, logger=_eu_data_act._LOGGER.name):
+        c._debug_dump_auth_state_on_401("https://p/proxy_api/x", {}, resp)
+    blob = caplog.text
+    assert uid not in blob                              # UUID in the NAME masked
+    assert "s_<uuid>@identity.vwgroup.io" in blob       # structure preserved
+    assert "affinity@eu-data-act.drivesomethinggreater.com" in blob
+    assert "mode=cookie" in blob
+    # derived fork-answer: only the LB cookie on the portal domain = anonymous
+    assert "portal_domain_cookies=['affinity']" in blob
+
+
+def test_401_dump_logs_once_per_instance(caplog) -> None:
+    # b14: one VW-EU setup reaches the portal from ~3 call sites; the snapshot
+    # should be logged exactly once so a pasted debug log stays readable.
+    from custom_components.vag_connect.cariad.auth import _eu_data_act
+    c = _connector([_Cookie("SESSID", "portal.example", "x")], bearer="tok")
+    resp = MagicMock()
+    resp.headers = {}
+    with caplog.at_level(logging.DEBUG, logger=_eu_data_act._LOGGER.name):
+        c._debug_dump_auth_state_on_401("https://p/proxy_api/a", {}, resp)
+        c._debug_dump_auth_state_on_401("https://p/proxy_api/b", {}, resp)
+        c._debug_dump_auth_state_on_401("https://p/proxy_api/c", {}, resp)
+    assert caplog.text.count("EU Data Act 401 auth-state on") == 1

--- a/tests/test_b14_triggers.py
+++ b/tests/test_b14_triggers.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b13 (experimental) — vehicle state-transition detector + named trigger/condition
+platform registration.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.trigger_detect import (
+    EVENT_KEYS,
+    VehicleTransitionDetector,
+)
+
+
+# ── detector edge logic ───────────────────────────────────────────────────────
+
+def _fires(prev_veh, cur_veh, vin="V1"):
+    """Feed two snapshots, return the list of fired event keys for `vin`."""
+    d = VehicleTransitionDetector()
+    fired: list[str] = []
+    for ev in EVENT_KEYS:
+        d.register(ev, None, lambda p, ev=ev: fired.append(p["event"]))
+    d.feed({vin: prev_veh})   # first snapshot — must NOT fire
+    d.feed({vin: cur_veh})    # second — the edge
+    return fired
+
+
+def test_first_snapshot_never_fires() -> None:
+    d = VehicleTransitionDetector()
+    fired: list[str] = []
+    d.register("started_charging", None, lambda p: fired.append(p["event"]))
+    d.feed({"V1": {"is_charging": True}})   # first sight of V1
+    assert fired == []
+
+
+def test_none_to_value_does_not_fire() -> None:
+    # unknown → known (e.g. after a restart) must be silent
+    assert _fires({"is_charging": None}, {"is_charging": True}) == []
+
+
+def test_started_and_stopped_charging() -> None:
+    assert _fires({"is_charging": False}, {"is_charging": True}) == ["started_charging"]
+    assert _fires({"is_charging": True}, {"is_charging": False}) == ["stopped_charging"]
+
+
+def test_plug_and_precondition_edges() -> None:
+    assert _fires({"plug_connected": False}, {"plug_connected": True}) == ["plugged_in"]
+    assert _fires({"climatisation_active": True}, {"climatisation_active": False}) == [
+        "stopped_preconditioning"
+    ]
+
+
+def test_lock_inversion() -> None:
+    # doors_locked True→False = unlocked; False→True = locked
+    assert _fires({"doors_locked": True}, {"doors_locked": False}) == ["unlocked"]
+    assert _fires({"doors_locked": False}, {"doors_locked": True}) == ["locked"]
+
+
+def test_charge_target_reached_upward_only() -> None:
+    # crosses up into target → fires once
+    assert _fires({"battery_soc": 70, "target_soc": 80},
+                  {"battery_soc": 82, "target_soc": 80}) == ["charge_target_reached"]
+    # already at/above target, stays there → does NOT re-fire
+    assert _fires({"battery_soc": 82, "target_soc": 80},
+                  {"battery_soc": 83, "target_soc": 80}) == []
+    # dropping does not fire
+    assert _fires({"battery_soc": 82, "target_soc": 80},
+                  {"battery_soc": 78, "target_soc": 80}) == []
+
+
+def test_unsub_stops_delivery() -> None:
+    d = VehicleTransitionDetector()
+    fired: list[str] = []
+    unsub = d.register("locked", None, lambda p: fired.append(p["event"]))
+    d.feed({"V1": {"doors_locked": False}})
+    unsub()
+    d.feed({"V1": {"doors_locked": True}})   # would be "locked" but unsubscribed
+    assert fired == []
+
+
+def test_vin_scoped_listener() -> None:
+    d = VehicleTransitionDetector()
+    fired: list[str] = []
+    d.register("started_charging", "V2", lambda p: fired.append(p["vin"]))
+    d.feed({"V1": {"is_charging": False}, "V2": {"is_charging": False}})
+    d.feed({"V1": {"is_charging": True}, "V2": {"is_charging": True}})
+    assert fired == ["V2"]   # only the V2-scoped listener fired
+
+
+def test_underscore_keys_ignored() -> None:
+    d = VehicleTransitionDetector()
+    fired: list[str] = []
+    d.register("started_charging", None, lambda p: fired.append(p["event"]))
+    d.feed({"_meta": {"is_charging": False}})
+    d.feed({"_meta": {"is_charging": True}})
+    assert fired == []
+
+
+def test_listener_exception_never_breaks_feed() -> None:
+    d = VehicleTransitionDetector()
+    ok: list[str] = []
+    d.register("locked", None, lambda p: (_ for _ in ()).throw(ValueError("boom")))
+    d.register("locked", None, lambda p: ok.append("ok"))
+    d.feed({"V1": {"doors_locked": False}})
+    d.feed({"V1": {"doors_locked": True}})   # first listener raises, second still runs
+    assert ok == ["ok"]
+
+
+# ── platform registration ─────────────────────────────────────────────────────
+
+def test_trigger_platform_registers_all_events() -> None:
+    from custom_components.vag_connect import trigger as trig
+    got = asyncio.run(trig.async_get_triggers(MagicMock()))
+    assert set(got) == set(EVENT_KEYS)
+    # every value is a concrete Trigger subclass
+    from homeassistant.helpers.trigger import Trigger
+    assert all(issubclass(c, Trigger) for c in got.values())
+
+
+def test_condition_platform_registers_expected() -> None:
+    from custom_components.vag_connect import condition as cond
+    got = asyncio.run(cond.async_get_conditions(MagicMock()))
+    assert set(got) == {
+        "is_charging", "is_plugged_in", "is_locked", "is_preconditioning",
+        "is_charge_target_reached",
+    }
+    from homeassistant.helpers.condition import Condition
+    assert all(issubclass(c, Condition) for c in got.values())
+
+
+def test_condition_any_vehicle_matches() -> None:
+    from custom_components.vag_connect import condition as cond
+    coord = MagicMock()
+    coord.vehicles = {"V1": {"is_charging": False}, "V2": {"is_charging": True}}
+    entry = MagicMock()
+    entry.runtime_data = coord
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = [entry]
+    assert cond._any_vehicle_matches(hass, "is_charging") is True
+    coord.vehicles = {"V1": {"is_charging": False}}
+    assert cond._any_vehicle_matches(hass, "is_charging") is False

--- a/tests/test_b14_triggers.py
+++ b/tests/test_b14_triggers.py
@@ -8,9 +8,27 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import MagicMock
 
+import pytest
+
 from custom_components.vag_connect.trigger_detect import (
     EVENT_KEYS,
     VehicleTransitionDetector,
+)
+
+# The named trigger/condition platform only exists on HA 2026.7+. The detector
+# tests below run everywhere; the two platform-registration tests need the real
+# base classes and are skipped on an older HA baseline (e.g. the CI floor).
+try:
+    from homeassistant.helpers.condition import Condition  # noqa: F401
+    from homeassistant.helpers.trigger import Trigger  # noqa: F401
+
+    _HAS_TRIGGER_PLATFORM = True
+except ImportError:
+    _HAS_TRIGGER_PLATFORM = False
+
+_needs_platform = pytest.mark.skipif(
+    not _HAS_TRIGGER_PLATFORM,
+    reason="named trigger/condition platform requires HA 2026.7+",
 )
 
 
@@ -110,6 +128,7 @@ def test_listener_exception_never_breaks_feed() -> None:
 
 # ── platform registration ─────────────────────────────────────────────────────
 
+@_needs_platform
 def test_trigger_platform_registers_all_events() -> None:
     from custom_components.vag_connect import trigger as trig
     got = asyncio.run(trig.async_get_triggers(MagicMock()))
@@ -119,6 +138,7 @@ def test_trigger_platform_registers_all_events() -> None:
     assert all(issubclass(c, Trigger) for c in got.values())
 
 
+@_needs_platform
 def test_condition_platform_registers_expected() -> None:
     from custom_components.vag_connect import condition as cond
     got = asyncio.run(cond.async_get_conditions(MagicMock()))

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -323,6 +323,20 @@ def test_brand_config_resolution() -> None:
     assert seat._client_id.startswith("f85e5b69")
     assert seat._state == "de__de__SEAT"
 
+    # #1340 — Audi/Škoda/Bentley each have their OWN portal client; the shared VW
+    # client left the session anonymous (login lands but every data read 401s).
+    audi = EUDataActConnector(object(), brand="audi")  # type: ignore[arg-type]
+    assert audi._client_id.startswith("cc29b87a")
+    assert audi._state == "de__de__AUDI"
+
+    skoda = EUDataActConnector(object(), brand="skoda")  # type: ignore[arg-type]
+    assert skoda._client_id.startswith("3ea88bf9")
+    assert skoda._state == "de__de__SKODA"
+
+    bentley = EUDataActConnector(object(), brand="bentley")  # type: ignore[arg-type]
+    assert bentley._client_id.startswith("d38aac0f")
+    assert bentley._state == "de__de__BENTLEY"
+
     # #1316 — VW Commercial Vehicles (Nutzfahrzeuge): same portal client as
     # passenger VW, but the state_brand MUST be the explicit, live-confirmed
     # "VOLKSWAGEN_COMMERCIAL_VEHICLES" — NOT the unknown-brand fallback


### PR DESCRIPTION
## v4.7.0b14

### The headline fix — Audi / Škoda / Bentley EU Data Act reads (report #1340)
Those three brands were signing in to the EU Data Act portal with the **Volkswagen** portal OIDC client. The sign-in landed on the portal host, so it *looked* successful, but the session stayed **anonymous** — every `proxy_api` data read then came back 401 and the feed was empty.

Each brand now uses its **own** portal client, on **both** portal-auth consumers:
- `_eu_data_act.py` — the cookie reader (`_EUDA_BRANDS`): Audi/Škoda get their own `client_id`, Bentley is now an explicit entry (it fell through to the VW client before).
- `_data_act_portal.py` — the token / device-grant login: `_brand_client_id()` on both the authorize call and the token exchange (it hard-coded the VW client for every brand — the same latent bug on that channel).

The three ids are grounded from each brand's portal sign-in redirect and cross-checked with a live unauthenticated `authorize` handshake (each id `302`s to `identity.vwgroup.io/signin-service/<that id>`). A consistency test keeps both consumers in lock-step.

### Also in b14
- **Experimental named triggers + conditions** (opt-in): charging / plug / lock / preconditioning transitions and charge-target-reached, derived from already-polled data (no extra API calls). Registers only on cores new enough for the platform; no-ops otherwise.
- **EU Data Act repair guide** — realm-aware "delete existing request" wording: the portal keeps one active request *per vehicle*, so the guidance now scopes deletion to the same car and warns mixed passenger/commercial accounts not to delete the other car's request (13 languages).
- **Redacted 401 auth-state debug line**: mask the UUID inside `s_`/`d_` cookie names, log once per setup instead of three times, add a `portal_domain_cookies` field so anonymous-vs-authenticated-but-refused is answered on the line itself.

### Tests
- Full suite: **5818 passed, 15 skipped**.
- ruff + mypy (strict) clean; translation parity green.
- New: `test_1340_portal_client_ids.py` (both consumers + agree), `test_b14_triggers.py`; extended `test_v2120` (audi/škoda/bentley) and `test_b13_cleanup` (cookie UUID mask, once-per-setup, portal_domain_cookies).

Thanks @cyrano330 for the root-cause trace on the portal client (#1340).
