### PR TITLE
b15: redact idk debug-log OIDC hops + harden portal login-success check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,22 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b15] - 2026-09-05 — Debug-log redaction + portal login-success hardening
+
+### Fixed
+- **Debug logs no longer leak login secrets.** On the legacy sign-in path, the OIDC redirect
+  hops were written to the debug log as truncated URLs — which still exposed the `code`
+  (authorization token) and `user_id` (account id) carried in the query string. They're now
+  logged as host + path only, so a debug log you paste into an issue stays clean. Thanks
+  @cyrano330 (#1340).
+
+### Changed
+- **The EU Data Act portal login now checks it actually authenticated.** "Landed on the portal"
+  was too weak a success test — a portal that signs you in anonymously (the shape of the
+  Audi/Škoda/Bentley brand-client bug) looked like success and only failed a call later. It now
+  catches an anonymous session at login time and shows the portal repair, so a future client
+  change surfaces clearly instead of as a silently empty feed. Thanks @cyrano330 (#1340).
+
 ## [4.7.0b14] - 2026-09-05 — Audi/Škoda/Bentley EU Data Act fix + experimental automation triggers
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -32,6 +32,7 @@ import asyncio
 import io
 import json
 import logging
+import os
 import re
 import uuid
 import zipfile
@@ -75,6 +76,12 @@ _PORTAL_REDIRECT_URI = f"{_PORTAL_BASE}/login"
 #   - CUPRA/SEAT: f85e5b69 — from the community EUDA constants, scope
 #     "openid profile cars". Both client+state combos handshake-verified
 #     (302 → signin).
+# Load-balancer / infrastructure cookies the portal sets on its OWN domain even
+# for an ANONYMOUS session. An authenticated cookie session also carries a real
+# session cookie here; if the portal-domain jar holds ONLY these, the login never
+# authenticated (the #1340 shape). (#1340 login-success hardening)
+_PORTAL_INFRA_COOKIES: frozenset[str] = frozenset({"affinity"})
+
 # Brands not listed fall back to the VW entry with a brand-derived state
 # suffix; account-level verification for those follows in a later release.
 _EUDA_VW = {
@@ -3948,11 +3955,55 @@ class EUDataActConnector:
             raise PortalInteractionRequiredError(
                 "login did not complete (unexpected landing page)"
             )
+        # Login-success hardening (#1340 @cyrano330): "landed on the portal host"
+        # is too weak — the portal's own login page is on the portal host too, so
+        # a wrong portal client id yields a clean "login succeeded" and a 401 one
+        # call later (exactly the #1340 disguise). In cookie mode an authenticated
+        # session leaves a real session cookie on the portal domain; if the jar
+        # holds ONLY the load balancer's cookie, the login never authenticated —
+        # surface the (soft, self-healing) portal repair here instead of a
+        # confusing downstream 401. Tight signature + env kill-switch, because
+        # this runs on every login.
+        if (
+            not self._bearer
+            and not os.getenv("VWEU_PORTAL_SESSION_CHECK_DISABLED")
+            and self._portal_session_is_anonymous()
+        ):
+            _LOGGER.warning(
+                "EU Data Act portal: landed on the portal host but the session "
+                "is anonymous — not authorised (#1340)."
+            )
+            raise PortalInteractionRequiredError(
+                "portal session not authorised (anonymous session)"
+            )
         self.logged_in = True
         self.last_login_interaction = ""  # #465/#1027 — recovered → clear Repair
         _LOGGER.info(
             "EU Data Act portal: login succeeded (read-only, ~15min cadence)"
         )
+
+    def _portal_session_is_anonymous(self) -> bool:
+        """#1340 hardening: True when the portal-domain cookie jar carries ONLY
+        infrastructure cookies (e.g. the load balancer's ``affinity``) — the
+        signature of a login that landed on the portal host without actually
+        authenticating. An authenticated cookie session also leaves a real
+        session cookie on the portal domain, which lands outside
+        ``_PORTAL_INFRA_COOKIES`` and makes this False.
+
+        Fails OPEN (returns False) if the jar can't be read — a hardening check
+        must never break a login on an edge case; the downstream 401 path still
+        catches a genuinely anonymous session.
+        """
+        try:
+            portal_host = urlparse(_PORTAL_BASE).netloc
+            portal_cookies = {
+                cookie.key
+                for cookie in getattr(self._session, "cookie_jar", ())
+                if portal_host in (cookie.get("domain") or "")
+            }
+        except Exception:  # noqa: BLE001 — never break login on a jar-read error
+            return False
+        return bool(portal_cookies) and portal_cookies <= _PORTAL_INFRA_COOKIES
 
     def _debug_dump_auth_state_on_401(
         self, url: str, sent_headers: dict[str, str], resp: Any

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -43,6 +43,23 @@ from ..models import BrandConfig, TokenSet
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _safe_url(url: str) -> str:
+    """Host+path of *url* with the query string STRIPPED.
+
+    The OIDC redirect hops on this legacy path carry ``code`` (the leading chars
+    of the authorization JWT), ``user_id`` (a real account UUID) and
+    ``relayState`` in the query string. Truncating the URL to N chars does NOT
+    hide those — ``code`` is usually the first parameter — so a tester who turns
+    debug logging on and pastes the log into an issue leaks them. Log only the
+    host+path, which is all the redirect trace needs. (#1340 @cyrano330)
+    """
+    try:
+        p = urlparse(url)
+        return f"{p.netloc}{p.path}" or "<empty-url>"
+    except Exception:  # noqa: BLE001
+        return "<unparseable-url>"
+
 _AUTH_TIMEOUT = ClientTimeout(total=30)  # per-request timeout for auth flows
 # v2.12.4 (#438) — token-endpoint statuses that mean "VW backend is having a
 # bad moment", not "your refresh token is dead". A 5xx here is transient
@@ -895,10 +912,10 @@ class IDKAuth:
                     else:
                         break
             except InvalidURL as exc:
-                _LOGGER.error("IDK Auth0 redirect: InvalidURL '%s' — %s", ref[:100], exc)
+                _LOGGER.error("IDK Auth0 redirect: InvalidURL '%s' — %s", _safe_url(ref), exc)
                 break
 
-        _LOGGER.debug("IDK Auth0: final redirect = %s", ref[:80] if ref else "(none)")
+        _LOGGER.debug("IDK Auth0: final redirect = %s", _safe_url(ref) if ref else "(none)")
 
         if not ref or not ref.startswith(prefix):
             # Print FULL URL on failure (esp. for /v2/login/ui/error which
@@ -1241,7 +1258,7 @@ class IDKAuth:
         prefix = self._brand.redirect_uri.split("://")[0] + "://"
         ref = pw_loc
         for hop in range(10):
-            _LOGGER.debug("IDK legacy: redirect hop %d → %s", hop + 1, ref[:100])
+            _LOGGER.debug("IDK legacy: redirect hop %d → %s", hop + 1, _safe_url(ref))
             if ref.startswith(prefix):
                 break
             if "terms-and-conditions" in ref:
@@ -1256,7 +1273,7 @@ class IDKAuth:
                 else:
                     break
 
-        _LOGGER.debug("IDK legacy: final ref=%s", ref[:100])
+        _LOGGER.debug("IDK legacy: final ref=%s", _safe_url(ref))
 
         # Save final redirect URL so MBB-mode callers can extract the
         # cross-service-signed id_token from the query/fragment (v1.26.3).
@@ -1484,7 +1501,7 @@ class IDKAuth:
             callback_url = self._idk_base + callback_url
 
         _LOGGER.debug("IDK Auth0: posting callback to %s fields=%s",
-                      callback_url[:60], list(parser.fields.keys()))
+                      _safe_url(callback_url), list(parser.fields.keys()))
 
         async with self._session.post(
             callback_url,
@@ -1495,7 +1512,7 @@ class IDKAuth:
         ) as resp:
             location = resp.headers.get("Location", "")
             _LOGGER.debug("IDK Auth0: callback status=%s location=%s",
-                          resp.status, location[:60])
+                          resp.status, _safe_url(location))
             return location if location else None
 
     async def _follow_to_app_redirect_get(
@@ -1624,10 +1641,10 @@ class IDKAuth:
                 _LOGGER.warning(
                     "IDK legacy: consent wall at %s — auto-skip failed, "
                     "raising MarketingConsentError",
-                    location[:120],
+                    _safe_url(location),
                 )
                 raise MarketingConsentError()
-            _LOGGER.debug("IDK legacy: following redirect → %s", location[:80])
+            _LOGGER.debug("IDK legacy: following redirect → %s", _safe_url(location))
             async with self._session.get(
                 location,
                 timeout=_AUTH_TIMEOUT, headers=self._base_headers(), allow_redirects=False

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b14"
+  "version": "4.7.0b15"
 }

--- a/tests/test_b15_security_hardening.py
+++ b/tests/test_b15_security_hardening.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""b15 — two #1340 (@cyrano330) follow-ups:
+
+1. The legacy IDK OIDC redirect hops logged the redirect URL truncated (not
+   redacted) at debug level, so ``code`` (auth JWT) and ``user_id`` (account
+   UUID) in the query survived a tester's copy-paste. Now host+path only.
+2. Login-success hardening: a portal login that lands on the portal host but
+   leaves only the load-balancer cookie is anonymous — surfaced as a portal
+   repair instead of a confusing 401 one call later.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+# ── 1. IDK redirect-hop URLs are redacted to host+path ────────────────────────
+
+def test_idk_safe_url_strips_secret_query() -> None:
+    from custom_components.vag_connect.cariad.auth.idk import _safe_url
+    leaky = (
+        "https://identity.vwgroup.io/oidc/v1/callback"
+        "?code=eyJHVGE_REAL_AUTH_JWT_LEADING_CHARS&user_id=3fa85f64-real-uuid"
+        "&relayState=abc"
+    )
+    out = _safe_url(leaky)
+    assert out == "identity.vwgroup.io/oidc/v1/callback"
+    assert "code=" not in out
+    assert "user_id=" not in out
+    assert "REAL_AUTH_JWT" not in out
+    assert "real-uuid" not in out
+
+
+def test_idk_safe_url_handles_junk() -> None:
+    from custom_components.vag_connect.cariad.auth.idk import _safe_url
+    assert _safe_url("") == "<empty-url>"
+    # never raises, even on nonsense
+    assert isinstance(_safe_url("::not a url::"), str)
+
+
+# ── 2. Login-success hardening — anonymous portal session detection ───────────
+
+class _Cookie:
+    def __init__(self, key: str, domain: str) -> None:
+        self.key = key
+        self._d = {"domain": domain}
+
+    def get(self, k: str, default=None):
+        return self._d.get(k, default)
+
+
+def _connector(cookies):
+    from custom_components.vag_connect.cariad.auth._eu_data_act import (
+        EUDataActConnector,
+    )
+    c = EUDataActConnector.__new__(EUDataActConnector)
+    sess = MagicMock()
+    sess.cookie_jar = cookies
+    c._session = sess  # type: ignore[attr-defined]
+    return c
+
+
+_PORTAL = "eu-data-act.drivesomethinggreater.com"
+_IDP = "identity.vwgroup.io"
+
+
+def test_anonymous_when_only_lb_cookie_on_portal_domain() -> None:
+    # the exact #1340 signature: everything auth-y is on the IDP, only the LB's
+    # affinity cookie is on the portal domain
+    c = _connector([
+        _Cookie("SESSION", _IDP),
+        _Cookie("JSESSIONID", _IDP),
+        _Cookie("affinity", _PORTAL),
+    ])
+    assert c._portal_session_is_anonymous() is True
+
+
+def test_not_anonymous_when_a_real_session_cookie_is_present() -> None:
+    c = _connector([
+        _Cookie("affinity", _PORTAL),
+        _Cookie("access_token", _PORTAL),   # a real authenticated session cookie
+    ])
+    assert c._portal_session_is_anonymous() is False
+
+
+def test_not_anonymous_when_no_portal_domain_cookie() -> None:
+    # no cookie on the portal domain at all → ambiguous, do NOT flag (never raise
+    # on an empty set — only on the confirmed affinity-only signature)
+    c = _connector([_Cookie("SESSION", _IDP)])
+    assert c._portal_session_is_anonymous() is False
+
+
+def test_not_anonymous_when_empty_jar() -> None:
+    c = _connector([])
+    assert c._portal_session_is_anonymous() is False


### PR DESCRIPTION
## v4.7.0b15 — two #1340 follow-ups from @cyrano330's b14 confirmation

Both grounded against the source; neither blocks b14 (which is confirmed working end-to-end).

### 🔒 Fixed — debug logs no longer leak login secrets
The legacy IDK sign-in path logged the OIDC redirect hops as **truncated** URLs (`ref[:100]`, `location[:60]`, …). Truncation doesn't hide the secrets — `code` (the authorization JWT) is usually the first query parameter, and `user_id` (a real account UUID) rides along too — so a tester who turns on debug logging and pastes it into an issue leaks both. All eight hop-logging sites (one at error level) now go through a `_safe_url()` that logs **host + path only**, which is all the redirect trace needs.

### Changed — portal login now checks it actually authenticated
"Landed on the portal host" was too weak a success test: the portal's own `login.html` satisfies it, so a wrong portal client id (the Audi/Škoda/Bentley bug this release chain just fixed) produced a clean "login succeeded" and a 401 one call later. In cookie mode, `login()` now checks the portal-domain cookie jar — if it holds **only** the load balancer's `affinity` cookie, the session never authenticated, and it raises the soft, self-healing portal repair at login time. So a future client rotation surfaces clearly instead of as a silently empty feed.

Kept deliberately safe (this runs on every login): tightly scoped to the exact anonymous signature, **fails open** on any jar-read error, and carries an env kill-switch `VWEU_PORTAL_SESSION_CHECK_DISABLED`.

### Tests
- Full suite: **5824 passed, 15 skipped**; ruff + mypy (strict) clean.
- New `test_b15_security_hardening.py`: `_safe_url` strips `code`/`user_id`; the anonymous-session check flags an affinity-only portal jar and — critically — does **not** flag a jar with a real session cookie, an IDP-only jar, or an empty jar.
- Regression caught + fixed in review: the hardening first tripped four login-flow tests whose `_FakeSession` has no `cookie_jar`; the fail-open `getattr` guard is the fix (real aiohttp sessions always have one).

Report #1340 (@cyrano330).
