### PR TITLE
v4.7.0b16 — EU Data Act resilience, T&C auto-accept, log-redaction hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,48 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.0b16] - 2026-09-06 — Škoda manual-key fallback, EU Data Act resilience + hardening
+
+### Added
+- **Škoda official API — a manual fallback when auto-setup can't create a key.** The integration
+  still sets up your official API key automatically whenever it can. When it can't — for example
+  the key service rejects the request, or you're signed in without the native app login — it now
+  shows a repair that lets you create a key in the MyŠkoda app and paste it in for the vehicle,
+  instead of silently doing nothing.
+- **The EU Data Act portal now accepts an updated terms-and-conditions step for you.** After you
+  sign in, VW can show a "please accept the updated terms" page — the same kind of interstitial as
+  the data-consent page we already accept. It's now accepted automatically so the login completes,
+  instead of stopping and asking you to do it in a browser. If it ever can't, the existing repair
+  still appears.
+- **A "data is stale" sensor you can build automations on.** A new diagnostic binary sensor turns
+  on when your car's own data-capture time has been frozen for too long (a lapsed portal feed can
+  keep serving days-old values as if they were live). The information was already there via the
+  portal-health sensor; this makes it a simple on/off you can alert on. Hidden for cars that don't
+  report a capture time.
+- **A dashboard-warning field some VWs report is now read.** A VW variant of the instrument-cluster
+  active-warnings field was going unmapped; it now feeds the existing (disabled-by-default)
+  raw-dashboard-warnings diagnostic (#1358).
+
+### Fixed
+- **The portal login check no longer false-flags a valid session.** The b15 anonymous-session
+  check compared cookie domains by plain substring, which missed a real session cookie scoped
+  to the parent domain and could then mark an authenticated login as anonymous. It now matches
+  host and parent domains correctly.
+- **A leftover "connectivity" entity no longer lingers as unavailable.** When an account's set of
+  read channels changed across versions, an old per-source connectivity sensor could stay in the
+  entity registry forever as `unavailable`/`unknown`. It's now cleaned up automatically once the
+  current channels are known. Thanks @cyrano330 (#1340).
+- **We stop hammering VW's portal during a portal-side outage.** When the EU Data Act portal is
+  returning server errors for a while, the poll now backs off (5 → 15 → 30 min) instead of retrying
+  every minute, and returns to normal cadence the moment data flows again.
+- **A brief download hiccup no longer wastes a whole poll.** If downloading the newest portal
+  dataset hits a transient error, the integration now falls back to the next-older delivered
+  dataset instead of skipping the poll — so you get data when the portal has any to give.
+
+### Changed
+- **Log redaction hardening.** An internal review pass tightened how the integration writes URLs
+  and errors to debug logs across all channels, so a debug log you paste into an issue stays clean.
+
 ## [4.7.0b15] - 2026-09-05 — Debug-log redaction + portal login-success hardening
 
 ### Fixed

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -229,7 +229,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: VagConnectConfigEntry) -
             raise ConfigEntryNotReady(
                 "VW Group Connect setup failed. Check logs for details."
             ) from err
-        raise ConfigEntryNotReady(str(err)) from err
+        # class only — str(err) can carry an aiohttp request URL; keep the raw
+        # detail on the chained cause, not in the user-facing not-ready message.
+        _LOGGER.debug("VW Group Connect setup not ready (%s)", type(err).__name__)
+        raise ConfigEntryNotReady(
+            "VW Group Connect setup failed. Check logs for details."
+        ) from err
 
     if not ok:
         raise ConfigEntryNotReady(
@@ -257,9 +262,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: VagConnectConfigEntry) -
     # changes already in place, so it's a single inner-method swap.
     try:
         await coordinator.async_start_push_managers()
-    except Exception:  # noqa: BLE001
-        _LOGGER.exception(
-            "VW Group Connect: push manager startup failed — falling back to polling"
+    except Exception as exc:  # noqa: BLE001
+        # class-only, not .exception() — a push-connect error's str() can carry the
+        # broker URL / auth token, and a traceback re-renders it. Level kept ERROR.
+        _LOGGER.error(
+            "VW Group Connect: push manager startup failed (%s) — falling back to"
+            " polling", type(exc).__name__,
         )
 
     if not hass.services.has_service(DOMAIN, "lock"):
@@ -322,7 +330,7 @@ def _register_services(hass: HomeAssistant) -> None:
         c = _get_coordinator(hass, vin)
         if c is None:
             raise ServiceValidationError(
-                f"Vehicle '{vin}' not found.",
+                f"Vehicle '…{vin[-6:]}' not found.",
                 translation_domain=DOMAIN,
                 translation_key="vehicle_not_found",
             )

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -1040,6 +1040,12 @@ async def async_setup_entry(
         # Cross-brand.
         for token in (vehicle.get("channel_status") or {}):
             entities.append(VagSourceConnectivitySensor(coordinator, vin, token))
+        # 6) #465 — automatable "data stale" binary (device_class=PROBLEM) for a
+        # car whose capture time can freeze while polls keep succeeding. Gated on a
+        # populated capture timestamp so brands that never carry one don't get a
+        # permanent "unknown" entity. Cross-brand (portal + Škoda-native).
+        if vehicle.get("last_seen_at") is not None:
+            entities.append(VagDataStaleSensor(coordinator, vin))
         return entities
 
     register_dynamic_spawner(entry, coordinator, async_add_entities, _build_for_vin)
@@ -1212,6 +1218,42 @@ class VagSourceConnectivitySensor(VagConnectEntity, BinarySensorEntity):
             if s.get(k) is not None:
                 attrs[k] = s.get(k)
         return attrs
+
+
+class VagDataStaleSensor(VagConnectEntity, BinarySensorEntity):
+    """#465 — True once the car's own data-capture time has frozen past the
+    stale-data threshold (the automatable twin of the stale-data Repair).
+
+    A poll can keep succeeding while the car's ``last_seen_at`` stops advancing — a
+    lapsed EU-DA feed presenting days-old data as live (cyrano330's ID.Buzz froze
+    ~44 h). ``portal_health``/``minutes_since_last_snapshot`` already expose this as
+    an enum/number; this adds a ``device_class=PROBLEM`` boolean a user can trigger
+    an automation on directly, brand-agnostic (also covers Škoda-native / BFF reads
+    that carry ``last_seen_at`` but no ``portal_health``)."""
+
+    # Stay visible when a poll fails — a staleness indicator that vanishes exactly
+    # when data goes stale would be worse than useless (mirrors the connectivity
+    # sensor).
+    _stay_available_on_poll_failure = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_translation_key = "data_stale"
+
+    def __init__(self, coordinator: VagConnectCoordinator, vin: str) -> None:
+        super().__init__(coordinator, vin, "data_stale")
+
+    @property
+    def is_on(self) -> bool | None:
+        val = self._vehicle.get("data_stale")
+        return bool(val) if val is not None else None
+
+    def _platform_attributes(self) -> dict[str, Any] | None:
+        v = self._vehicle
+        attrs: dict[str, Any] = {}
+        for k in ("minutes_since_last_snapshot", "portal_health", "last_snapshot_at"):
+            if v.get(k) is not None:
+                attrs[k] = v.get(k)
+        return attrs or None
 
 
 # Per-door binary sensors.

--- a/custom_components/vag_connect/cariad/_tibber_source.py
+++ b/custom_components/vag_connect/cariad/_tibber_source.py
@@ -242,7 +242,7 @@ class TibberDataSource:
                     return False
                 body = await resp.json(content_type=None)
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Tibber token refresh failed: %s", err)
+            _LOGGER.debug("Tibber token refresh failed: %s", type(err).__name__)
             return False
         at = body.get("access_token")
         if not isinstance(at, str) or not at:
@@ -264,7 +264,7 @@ class TibberDataSource:
                     "client_secret": self._client_secret,
                 })
             except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Tibber token-persist hook failed: %s", err)
+                _LOGGER.debug("Tibber token-persist hook failed: %s", type(err).__name__)
         return True
 
     async def _get(self, path: str, *, _retried: bool = False) -> Any:
@@ -283,11 +283,14 @@ class TibberDataSource:
                         return await self._get(path, _retried=True)
                     return None
                 if resp.status != 200:
-                    _LOGGER.debug("Tibber GET %s -> HTTP %s", path, resp.status)
+                    # path dropped — Tibber paths carry account-scoped
+                    # home_id/device_id UUIDs.
+                    _LOGGER.debug("Tibber GET → HTTP %s", resp.status)
                     return None
                 return await resp.json(content_type=None)
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Tibber GET %s failed: %s", path, err)
+            # class only + no path (UUIDs); a raw err str() carries the URL too.
+            _LOGGER.debug("Tibber GET failed: %s", type(err).__name__)
             return None
 
     async def fetch_vehicles(self) -> dict[str, VehicleData]:

--- a/custom_components/vag_connect/cariad/_util.py
+++ b/custom_components/vag_connect/cariad/_util.py
@@ -325,8 +325,13 @@ def json_safe(obj: Any) -> Any:
             return [json_safe(item) for item in obj]
         # Unknown type — fallback to repr-string so we never crash
         return str(obj)
-    except Exception:  # noqa: BLE001 — defensive guarantee
-        _LOGGER.debug("json_safe: fallback for %s", type(obj).__name__, exc_info=True)
+    except Exception as exc:  # noqa: BLE001 — defensive guarantee
+        # Class only, not exc_info — json_safe walks diagnostics objects that may
+        # hold secrets; a serialization traceback must not surface their values.
+        _LOGGER.debug(
+            "json_safe: fallback for %s (%s)",
+            type(obj).__name__, type(exc).__name__,
+        )
         return str(obj)
 
 

--- a/custom_components/vag_connect/cariad/api/audi.py
+++ b/custom_components/vag_connect/cariad/api/audi.py
@@ -88,8 +88,11 @@ class AudiClient(VWEUClient):
             ) as resp:
                 if resp.status != 200:
                     body = await resp.text()
+                    # Never log the token-exchange body — it can carry token
+                    # fragments/error detail; a byte count is enough for triage.
                     _LOGGER.warning(
-                        "AZS token exchange failed HTTP %d: %s", resp.status, body[:200]
+                        "AZS token exchange failed HTTP %d (%d-byte body withheld)",
+                        resp.status, len(body),
                     )
                     return None
                 data = await resp.json()
@@ -98,7 +101,7 @@ class AudiClient(VWEUClient):
                     _LOGGER.info("Audi AZS token acquired for image fetching")
                 return str(token) if token else None
         except Exception as err:  # noqa: BLE001
-            _LOGGER.warning("AZS token exchange error: %s", err)
+            _LOGGER.warning("AZS token exchange error: %s", type(err).__name__)
             return None
 
     # ── v1.14.0 (#28) — ICE Remote Engine Start ─────────────────────────
@@ -182,6 +185,6 @@ class AudiClient(VWEUClient):
                 self._azs_token = None
                 _LOGGER.warning("Audi images: empty response from vgql — AZS token reset for retry")
         except Exception as err:  # noqa: BLE001
-            _LOGGER.warning("Audi image fetch failed: %s", err)
+            _LOGGER.warning("Audi image fetch failed: %s", type(err).__name__)
             self._azs_token = None
             self._image_data = {}

--- a/custom_components/vag_connect/cariad/api/base.py
+++ b/custom_components/vag_connect/cariad/api/base.py
@@ -675,8 +675,18 @@ class CariadBaseClient:
                     " the integration options; the primary channel is"
                     " unaffected.", type(err).__name__,
                 )
+                # NB: neither the raw ``err`` nor ``exc_info`` may appear here.
+                # The comment above is the reason — aiohttp.InvalidURL.__str__ puts
+                # the whole OAuth callback URL (``…#access_token=<JWT>`` → the user's
+                # email + a live token) in the message, and a traceback's final line
+                # renders that same __str__. DEBUG is exactly what a reporter pastes
+                # into an issue (cf. #1355), so class-name only — no secret, not even
+                # in beta.
                 _LOGGER.debug(
-                    "vw.de silent resume failure details: %s", err, exc_info=True,
+                    "vw.de silent resume failure details: %s"
+                    " (message + traceback withheld — the exception string can"
+                    " carry the OAuth callback token/email)",
+                    type(err).__name__,
                 )
                 await session.close()
                 return False
@@ -1419,7 +1429,10 @@ class CariadBaseClient:
             try:
                 await self._refresh_tokens(stale_access_token=self._access_token)
             except Exception as _e:  # noqa: BLE001 — reactive 401 path still backs us up
-                _LOGGER.debug("proactive device_grant re-mint failed: %s", _e)
+                # class only — a raw aiohttp error's str() carries the request URL.
+                _LOGGER.debug(
+                    "proactive device_grant re-mint failed: %s", type(_e).__name__
+                )
         headers = kwargs.pop("headers", {})
         token_used = self._access_token
         headers["Authorization"] = f"Bearer {token_used}"
@@ -1480,7 +1493,8 @@ class CariadBaseClient:
                 return await self._request(
                     method, url, retry=retry, _attempt=_attempt + 1, **kwargs
                 )
-            raise APIError(0, url, f"transient: {type(err).__name__}: {err}") from err
+            # drop the raw {err} — it would sit in self.body; class name suffices.
+            raise APIError(0, url, f"transient: {type(err).__name__}") from err
 
     async def _refresh_tokens(
         self, *, for_command: bool = False, stale_access_token: str | None = None
@@ -1794,7 +1808,12 @@ class CariadBaseClient:
             stats["success"] = int(stats.get("success", 0)) + 1
         except Exception as err:  # noqa: BLE001
             stats["fail"] = int(stats.get("fail", 0)) + 1
-            stats["last_error"] = str(err)[:200]
+            # class + status only — this dict is surfaced in diagnostics, and a raw
+            # str(err) can carry a VIN-path URL / response body.
+            _st = getattr(err, "status", None)
+            stats["last_error"] = (
+                f"{type(err).__name__}" + (f" (HTTP {_st})" if _st else "")
+            )
             raise
 
     def _note_parser_job(self, job_name: str, *, present: bool) -> None:

--- a/custom_components/vag_connect/cariad/api/graphql.py
+++ b/custom_components/vag_connect/cariad/api/graphql.py
@@ -319,16 +319,21 @@ class VehicleImageFetcher:
             ) as resp:
                 if resp.status != 200:
                     body = await resp.text()
+                    # body withheld — a GraphQL error body can echo VIN/nickname;
+                    # a byte count is enough for triage.
                     _LOGGER.warning(
-                        "GraphQL images failed for %s: HTTP %d @ %s — %s",
-                        brand, resp.status, endpoint, body[:200],
+                        "GraphQL images failed for %s: HTTP %d @ %s (%d-byte body)",
+                        brand, resp.status, endpoint, len(body),
                     )
                     return {}
                 data = await resp.json()
         except Exception as err:  # noqa: BLE001
-            err_str = str(err)
-            if err_str:
-                _LOGGER.warning("GraphQL image fetch failed for %s: %s", brand, err_str)
+            # class only — str(err) carries the request URL on a redirect/SSO hop.
+            if str(err):
+                _LOGGER.warning(
+                    "GraphQL image fetch failed for %s (%s)",
+                    brand, type(err).__name__,
+                )
             else:
                 # Empty error = connection reset / server blocked request (common for non-Audi brands)
                 _LOGGER.debug(
@@ -364,12 +369,13 @@ class VehicleImageFetcher:
                     continue
                 code = (err.get("extensions") or {}).get("code", "?")
                 path = err.get("path", [])
-                msg = err.get("message", "")
+                # msg withheld — a server-authored error message can echo the
+                # VIN/input; code + path already identify the affected field.
                 _LOGGER.info(
                     "GraphQL partial error (PPC/PPE platform pattern): "
-                    "code=%s path=%s msg=%s — affected VIN(s) skipped, "
+                    "code=%s path=%s — affected VIN(s) skipped, "
                     "other vehicles render normally",
-                    code, path, msg[:120],
+                    code, path,
                 )
         try:
             vehicles = data.get("data", {}).get("userVehicles", []) or []
@@ -413,10 +419,10 @@ class VehicleImageFetcher:
                 )
                 _LOGGER.debug(
                     "GraphQL images for %s (%s): %d mediaTypes",
-                    vin, media.get("shortName", "?"), len(urls),
+                    vin[-6:], media.get("shortName", "?"), len(urls),
                 )
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("GraphQL response parse error: %s", err)
+            _LOGGER.debug("GraphQL response parse error: %s", type(err).__name__)
         return result
 
     @staticmethod

--- a/custom_components/vag_connect/cariad/api/plugandplay.py
+++ b/custom_components/vag_connect/cariad/api/plugandplay.py
@@ -212,7 +212,8 @@ class PlugAndPlayCloudClient:
             # coordinator suppresses the per-poll Error-Reporter flood and fires a
             # single re-auth Repair instead of ~20 buffered 401s (acpp, Prash).
             raise AuthenticationError(
-                f"plug&play token rejected (401): {self.API_BASE}/vehicle/{vin}"
+                # mask the VIN — this message is logged/surfaced on the poll path.
+                f"plug&play token rejected (401) for vehicle …{vin[-6:]}"
             )
         if status != 200 or not isinstance(body, dict):
             # 404 here specifically means the VIN is not enrolled in THIS account
@@ -247,10 +248,13 @@ class PlugAndPlayCloudClient:
                     # on a live read while mocked tests stay green — exactly how the
                     # multi-value Accept-Language carport 400 hid itself. Log it so a
                     # future live-only regression is visible in debug.
+                    # log the friendly resource key, not `sub` (it carries the VIN).
                     _LOGGER.debug(
-                        "plug&play sub-resource %s → HTTP %s (skipped)", sub, s)
+                        "plug&play sub-resource %s → HTTP %s (skipped)", key, s)
             except Exception as exc:  # noqa: BLE001 — defence-in-depth
-                _LOGGER.debug("plug&play sub-resource %s failed: %s", sub, exc)
+                # key (no VIN) + class name (a raw exc's str carries the VIN-URL).
+                _LOGGER.debug(
+                    "plug&play sub-resource %s failed: %s", key, type(exc).__name__)
         return snap
 
     async def get_vehicles(self) -> list[str]:

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -431,7 +431,8 @@ class PorscheClient:
                 return await self._request(
                     method, url, retry=retry, _attempt=_attempt + 1, **kwargs,
                 )
-            raise APIError(0, url, f"transient: {type(err).__name__}: {err}") from err
+            # drop the raw {err} — it would sit in self.body; class name suffices.
+            raise APIError(0, url, f"transient: {type(err).__name__}") from err
 
     # v1.25.0 PR-B: rate-limit header capture (mirror of base.py:_capture_rate_limit_headers)
     def _capture_rate_limit_headers(self, headers: Any) -> None:

--- a/custom_components/vag_connect/cariad/api/seat_cupra.py
+++ b/custom_components/vag_connect/cariad/api/seat_cupra.py
@@ -315,16 +315,11 @@ class SeatCupraClient(CariadBaseClient):
             # The diagnostics dump still surfaces the failure via the
             # parser_stats counter, this branch just keeps the rest of
             # the poll running.
-            _LOGGER.debug(
-                "charging_statistics soft-fail (%d) on %s",
-                err.status, path,
-            )
+            # `path` carries the VIN — status alone is enough for this soft-fail.
+            _LOGGER.debug("charging_statistics soft-fail (%d)", err.status)
             return {}
         except Exception:  # noqa: BLE001 - best-effort host
-            _LOGGER.debug(
-                "charging_statistics unexpected error on %s - returning {}",
-                path,
-            )
+            _LOGGER.debug("charging_statistics unexpected error - returning {}")
             return {}
 
     async def get_vehicles(self) -> list[str]:
@@ -2694,10 +2689,11 @@ class SeatCupraClient(CariadBaseClient):
         except APIError as err:
             if err.status != 404:
                 raise
+            # URLs dropped — they carry the raw VIN in the path; label + masked
+            # vin already identify the fallback.
             _LOGGER.debug(
-                "OLA %s: 404 on primary %s — falling back to legacy %s "
-                "(vin ***%s)",
-                label, primary_url, fallback_url, vin[-6:],
+                "OLA %s: 404 on primary — falling back to legacy (vin ***%s)",
+                label, vin[-6:],
             )
         fallback_kwargs: dict[str, Any] = {"json": fallback_json}
         if fallback_headers:

--- a/custom_components/vag_connect/cariad/api/skoda.py
+++ b/custom_components/vag_connect/cariad/api/skoda.py
@@ -594,8 +594,12 @@ class SkodaClient(CariadBaseClient):
             uid = data.get("id") if isinstance(data, dict) else None
             if isinstance(uid, str) and uid:
                 self._user_id = uid
-        except Exception:  # noqa: BLE001
-            _LOGGER.debug("Škoda: /v1/users user-id fetch failed", exc_info=True)
+        except Exception as exc:  # noqa: BLE001
+            # Class only — keep the sweep posture uniform (the URL is static today,
+            # but no exception string reaches a reporter's DEBUG log verbatim).
+            _LOGGER.debug(
+                "Škoda: /v1/users user-id fetch failed (%s)", type(exc).__name__
+            )
 
     async def authenticate(self, mfa_code: str | None = None) -> None:
         """Authenticate, then capture the account user-id for the push channel.

--- a/custom_components/vag_connect/cariad/api/vw_eu.py
+++ b/custom_components/vag_connect/cariad/api/vw_eu.py
@@ -482,15 +482,16 @@ class VWEUClient(CariadBaseClient):
 
         vins = [v["vin"] for v in supported if v.get("vin")]
         if vehicles:
+            # field NAMES only — values can carry the VIN/nickname (PII); the
+            # debug intent is "which keys did CARIAD return".
             _LOGGER.debug(
                 "VAG vehicles raw fields (first car): %s",
-                {k: str(v)[:40] for k, v in vehicles[0].items()
-                 if k not in ("vin",)},
+                sorted(vehicles[0].keys()),
             )
         _LOGGER.debug(
             "Found %d vehicle(s): %s",
             len(vins),
-            {k: m["model"] for k, m in self._vehicle_metadata.items()},
+            {k[-6:]: m["model"] for k, m in self._vehicle_metadata.items()},
         )
 
         # v2.1.0 — HomeRegion full wire-in. Resolve per-VIN base URLs
@@ -777,7 +778,10 @@ class VWEUClient(CariadBaseClient):
             # attestation/ACL-closed (403 XID_APP_VW) for VW EU passenger cars
             # post-lockdown. Log at debug so a #923-class diagnostic shows the
             # attempt+failure instead of a silent gap.
-            _LOGGER.debug("parkingposition fetch failed for %s: %s", vin[-6:], exc)
+            _LOGGER.debug(
+                "parkingposition fetch failed for %s: %s",
+                vin[-6:], type(exc).__name__,
+            )
 
         # v2.7.0b11 — Trip statistics (separate endpoint, shortTerm/longTerm/
         # cyclic). Lifetime and last-trip stats live here, NOT in
@@ -799,7 +803,10 @@ class VWEUClient(CariadBaseClient):
             with self._parser_job("battery_health"):
                 soh_raw = await self._get(url, params={"jobs": "batteryHealthState"})
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("batteryHealthState fetch failed for %s: %s", vin[-6:], exc)
+            _LOGGER.debug(
+                "batteryHealthState fetch failed for %s: %s",
+                vin[-6:], type(exc).__name__,
+            )
 
         d = self._parse_status(vin, raw, parking)
         self._parse_trip_statistics(d, trip_short, trip_long)
@@ -1381,9 +1388,10 @@ class VWEUClient(CariadBaseClient):
                     self._mbb_backend_cache.set(vin, "cariad")
                 return
             except APIError as err:
-                # APIError's message includes body[:200]; use str(err) for the
-                # wrapper-404 marker detection (no separate .body attribute).
-                if is_cariad_wrapper_404(str(err)):
+                # Marker lives in the response body. APIError's message is now
+                # redacted (body stripped, #1355) but keeps the raw body as an
+                # attribute — read that (fall back to the message for safety).
+                if is_cariad_wrapper_404(f"{getattr(err, 'body', '')} {err}"):
                     break  # whole vehicle speaks MBB → switch to the legacy stack
                 if (
                     getattr(err, "status", None) == 404
@@ -1836,9 +1844,10 @@ class VWEUClient(CariadBaseClient):
                 resp = await self._mbb_get(url)
             except APIError as err:
                 last_status = err.status
+                # body dropped — an MBB error body can echo the VIN; status is enough.
                 _LOGGER.warning(
-                    "MBB enum %s /%s → HTTP %s: %s",
-                    host_label, country, err.status, str(err.body)[:160],
+                    "MBB enum %s /%s → HTTP %s",
+                    host_label, country, err.status,
                 )
                 continue
             except Exception as err:  # noqa: BLE001
@@ -1985,15 +1994,15 @@ class VWEUClient(CariadBaseClient):
                 self._mbb_oplist_denied[vin] = now + _MBB_OPLIST_SOFT_DENY_TTL
                 _LOGGER.log(
                     logging.WARNING if first_denial else logging.DEBUG,
-                    "MBB operationList ***%s → HTTP %s: %s. Backing off %d min "
+                    "MBB operationList ***%s → HTTP %s. Backing off %d min "
                     "(no explicit gateway verdict, so this may be transient).",
-                    vin[-6:], err.status, body[:160],
+                    vin[-6:], err.status,
                     int(_MBB_OPLIST_SOFT_DENY_TTL.total_seconds() // 60),
                 )
                 return None
             _LOGGER.warning(
-                "MBB operationList ***%s → HTTP %s: %s",
-                vin[-6:], err.status, body[:160],
+                "MBB operationList ***%s → HTTP %s",
+                vin[-6:], err.status,
             )
             return None
         except Exception as err:  # noqa: BLE001
@@ -2096,9 +2105,11 @@ class VWEUClient(CariadBaseClient):
             # per-poll token-refresh storm when the data-plane ACL 401s the read.
             resp = await self._mbb_get(url, _retry=False)
         except APIError as err:
+            # body dropped — the VSR error body can echo the VIN/request; the
+            # masked VIN + host + country + status already give the diagnostic.
             _LOGGER.warning(
-                "MBB VSR read ***%s via %s/%s → HTTP %s: %s",
-                vin[-6:], host_label, country, err.status, str(err.body)[:200],
+                "MBB VSR read ***%s via %s/%s → HTTP %s",
+                vin[-6:], host_label, country, err.status,
             )
             return d
         except Exception as err:  # noqa: BLE001

--- a/custom_components/vag_connect/cariad/api/vw_na.py
+++ b/custom_components/vag_connect/cariad/api/vw_na.py
@@ -730,9 +730,11 @@ class VWNAClient:
                     if isinstance(model, str) and model:
                         self._vin_to_model[vin] = model
                     vins.append(vin)
+                    # uuid (account-scoped vehicle id) + nickname (owner free-text)
+                    # are PII — log presence flags, not the raw values.
                     _LOGGER.debug(
-                        "VW NA: found VIN %s uuid=%s nickname=%s model=%s",
-                        _mask_vin(vin), uuid, nickname, model,
+                        "VW NA: found VIN %s (uuid set=%s, nickname set=%s) model=%s",
+                        _mask_vin(vin), bool(uuid), bool(nickname), model,
                     )
                 for value in node.values():
                     _collect(value)
@@ -816,7 +818,7 @@ class VWNAClient:
         except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
                 "VW NA privileges fetch errored for vin ***%s: %s",
-                vin[-6:], exc,
+                vin[-6:], type(exc).__name__,
             )
             return {}
         if not isinstance(data, dict):

--- a/custom_components/vag_connect/cariad/auth/_data_act_portal.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_portal.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
+import re
 import secrets
 import time
 from typing import TYPE_CHECKING
@@ -75,6 +76,32 @@ from ..exceptions import AuthenticationError
 from ..models import TokenSet
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# --- Log/exception redaction (#1355) ---------------------------------------
+# This module has no _safe_url of its own (idk.py and _eu_data_act.py each ship
+# one); add a matching helper so no state/relayState/code/token in a URL query
+# or account/session UUID in a path ever reaches a log line OR an exception
+# message a tester copy-pastes. Same shape as those two helpers.
+_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+
+def _safe_url(url: str) -> str:
+    """Return host+path of *url* with query AND fragment STRIPPED and any
+    UUID-shaped PATH segment masked.
+
+    The portal/IDP hops carry ``state`` / ``relayState`` / ``code`` / tokens in
+    the query or fragment, and signin-service paths embed the client/account
+    UUID as a path segment. Truncating the URL to N chars hides none of it, so:
+    keep only host+path, drop the fragment, mask UUID path segments.
+    """
+    try:
+        p = urlparse(url)
+        return _UUID_RE.sub("<uuid>", f"{p.netloc}{p.path}") or "<empty-url>"
+    except Exception:  # noqa: BLE001
+        return "<unparseable-url>"
 
 
 # Portal endpoints — public web URLs. The OIDC client identifier is
@@ -230,7 +257,9 @@ class DataActPortalAuth:
                     )
         except Exception as exc:  # noqa: BLE001
             raise AuthenticationError(
-                f"Data Act portal: could not reach landing page ({exc})"
+                # class only — a raw aiohttp error's str() carries the full URL.
+                f"Data Act portal: could not reach landing page "
+                f"({type(exc).__name__})"
             ) from exc
 
         # Step 2 — OIDC authorize against identity.vwgroup.io with the
@@ -269,13 +298,13 @@ class DataActPortalAuth:
             raise
         except Exception as exc:  # noqa: BLE001
             raise AuthenticationError(
-                f"Data Act portal: IDP authorize failed ({exc})"
+                f"Data Act portal: IDP authorize failed ({type(exc).__name__})"
             ) from exc
 
         if "signin-service" not in landing_url and "u/login" not in landing_url:
             raise AuthenticationError(
                 f"Data Act portal: unexpected landing URL "
-                f"{landing_url[:120]} — IDP may have rejected client_id"
+                f"{_safe_url(landing_url)} — IDP may have rejected client_id"
             )
 
         # Step 3 — POST credentials. The portal-bound flow happens to
@@ -290,7 +319,6 @@ class DataActPortalAuth:
         # rendered by the SPA. Mirrors the multi-fallback strategy
         # already in idk.py:_parse_csrf_robust so a future markup
         # migration on either side does not need two patches.
-        import re  # noqa: PLC0415
         from html.parser import HTMLParser  # noqa: PLC0415
 
         class _IdentifierFormParser(HTMLParser):
@@ -392,7 +420,8 @@ class DataActPortalAuth:
             raise
         except Exception as exc:  # noqa: BLE001
             raise AuthenticationError(
-                f"Data Act portal: identifier POST failed ({exc})"
+                f"Data Act portal: identifier POST failed "
+                f"({type(exc).__name__} at {_safe_url(identifier_url)})"
             ) from exc
 
         pw_parser = _IdentifierFormParser()
@@ -445,7 +474,7 @@ class DataActPortalAuth:
                     "Data Act portal SPA: entered SPA branch - "
                     "landing_url=%s identifier_url=%s "
                     "password_html_len=%d landing_html_len=%d",
-                    landing_url[:120], identifier_url[:120],
+                    _safe_url(landing_url), _safe_url(identifier_url),
                     len(password_html or ""), len(landing_html or ""),
                 )
                 state_from_url = ""
@@ -516,7 +545,7 @@ class DataActPortalAuth:
                             "Data Act portal SPA: templateModel found in "
                             "%s — hmac len=%d, postAction=%s",
                             label, len(template_hmac),
-                            template_post_action[:80],
+                            _safe_url(template_post_action),
                         )
                         break
 
@@ -617,8 +646,9 @@ class DataActPortalAuth:
                         break
                     _LOGGER.debug(
                         "Data Act portal SPA: no state in %s "
-                        "(first 300 chars: %s)",
-                        label, src_html[:300].replace("\n", " "),
+                        "(len=%d, 'state' substring present=%s)",
+                        label, len(src_html),
+                        "state" in src_html.lower(),
                     )
                 if not state_from_url:
                     # 4. URL query strings as last resort.
@@ -680,25 +710,15 @@ class DataActPortalAuth:
                             state_source = f"{label}/relayState-url"
                             break
                 if not state_from_url:
-                    # v2.10.11 (#388 swebachus) - expanded forensic dump
-                    # covering BOTH HTMLs and the raw URL strings, plus
-                    # the location around any "state" substring so the
-                    # next trace surfaces the exact context the token
-                    # lives in (or proves it is purely JS-rendered post
-                    # bundle init, in which case we need a different
-                    # entry point altogether).
-                    def _state_context(src: str) -> str:
-                        idx = src.lower().find("state")
-                        if idx < 0:
-                            return "(no 'state' substring)"
-                        start = max(0, idx - 30)
-                        end = min(len(src), idx + 80)
-                        return src[start:end].replace("\n", " ")
-
+                    # v2.10.11 (#388 swebachus) - forensic dump covering BOTH
+                    # HTMLs and the raw URL strings. #1355 — the raw window
+                    # around any "state" substring was removed (it emitted the
+                    # session token verbatim); only presence booleans + lengths
+                    # are logged now.
                     _LOGGER.warning(
                         "Data Act portal SPA: no state token. "
                         "landing_url=%s identifier_url=%s",
-                        landing_url[:200], identifier_url[:200],
+                        _safe_url(landing_url), _safe_url(identifier_url),
                     )
                     title_m = re.search(
                         r"<title>([^<]+)</title>",
@@ -707,13 +727,12 @@ class DataActPortalAuth:
                     _LOGGER.warning(
                         "Data Act portal SPA: password_html title=%s "
                         "len=%d, contains '<input'=%s, contains 'state'=%s, "
-                        "contains '__STORE__'=%s, state-context=%r",
+                        "contains '__STORE__'=%s",
                         (title_m.group(1) if title_m else "(none)"),
                         len(password_html or ""),
                         "<input" in (password_html or "").lower(),
                         "state" in (password_html or "").lower(),
                         "__STORE__" in (password_html or ""),
-                        _state_context(password_html or ""),
                     )
                     title_l = re.search(
                         r"<title>([^<]+)</title>",
@@ -722,13 +741,12 @@ class DataActPortalAuth:
                     _LOGGER.warning(
                         "Data Act portal SPA: landing_html title=%s "
                         "len=%d, contains '<input'=%s, contains 'state'=%s, "
-                        "contains '__STORE__'=%s, state-context=%r",
+                        "contains '__STORE__'=%s",
                         (title_l.group(1) if title_l else "(none)"),
                         len(landing_html or ""),
                         "<input" in (landing_html or "").lower(),
                         "state" in (landing_html or "").lower(),
                         "__STORE__" in (landing_html or ""),
-                        _state_context(landing_html or ""),
                     )
                     flow_hint = (
                         "signin-service v1 (legacy IDK)"
@@ -747,8 +765,8 @@ class DataActPortalAuth:
                     )
                 _LOGGER.debug(
                     "Data Act portal SPA: state token found via %s "
-                    "(first 12 chars: %s...)",
-                    state_source, state_from_url[:12],
+                    "(present=%s)",
+                    state_source, bool(state_from_url),
                 )
                 from urllib.parse import quote as _quote  # noqa: PLC0415
                 # v2.11.3 — POST URL + body shape now diverges by auth
@@ -832,12 +850,12 @@ class DataActPortalAuth:
                                     "Data Act portal SPA: identifier POST "
                                     "returned HTTP %d to %s",
                                     resp.status,
-                                    identifier_post_url[:120],
+                                    _safe_url(identifier_post_url),
                                 )
                     except Exception as exc:  # noqa: BLE001
                         _LOGGER.warning(
                             "Data Act portal SPA: identifier POST failed: %s",
-                            exc,
+                            type(exc).__name__,
                         )
 
                     # Step 2 — extract fresh hmac from password page
@@ -897,8 +915,8 @@ class DataActPortalAuth:
                         "Data Act portal SPA: 2-step signin-service "
                         "complete — identifier_url=%s authenticate_url=%s "
                         "new_hmac_found=%s",
-                        identifier_post_url[:80],
-                        spa_post_url[:80],
+                        _safe_url(identifier_post_url),
+                        _safe_url(spa_post_url),
                         bool(new_hmac),
                     )
                 elif is_signin_service_state:
@@ -960,7 +978,8 @@ class DataActPortalAuth:
                             callback_url = str(resp.url)
                 except Exception as exc:  # noqa: BLE001
                     _LOGGER.debug(
-                        "Data Act portal SPA POST (form) failed: %s", exc
+                        "Data Act portal SPA POST (form) failed: %s (%s)",
+                        type(exc).__name__, _safe_url(spa_post_url),
                     )
                 # JSON fallback for SPA-only Auth0 deployments
                 # (matches the idk.py order). Triggered when the form
@@ -986,8 +1005,8 @@ class DataActPortalAuth:
                                 callback_url = str(resp.url)
                     except Exception as exc:  # noqa: BLE001
                         _LOGGER.debug(
-                            "Data Act portal SPA POST (json) failed: %s",
-                            exc,
+                            "Data Act portal SPA POST (json) failed: %s (%s)",
+                            type(exc).__name__, _safe_url(spa_post_url),
                         )
                 if not callback_url or (
                     "drivesomethinggreater.com" not in callback_url
@@ -1061,7 +1080,8 @@ class DataActPortalAuth:
             raise
         except Exception as exc:  # noqa: BLE001
             raise AuthenticationError(
-                f"Data Act portal: password POST failed ({exc})"
+                f"Data Act portal: password POST failed "
+                f"({type(exc).__name__} at {_safe_url(password_action_url)})"
             ) from exc
 
         # Step 4 + 5 — callback parsing + token exchange. Factored into
@@ -1099,7 +1119,7 @@ class DataActPortalAuth:
         ):
             raise AuthenticationError(
                 f"Data Act portal: login did not land on portal host "
-                f"(final URL: {callback_url[:120]})"
+                f"(final URL: {_safe_url(callback_url)})"
             )
 
         all_params = {
@@ -1167,7 +1187,8 @@ class DataActPortalAuth:
             raise
         except Exception as exc:  # noqa: BLE001
             raise AuthenticationError(
-                f"Data Act portal: token exchange failed ({exc})"
+                f"Data Act portal: token exchange failed "
+                f"({type(exc).__name__})"
             ) from exc
 
         access_token = token_json.get("access_token", "")

--- a/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
+++ b/custom_components/vag_connect/cariad/auth/_data_act_scraper.py
@@ -923,7 +923,7 @@ class DataActScraper:
                 )
         except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "AEM revive GET %s raised %s: %s", path, type(exc).__name__, exc,
+                "AEM revive GET %s raised %s", path, type(exc).__name__,
             )
 
     async def _csrf_get(self, url: str) -> tuple[str | None, bool]:
@@ -957,8 +957,8 @@ class DataActScraper:
                 data = await resp.json(content_type=None)
         except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "CSRF token fetch: %s raised %s: %s",
-                _CSRF_TOKEN_PATH, type(exc).__name__, exc,
+                "CSRF token fetch: %s raised %s",
+                _CSRF_TOKEN_PATH, type(exc).__name__,
             )
             return None, False
         # ``token`` is the field the portal's own Granite clientlib reads.
@@ -1028,7 +1028,8 @@ class DataActScraper:
         except DataActSessionExpiredError:
             raise
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("metadata/partial fetch failed: %s", exc)
+            # Class only — an aiohttp error's str() echoes the VIN-path URL.
+            _LOGGER.debug("metadata/partial fetch failed: %s", type(exc).__name__)
             return None
 
         # Payload shape captured 2026-06-03: either a list of request
@@ -1214,9 +1215,10 @@ class DataActScraper:
                     if not last:
                         _LOGGER.info(
                             "kickoff_custom_data_request: portal rejected "
-                            "Duration=%r (HTTP %s), retrying with %r: %s",
+                            "Duration=%r (HTTP %s), retrying with %r "
+                            "(body %d bytes)",
                             duration, resp.status, attempts[index + 1][0],
-                            body_text[:200],
+                            len(body_text),
                         )
                         continue
                     # b11 (#1273) — split severity by status. A 4xx is a genuine
@@ -1230,22 +1232,26 @@ class DataActScraper:
                     if 400 <= resp.status < 500:
                         _LOGGER.warning(
                             "kickoff_custom_data_request HTTP %s for VIN %s — no "
-                            "data feed will start until this is resolved: %s",
-                            resp.status, _mask_vin(vin), body_text[:300],
+                            "data feed will start until this is resolved "
+                            "(body %d bytes)",
+                            resp.status, _mask_vin(vin), len(body_text),
                         )
                     else:
                         _LOGGER.info(
                             "kickoff_custom_data_request HTTP %s for VIN %s — a "
                             "request likely already exists and isn't readable back "
                             "on this portal session; a live feed may still "
-                            "deliver: %s",
-                            resp.status, _mask_vin(vin), body_text[:300],
+                            "deliver (body %d bytes)",
+                            resp.status, _mask_vin(vin), len(body_text),
                         )
                     return None
             except DataActSessionExpiredError:
                 raise
             except Exception as exc:  # noqa: BLE001
-                _LOGGER.debug("kickoff_custom_data_request failed: %s", exc)
+                # Class only — str(exc) echoes the VIN-path request URL.
+                _LOGGER.debug(
+                    "kickoff_custom_data_request failed: %s", type(exc).__name__
+                )
                 return None
         # Every attempt now returns inside the loop (success via readback, or a
         # detected failure); this is only reached if the attempt list were empty.
@@ -1318,14 +1324,18 @@ class DataActScraper:
                 if resp.status not in (200, 201, 202):
                     body_text = await resp.text(errors="replace")
                     _LOGGER.warning(
-                        "kickoff_historical_export HTTP %s for VIN %s: %s",
-                        resp.status, _mask_vin(vin), body_text[:300],
+                        "kickoff_historical_export HTTP %s for VIN %s "
+                        "(body %d bytes)",
+                        resp.status, _mask_vin(vin), len(body_text),
                     )
                     return False
         except DataActSessionExpiredError:
             raise
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("kickoff_historical_export failed: %s", exc)
+            # Class only — str(exc) echoes the VIN-path request URL.
+            _LOGGER.debug(
+                "kickoff_historical_export failed: %s", type(exc).__name__
+            )
             return False
 
         _LOGGER.info(

--- a/custom_components/vag_connect/cariad/auth/_device_grant.py
+++ b/custom_components/vag_connect/cariad/auth/_device_grant.py
@@ -205,7 +205,10 @@ class DeviceAuthorizationGrant:
                 payload = await resp.json(content_type=None)
         except Exception as exc:  # noqa: BLE001
             raise AuthenticationError(
-                f"Device grant: /device_authorization request failed ({exc})"
+                # Class only — this message surfaces to the user/config-flow; keep
+                # any transport-exception text (which can echo the request URL) out.
+                f"Device grant: /device_authorization request failed "
+                f"({type(exc).__name__})"
             ) from exc
 
         if status != 200:
@@ -401,7 +404,8 @@ class DeviceAuthorizationGrant:
         except Exception as exc:  # noqa: BLE001
             # network/transport blip — transient, NOT a dead refresh token
             raise TokenRefreshRetryError(
-                f"Device grant refresh: request failed ({exc})"
+                # Class only — keep transport-exception text (can echo the URL) out.
+                f"Device grant refresh: request failed ({type(exc).__name__})"
             ) from exc
 
         if status != 200:

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -82,6 +82,17 @@ _PORTAL_REDIRECT_URI = f"{_PORTAL_BASE}/login"
 # authenticated (the #1340 shape). (#1340 login-success hardening)
 _PORTAL_INFRA_COOKIES: frozenset[str] = frozenset({"affinity"})
 
+
+def _domain_covers_host(cookie_domain: str, host: str) -> bool:
+    """True if a cookie scoped to *cookie_domain* would be sent to *host* — the
+    cookie's domain is the host itself OR a parent of it. A bare substring test
+    misses a PARENT-domain cookie (e.g. ``.drivesomethinggreater.com`` for host
+    ``eu-data-act.drivesomethinggreater.com``) and would then false-flag a real
+    authenticated session as anonymous. (#1340 login-success hardening)
+    """
+    d = (cookie_domain or "").lstrip(".")
+    return bool(d) and (host == d or host.endswith("." + d))
+
 # Brands not listed fall back to the VW entry with a brand-derived state
 # suffix; account-level verification for those follows in a later release.
 _EUDA_VW = {
@@ -166,6 +177,10 @@ _RETRIABLE_STATUSES = frozenset({500, 502, 503, 504})
 # (→ "delivery_not_ready"). Splitting them keeps a normal wait from reading as a fault.
 _PORTAL_OUTAGE_STATUSES = frozenset({429, 500, 502, 503, 504})
 _PORTAL_RETRY_DELAYS = (3.0, 6.0)  # backoff (s) before giving up on a soft call
+# On a transient download error we fall back to the next-older listed dataset
+# (TommiG1 loops the listing newest→oldest). Capped so a full-portal outage where
+# every file 5xxs cannot turn one poll into many hammering requests.
+_MAX_DATASET_FALLBACK = 3
 
 
 def _request_start_date(meta: Any, identifier: str) -> str | None:
@@ -376,19 +391,43 @@ def _login_error(html: str) -> str | None:
     return str(err) if err else None
 
 
-def _safe_url(url: str) -> str:
-    """Return host+path of *url* with the query string STRIPPED.
+_URL_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
 
-    Query strings on the signin-service flow carry ``relayState`` / ``code``
-    / login tokens — never log them. This yields only the part that is safe
-    to log (host + path) so #527 reporters' real failure step can be pinned
-    from a debug log without leaking secrets.
+
+def _safe_url(url: str) -> str:
+    """Return host+path of *url* with the query AND fragment STRIPPED and any
+    UUID-shaped PATH segment masked.
+
+    Query/fragment on the signin-service flow carry ``relayState`` / ``code`` /
+    login tokens, and the consent grant page carries the account UUID as a **path**
+    segment (``/signin-service/v1/consent/users/<uuid>/…``) — never log any of it.
+    This yields only the part that is safe to log (host + path, UUIDs masked) so
+    #527 reporters' real failure step can be pinned from a debug log without
+    leaking secrets. (#1355 — a bare host+path leaked the path UUID.)
     """
     try:
         p = urlparse(url)
-        return f"{p.netloc}{p.path}"
+        return _URL_UUID_RE.sub("<uuid>", f"{p.netloc}{p.path}")
     except Exception:  # noqa: BLE001
         return "<unparseable-url>"
+
+
+_VIN_RE = re.compile(r"\b[A-HJ-NPR-Z0-9]{17}\b")
+
+
+def _safe_api_url(url: str) -> str:
+    """Like :func:`_safe_url`, but ALSO masks the 17-char VIN path segment.
+
+    The proxy_api data paths embed the full VIN (and a data-request identifier
+    UUID) as PATH segments — ``/…/vehicles/<VIN>/<identifier>/download``.
+    ``_safe_url`` strips the query and masks the UUID identifier, but a VIN is
+    not UUID-shaped and would survive. This masks it too, so neither the VIN
+    nor the request identifier reaches a log line or an exception message a
+    tester copy-pastes. (#1355)
+    """
+    return _VIN_RE.sub("<vin>", _safe_url(url))
 
 
 # v2.15.4 (#527) — interstitial markers. The portal login lands on the
@@ -502,7 +541,7 @@ def classify_portal_login_failure(
     # reporter who enabled debug logging saw nothing about WHY it was classified.
     _LOGGER.debug(
         "EU-DA portal login classify: pageType=%r errorCode=%r url=%s",
-        str(page_type)[:80], str(err_code)[:80], landing_url[:100],
+        str(page_type)[:80], str(err_code)[:80], _safe_url(landing_url),
     )
 
     # 1. Interstitials we recognise — reuse the main-chain exceptions.
@@ -3191,10 +3230,18 @@ def map_dataset_to_vehicle_data(
         _bem_num = _to_float(_bem_raw)
         if _bem_num is None or _bem_num >= 1_000_000_000:
             d.aux_battery_bem_alert_at = _epoch_or_iso(_bem_raw)
-    # active_warnings_in_instrument_cluster_feff_filtered — RAW hex/interpreted
-    # bitmask only. Do NOT attempt an enum decode we can't verify; surface the
-    # raw value as a disabled-by-default diagnostic.
-    _warn = first("active_warnings_in_instrument_cluster_feff_filtered")
+    # active_warnings_in_instrument_cluster_* — RAW hex/interpreted bitmask only.
+    # Do NOT attempt an enum decode we can't verify; surface the raw value as a
+    # disabled-by-default diagnostic. VW ships this under several mask-suffix
+    # variants (_feff_filtered, _fff, _0001[_filtered]) depending on the car — a VW
+    # ID.4 reports `_fff` where we previously only read `_feff_filtered` (#1358
+    # Scout) — so read whichever variant is present (first-freshest wins).
+    _warn = first(
+        "active_warnings_in_instrument_cluster_feff_filtered",
+        "active_warnings_in_instrument_cluster_fff",
+        "active_warnings_in_instrument_cluster_0001_filtered",
+        "active_warnings_in_instrument_cluster_0001",
+    )
     if _warn is not None:
         d.dashboard_warnings_raw = str(_warn)
     # #901 (Mezzo1973, volkswagen) — best-effort LOW-confidence mapping of four
@@ -3657,10 +3704,12 @@ class EUDataActConnector:
                 timeout=ClientTimeout(total=_TIMEOUT_S),
             ) as resp:
                 result = (str(resp.url), await resp.text(errors="replace"), resp.status)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            # No exc_info: an aiohttp client error's str() can embed the raw
+            # callback URL (code / relayState). Log only the exception TYPE. (#1355)
             _LOGGER.debug(
-                "EU Data Act portal: marketing-consent auto-skip failed",
-                exc_info=True,
+                "EU Data Act portal: marketing-consent auto-skip failed (%s)",
+                type(exc).__name__,
             )
             return None
         # DEBUG, not INFO: this is a silent "not now" no-op the user can't act on
@@ -3691,6 +3740,25 @@ class EUDataActConnector:
         )
         blob = f"{url_l}\n{landing_html.lower()}"
         return _is_generic_consent_page(landing_url, page_type, blob)
+
+    @staticmethod
+    def _is_terms_landing(landing_url: str, landing_html: str) -> bool:
+        """True if the post-credential landing is a legal terms-and-conditions wall.
+
+        Detected exactly the way the fallback classifier does (``_TC_MARKERS`` in
+        the URL/body, or a templateModel pageType of ``termsAndConditions``).
+        Distinct from the generic OAuth consent grant (``_is_consent_landing``) and
+        the marketing-consent interstitial — this is the account being asked to
+        accept UPDATED legal terms after a valid credential step.
+        """
+        blob = f"{landing_url}\n{landing_html}".lower()
+        if any(m in blob for m in _TC_MARKERS):
+            return True
+        model = _extract_template_model(landing_html) or {}
+        page_type = str(
+            model.get("template") or model.get("templateName") or ""
+        ).lower()
+        return "termsandconditions" in page_type
 
     async def _accept_consent_page(
         self, consent_url: str, consent_html: str
@@ -3758,6 +3826,61 @@ class EUDataActConnector:
         )
         return new_landing, new_html, new_status
 
+    async def _accept_terms_page(
+        self, terms_url: str, terms_html: str
+    ) -> tuple[str, str, int] | None:
+        """Scrape + POST the terms-and-conditions form to ACCEPT it.
+
+        v4.7.x — adopted from TommiG1/HA_VAG-EU-Data-Act, mirroring our own consent
+        auto-accept (#527). A genuine brand-own T&C interstitial after a valid
+        credential POST is the SAME Auth0 signin-service form as the consent grant
+        (hidden ``_csrf`` / ``relayState`` / ``hmac``); consent and T&C differ only
+        in the landing marker, so the accept is the same form-POST. The user has
+        already authenticated and configured the integration to read their OWN car's
+        data (EU Data Act, Art. 4), so accepting the updated terms completes the
+        flow the user asked for — exactly as the official app does.
+
+        Bounded: accept at most ONCE. If the form cannot be parsed (or the POST
+        fails), return ``None`` and let the caller fall through to the typed
+        ``TermsAndConditionsError`` Repair — and if the accept POST re-lands on a
+        T&C page, the caller's ``landed_failed`` classification raises the same
+        Repair, so there is never a silent loop (mirrors TommiG1's "raise if the
+        terms form appears twice"). The wrong-CLIENT T&C artefact (#1340) is already
+        eliminated at the source by the per-brand portal client_ids, so this only
+        ever clears a real, account-level T&C update.
+        """
+        fields, action = _login_fields(terms_html)
+        # Gate on the form's own anti-CSRF / continuation fields — without them
+        # this is not an acceptable T&C form and a POST would just 400.
+        if not ({"_csrf", "hmac", "relayState"} & set(fields)):
+            _LOGGER.debug(
+                "EU Data Act portal: T&C page at %s carried no form fields — "
+                "cannot auto-accept, leaving to classifier",
+                _safe_url(terms_url),
+            )
+            return None
+        accept_action = _resolve_action(terms_url, action)
+        try:
+            async with self._session.post(
+                accept_action, data=fields,
+                headers={"User-Agent": _USER_AGENT, "Referer": terms_url},
+                allow_redirects=True, timeout=ClientTimeout(total=_TIMEOUT_S),
+            ) as resp:
+                new_landing = str(resp.url)
+                new_html = await resp.text(errors="replace")
+                new_status = resp.status
+        except Exception as exc:  # noqa: BLE001 — best-effort accept
+            _LOGGER.debug(
+                "EU Data Act portal: T&C accept POST failed (%s) — leaving to "
+                "classifier", type(exc).__name__,
+            )
+            return None
+        _LOGGER.debug(
+            "EU Data Act portal: T&C accepted → landing=%s status=%s",
+            _safe_url(new_landing), new_status,
+        )
+        return new_landing, new_html, new_status
+
     async def login(self, email: str, password: str) -> None:
         """Run the OIDC code-flow login; portal backend sets cookies.
 
@@ -3800,7 +3923,13 @@ class EUDataActConnector:
             ):
                 pass
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("EU Data Act: priming GET failed (ignored): %s", exc)
+            # Class only, never str(exc) — an aiohttp error's message echoes the
+            # request URL. (Here it is the static portal base, but keep the sweep
+            # posture uniform so no future URL change re-opens a leak.)
+            _LOGGER.debug(
+                "EU Data Act: priming GET failed (ignored): %s",
+                type(exc).__name__,
+            )
 
         # 1. Start OIDC directly at the IDP (portal's own servlet 500s for
         #    non-browser clients). response_type=code; portal does the
@@ -3884,9 +4013,30 @@ class EUDataActConnector:
             if accepted is not None:
                 landing, landing_html, status = accepted
 
+        # 3c. Legal terms-and-conditions wall — auto-accept it, the same way we
+        # accept the OAuth consent grant above (adopted from TommiG1; consent and
+        # T&C are the SAME Auth0 form-POST, only the marker differs). The user has
+        # authenticated and asked the integration to read their own car's data, so
+        # accepting an updated-terms interstitial completes exactly the flow they
+        # requested. Bounded to ONE attempt: on a parse/POST failure or a re-render
+        # the ``landed_failed`` block below still raises the typed
+        # ``TermsAndConditionsError`` Repair, so there is no silent loop. (The
+        # wrong-CLIENT T&C artefact is already gone at the source via #1340's
+        # per-brand client_ids, so this only clears a genuine account-level T&C.)
+        if self._is_terms_landing(landing, landing_html):
+            _LOGGER.info(
+                "EU Data Act portal: terms-and-conditions page at %s — "
+                "auto-accepting (user already authenticated; mirrors the consent "
+                "grant + official-app behaviour)",
+                _safe_url(landing),
+            )
+            accepted = await self._accept_terms_page(landing, landing_html)
+            if accepted is not None:
+                landing, landing_html, status = accepted
+
         # v4.6.0 — OPTIONAL marketing-consent interstitial. Distinct from the
-        # generic OAuth grant above (which we accept) AND from the legal T&C wall
-        # below (which we deliberately do NOT auto-clear). VW randomly injects a
+        # generic OAuth grant AND the legal T&C wall above (both of which we now
+        # auto-accept). VW randomly injects a
         # marketing-consent page after a valid login; its URL carries an OIDC
         # ``callback=`` that, when followed, completes the login WITHOUT granting
         # marketing scopes (the "not now" path). Port of idk._skip_marketing_consent
@@ -3999,7 +4149,7 @@ class EUDataActConnector:
             portal_cookies = {
                 cookie.key
                 for cookie in getattr(self._session, "cookie_jar", ())
-                if portal_host in (cookie.get("domain") or "")
+                if _domain_covers_host(cookie.get("domain") or "", portal_host)
             }
         except Exception:  # noqa: BLE001 — never break login on a jar-read error
             return False
@@ -4040,23 +4190,34 @@ class EUDataActConnector:
                     name = _EMBEDDED_UUID_RE.sub("<uuid>", cookie.key)
                     dom = cookie.get("domain") or "?"
                     cookies.append(f"{name}@{dom}")
-                    if portal_host in dom:
+                    if _domain_covers_host(dom, portal_host):
                         portal_cookies.append(name)
             except Exception:  # noqa: BLE001
                 cookies = ["<cookie jar unreadable>"]
             resp_hdrs = getattr(resp, "headers", {})
             www_auth = str(resp_hdrs.get("WWW-Authenticate", ""))
+            # Log ONLY the challenge SCHEME (the token before the first space:
+            # "Bearer"/"Basic"/…). The params that follow (realm / nonce /
+            # error_description) are free text — never log them. And the request
+            # URL goes through _safe_api_url so the VIN + identifier in the path
+            # are masked, not just the query stripped. (#1355)
+            www_auth_scheme = www_auth.split(" ", 1)[0] if www_auth else ""
             _LOGGER.debug(
                 "EU Data Act 401 auth-state on %s: mode=%s sent_authorization=%s "
                 "session_cookies=%s portal_domain_cookies=%s "
-                "resp_www_authenticate=%r resp_set_cookie=%s "
+                "resp_www_authenticate_scheme=%r resp_set_cookie=%s "
                 "(#1340 diagnostic — names/flags only, no secret values)",
-                url.split("?")[0], mode, sent_authorization, cookies or "<none>",
-                portal_cookies or "<none>", www_auth[:80], "Set-Cookie" in resp_hdrs,
+                _safe_api_url(url), mode, sent_authorization, cookies or "<none>",
+                portal_cookies or "<none>", www_auth_scheme, "Set-Cookie" in resp_hdrs,
             )
             self._logged_401_auth_state = True
-        except Exception:  # noqa: BLE001 — diagnostics must never break the flow
-            _LOGGER.debug("EU Data Act 401 auth-state dump failed", exc_info=True)
+        except Exception as exc:  # noqa: BLE001 — diagnostics must never break the flow
+            # Class only, not exc_info — this guards the 401-diagnostic builder,
+            # which has the VIN-path url + cookie names in scope; a traceback dump
+            # could surface them. The failure class is enough to debug the dumper.
+            _LOGGER.debug(
+                "EU Data Act 401 auth-state dump failed (%s)", type(exc).__name__
+            )
 
     async def _get_json(
         self,
@@ -4118,7 +4279,7 @@ class EUDataActConnector:
                                 url, eff_headers, resp
                             )
                         raise AuthenticationError(
-                            f"EU Data Act GET {url} → HTTP {resp.status}"
+                            f"EU Data Act GET {_safe_api_url(url)} → HTTP {resp.status}"
                         )
                     return await resp.json(content_type=None)
             except (TimeoutError, ClientConnectionError):
@@ -4157,6 +4318,41 @@ class EUDataActConnector:
 
         walk(payload)
         return vins
+
+    async def _download_dataset_raw(
+        self, vin: str, identifier: str, name: str, request_type: str,
+    ) -> tuple[bytes | None, bool, int | None]:
+        """Download ONE dataset ZIP by name. Returns ``(raw|None, transient, status)``.
+
+        ``(raw, False, 200)`` on success; ``(None, True, status)`` on a transient
+        outage status (5xx/429/404); ``(None, True, None)`` on a transport
+        timeout/disconnect. A non-transient ``>= 400`` (401/403 session-expired) is
+        raised as ``AuthenticationError``, exactly as the single-download path did —
+        so the caller's newest→oldest fallback only ever chases genuine outages,
+        never a dead session. This GET bypasses ``_get_json``, so the Bearer header
+        (v2.13.0) is merged in without clobbering the filename/type headers the
+        download endpoint requires.
+        """
+        dl_headers = {"filename": name, "type": request_type}
+        if self._bearer:
+            dl_headers["Authorization"] = f"Bearer {self._bearer}"
+        try:
+            async with self._session.get(
+                f"{_PORTAL_BASE}{_DOWNLOAD_PATH.format(vin=vin, identifier=identifier)}",
+                headers=dl_headers,
+                timeout=ClientTimeout(total=_TIMEOUT_S),
+            ) as resp:
+                if resp.status in _TRANSIENT_STATUSES:
+                    return None, True, resp.status
+                if resp.status >= 400:
+                    raise AuthenticationError(
+                        f"EU Data Act portal: download → HTTP {resp.status}"
+                    )
+                return await resp.read(), False, resp.status
+        except (TimeoutError, ClientConnectionError):
+            # v2.14.8 — a transport timeout/disconnect on the ZIP download is a
+            # portal hiccup, not a dead session; report it as transient.
+            return None, True, None
 
     async def get_vehicle_data(
         self, vin: str, request_type: str = "partial"
@@ -4310,51 +4506,44 @@ class EUDataActConnector:
         # Newest by delivery ts when present; files without a ts sort below those
         # with one (-inf), and ties / a fully-tsless listing fall back to array
         # order (the original names[-1] behaviour).
-        newest = max(
-            cands, key=lambda c: (c[1] if c[1] is not None else float("-inf"), c[2])
-        )[0]
-        # 3. download ZIP → JSON. This GET bypasses _get_json, so the Bearer
-        # header (v2.13.0) must be merged in separately without clobbering the
-        # filename/type headers the download endpoint requires.
-        dl_headers = {"filename": newest, "type": request_type}
-        if self._bearer:
-            dl_headers["Authorization"] = f"Bearer {self._bearer}"
-        try:
-            async with self._session.get(
-                f"{_PORTAL_BASE}{_DOWNLOAD_PATH.format(vin=vin, identifier=identifier)}",
-                headers=dl_headers,
-                timeout=ClientTimeout(total=_TIMEOUT_S),
-            ) as resp:
-                if resp.status in _TRANSIENT_STATUSES:
-                    # Same outage story as the listing call — the ZIP download
-                    # 500s mid-outage. Don't burn the session; just skip this poll.
-                    self._note_no_data(
-                        "portal_error"
-                        if resp.status in _PORTAL_OUTAGE_STATUSES else "empty"
-                    )
-                    _LOGGER.info(
-                        "EU Data Act portal: dataset download returned a transient "
-                        "error (HTTP %s) for %s; treating as no data this poll.",
-                        resp.status, vin[-6:],
-                    )
-                    return d
-                if resp.status >= 400:
-                    raise AuthenticationError(
-                        f"EU Data Act portal: download → HTTP {resp.status}"
-                    )
-                raw = await resp.read()
-        except (TimeoutError, ClientConnectionError):
-            # v2.14.8 — same as the soft GETs: a transport timeout/disconnect on
-            # the ZIP download is a portal hiccup, not a dead session. Skip the
-            # poll instead of letting a raw TimeoutError bubble to the coordinator.
-            self._note_no_data("portal_error")
+        # 3. download ZIP → JSON, newest→oldest with a transient fallback. On a
+        # transient download error (5xx/429/timeout) we try the next-older listed
+        # dataset instead of skipping the whole poll (adopted from TommiG1, which
+        # loops the listing newest→oldest). A non-transient 401/403 still raises
+        # (session expired), and a parsed-but-EMPTY newest is NEVER overridden by an
+        # older dataset (only download outages fall back — we don't serve stale
+        # telemetry as fresh). Capped at _MAX_DATASET_FALLBACK so a full outage
+        # can't turn one poll into many hammering requests.
+        ranked = [
+            c[0] for c in sorted(
+                cands,
+                key=lambda c: (c[1] if c[1] is not None else float("-inf"), c[2]),
+                reverse=True,
+            )
+        ]
+        raw: bytes | None = None
+        chosen: str | None = None
+        saw_outage = False
+        for name in ranked[:_MAX_DATASET_FALLBACK]:
+            got, _transient, st = await self._download_dataset_raw(
+                vin, identifier, name, request_type
+            )
+            if got is not None:
+                raw, chosen = got, name
+                break
+            if st is not None and st in _PORTAL_OUTAGE_STATUSES:
+                saw_outage = True
+        if raw is None or chosen is None:
+            # Every attempted dataset returned a transient outage / timeout — same
+            # "don't burn the session, no data this poll" outcome as before.
+            self._note_no_data("portal_error" if saw_outage else "empty")
             _LOGGER.info(
-                "EU Data Act portal: dataset download timed out / disconnected "
-                "for %s; treating as no data this poll.",
-                vin[-6:],
+                "EU Data Act portal: all %d candidate dataset(s) returned a "
+                "transient error for %s; treating as no data this poll.",
+                min(len(ranked), _MAX_DATASET_FALLBACK), vin[-6:],
             )
             return d
-        payload = _unzip_json(raw, newest)
+        payload = _unzip_json(raw, chosen)
         field_ts: dict[str, float] = {}  # #529: resolved per-field capture ts
         field_syn: dict[str, set[str]] = {}  # v2.15.4: bare/qualified synonym map
         contested: dict[str, set[str]] = {}  # same capture time, disagreeing values
@@ -4378,7 +4567,7 @@ class EUDataActConnector:
         # never disturb the poll, so it is fully guarded.
         if self.on_raw_dataset is not None:
             try:
-                self.on_raw_dataset(vin, raw, newest)
+                self.on_raw_dataset(vin, raw, chosen)
             except Exception:  # noqa: BLE001  # pragma: no cover - defensive
                 _LOGGER.debug("EU Data Act: raw-dataset archive hook failed")
         return map_dataset_to_vehicle_data(

--- a/custom_components/vag_connect/cariad/auth/_mbboauth.py
+++ b/custom_components/vag_connect/cariad/auth/_mbboauth.py
@@ -59,7 +59,12 @@ def _refresh_error(status: int, body: str, retryable: bool) -> Exception:
             err_code = str(json.loads(body).get("error", ""))
     except (ValueError, AttributeError):
         err_code = ""
-    msg = f"MBB token exchange HTTP {status}: {body[:400]}"
+    # Redaction (#1355): NEVER interpolate the raw token-endpoint body — a
+    # response body can carry credential material. Surface the HTTP status plus
+    # the parsed OAuth ``error`` code only.
+    msg = f"MBB token exchange HTTP {status}"
+    if err_code:
+        msg += f" (error={err_code})"
     if retryable and err_code not in _HARD_REFRESH_ERRORS:
         return TokenRefreshRetryError(msg)
     return AuthenticationError(msg)
@@ -343,18 +348,35 @@ async def register(
         ) as resp:
             text = await resp.text()
             if resp.status not in (200, 201):
-                raise AuthenticationError(
-                    f"MBB register HTTP {resp.status}: {text[:200]}"
-                )
+                # Redaction (#1355): never echo the register body — surface the
+                # status plus the parsed error code only.
+                err_code = ""
+                try:
+                    err_code = str(json.loads(text).get("error", ""))
+                except (ValueError, AttributeError):
+                    err_code = ""
+                msg = f"MBB register HTTP {resp.status}"
+                if err_code:
+                    msg += f" (error={err_code})"
+                raise AuthenticationError(msg)
             try:
                 payload = json.loads(text)
             except ValueError as exc:
+                # Redaction (#1355): the status already passed the 2xx check, so
+                # ``text`` is a SUCCESSFUL register body — it carries the
+                # per-device client_id/secret. Log only that it was non-JSON and
+                # its length; never the body itself.
                 raise AuthenticationError(
-                    f"MBB register response not JSON: {text[:120]}"
+                    f"MBB register response not JSON "
+                    f"(HTTP {resp.status}, {len(text)} bytes)"
                 ) from exc
             return payload.get("client_id"), payload.get("client_secret")
     except ClientError as exc:
-        raise AuthenticationError(f"MBB register failed: {exc}") from exc
+        # Redaction (#1355): an aiohttp ClientError stringifies to the offending
+        # request URL — log the exception type name only.
+        raise AuthenticationError(
+            f"MBB register failed: {type(exc).__name__}"
+        ) from exc
 
 
 async def mint_mbb_bearer(

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -152,6 +152,31 @@ _PROACTIVE_ROLL_INTERVAL_S = 600.0
 # session-resume can't re-establish and every restart loops / re-prompts OTP.
 _COOKIE_HOSTS = (f"{_SITE_BASE}/", f"{_IDENTITY_BASE}/")
 
+# #1355 — redact a URL before it reaches a log OR a copy-pasteable exception
+# message. The auth landing URLs on this flow carry the OAuth ``state`` / ``code``
+# in the query (and the consent page carries the account UUID as a PATH segment),
+# so a bare ``url[:80]`` slice is NOT redaction — the secret sits at the front or
+# the tail. Mirror the ``_safe_url`` in idk.py / _eu_data_act.py: keep host+path
+# only, drop query + fragment, mask UUID path segments.
+_URL_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+# vw.de authproxy read URLs carry the VIN in the path (…/proxy/vehicles/{vin}/…);
+# a VIN is owner-identifying PII, so mask it too. Canonical 17-char VIN charset,
+# word-bounded — the surrounding literal path segments are lowercase, so no
+# false-positive masking.
+_VIN_RE = re.compile(r"\b[A-HJ-NPR-Z0-9]{17}\b")
+
+
+def _safe_url(url: str) -> str:
+    """Host+path of *url*, query + fragment stripped, UUID + VIN path segments masked."""
+    try:
+        p = urlparse(url)
+        safe = _URL_UUID_RE.sub("<uuid>", f"{p.netloc}{p.path}")
+        return _VIN_RE.sub("<vin>", safe) or "<empty-url>"
+    except Exception:  # noqa: BLE001
+        return "<unparseable-url>"
+
 
 def _redacted_cookie_summary(cookies: list[dict[str, Any]]) -> str:
     """A value-free, one-line summary of a cookie set for debug logging (#966).
@@ -574,7 +599,7 @@ class WebsiteAuthProxyConnector:
         if "/u/login" not in login_url and "signin-service" not in login_url:
             raise AuthenticationError(
                 "Website authproxy: did not reach the VW identity login "
-                f"(landed at {login_url[:80]})"
+                f"(landed at {_safe_url(login_url)})"
             )
 
         auth0_state = self._auth0_state(login_url, login_html)
@@ -777,9 +802,14 @@ class WebsiteAuthProxyConnector:
         # logged it, which left a reporter's debug log unable to show where the
         # chain actually went: the single fact needed to tell a dead SSO from a
         # misclassified good one.
+        # Mask the PATH too, not just the (already-dropped) query: the consent hop
+        # carries the account UUID as a path segment (…/consent/users/<uuid>/…) and
+        # a read path can carry the VIN. (#1355)
         _LOGGER.debug(
             "Website authproxy refresh GET landed host=%s path=%s status=%s",
-            landed_host, landed_path, status,
+            landed_host,
+            _VIN_RE.sub("<vin>", _URL_UUID_RE.sub("<uuid>", landed_path)),
+            status,
         )
         if not on_portal and (
             "/u/login" in landed_path or "/signin-service" in landed_path
@@ -800,7 +830,8 @@ class WebsiteAuthProxyConnector:
             )
             return
         raise AuthenticationError(
-            f"Website authproxy: refresh did not land on the portal ({landed[:80]})"
+            "Website authproxy: refresh did not land on the portal "
+            f"({_safe_url(landed)})"
         )
 
     async def maybe_roll(self, *, force: bool = False) -> None:
@@ -822,14 +853,16 @@ class WebsiteAuthProxyConnector:
         self._last_roll = now
         try:
             await self.refresh()
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             # A proactive roll is opportunistic: if it fails (transient network,
             # or a genuinely-dead SSO), swallow it and let the subsequent read's
             # reactive refresh()/re-login handle it. Never propagate from here.
+            # Log the exception CLASS only, never exc_info — a chained aiohttp
+            # error's str() carries the VIN-path read URL (PII).
             _LOGGER.debug(
-                "Website authproxy: proactive session roll skipped (will rely on"
-                " the reactive path this cycle)",
-                exc_info=True,
+                "Website authproxy: proactive session roll skipped (%s; will rely"
+                " on the reactive path this cycle)",
+                type(exc).__name__,
             )
 
     def _finalise_login(self, landed_url: str) -> None:
@@ -843,7 +876,7 @@ class WebsiteAuthProxyConnector:
         else:
             raise AuthenticationError(
                 "Website authproxy: login did not complete "
-                f"(ended at {landed_url[:80]})"
+                f"(ended at {_safe_url(landed_url)})"
             )
 
     @staticmethod
@@ -1175,7 +1208,7 @@ class WebsiteAuthProxyConnector:
                     # WeConnect gdc) — never a dead session → no data this poll.
                     _LOGGER.debug(
                         "Website authproxy GET %s → 412 precondition "
-                        "(no data this poll)", url,
+                        "(no data this poll)", _safe_url(url),
                     )
                     if record_as:
                         self.probe_outcomes[record_as] = "412 precondition (wrong-platform gdc?)"
@@ -1185,13 +1218,13 @@ class WebsiteAuthProxyConnector:
                         _LOGGER.debug(
                             "Website authproxy GET %s → HTTP %s (optional read "
                             "unavailable for this car — not a session failure)",
-                            url, resp.status,
+                            _safe_url(url), resp.status,
                         )
                         if record_as:
                             self.probe_outcomes[record_as] = str(resp.status)
                         return None
                     raise AuthenticationError(
-                        f"Website authproxy GET {url} → HTTP {resp.status}"
+                        f"Website authproxy GET {_safe_url(url)} → HTTP {resp.status}"
                     )
                 if resp.status >= 400:
                     if (
@@ -1204,13 +1237,13 @@ class WebsiteAuthProxyConnector:
                     if soft:
                         _LOGGER.debug(
                             "Website authproxy GET %s → HTTP %s "
-                            "(soft; no data this poll)", url, resp.status,
+                            "(soft; no data this poll)", _safe_url(url), resp.status,
                         )
                         if record_as:
                             self.probe_outcomes[record_as] = str(resp.status)
                         return None
                     raise AuthenticationError(
-                        f"Website authproxy GET {url} → HTTP {resp.status}"
+                        f"Website authproxy GET {_safe_url(url)} → HTTP {resp.status}"
                     )
                 body = await resp.json(content_type=None)
                 self._capture_raw(url, body)
@@ -1297,10 +1330,10 @@ class WebsiteAuthProxyConnector:
             await self.get_relations()
         except AuthenticationError:
             raise
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "Website authproxy: platform probe skipped for %s", vin[-6:],
-                exc_info=True,
+                "Website authproxy: platform probe skipped for %s (%s)",
+                vin[-6:], type(exc).__name__,
             )
 
     async def get_master_data(self, vin: str) -> AuthproxyVehicleInfo:
@@ -1563,10 +1596,10 @@ class WebsiteAuthProxyConnector:
             rels = await self.get_relations()  # also populates self._vin_backend
         except AuthenticationError:
             raise
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "Website authproxy relations preflight skipped for %s", vin[-6:],
-                exc_info=True,
+                "Website authproxy relations preflight skipped for %s (%s)",
+                vin[-6:], type(exc).__name__,
             )
 
         charging = await self._get_json(
@@ -1595,10 +1628,10 @@ class WebsiteAuthProxyConnector:
                 got_data = True
         except AuthenticationError:
             raise
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "Website authproxy warninglights read skipped for %s", vin[-6:],
-                exc_info=True,
+                "Website authproxy warninglights read skipped for %s (%s)",
+                vin[-6:], type(exc).__name__,
             )
 
         # v2.16.0 — last confirmed remote lock/unlock command (BETA, fail-soft).
@@ -1609,10 +1642,10 @@ class WebsiteAuthProxyConnector:
                 got_data = True
         except AuthenticationError:
             raise
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "Website authproxy lock-history read skipped for %s", vin[-6:],
-                exc_info=True,
+                "Website authproxy lock-history read skipped for %s (%s)",
+                vin[-6:], type(exc).__name__,
             )
 
         # v2.16.0 — nickname + licence plate from the relations LIST parse
@@ -1634,10 +1667,10 @@ class WebsiteAuthProxyConnector:
                     d.license_plate = match.license_plate
         except AuthenticationError:
             raise
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "Website authproxy relation enrich skipped for %s", vin[-6:],
-                exc_info=True,
+                "Website authproxy relation enrich skipped for %s (%s)",
+                vin[-6:], type(exc).__name__,
             )
 
         # #923 — EXPERIMENTAL parkingposition read, gated on the opt-in test
@@ -1662,10 +1695,10 @@ class WebsiteAuthProxyConnector:
                     self._position_available = True
             except AuthenticationError:
                 raise
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 _LOGGER.debug(
-                    "Website authproxy parkingposition read skipped for %s",
-                    vin[-6:], exc_info=True,
+                    "Website authproxy parkingposition read skipped for %s (%s)",
+                    vin[-6:], type(exc).__name__,
                 )
 
         # SoH probe (4.3.2 batteryHealthState) — same opt-in test-cohort gate as
@@ -1684,10 +1717,10 @@ class WebsiteAuthProxyConnector:
                     self._soh_available = True
             except AuthenticationError:
                 raise
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 _LOGGER.debug(
-                    "Website authproxy SoH probe skipped for %s",
-                    vin[-6:], exc_info=True,
+                    "Website authproxy SoH probe skipped for %s (%s)",
+                    vin[-6:], type(exc).__name__,
                 )
 
         if got_data:

--- a/custom_components/vag_connect/cariad/auth/idk.py
+++ b/custom_components/vag_connect/cariad/auth/idk.py
@@ -44,19 +44,27 @@ from ..models import BrandConfig, TokenSet
 _LOGGER = logging.getLogger(__name__)
 
 
-def _safe_url(url: str) -> str:
-    """Host+path of *url* with the query string STRIPPED.
+_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
 
-    The OIDC redirect hops on this legacy path carry ``code`` (the leading chars
-    of the authorization JWT), ``user_id`` (a real account UUID) and
-    ``relayState`` in the query string. Truncating the URL to N chars does NOT
-    hide those — ``code`` is usually the first parameter — so a tester who turns
-    debug logging on and pastes the log into an issue leaks them. Log only the
-    host+path, which is all the redirect trace needs. (#1340 @cyrano330)
+
+def _safe_url(url: str) -> str:
+    """Host+path of *url* with the query AND fragment STRIPPED and any UUID-shaped
+    PATH segment masked.
+
+    The OIDC hops on this legacy path carry ``code`` (the authorization JWT),
+    ``user_id`` (a real account UUID), ``relayState`` and — on hybrid flows —
+    ``access_token``/``id_token`` in the **query or fragment**, AND the consent
+    page carries the account UUID as a **path** segment
+    (``/signin-service/v1/consent/users/<uuid>/…``). Truncating the URL to N chars
+    hides none of it. So: keep only host+path, drop the fragment, and mask UUID
+    path segments — the redirect trace stays readable, the secrets never reach a
+    pasted debug log. (#1340/#1355 @cyrano330)
     """
     try:
         p = urlparse(url)
-        return f"{p.netloc}{p.path}" or "<empty-url>"
+        return _UUID_RE.sub("<uuid>", f"{p.netloc}{p.path}") or "<empty-url>"
     except Exception:  # noqa: BLE001
         return "<unparseable-url>"
 
@@ -544,7 +552,7 @@ class IDKAuth:
             html = await resp.text(errors="replace")
             _LOGGER.debug(
                 "IDK step1: status=%s url=%s html_len=%d",
-                resp.status, login_url[:80], len(html),
+                resp.status, _safe_url(login_url), len(html),
             )
             initial_status = resp.status
         # v2.10.1 (#388 / #393) — when the Auth0 Universal Login front-end
@@ -578,17 +586,17 @@ class IDKAuth:
                 html = await retry_resp.text(errors="replace")
                 _LOGGER.debug(
                     "IDK step1 browser-UA retry: status=%s url=%s html_len=%d",
-                    retry_resp.status, login_url[:80], len(html),
+                    retry_resp.status, _safe_url(login_url), len(html),
                 )
                 if retry_resp.status != 200:
                     raise AuthenticationError(
                         f"Authorization page HTTP {retry_resp.status} at "
-                        f"{login_url} (after browser-UA retry; first "
+                        f"{_safe_url(login_url)} (after browser-UA retry; first "
                         f"attempt was HTTP {initial_status})"
                     )
         elif initial_status != 200:
             raise AuthenticationError(
-                f"Authorization page HTTP {initial_status} at {login_url}"
+                f"Authorization page HTTP {initial_status} at {_safe_url(login_url)}"
             )
 
         # v2.24.0 — learn the signin client id from the URL we actually landed
@@ -653,8 +661,8 @@ class IDKAuth:
             raise AuthenticationError("Auth0: could not find state token.")
 
         _LOGGER.debug(
-            "IDK Auth0: state=%s... (from_html=%s)",
-            auth0_state[:20], bool(state_from_html),
+            "IDK Auth0: state_present=%s (from_html=%s)",
+            bool(auth0_state), bool(state_from_html),
         )
 
         # Step 2 — POST credentials (combined, NOT identifier-first)
@@ -677,7 +685,7 @@ class IDKAuth:
         post_url = f"{self._idk_base}/u/login?state={_quote(auth0_state, safe='')}"
         _LOGGER.debug(
             "IDK Auth0: brand=%s post_url=%s",
-            self._brand.name, post_url[:80],
+            self._brand.name, _safe_url(post_url),
         )
 
         try:
@@ -694,12 +702,17 @@ class IDKAuth:
                 location = _make_absolute(self._idk_base, raw_loc) if raw_loc else ""
                 resp_html = await resp.text(errors="replace")
         except InvalidURL as exc:
-            _LOGGER.error("IDK Auth0: InvalidURL posting to %s — %s", post_url, exc)
-            raise AuthenticationError(f"Invalid login URL: {post_url[:100]}") from exc
+            _LOGGER.error(
+                "IDK Auth0: InvalidURL posting to %s — %s",
+                _safe_url(post_url), type(exc).__name__,
+            )
+            raise AuthenticationError(
+                f"Invalid login URL: {_safe_url(post_url)}"
+            ) from exc
 
         _LOGGER.debug(
             "IDK Auth0 POST: status=%s location=%s",
-            status, location[:80] if location else "(none)",
+            status, _safe_url(location) if location else "(none)",
         )
 
         if status == 400:
@@ -758,8 +771,8 @@ class IDKAuth:
                         json_html = await json_resp.text(errors="replace")
                 except Exception as exc:  # noqa: BLE001
                     _LOGGER.debug(
-                        "IDK Auth0 JSON fallback POST failed: %s: %s",
-                        type(exc).__name__, exc,
+                        "IDK Auth0 JSON fallback POST failed: %s",
+                        type(exc).__name__,
                     )
 
                 if json_status in (200, 302, 303) and json_location:
@@ -796,7 +809,7 @@ class IDKAuth:
             raise RateLimitError()
         if status not in (302, 303):
             raise AuthenticationError(
-                f"Auth0 POST returned HTTP {status}: {resp_html[:200]}"
+                f"Auth0 POST returned HTTP {status} (body {len(resp_html)} chars)"
             )
 
         # Step 3 — follow redirect chain manually until app:// URI
@@ -810,7 +823,10 @@ class IDKAuth:
                 uid = parse_qs(urlparse(ref).query).get("user_id", [""])[0]
                 if uid:
                     self.user_id = uid
-                    _LOGGER.debug("IDK Auth0: captured user_id from redirect: %s", uid[:8])
+                    _LOGGER.debug(
+                        "IDK Auth0: captured user_id from redirect (present=%s)",
+                        bool(uid),
+                    )
             if ref.startswith(prefix):
                 break
             # Detect MFA — v2.2.0 (#183 follow-on) discriminates Email-OTP
@@ -822,7 +838,7 @@ class IDKAuth:
                 _LOGGER.debug(
                     "IDK Auth0: %s challenge at %s",
                     "Email-OTP" if is_email_2fa else "TOTP",
-                    ref[:80],
+                    _safe_url(ref),
                 )
                 if mfa_code:
                     mfa_state = parse_qs(urlparse(ref).query).get("state", [auth0_state])[0]
@@ -881,21 +897,21 @@ class IDKAuth:
                 if "terms-and-conditions" in ref:
                     _LOGGER.warning(
                         "IDK Auth0: T&C wall at %s — cannot auto-skip "
-                        "(legal acceptance required)", ref[:120],
+                        "(legal acceptance required)", _safe_url(ref),
                     )
                     raise TermsAndConditionsError()
                 skipped = await self._skip_marketing_consent(ref)
                 if skipped:
                     _LOGGER.info(
                         "IDK Auth0: marketing-consent auto-skipped (#309) → %s",
-                        skipped[:80],
+                        _safe_url(skipped),
                     )
                     ref = skipped
                     continue
                 _LOGGER.warning(
                     "IDK Auth0: consent wall at %s — auto-skip failed, "
                     "raising MarketingConsentError for Repair flow",
-                    ref[:120],
+                    _safe_url(ref),
                 )
                 raise MarketingConsentError()
 
@@ -912,7 +928,10 @@ class IDKAuth:
                     else:
                         break
             except InvalidURL as exc:
-                _LOGGER.error("IDK Auth0 redirect: InvalidURL '%s' — %s", _safe_url(ref), exc)
+                _LOGGER.error(
+                    "IDK Auth0 redirect: InvalidURL '%s' — %s",
+                    _safe_url(ref), type(exc).__name__,
+                )
                 break
 
         _LOGGER.debug("IDK Auth0: final redirect = %s", _safe_url(ref) if ref else "(none)")
@@ -921,7 +940,7 @@ class IDKAuth:
             # Print FULL URL on failure (esp. for /v2/login/ui/error which
             # carries error_description in query params we need to debug).
             raise AuthenticationError(
-                f"Auth0: no app:// redirect after login. Last: {ref}"
+                f"Auth0: no app:// redirect after login. Last: {_safe_url(ref)}"
             )
 
         # Save final redirect URL so MBB-mode callers can extract the
@@ -962,8 +981,8 @@ class IDKAuth:
                 raise AuthenticationError(
                     f"Hybrid-full flow: missing id_token "
                     f"({bool(id_tok)}) or access_token ({bool(access_tok)}) "
-                    f"in callback URL. Auth0 may have stripped the hybrid "
-                    f"response_type for this client. URL: {ref[:200]}"
+                    f"in callback URL ({len(ref)} chars). Auth0 may have "
+                    f"stripped the hybrid response_type for this client."
                 )
             _LOGGER.debug(
                 "IDK Auth0 hybrid_full: access_token (%d chars) + id_token "
@@ -1017,7 +1036,7 @@ class IDKAuth:
                 raise AuthenticationError(
                     f"MBB hybrid-flow: no id_token in redirect URL "
                     f"({len(ref)} chars). Auth0 may have stripped "
-                    f"response_type=id_token for this client. URL: {ref[:200]}"
+                    f"response_type=id_token for this client."
                 )
             _LOGGER.debug(
                 "IDK Auth0 MBB hybrid: id_token captured (%d chars)", len(id_tok)
@@ -1026,7 +1045,7 @@ class IDKAuth:
 
         auth_code = _extract_auth_code(ref, self._brand.redirect_uri)
         if not auth_code:
-            raise AuthenticationError(f"Auth0: no code in: {ref[:80]}")
+            raise AuthenticationError(f"Auth0: no code in: {_safe_url(ref)}")
 
         _LOGGER.debug("IDK Auth0: got auth code, exchanging tokens")
         return await self._exchange_code(auth_code, verifier)
@@ -1074,7 +1093,7 @@ class IDKAuth:
             resp_html = await resp.text(errors="replace")
             _LOGGER.debug(
                 "IDK Auth0 form POST %s → status=%s url=%s html_len=%d",
-                url[-40:], resp.status, final_url[-60:], len(resp_html),
+                _safe_url(url), resp.status, _safe_url(final_url), len(resp_html),
             )
             if resp.status == 401:
                 raise AuthenticationError("Invalid email or password (Auth0 401).")
@@ -1082,13 +1101,14 @@ class IDKAuth:
                 raise RateLimitError()
             if resp.status not in (200, 302, 400):
                 raise AuthenticationError(
-                    f"Auth0 form POST returned HTTP {resp.status}: {resp_html[:200]}"
+                    f"Auth0 form POST returned HTTP {resp.status} "
+                    f"(body {len(resp_html)} chars)"
                 )
             # 400: Auth0 returns login page again — caller decides what to do
             if resp.status == 400:
                 _LOGGER.debug(
                     "IDK Auth0 form POST 400 — html_len=%d url=%s",
-                    len(resp_html), final_url[-60:],
+                    len(resp_html), _safe_url(final_url),
                 )
         return final_url, resp_html
 
@@ -1116,7 +1136,7 @@ class IDKAuth:
         _LOGGER.debug(
             "IDK legacy: step1 fields=%s action=%s",
             list(csrf1.fields.keys()),
-            csrf1.form_action[:80] if csrf1.form_action else "(none)",
+            _safe_url(csrf1.form_action) if csrf1.form_action else "(none)",
         )
         if not csrf1.fields.get("_csrf") and not csrf1.fields.get("hmac") \
                 and not csrf1.fields.get("relayState"):
@@ -1133,7 +1153,7 @@ class IDKAuth:
         submit_data: dict[str, str] = {**csrf1.fields, "email": email}
 
         # Step 2 — POST email (upstream: cookies=step1_cookies, allow_redirects=True)
-        _LOGGER.debug("IDK legacy: posting email to %s", email_url[:100])
+        _LOGGER.debug("IDK legacy: posting email to %s", _safe_url(email_url))
         async with self._session.post(
             email_url,
             timeout=_AUTH_TIMEOUT, data=submit_data,
@@ -1147,7 +1167,7 @@ class IDKAuth:
                 raise UpstreamUnavailableError(resp.status, self._brand.name)
             if resp.status != 200:
                 raise AuthenticationError(
-                    f"Email POST HTTP {resp.status} at {email_url[:80]}"
+                    f"Email POST HTTP {resp.status} at {_safe_url(email_url)}"
                 )
             html2 = await resp.text()
 
@@ -1160,7 +1180,8 @@ class IDKAuth:
             # Password URL: replace "identifier" with "authenticate" in email_url
             pw_url = email_url.replace("identifier", "authenticate")
             _LOGGER.debug(
-                "IDK legacy: hmac from JS, step1 fields kept, pw_url=%s", pw_url[:100]
+                "IDK legacy: hmac from JS, step1 fields kept, pw_url=%s",
+                _safe_url(pw_url),
             )
         else:
             # Fallback: try form fields from password page
@@ -1177,7 +1198,7 @@ class IDKAuth:
                     )
             _LOGGER.debug(
                 "IDK legacy: no hmac in JS, using form fields=%s pw_url=%s",
-                list(csrf2.fields.keys()), pw_url[:100],
+                list(csrf2.fields.keys()), _safe_url(pw_url),
             )
 
         submit_data["password"] = password
@@ -1185,7 +1206,7 @@ class IDKAuth:
         # Step 4 — POST password (upstream: allow_redirects=False, manual redirects)
         _LOGGER.debug(
             "IDK legacy: posting password to %s fields=%s",
-            pw_url[:100], list(submit_data.keys()),
+            _safe_url(pw_url), list(submit_data.keys()),
         )
         async with self._session.post(
             pw_url,
@@ -1198,7 +1219,7 @@ class IDKAuth:
 
         _LOGGER.debug(
             "IDK legacy: password POST status=%s location=%s",
-            pw_status, pw_loc[:80] if pw_loc else "(none)",
+            pw_status, _safe_url(pw_loc) if pw_loc else "(none)",
         )
 
         if pw_status == 200:
@@ -1239,7 +1260,8 @@ class IDKAuth:
             raise UpstreamUnavailableError(pw_status, self._brand.name)
         if pw_status not in (302, 303):
             raise AuthenticationError(
-                f"Password POST HTTP {pw_status} at {pw_url[:80]}: {pw_body[:200]}"
+                f"Password POST HTTP {pw_status} at {_safe_url(pw_url)} "
+                f"(body {len(pw_body)} chars)"
             )
         if not pw_loc:
             # v2.5.1 — audi_connect PR #731 inspiration: a missing Location
@@ -1291,7 +1313,7 @@ class IDKAuth:
 
         auth_code = _extract_auth_code(ref, self._brand.redirect_uri)
         if not auth_code:
-            raise AuthenticationError(f"Legacy: no code in: {ref[:100]}")
+            raise AuthenticationError(f"Legacy: no code in: {_safe_url(ref)}")
 
         return await self._exchange_code(auth_code, verifier)
 
@@ -1588,14 +1610,15 @@ class IDKAuth:
             if resp.status not in (302, 303, 301, 307, 308):
                 body = await resp.text()
                 raise AuthenticationError(
-                    f"Password POST returned HTTP {resp.status} at {url[:100]}: {body[:200]}"
+                    f"Password POST returned HTTP {resp.status} at "
+                    f"{_safe_url(url)} (body {len(body)} chars)"
                 )
             raw_loc = resp.headers.get("Location", "")
             location = _make_absolute(url, raw_loc) if raw_loc else ""
             current_base = url
             _LOGGER.debug(
                 "IDK legacy: password POST status=%s location=%s",
-                resp.status, location[:80] if location else "(none)",
+                resp.status, _safe_url(location) if location else "(none)",
             )
             if not location:
                 raise AuthenticationError(
@@ -1612,7 +1635,9 @@ class IDKAuth:
                 uid = parse_qs(urlparse(location).query).get("user_id", [""])[0]
                 if uid:
                     self.user_id = uid
-                    _LOGGER.debug("IDK: captured user_id from redirect: %s", uid[:8])
+                    _LOGGER.debug(
+                        "IDK: captured user_id from redirect (present=%s)", bool(uid)
+                    )
             if location.startswith(prefix):
                 return location
             # v2.2.0 / v2.5.1 — Consent-wall detection (symmetric with
@@ -1634,7 +1659,7 @@ class IDKAuth:
                 if skipped:
                     _LOGGER.info(
                         "IDK legacy: marketing-consent auto-skipped (#309) → %s",
-                        skipped[:80],
+                        _safe_url(skipped),
                     )
                     location = skipped
                     continue
@@ -1658,7 +1683,7 @@ class IDKAuth:
                 else:
                     _LOGGER.debug(
                         "IDK legacy: redirect chain ended — status=%s url=%s",
-                        resp.status, location[:80],
+                        resp.status, _safe_url(location),
                     )
                     break
 
@@ -1894,11 +1919,13 @@ class IDKAuth:
                             resp.status,
                         )
                         last_error = AuthenticationError(
-                            f"Token exchange failed HTTP {resp.status}: {body[:200]}"
+                            f"Token exchange failed HTTP {resp.status} "
+                            f"(body {len(body)} chars)"
                         )
                         continue
                     raise AuthenticationError(
-                        f"Token exchange failed HTTP {resp.status}: {body[:200]}"
+                        f"Token exchange failed HTTP {resp.status} "
+                        f"(body {len(body)} chars)"
                     )
             except (AuthenticationError, UpstreamUnavailableError):
                 raise
@@ -1919,7 +1946,7 @@ class IDKAuth:
             "redirectUri": self._brand.redirect_uri,
             "verifier": verifier,
         }
-        _LOGGER.debug("Škoda token exchange: %s", url)
+        _LOGGER.debug("Škoda token exchange: %s", _safe_url(url))
         async with self._session.post(
             url, timeout=_AUTH_TIMEOUT, json=payload,
             headers={
@@ -1931,7 +1958,8 @@ class IDKAuth:
             if resp.status != 200:
                 body = await resp.text()
                 raise AuthenticationError(
-                    f"Škoda token exchange failed HTTP {resp.status}: {body[:200]}"
+                    f"Škoda token exchange failed HTTP {resp.status} "
+                    f"(body {len(body)} chars)"
                 )
             data: dict[str, Any] = await resp.json()
 
@@ -1962,7 +1990,7 @@ class IDKAuth:
         if not callback:
             _LOGGER.debug(
                 "IDK consent-skip: no callback param in %s — cannot auto-skip",
-                consent_url[:100],
+                _safe_url(consent_url),
             )
             return None
 
@@ -1977,16 +2005,16 @@ class IDKAuth:
                 next_loc = cb_resp.headers.get("Location", "")
                 _LOGGER.debug(
                     "IDK consent-skip: callback %s → status=%s next=%s",
-                    cb_url[:80], cb_resp.status,
-                    next_loc[:80] if next_loc else "(none)",
+                    _safe_url(cb_url), cb_resp.status,
+                    _safe_url(next_loc) if next_loc else "(none)",
                 )
                 if not next_loc:
                     return None
                 return _make_absolute(cb_url, next_loc)
         except (InvalidURL, Exception) as exc:  # noqa: BLE001
             _LOGGER.warning(
-                "IDK consent-skip: callback GET failed — %s: %s",
-                type(exc).__name__, exc,
+                "IDK consent-skip: callback GET failed — %s",
+                type(exc).__name__,
             )
             return None
 

--- a/custom_components/vag_connect/cariad/auth/porsche.py
+++ b/custom_components/vag_connect/cariad/auth/porsche.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 import logging
 import os
 import re
@@ -93,6 +94,23 @@ def _pkce() -> tuple[str, str]:
     digest   = hashlib.sha256(verifier.encode()).digest()
     challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
     return verifier, challenge
+
+
+def _oauth_error_code(body: str) -> str:
+    """Best-effort OAuth ``error`` code from a token-endpoint body.
+
+    Redaction helper (#1355): the raw Auth0 token-endpoint body can echo
+    request context / secrets, so it must never reach an exception message a
+    tester copy-pastes. Return only the standardized short ``error`` code
+    (e.g. ``invalid_grant``) — never the raw body or ``error_description``.
+    """
+    try:
+        parsed = json.loads(body)
+    except (ValueError, TypeError):
+        return "non-JSON body"
+    if isinstance(parsed, dict) and parsed.get("error"):
+        return str(parsed["error"])
+    return "no error field"
 
 
 class PorscheAuth:
@@ -289,7 +307,10 @@ class PorscheAuth:
         ) as resp:
             if resp.status != 200:
                 body = await resp.text()
-                raise AuthenticationError(f"Porsche token exchange failed {resp.status}: {body[:200]}")
+                raise AuthenticationError(
+                    f"Porsche token exchange failed {resp.status}: "
+                    f"{_oauth_error_code(body)}"
+                )
             data = await resp.json()
 
         return TokenSet(
@@ -416,7 +437,7 @@ class PorscheOneDeviceAuth:
                 body = await resp.text()
                 raise AuthenticationError(
                     f"Porsche One device authorization failed "
-                    f"({resp.status}): {body[:200]}"
+                    f"({resp.status}): {_oauth_error_code(body)}"
                 )
             data = await resp.json()
         if "device_code" not in data or "user_code" not in data:
@@ -486,7 +507,8 @@ class PorscheOneDeviceAuth:
             if resp.status != 200:
                 body = await resp.text()
                 raise AuthenticationError(
-                    f"Porsche One refresh failed ({resp.status}): {body[:200]}"
+                    f"Porsche One refresh failed ({resp.status}): "
+                    f"{_oauth_error_code(body)}"
                 )
             data = await resp.json()
         return TokenSet(

--- a/custom_components/vag_connect/cariad/dataset_archive.py
+++ b/custom_components/vag_connect/cariad/dataset_archive.py
@@ -104,7 +104,7 @@ class DatasetArchive:
             vdir = self.vin_dir(vin)
             vdir.mkdir(parents=True, exist_ok=True)
         except OSError as exc:  # pragma: no cover - unusual FS failure
-            _LOGGER.debug("dataset archive: cannot create dir: %s", exc)
+            _LOGGER.debug("dataset archive: cannot create dir: %s", type(exc).__name__)
             return None
 
         tag = _content_tag(data)
@@ -121,7 +121,7 @@ class DatasetArchive:
         try:
             path.write_bytes(data)
         except OSError as exc:
-            _LOGGER.debug("dataset archive: write failed: %s", exc)
+            _LOGGER.debug("dataset archive: write failed: %s", type(exc).__name__)
             return None
         self._prune(vdir)
         return path

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -4,7 +4,72 @@
 
 from __future__ import annotations
 
+import re
 from enum import StrEnum
+
+# ── redaction (self-contained; this is a leaf module, no cross-imports) ──────
+_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+_VIN_RE = re.compile(r"\b[A-HJ-NPR-Z0-9]{17}\b")
+
+
+def _redact_url(url: str) -> str:
+    """Host+path of *url*, query + fragment dropped, UUID/VIN path segments masked.
+
+    An APIError message is logged and re-raised in many places via ``str(err)``;
+    the raw request URL carries the VIN (``…/vehicles/<VIN>/…``) and sometimes a
+    UUID data-request id, and the query can carry tokens. Keeping only host+path
+    with those masked lets the error stay diagnosable without leaking PII/secrets
+    into a debug log a reporter pastes into an issue. (#1355)
+    """
+    try:
+        from urllib.parse import urlparse  # noqa: PLC0415
+
+        p = urlparse(url)
+        safe = _UUID_RE.sub("<uuid>", f"{p.netloc}{p.path}")
+        return _VIN_RE.sub("<vin>", safe) or "<empty-url>"
+    except Exception:  # noqa: BLE001
+        return "<unparseable-url>"
+
+
+def extract_safe_error_code(body: str) -> str:
+    """Pull the bounded backend error CODE from a raw error *body*, for surfacing.
+
+    Since ``str(APIError)`` no longer carries the body (#1355 redaction), a command
+    that fails with a backend reason (e.g. ``USER_NOT_AUTHORIZED`` /
+    ``missingCapability``) would otherwise reach the user as a bare "API error 403".
+    This returns ONLY the enum-like code field (``errorCode`` / ``error`` /
+    ``code``, incl. one nested ``error`` object) — never free-text fields like
+    ``error_description`` / ``message`` / ``info`` which can carry PII — capped to
+    60 chars. Returns "" when no code is present. Never raises.
+    """
+    if not body or not isinstance(body, str):
+        return ""
+    try:
+        import json  # noqa: PLC0415
+
+        data = json.loads(body)
+    except Exception:  # noqa: BLE001
+        return ""
+
+    def _dig(d: object, depth: int = 0) -> str:
+        if depth > 2 or not isinstance(d, dict):
+            return ""
+        for key in ("errorCode", "error", "code"):
+            val = d.get(key)
+            if isinstance(val, str) and val:
+                return val
+            if isinstance(val, int):
+                return str(val)
+            if isinstance(val, dict):
+                nested = _dig(val, depth + 1)
+                if nested:
+                    return nested
+        return ""
+
+    code = _dig(data)
+    return code[:60] if code else ""
 
 
 class CommandProfile(StrEnum):
@@ -121,7 +186,10 @@ def classify_command_failure(exc: BaseException) -> CommandFailureReason:
         return CommandFailureReason.UNKNOWN
 
     status = getattr(exc, "status", 0) or 0
-    body = str(exc).lower()
+    # Read markers from the RAW body attribute, not str(exc): the APIError message
+    # is now redacted (no body), and the raw body is the full 4 KB the backend
+    # sent, not the old 200-char message slice. (redaction #1355)
+    body = (getattr(exc, "body", "") or "").lower()
 
     # Body-content first — these are unambiguous markers regardless of
     # which 4xx the backend used.
@@ -452,7 +520,10 @@ class VehicleNotFoundError(CariadError):
     """VIN not found in the account garage."""
 
     def __init__(self, vin: str) -> None:
-        super().__init__(f"Vehicle {vin} not found in account garage.")
+        # Mask the VIN in the message — VehicleNotFoundError is logged/re-raised
+        # via str() on the poll + command paths; keep the raw VIN as an attribute.
+        masked = f"…{vin[-6:]}" if isinstance(vin, str) and len(vin) >= 6 else "?"
+        super().__init__(f"Vehicle {masked} not found in account garage.")
         self.vin = vin
 
 
@@ -471,7 +542,11 @@ class APIError(CariadError):
     """Unexpected API response."""
 
     def __init__(self, status: int, url: str, body: str = "") -> None:
-        super().__init__(f"API error {status} for {url}: {body[:200]}")
+        # Message is REDACTED: many call sites log or re-raise ``str(APIError)``,
+        # and the raw url (VIN/UUID path, token query) + response body would leak
+        # there. The raw url/body are kept as ATTRIBUTES below for classification
+        # and retry; only the human-facing message is masked. (#1355)
+        super().__init__(f"API error {status} for {_redact_url(url)}")
         self.status = status
         self.url = url
         # v2.9.0 - keep the raw body around so callers can inspect for

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -855,6 +855,10 @@ class VehicleData:
     # the car's own data-capture age in whole minutes (diagnostic).
     portal_health: str | None = None
     minutes_since_last_snapshot: int | None = None
+    # #465 — automatable stale-data flag (True once the car's own capture age
+    # passes the same 72h/8x-interval threshold as the stale-data Repair). None for
+    # a read that carries no capture timestamp, so the binary_sensor self-hides.
+    data_stale: bool | None = None
 
     # Service
     service_km: int | None = None

--- a/custom_components/vag_connect/cariad/push/audi_vw_fcm.py
+++ b/custom_components/vag_connect/cariad/push/audi_vw_fcm.py
@@ -331,16 +331,16 @@ class AudiVWPushManager(PushManager):
                     "brand=%s): %s — reconnecting in %.1fs",
                     len(self._vins),
                     self._brand,
-                    err,
+                    type(err).__name__,
                     self._backoff_seconds,
                 )
                 self._state = PushManagerState.RECONNECTING
                 # v2.2.0 PR #14/20 — record this strike. After 3
                 # consecutive failures the breaker trips and we
                 # exit the outer loop (check below after backoff).
-                self._record_failure(
-                    f"connect-loop: {type(err).__name__}: {str(err)[:160]}"
-                )
+                # class only — str(err)[:160] is truncation, not redaction (an
+                # aiohttp/FCM connect error's str() carries the endpoint URL).
+                self._record_failure(f"connect-loop: {type(err).__name__}")
                 try:
                     await asyncio.wait_for(
                         self._stop_event.wait(),

--- a/custom_components/vag_connect/cariad/push/cupra_seat_fcm.py
+++ b/custom_components/vag_connect/cariad/push/cupra_seat_fcm.py
@@ -255,16 +255,16 @@ class CupraSeatPushManager(PushManager):
                     "brand=%s): %s — reconnecting in %.1fs",
                     len(self._vins),
                     self._brand,
-                    err,
+                    type(err).__name__,
                     self._backoff_seconds,
                 )
                 self._state = PushManagerState.RECONNECTING
                 # v2.2.0 PR #13/20 — record this strike. After 3
                 # consecutive failures the breaker trips and we
                 # exit the outer loop (check below after backoff).
-                self._record_failure(
-                    f"connect-loop: {type(err).__name__}: {str(err)[:160]}"
-                )
+                # class only — str(err)[:160] is truncation, not redaction (an
+                # aiohttp/FCM connect error's str() carries the endpoint URL).
+                self._record_failure(f"connect-loop: {type(err).__name__}")
                 try:
                     await asyncio.wait_for(
                         self._stop_event.wait(),

--- a/custom_components/vag_connect/cariad/push/skoda_mqtt.py
+++ b/custom_components/vag_connect/cariad/push/skoda_mqtt.py
@@ -295,7 +295,7 @@ class SkodaPushManager(PushManager):
                     "Skoda push: connection lost (vin count=%d): %s — "
                     "reconnecting in %.1fs",
                     len(self._vins),
-                    err,
+                    type(err).__name__,
                     self._backoff_seconds,
                 )
                 self._state = PushManagerState.RECONNECTING
@@ -303,9 +303,9 @@ class SkodaPushManager(PushManager):
                 # consecutive failures the breaker trips and the next
                 # iteration of the outer loop will exit (we check
                 # is_tripped after the backoff sleep below).
-                self._record_failure(
-                    f"connect-loop: {type(err).__name__}: {str(err)[:160]}"
-                )
+                # class only — str(err)[:160] is truncation, not redaction: an
+                # aiohttp/mqtt connect error's str() carries the broker URL/host.
+                self._record_failure(f"connect-loop: {type(err).__name__}")
                 # Sleep with cancellation support
                 try:
                     await asyncio.wait_for(
@@ -532,8 +532,12 @@ class SkodaPushManager(PushManager):
                 timestamp=timestamp,
                 raw_payload=body or None,
             )
-        except Exception:  # noqa: BLE001 - decode must never crash the loop
-            _LOGGER.debug("Skoda push: undecodable MQTT message", exc_info=True)
+        except Exception as exc:  # noqa: BLE001 - decode must never crash the loop
+            # Class only, not exc_info — a malformed-field conversion error can put
+            # a payload value (e.g. the VIN) into its message/traceback.
+            _LOGGER.debug(
+                "Skoda push: undecodable MQTT message (%s)", type(exc).__name__
+            )
             return None
 
     # v2.2.0 Phase 5a PR #18/20: ``_advance_backoff`` + ``_reset_backoff``

--- a/custom_components/vag_connect/companion/addon_transport.py
+++ b/custom_components/vag_connect/companion/addon_transport.py
@@ -194,8 +194,11 @@ async def probe_addon(
     except CompanionTransportError as err:
         return False, str(err)
     except Exception as err:  # noqa: BLE001 - a probe must never crash setup
-        _LOGGER.debug("Companion add-on probe failed: %s", err, exc_info=True)
-        return False, str(err)
+        # class-only — a transport error's str() can carry the add-on host:port and,
+        # depending on the transport, the auth token; keep it out of the DEBUG log
+        # AND out of the reason string the config flow renders back to the user.
+        _LOGGER.debug("Companion add-on probe failed (%s)", type(err).__name__)
+        return False, type(err).__name__
     finally:
         with_close = transport.close()
         try:

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -250,9 +250,13 @@ async def _validate_credentials(
                 "VW Group Connect unexpected error during %s auth: %s",
                 brand, type(err).__name__,
             )
+            # class name only, never str(err): the comment above is the reason —
+            # a chained aiohttp InvalidURL carries the form-encoded request URL
+            # (username/redirect). format_tb renders frame/file/line/source only,
+            # never the exception message, so the traceback itself stays safe.
             _LOGGER.debug(
-                "VW Group Connect %s auth traceback: %s\n%s",
-                brand, err,
+                "VW Group Connect %s auth traceback (%s):\n%s",
+                brand, type(err).__name__,
                 "".join(traceback.format_tb(err.__traceback__)),
             )
             raise ValueError("cannot_connect") from err
@@ -639,7 +643,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             await transport.connect()
             version = await transport.current_app_version(preset.package)
         except CompanionTransportError as err:
-            _LOGGER.warning("Companion ADB probe failed: %s", err)
+            _LOGGER.warning("Companion ADB probe failed: %s", type(err).__name__)
             # v2.26.0 — a bare "InvalidCommandError" is the fingerprint of
             # Android 11+ "wireless debugging": the pure-python transport reaches
             # the port but it speaks TLS + pairing, which adb-shell cannot. Point
@@ -1532,7 +1536,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             self._dag_error = str(err)
             _LOGGER.warning(
                 "Browser login Phase 1 failed for %s: %s",
-                self._dag_brand, err,
+                self._dag_brand, type(err).__name__,
             )
             if hasattr(self, "_dag_session") and self._dag_session is not None:
                 await self._dag_session.close()
@@ -1585,12 +1589,15 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             # not a transient failure: MBB (durable login + commands) simply
             # doesn't cover MEB cars. Flag it so the flow aborts with a clear
             # "use EU Data Act instead" message rather than looping the VIN form.
-            low = str(err).lower()
+            # Read the marker from message AND the raw body attribute: APIError's
+            # message is now redacted (body stripped, #1355), so an MBB exchange
+            # that raises APIError would otherwise hide "invalid_grant" here.
+            low = (str(err) + " " + str(getattr(err, "body", ""))).lower()
             if self._dag_mbb and ("unknown user" in low or "invalid_grant" in low):
                 self._dag_mbb_ineligible = True
             _LOGGER.warning(
                 "Browser login Phase 2 failed for %s: %s",
-                self._dag_brand, err,
+                self._dag_brand, type(err).__name__,
             )
         finally:
             sess = getattr(self, "_dag_session", None)

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -158,6 +158,22 @@ def _drop_anchored_sleep_s(
     return max(float(floor_s), min(remaining, float(interval_s)))
 
 
+_PORTAL_5XX_BACKOFF_S = (300, 900, 1800)  # 5 / 15 / 30 min
+
+
+def _portal_5xx_backoff_s(streak: int) -> float:
+    """Escalating minimum sleep during a sustained EU-DA portal 5xx outage.
+
+    ``streak`` 0 → 0.0 (no floor raised). 1→5 min, 2→15 min, 3+→30 min (saturates).
+    Layered ON TOP of the drop-anchored scheduler: without it, a stale capture
+    anchor collapses the sleep to ``_DROP_RETRY_S`` (~60 s) and we poll VW's portal
+    every minute for hours during its own 5xx outage. This adopts TommiG1's
+    5/15/30 min spacing, which also cuts our 429-throttle risk while VW is down."""
+    if streak <= 0:
+        return 0.0
+    return float(_PORTAL_5XX_BACKOFF_S[min(streak, len(_PORTAL_5XX_BACKOFF_S)) - 1])
+
+
 def _is_selfhealing_poll_error(err: object) -> bool:
     """True for a poll error that must NOT be escalated to the public Error
     Reporter, because it self-heals and is not our bug:
@@ -1015,6 +1031,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # Drop-anchored scheduling — the freshest snapshot capture time seen so
         # far, used to align the next portal poll to the ~15-min drop cadence.
         self._newest_capture_at: datetime | None = None
+        # Consecutive EU-DA portal 5xx outages → escalating poll backoff (5/15/30m).
+        self._consecutive_portal_5xx = 0
 
         # Per-VIN consecutive-failure counter (v1.8.7). Reset to 0 on every
         # successful poll. Used by ``is_vehicle_available`` to apply
@@ -1588,8 +1606,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # both arm paths; idempotent, fail-soft.
             try:
                 await self._apply_test_cohort()
-            except Exception:  # noqa: BLE001
-                _LOGGER.debug("test-cohort apply skipped", exc_info=True)
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.debug("test-cohort apply skipped (%s)", type(exc).__name__)
 
             # Skip vehicles the user has disabled in HA so a deactivated car
             # stops consuming the daily request budget. Reassigning here means
@@ -1601,8 +1619,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # get it painlessly. Idempotent + fail-soft (never sinks the poll).
             try:
                 await self._auto_enroll_skoda_official(vins)
-            except Exception:  # noqa: BLE001
-                _LOGGER.debug("Škoda official auto-enroll skipped", exc_info=True)
+            except Exception as exc:  # noqa: BLE001
+                # class-only — the enroll path mints/handles the X-API-Key and hits
+                # the VIN-path official API; a raw error can carry either.
+                _LOGGER.debug(
+                    "Škoda official auto-enroll skipped (%s)", type(exc).__name__
+                )
             # Fetch status for all vehicles
             self._push_official_mode()  # #1286 — official_only routing before read
             results = await asyncio.gather(
@@ -1624,7 +1646,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             prepared: list[tuple[str, dict[str, Any] | None, bool, bool]] = []
             for vin, result in zip(vins, results):
                 if isinstance(result, Exception):
-                    _LOGGER.warning("Could not fetch status for %s: %s", mask_vin(vin), result)
+                    # class + plain status only — a raw aiohttp error's str()
+                    # carries the VIN-path URL; APIError is already redacted.
+                    _rstatus = getattr(result, "status", None)
+                    _LOGGER.warning(
+                        "Could not fetch status for %s: %s%s",
+                        mask_vin(vin), type(result).__name__,
+                        f" (HTTP {_rstatus})" if _rstatus else "",
+                    )
                     prepared.append((vin, None, True, False))
                     continue
                 if isinstance(result, VehicleData):
@@ -1714,13 +1743,18 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     # strategies only, default ON; session-expiry surfaces a repair)
                     try:
                         await self._ensure_data_act_custom_request_kickoff()
-                    except Exception:  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
                         _LOGGER.debug(
-                            "Data Act kickoff helper raised - non-fatal, continuing",
-                            exc_info=True,
+                            "Data Act kickoff helper raised - non-fatal, continuing"
+                            " (%s)", type(exc).__name__,
                         )
-                except Exception:  # noqa: BLE001 - a background task must not die silently
-                    _LOGGER.exception("VW Group Connect: background setup finish failed")
+                except Exception as exc:  # noqa: BLE001 - a background task must not die silently
+                    # class-only, not .exception() — this wraps the auth-arm + read
+                    # kickoffs; a raw aiohttp error's str() carries the VIN-path URL.
+                    _LOGGER.error(
+                        "VW Group Connect: background setup finish failed (%s)",
+                        type(exc).__name__,
+                    )
                 # Start background polling — after the prefetches, as it was inline.
                 self.hass.async_create_background_task(
                     self._poll_loop(), f"{DOMAIN}_poll"
@@ -1786,7 +1820,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 "(message redacted, see DEBUG for details)",
                 type(err).__name__,
             )
-            _LOGGER.debug("VW Group Connect setup failed details: %s", err)
+            # NB: NOT the raw err — the comment above is the reason (its str()
+            # carries code=<JWT> → the user's email + a live token). The class
+            # name is already logged at ERROR; nothing more is safe here. (#1355)
+            _LOGGER.debug(
+                "VW Group Connect setup failed details withheld (%s) — the"
+                " exception message can carry an OAuth code/token",
+                type(err).__name__,
+            )
             return False
 
     def _trigger_reauth(self, reason: str) -> None:
@@ -2067,7 +2108,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception as exc:  # noqa: BLE001
                 _LOGGER.debug(
                     "Data Act kickoff: VIN %s probe failed (%s) - skipping",
-                    mask_vin(vin), exc,
+                    mask_vin(vin), type(exc).__name__,
                 )
 
         if changed:
@@ -2251,8 +2292,10 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     CONF_HISTORICAL_EXPORT_STATE: dict(self._historical_state()),
                 },
             )
-        except Exception:  # noqa: BLE001
-            _LOGGER.debug("historical-export state persist skipped", exc_info=True)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug(
+                "historical-export state persist skipped (%s)", type(exc).__name__
+            )
 
     def _record_historical_pending(self, vin: str) -> None:
         self._historical_state()[vin] = {
@@ -2321,8 +2364,10 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     raise_issue_historical_timeout(
                         self.hass, self.entry.entry_id, vin, masked_vin=mask_vin(vin),
                     )
-                except Exception:  # noqa: BLE001
-                    _LOGGER.debug("historical timeout repair skipped", exc_info=True)
+                except Exception as exc:  # noqa: BLE001
+                    _LOGGER.debug(
+                        "historical timeout repair skipped (%s)", type(exc).__name__
+                    )
                 continue
             if st[vin].get("checked_at") and (now - _parse("checked_at")).total_seconds() < 1800:
                 continue  # throttle import attempts to ~30 min
@@ -2332,9 +2377,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 if await self.async_import_historical_export(vin):
                     st[vin] = {"state": "done",
                                "submitted_at": st[vin].get("submitted_at")}
-            except Exception:  # noqa: BLE001 — not-ready-yet is not fatal
-                _LOGGER.debug("historical import retry for %s deferred",
-                              vin[-6:], exc_info=True)
+            except Exception as exc:  # noqa: BLE001 — not-ready-yet is not fatal
+                # class-only — the import fetches the VIN-path export ZIP; a raw
+                # aiohttp error's str() carries that URL.
+                _LOGGER.debug("historical import retry for %s deferred (%s)",
+                              vin[-6:], type(exc).__name__)
         if changed:
             self._persist_historical_state()
 
@@ -2388,7 +2435,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         except Exception as err:  # noqa: BLE001 - a hand-supplied file may be anything
             _LOGGER.warning(
                 "EU Data Act: could not parse local export %s: %s",
-                os.path.basename(path), err,
+                os.path.basename(path), type(err).__name__,
             )
             parsed = None
         if parsed is None or getattr(parsed, "no_data", True):
@@ -2446,9 +2493,10 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         self._last_runtime_kickoff = now
         try:
             await self._ensure_data_act_custom_request_kickoff()
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "Data Act runtime kickoff raised — non-fatal", exc_info=True,
+                "Data Act runtime kickoff raised — non-fatal (%s)",
+                type(exc).__name__,
             )
 
     async def async_create_data_act_request(self) -> None:
@@ -2723,8 +2771,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if by_vin:
             try:
                 arm(keys_by_vin=by_vin)
-            except Exception:  # noqa: BLE001
-                _LOGGER.debug("Škoda official arm-from-map failed", exc_info=True)
+            except Exception as exc:  # noqa: BLE001
+                # class-only — by_vin holds the per-VIN X-API-Key; a validation
+                # error could echo the key value.
+                _LOGGER.debug(
+                    "Škoda official arm-from-map failed (%s)", type(exc).__name__
+                )
 
     def _armed_data_channels(self, vin: str) -> list[str]:
         """Tokens of the read channels armed for this vehicle (data sources) —
@@ -2800,6 +2852,75 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             status[token] = entry
         return status
 
+    def _reconcile_connectivity_entities(self) -> None:
+        """Prune stale per-source connectivity binary_sensors from the registry.
+
+        The connectivity sensors are created dynamically, one per armed read channel
+        (unique_id ``{vin}_connectivity_{token}`` — see ``VagSourceConnectivity
+        Sensor``). When an account's channel set changes across versions or a
+        reconfigure — e.g. an EU-Data-Act *token*-path primary whose channel label
+        differs from an earlier build's ``eu_data_act`` — the old sensor is never
+        re-created and lingers in the registry forever as a permanent
+        ``unknown``/``unavailable`` leftover the user has to delete by hand (#1340,
+        cyrano330). This removes any ``{vin}_connectivity_{token}`` entity whose
+        ``token`` is not in the vehicle's CURRENT ``channel_status`` (the exact keys
+        the sensors are built from). Conservative + fail-soft: a VIN with no
+        channel_status yet (its poll hasn't produced one) is skipped, so a sensor
+        whose validity we cannot determine is never removed. Scoped to THIS config
+        entry, so it can never touch another integration or a second VAG entry.
+        """
+        try:
+            from homeassistant.helpers import (  # noqa: PLC0415
+                entity_registry as er,
+            )
+
+            registry = er.async_get(self.hass)
+            entries = er.async_entries_for_config_entry(
+                registry, self.entry.entry_id
+            )
+            for vin, vdata in list((self.vehicles or {}).items()):
+                cs = (
+                    vdata.get("channel_status") if isinstance(vdata, dict) else None
+                )
+                if not isinstance(cs, dict) or not cs:
+                    continue  # valid set unknown for this VIN → prune nothing
+                valid = {f"connectivity_{token}" for token in cs}
+                prefix = f"{vin}_connectivity_"
+                for entry in entries:
+                    uid = entry.unique_id or ""
+                    if not uid.startswith(prefix):
+                        continue
+                    key = uid[len(vin) + 1:]  # "{vin}_" → "connectivity_{token}"
+                    if key in valid:
+                        continue
+                    _LOGGER.info(
+                        "VW Group Connect: removing orphaned connectivity entity "
+                        "%s (that read channel is no longer armed for this "
+                        "account)", entry.entity_id,
+                    )
+                    try:
+                        registry.async_remove(entry.entity_id)
+                    except Exception:  # noqa: BLE001 — keep pruning the rest
+                        pass
+        except Exception:  # noqa: BLE001 — housekeeping must never break the poll
+            return
+
+    def _note_portal_outage(self, portal_outage: bool) -> None:
+        """Advance or reset the consecutive EU-DA portal 5xx-outage streak.
+
+        Called once per poll cycle with whether the portal's last read was a
+        transient outage (``last_no_data_reason == "portal_error"``). The streak
+        drives ``_portal_5xx_backoff_s`` (5/15/30 min). Saturates at the interval
+        count so it never overflows; any non-outage poll (fresh data, an ``empty``
+        no-content drop, or a non-portal entry) resets it to 0."""
+        if portal_outage:
+            self._consecutive_portal_5xx = min(
+                getattr(self, "_consecutive_portal_5xx", 0) + 1,
+                len(_PORTAL_5XX_BACKOFF_S),
+            )
+        else:
+            self._consecutive_portal_5xx = 0
+
     def _skoda_probe(self, key: str, label: str) -> None:
         """Write a PII-free outcome label into the client's ``probe_outcomes`` so the
         integration diagnostics surface it. No-op if the client has no such sink.
@@ -2863,7 +2984,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         client = self._cariad_client
         if str(self.entry.data.get(CONF_BRAND, "")) != "skoda":
             return
-        if self._skoda_official_mode() == "mysmob_only":
+        mode = self._skoda_official_mode()
+        if mode == "mysmob_only":
             # Official channel switched off by the user → don't mint or arm it.
             self._skoda_probe(
                 "skoda_official", "disabled by source mode (mysmob_only)"
@@ -2873,6 +2995,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # Record WHY the official channel can't auto-enrol (portal-fallback or a
             # non-native login) so diagnostics explain its absence. PII-free.
             self._skoda_probe("skoda_official", "gate: not a native mysmob login")
+            # Can't auto-mint (no native mysmob login) → offer the manual key+VIN repair.
+            self._reconcile_skoda_manual_key_repair(vins)
             return
         # Feed the client the HA instance locale so the app-identity keygen headers
         # (X-DEVICE-LANGUAGE / X-DEVICE-COUNTRY) carry the user's real HA setting in
@@ -2901,6 +3025,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             if str(v).upper() not in stored_upper and str(v).upper() not in attempted
         ]
         if not to_mint:
+            # Every VIN already has a key → nothing to mint; clear any manual-key repair.
+            self._reconcile_skoda_manual_key_repair(vins)
             if stored:
                 self._arm_official_from_map(stored)
                 # Once per session: is ANOTHER integration/app using the same
@@ -2911,9 +3037,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     self._skoda_multi_int_checked = True
                     try:
                         self._check_skoda_multi_integration(await list_keys(), stored, vins)
-                    except Exception:  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
+                        # class-only — list_keys() hits the official API and returns
+                        # key material; a raw error can carry the URL or a key.
                         _LOGGER.debug(
-                            "Škoda multi-integration check skipped", exc_info=True
+                            "Škoda multi-integration check skipped (%s)",
+                            type(exc).__name__,
                         )
             return
         # Quota check (maxKeys 5 per VIN) — one GET before minting.
@@ -2953,6 +3082,8 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             )
             if quota_full:
                 repairs.raise_issue_skoda_official_quota(self.hass, self.entry.entry_id)
+            # Auto-mint produced no key (keygen rejected / quota) → manual key+VIN fallback.
+            self._reconcile_skoda_manual_key_repair(to_mint)
             return
         full = {**stored, **newly}
         self._arm_official_from_map(full)
@@ -2961,7 +3092,29 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         self.hass.config_entries.async_update_entry(
             self.entry, data={**self.entry.data, CONF_SKODA_OFFICIAL_KEYS: full})
         repairs.raise_issue_skoda_official_enrolled(self.hass, self.entry.entry_id)
+        # Keys minted → the manual key+VIN fallback is no longer needed.
+        repairs.clear_issue_skoda_official_manual_key(self.hass, self.entry.entry_id)
         self._skoda_probe("skoda_official", f"enrolled ({len(newly)} new key(s))")
+
+    def _reconcile_skoda_manual_key_repair(self, vins: list[str]) -> None:
+        """Auto-mint stays the primary path; when it can't produce a key for a VIN
+        (non-native login, or the keygen rejects it) this surfaces the interactive
+        'paste your MyŠkoda API key + VIN' repair for the still-uncovered VINs — and
+        clears it once every VIN has a key (minted OR manually supplied). #1286."""
+        from . import repairs  # noqa: PLC0415
+        from .const import CONF_SKODA_OFFICIAL_KEYS  # noqa: PLC0415
+        stored = {
+            str(k).upper() for k in (self.entry.data.get(CONF_SKODA_OFFICIAL_KEYS) or {})
+        }
+        missing = [str(v).upper() for v in vins if str(v).upper() not in stored]
+        if missing:
+            repairs.raise_issue_skoda_official_manual_key(
+                self.hass, self.entry.entry_id, missing
+            )
+        else:
+            repairs.clear_issue_skoda_official_manual_key(
+                self.hass, self.entry.entry_id
+            )
 
     async def _arm_supplementary_channels(self) -> None:
         """v2.15.0b1 (C1) — arm configured supplementary read channels on the
@@ -3244,7 +3397,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
                 "C1 supplementary merge failed for %s — keeping primary: %s",
-                mask_vin(vin), err,
+                mask_vin(vin), type(err).__name__,
             )
             # Still attribute what we did get — losing provenance exactly when
             # a channel misbehaves is when it's most worth having.
@@ -3291,7 +3444,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
                 "GAP-2.1 supplementary revive failed for %s: %s",
-                mask_vin(vin), err,
+                mask_vin(vin), type(err).__name__,
             )
             return None
         # A supplementary channel contributed IFF the merge added a
@@ -3337,7 +3490,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         try:
             vins = await portal.list_vehicle_vins()
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("#1222 EU Data Act enumeration fallback failed: %s", err)
+            _LOGGER.debug("#1222 EU Data Act enumeration fallback failed: %s", type(err).__name__)
             return []
         if vins:
             _LOGGER.warning(
@@ -3376,7 +3529,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug(
                     "hard-failure supplementary revive failed for %s: %s",
-                    mask_vin(vin), err,
+                    mask_vin(vin), type(err).__name__,
                 )
         # 2) Škoda OFFICIAL public API — a FAILOVER-ONLY source (rate-limited to
         # 20 req/hour/key, so never read on a healthy cycle; only here, on a hard
@@ -3395,7 +3548,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug(
                     "official-API failover read failed for %s: %s",
-                    mask_vin(vin), err,
+                    mask_vin(vin), type(err).__name__,
                 )
         return None
 
@@ -3425,9 +3578,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             return
         try:
             off = await read(vin)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            # class-only — official_live_read hits the VIN-path API with the
+            # X-API-Key; a raw aiohttp error re-leaks the VIN-URL the mask hides.
             _LOGGER.debug(
-                "official live-read raised for %s", mask_vin(vin), exc_info=True
+                "official live-read raised for %s (%s)",
+                mask_vin(vin), type(exc).__name__,
             )
             return
         if off is None:
@@ -3531,6 +3687,24 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 )
             else:
                 sleep_s = float(interval_s)
+            # Escalating backoff during a SUSTAINED portal 5xx outage. The previous
+            # poll's ``last_no_data_reason`` is the signal: on ``portal_error``
+            # (5xx/429/timeout) widen the sleep 5→15→30 min, replacing the ~60 s
+            # drop-retry collapse that otherwise hammers VW's portal every minute
+            # for hours during its own outage; any other outcome (fresh data, an
+            # ``empty`` no-content drop, or a non-portal entry) resets the streak.
+            # Adopted from TommiG1's SERVER_ERROR_BACKOFF_INTERVALS.
+            _portal_outage = _portal is not None and getattr(
+                _portal, "last_no_data_reason", ""
+            ) == "portal_error"
+            self._note_portal_outage(_portal_outage)
+            _boff = _portal_5xx_backoff_s(self._consecutive_portal_5xx)
+            if _boff > sleep_s:
+                sleep_s = _boff
+                _LOGGER.debug(
+                    "EU Data Act portal 5xx streak %d → backing off, next poll "
+                    "in %.0fs", self._consecutive_portal_5xx, sleep_s,
+                )
             await asyncio.sleep(sleep_s)
             if not self._started:
                 break
@@ -3599,7 +3773,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         if _revived is not None:
                             result = _revived
                     if isinstance(result, Exception):
-                        _LOGGER.debug("Poll failed for %s: %s", mask_vin(vin), result)
+                        _LOGGER.debug("Poll failed for %s: %s", mask_vin(vin), type(result).__name__)
                         old = self.vehicles.get(vin, {})
                         old["_poll_failed"] = True
                         fresh[vin] = old
@@ -3733,7 +3907,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                             _LOGGER.warning(
                                 "VW Group Connect: post-parse failure for %s — "
                                 "keeping previous data: %s",
-                                mask_vin(vin), parse_err,
+                                mask_vin(vin), type(parse_err).__name__,
                             )
                             old = self.vehicles.get(vin, {})
                             old["_poll_failed"] = True
@@ -3787,10 +3961,10 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         if self._skoda_official_mode() in ("auto", "prefer_official"):
                             try:
                                 await self._merge_official_live(vin, enriched)
-                            except Exception:  # noqa: BLE001
+                            except Exception as exc:  # noqa: BLE001
                                 _LOGGER.debug(
-                                    "official live-source merge skipped for %s",
-                                    mask_vin(vin), exc_info=True,
+                                    "official live-source merge skipped for %s (%s)",
+                                    mask_vin(vin), type(exc).__name__,
                                 )
                         # Per-source connectivity map for the connectivity
                         # binary_sensors (which sources this car is connected to,
@@ -3800,9 +3974,10 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                             enriched["channel_status"] = self._compute_channel_status(
                                 vin, enriched
                             )
-                        except Exception:  # noqa: BLE001
+                        except Exception as exc:  # noqa: BLE001
                             _LOGGER.debug(
-                                "channel-status compute skipped", exc_info=True
+                                "channel-status compute skipped (%s)",
+                                type(exc).__name__,
                             )
                         fresh[vin] = self._apply_optimistic_hold(vin, enriched)
                         any_success = True
@@ -3857,13 +4032,23 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     self._save_vehicle_cache()
                 except Exception:  # noqa: BLE001
                     pass
+                # #1340 — one-time registry cleanup: now that the first poll has
+                # settled channel_status (all channels armed, incl. the in-poll
+                # Škoda-official arm), prune connectivity sensors for channels this
+                # account no longer arms (cyrano330's orphaned connectivity_eu_data_
+                # act). Runs once per session; fail-soft, never blocks the poll.
+                if not getattr(self, "_connectivity_reconciled", False):
+                    self._connectivity_reconciled = True
+                    self._reconcile_connectivity_entities()
                 # Stage-1 — advance any pending one-time historical export
                 # (import when ready, time out when stuck). Real work only for a
                 # VIN with a pending export; never breaks the poll.
                 try:
                     await self._advance_historical_exports()
-                except Exception:  # noqa: BLE001
-                    _LOGGER.debug("historical-export advance skipped", exc_info=True)
+                except Exception as exc:  # noqa: BLE001
+                    _LOGGER.debug(
+                        "historical-export advance skipped (%s)", type(exc).__name__
+                    )
                 # v2.25.0 (#966/#632) — the per-VIN _merge_supplementary above
                 # may have refreshed the vw.de session on a mid-poll 401,
                 # rotating its cookie jar. Persist the rotated cookies here (once
@@ -4037,11 +4222,19 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 # Reporter; see _is_selfhealing_poll_error.
                 is_transient_upstream = _is_selfhealing_poll_error(err)
                 if is_transient_upstream:
+                    # class + status only — a status-0 transient network error is
+                    # a raw aiohttp exception whose str() carries the request URL.
                     _LOGGER.warning(
-                        "VW Group Connect: VW backend temporarily unavailable — %s", err
+                        "VW Group Connect: VW backend temporarily unavailable —"
+                        " %s (status=%s)",
+                        type(err).__name__, getattr(err, "status", None),
                     )
                 else:
-                    _LOGGER.error("VW Group Connect poll error: %s", err)
+                    # class + status only — raw err str() can carry a VIN-path URL.
+                    _LOGGER.error(
+                        "VW Group Connect poll error: %s (status=%s)",
+                        type(err).__name__, getattr(err, "status", None),
+                    )
                     # v1.9.0 — Error Reporter: outer poll-loop crash gets a
                     # buffer entry too. Critical because these are the kind of
                     # errors users hit and never know about (silent except).
@@ -4191,12 +4384,18 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         "raw_payload": event.raw_payload,
                     },
                 )
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("VAG push: bus emission failed")
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.error(
+                    "VAG push: bus emission failed (%s)", type(exc).__name__
+                )
             try:
                 await self.async_request_refresh()
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("VAG push: refresh after event failed")
+            except Exception as exc:  # noqa: BLE001
+                # class-only, not .exception() — the refresh drives VIN-path reads;
+                # a raw aiohttp error's str()/traceback carries the URL.
+                _LOGGER.error(
+                    "VAG push: refresh after event failed (%s)", type(exc).__name__
+                )
 
         token_provider = getattr(client, "async_get_access_token", None)
         if token_provider is None:
@@ -5141,7 +5340,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(
                 "Capabilities fetch failed for %s: %s",
                 mask_vin(vin),
-                err,
+                type(err).__name__,
             )
             return
         if not isinstance(data, dict):
@@ -5191,7 +5390,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             data = await client.get_vehicle_static_info(vin)
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
-                "Static info fetch failed for %s: %s", mask_vin(vin), err,
+                "Static info fetch failed for %s: %s", mask_vin(vin), type(err).__name__,
             )
             return
         if not isinstance(data, dict):
@@ -5290,7 +5489,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             )
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
-                "Trip stats fetch failed for %s: %s", mask_vin(vin), err
+                "Trip stats fetch failed for %s: %s", mask_vin(vin), type(err).__name__
             )
             return
         # ``return_exceptions=True`` — drop exceptions to None so the parser
@@ -5353,7 +5552,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             resp = await client.get_charging_history(vin)
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
-                "Charging-history fetch failed for %s: %s", mask_vin(vin), err
+                "Charging-history fetch failed for %s: %s", mask_vin(vin), type(err).__name__
             )
             return
         parsed = _parse_charging_history(resp)
@@ -5405,7 +5604,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         try:
             resp = await client.get_latest_fueling()
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Fueling fetch failed for %s: %s", mask_vin(vin), err)
+            _LOGGER.debug("Fueling fetch failed for %s: %s", mask_vin(vin), type(err).__name__)
             return
         # Stamp even on empty so a non-enrolled account isn't re-hammered.
         self._fueling_fetched_at[vin] = datetime.now(tz=timezone.utc)
@@ -5444,7 +5643,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         try:
             resp = await client.get_my_parking()
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Parking fetch failed for %s: %s", mask_vin(vin), err)
+            _LOGGER.debug("Parking fetch failed for %s: %s", mask_vin(vin), type(err).__name__)
             return
         self._parking_fetched_at[vin] = datetime.now(tz=timezone.utc)
         parsed = _parse_parking(resp)
@@ -5490,7 +5689,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         try:
             resp = await (fn(vin) if takes_vin else fn())
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("%s failed for %s: %s", method, mask_vin(vin), err)
+            _LOGGER.debug("%s failed for %s: %s", method, mask_vin(vin), type(err).__name__)
             return
         store[vin] = datetime.now(tz=timezone.utc)
         parsed = parse(resp)
@@ -5574,7 +5773,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             )
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
-                "Battery-care fetch failed for %s: %s", mask_vin(vin), err
+                "Battery-care fetch failed for %s: %s", mask_vin(vin), type(err).__name__
             )
             return
         # ``return_exceptions=True`` — drop exceptions to None so we
@@ -5645,7 +5844,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(
                 "Charging-profiles fetch failed for %s: %s",
                 mask_vin(vin),
-                err,
+                type(err).__name__,
             )
             return
         parsed = _parse_charging_profiles(resp)
@@ -5745,7 +5944,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                         message=(
                             f"Das Fahrzeug **{mask_vin(stale_vin)}** ist "
                             f"nicht mehr in deinem VAG-Konto verfügbar "
-                            f"({self.entry.data.get(CONF_USERNAME, 'unbekannt')}). "
+                            f"({mask_email(self.entry.data.get(CONF_USERNAME, 'unbekannt'))}). "
                             f"Mögliche Ursachen:\n\n"
                             f"- Verkauft / Eigentümerwechsel\n"
                             f"- Connect-Subscription ist abgelaufen\n"
@@ -6110,6 +6309,12 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             )
             _threshold_s = max(STALE_DATA_MIN_AGE_S, 8 * _interval_s)
             _age = _capture_age_s(data)
+            # #465 — automatable twin of the stale-data Repair: a
+            # device_class=PROBLEM binary the user can drive automations off,
+            # from the SAME capture-age + threshold so the binary and the Repair
+            # can never disagree. Brand-agnostic; None (→ entity hidden) for a read
+            # that carries no capture timestamp.
+            data["data_stale"] = _age >= _threshold_s if _age is not None else None
             if _age is not None and _age >= _threshold_s:
                 raise_issue_stale_data(
                     self.hass, self.entry.entry_id, _vin_sd,
@@ -6378,7 +6583,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     if _revived is not None:
                         result = _revived
                 if isinstance(result, Exception):
-                    _LOGGER.debug("Refresh failed for %s: %s", mask_vin(vin), result)
+                    _LOGGER.debug("Refresh failed for %s: %s", mask_vin(vin), type(result).__name__)
                     continue
                 if isinstance(result, VehicleData):
                     # v2.29.x — portal-safety, mirroring the poll path
@@ -6419,7 +6624,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("VW Group Connect: Manual refresh OK")
             return dict(self.vehicles)
         except Exception as err:  # noqa: BLE001
-            _LOGGER.error("VW Group Connect: Manual refresh failed: %s", err)
+            # class + status only — raw err str() can carry a VIN-path URL.
+            _LOGGER.error(
+                "VW Group Connect: Manual refresh failed: %s (status=%s)",
+                type(err).__name__, getattr(err, "status", None),
+            )
             with self._vehicles_lock:
                 return dict(self.vehicles)
 
@@ -7477,7 +7686,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
 
         vehicle = self.vehicles.get(vin)
         if not isinstance(vehicle, dict):
-            raise HomeAssistantError(f"Vehicle '{vin}' not found for ABRP send.")
+            raise HomeAssistantError(f"Vehicle '…{vin[-6:]}' not found for ABRP send.")
 
         resolved_key, resolved_token = self._abrp_credentials(
             vin, api_key=api_key, token=token
@@ -7764,10 +7973,10 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         # the finally above, exactly as before.
         try:
             await self.async_request_refresh()
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             _LOGGER.debug(
-                "VW Group Connect: post-command refresh failed for %s(%s)",
-                method, mask_vin(vin), exc_info=True,
+                "VW Group Connect: post-command refresh failed for %s(%s) [%s]",
+                method, mask_vin(vin), type(exc).__name__,
             )
 
     async def _dispatch_cmd_locked(self, vin: str, method: str, **kwargs: Any) -> None:
@@ -7801,7 +8010,13 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 )
             except Exception:  # noqa: BLE001
                 pass
-            _LOGGER.error("VW Group Connect: %s(%s) failed: %s", method, mask_vin(vin), err)
+            # class + status only — raw err str() can carry the VIN-path command
+            # URL; the classified reason is already logged one branch up.
+            _LOGGER.error(
+                "VW Group Connect: %s(%s) failed: %s (status=%s)",
+                method, mask_vin(vin), type(err).__name__,
+                getattr(err, "status", None),
+            )
             # b15 — a two-way primary (Audi BFF) that refuses a command with an
             # auth 401/403 (the shape a revoked device-grant takes) → try the
             # durable MBB fallback ONCE before surfacing, iff the user opted in
@@ -7885,8 +8100,15 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 from .cariad.exceptions import (  # noqa: PLC0415
                     CommandFailureReason,
                     classify_command_failure,
+                    extract_safe_error_code,
                 )
 
+                # #1355 — str(APIError) no longer carries the body, so surface the
+                # SAFE backend error CODE (enum-like, e.g. USER_NOT_AUTHORIZED) so
+                # the user still learns what the car said without leaking the body.
+                _code = extract_safe_error_code(getattr(err, "body", ""))
+                if _code and _code not in msg:
+                    msg = f"{msg} ({_code})"
                 if classify_command_failure(err) in (
                     CommandFailureReason.MISSING_CAPABILITY,
                     CommandFailureReason.NOT_ENTITLED,

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -538,7 +538,9 @@ async def async_get_config_entry_diagnostics(
         try:
             capabilities = capabilities_fn()
         except Exception as err:  # noqa: BLE001
-            capabilities = {"error": f"{type(err).__name__}: {err}"}
+            # class only — str(err) can carry a VIN/internal value; matches the
+            # sibling raw_responses/command error handlers below.
+            capabilities = {"error": type(err).__name__}
 
     # v3.0.0 — the RAW brand API responses (aggressively redacted). The Scout
     # already surfaces the unmapped field NAMES; this adds the surrounding

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.0b15"
+  "version": "4.7.0b16"
 }

--- a/custom_components/vag_connect/repairs.py
+++ b/custom_components/vag_connect/repairs.py
@@ -24,11 +24,18 @@ from typing import Any
 
 import logging
 
+import voluptuous as vol
 
 from homeassistant import data_entry_flow
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.issue_registry as ir
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+)
 
 from .const import DOMAIN
 
@@ -671,6 +678,90 @@ class _AuthRepairFlow(RepairsFlow):
         return self.async_create_entry(title="", data={})
 
 
+def raise_issue_skoda_official_manual_key(
+    hass: HomeAssistant, entry_id: str, vins: list[str]
+) -> None:
+    """Auto-mint could not create an official API key (a non-native login, or the
+    keygen rejected the request) — so instead of silently doing nothing, ask the
+    user to create a key in the MyŠkoda app and paste it here, per vehicle, via an
+    interactive repair. Auto-mint still runs whenever it CAN; this is the fallback
+    for when it can't. #1286."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"{entry_id}_skoda_official_manual_key",
+        is_fixable=True,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="skoda_official_manual_key",
+        data={
+            "entry_id": entry_id,
+            "reason": "skoda_official_manual_key",
+            # issue-registry data values must be scalars → join VINs to a string.
+            "vins": ",".join(str(v).upper() for v in vins if v),
+        },
+    )
+
+
+def clear_issue_skoda_official_manual_key(hass: HomeAssistant, entry_id: str) -> None:
+    """Clear the manual-key repair once a key has been supplied / minted."""
+    ir.async_delete_issue(hass, DOMAIN, f"{entry_id}_skoda_official_manual_key")
+
+
+class _SkodaOfficialKeyRepairFlow(RepairsFlow):
+    """Manual fallback for the Škoda official API when auto-minting can't create a
+    key. The user makes an API key in the MyŠkoda app and pastes it together with
+    the vehicle it belongs to; we store it exactly like a minted one and reload.
+    """
+
+    def __init__(self, entry_id: str, vins: list[str]) -> None:
+        self._entry_id = entry_id
+        self._vins = [str(v).upper() for v in vins if v]
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        return await self.async_step_enter_key(user_input)
+
+    async def async_step_enter_key(
+        self, user_input: dict[str, Any] | None = None
+    ) -> data_entry_flow.FlowResult:
+        from .const import CONF_SKODA_OFFICIAL_KEYS  # noqa: PLC0415
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if entry is None:
+                return self.async_abort(reason="entry_gone")
+            key = str(user_input.get("api_key", "")).strip()
+            vin = str(user_input.get("vin", "")).strip().upper()
+            if not key:
+                errors["api_key"] = "key_required"
+            else:
+                stored = dict(entry.data.get(CONF_SKODA_OFFICIAL_KEYS) or {})
+                stored[vin] = {"key": key, "id": "manual", "validUntil": ""}
+                self.hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, CONF_SKODA_OFFICIAL_KEYS: stored}
+                )
+                await self.hass.config_entries.async_reload(self._entry_id)
+                return self.async_create_entry(title="", data={})
+
+        if self._vins:
+            vin_key: Any = vol.Required("vin", default=self._vins[0])
+            vin_field: Any = SelectSelector(
+                SelectSelectorConfig(
+                    options=self._vins, mode=SelectSelectorMode.DROPDOWN
+                )
+            )
+        else:
+            vin_key = vol.Required("vin")
+            vin_field = TextSelector()
+        schema = vol.Schema({vin_key: vin_field, vol.Required("api_key"): TextSelector()})
+        return self.async_show_form(
+            step_id="enter_key", data_schema=schema, errors=errors
+        )
+
+
 async def async_create_fix_flow(
     hass: HomeAssistant,
     issue_id: str,
@@ -679,4 +770,7 @@ async def async_create_fix_flow(
     """v2.0.0 — HA RepairsFlow factory. Called when user clicks 'Repair'."""
     entry_id = (data or {}).get("entry_id", "")
     reason = (data or {}).get("reason", "auth_failed")
+    if reason == "skoda_official_manual_key":
+        vins = [v for v in str((data or {}).get("vins") or "").split(",") if v]
+        return _SkodaOfficialKeyRepairFlow(entry_id, vins)
     return _AuthRepairFlow(entry_id, reason)

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1771,6 +1771,9 @@
       },
       "data_source": {
         "name": "Source: {source}"
+      },
+      "data_stale": {
+        "name": "Data stale"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Škoda official API — add your API key",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Add a MyŠkoda API key",
+            "description": "Home Assistant couldn't create an official Škoda API key for this car automatically. Create one in the MyŠkoda app, then choose the vehicle and paste the key here. Automatic creation keeps trying in the background — this is just the manual fallback.",
+            "data": {
+              "vin": "Vehicle",
+              "api_key": "MyŠkoda API key (starts with msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Please paste your MyŠkoda API key."
+        },
+        "abort": {
+          "entry_gone": "That integration entry no longer exists."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Sign-in failed — {brand}",
       "description": "Home Assistant couldn't sign in to your {brand} account — usually a wrong or changed password, though a temporary block can look the same.\n\nSettings → Devices & Services → VW Group Connect → ⋮ → Reconfigure to re-enter your credentials."

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Zdroj: {source}"
+      },
+      "data_stale": {
+        "name": "Data zastaralá"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Oficiální API Škoda — přidejte svůj API klíč",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Přidat API klíč MyŠkoda",
+            "description": "Home Assistant nedokázal pro toto auto automaticky vytvořit oficiální API klíč Škoda. Vytvořte jej v aplikaci MyŠkoda, poté vyberte vozidlo a vložte klíč sem. Automatické vytváření zkouší dál na pozadí — toto je jen ruční záložní možnost.",
+            "data": {
+              "vin": "Vozidlo",
+              "api_key": "API klíč MyŠkoda (začíná na msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Vložte prosím svůj API klíč MyŠkoda."
+        },
+        "abort": {
+          "entry_gone": "Tento záznam integrace již neexistuje."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Přihlášení selhalo — {brand}",
       "description": "Home Assistant se nemohl přihlásit k účtu {brand} — obvykle nesprávné nebo změněné heslo, ale dočasné zablokování může vypadat stejně.\n\nNastavení → Zařízení a služby → VW Group Connect → ⋮ → Překonfigurovat a znovu zadat přihlašovací údaje."

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Kilde: {source}"
+      },
+      "data_stale": {
+        "name": "Data forældet"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Škoda officielt API — tilføj din API-nøgle",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Tilføj en MyŠkoda API-nøgle",
+            "description": "Home Assistant kunne ikke automatisk oprette en officiel Škoda API-nøgle til denne bil. Opret en i MyŠkoda-appen, vælg derefter køretøjet og indsæt nøglen her. Den automatiske oprettelse forsøger fortsat i baggrunden — dette er blot den manuelle løsning.",
+            "data": {
+              "vin": "Køretøj",
+              "api_key": "MyŠkoda API-nøgle (starter med msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Indsæt venligst din MyŠkoda API-nøgle."
+        },
+        "abort": {
+          "entry_gone": "Den integrationspost findes ikke længere."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Login mislykkedes — {brand}",
       "description": "Home Assistant kunne ikke logge ind på din {brand}-konto — normalt en forkert eller ændret adgangskode, men en midlertidig blokering kan se ens ud.\n\nIndstillinger → Enheder og tjenester → VW Group Connect → ⋮ → Rekonfigurer for at indtaste dine loginoplysninger igen."

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Quelle: {source}"
+      },
+      "data_stale": {
+        "name": "Daten veraltet"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Škoda offizielle API — API-Schlüssel hinzufügen",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "MyŠkoda API-Schlüssel hinzufügen",
+            "description": "Home Assistant konnte für dieses Auto nicht automatisch einen offiziellen Škoda API-Schlüssel erstellen. Erstelle einen in der MyŠkoda App, wähle dann das Fahrzeug und füge den Schlüssel hier ein. Die automatische Erstellung läuft im Hintergrund weiter — das hier ist nur die manuelle Alternative.",
+            "data": {
+              "vin": "Fahrzeug",
+              "api_key": "MyŠkoda API-Schlüssel (beginnt mit msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Bitte füge deinen MyŠkoda API-Schlüssel ein."
+        },
+        "abort": {
+          "entry_gone": "Dieser Integrationseintrag existiert nicht mehr."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Anmeldung fehlgeschlagen — {brand}",
       "description": "Home Assistant konnte sich nicht bei deinem {brand}-Konto anmelden — meist ein falsches oder geändertes Passwort, aber eine vorübergehende Sperre kann gleich aussehen.\n\nEinstellungen → Geräte & Dienste → VW Group Connect → ⋮ → Neu konfigurieren, um die Zugangsdaten erneut einzugeben."

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Source: {source}"
+      },
+      "data_stale": {
+        "name": "Data stale"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Škoda official API — add your API key",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Add a MyŠkoda API key",
+            "description": "Home Assistant couldn't create an official Škoda API key for this car automatically. Create one in the MyŠkoda app, then choose the vehicle and paste the key here. Automatic creation keeps trying in the background — this is just the manual fallback.",
+            "data": {
+              "vin": "Vehicle",
+              "api_key": "MyŠkoda API key (starts with msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Please paste your MyŠkoda API key."
+        },
+        "abort": {
+          "entry_gone": "That integration entry no longer exists."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Sign-in failed — {brand}",
       "description": "Home Assistant couldn't sign in to your {brand} account — usually a wrong or changed password, though a temporary block can look the same.\n\nSettings → Devices & Services → VW Group Connect → ⋮ → Reconfigure to re-enter your credentials."

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Fuente: {source}"
+      },
+      "data_stale": {
+        "name": "Datos obsoletos"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "API oficial de Škoda — añade tu clave de API",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Añadir una clave de API de MyŠkoda",
+            "description": "Home Assistant no pudo crear automáticamente una clave de API oficial de Škoda para este coche. Crea una en la aplicación MyŠkoda, luego elige el vehículo y pega la clave aquí. La creación automática sigue intentándolo en segundo plano — esto es solo la alternativa manual.",
+            "data": {
+              "vin": "Vehículo",
+              "api_key": "Clave de API de MyŠkoda (empieza por msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Pega tu clave de API de MyŠkoda."
+        },
+        "abort": {
+          "entry_gone": "Esa entrada de integración ya no existe."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Error de inicio de sesión — {brand}",
       "description": "Home Assistant no pudo iniciar sesión en tu cuenta de {brand} — normalmente una contraseña incorrecta o cambiada, aunque un bloqueo temporal puede parecer igual.\n\nAjustes → Dispositivos y servicios → VW Group Connect → ⋮ → Reconfigurar para volver a introducir tus credenciales."

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Lähde: {source}"
+      },
+      "data_stale": {
+        "name": "Tiedot vanhentuneet"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Škodan virallinen API — lisää API-avaimesi",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Lisää MyŠkoda-API-avain",
+            "description": "Home Assistant ei voinut luoda tälle autolle virallista Škoda-API-avainta automaattisesti. Luo sellainen MyŠkoda-sovelluksessa, valitse sitten ajoneuvo ja liitä avain tähän. Automaattinen luonti jatkaa yrittämistä taustalla — tämä on vain manuaalinen vaihtoehto.",
+            "data": {
+              "vin": "Ajoneuvo",
+              "api_key": "MyŠkoda-API-avain (alkaa msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Liitä MyŠkoda-API-avaimesi."
+        },
+        "abort": {
+          "entry_gone": "Kyseistä integraatiomerkintää ei enää ole."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Kirjautuminen epäonnistui — {brand}",
       "description": "Home Assistant ei voinut kirjautua {brand}-tilillesi — yleensä väärä tai muutettu salasana, mutta tilapäinen esto voi näyttää samalta.\n\nAsetukset → Laitteet ja palvelut → VW Group Connect → ⋮ → Määritä uudelleen ja anna kirjautumistiedot uudelleen."

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Source : {source}"
+      },
+      "data_stale": {
+        "name": "Données obsolètes"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "API officielle Škoda — ajoutez votre clé d'API",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Ajouter une clé d'API MyŠkoda",
+            "description": "Home Assistant n'a pas pu créer automatiquement de clé d'API officielle Škoda pour cette voiture. Créez-en une dans l'application MyŠkoda, puis choisissez le véhicule et collez la clé ici. La création automatique continue d'essayer en arrière-plan — ceci n'est que la solution manuelle.",
+            "data": {
+              "vin": "Véhicule",
+              "api_key": "Clé d'API MyŠkoda (commence par msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Veuillez coller votre clé d'API MyŠkoda."
+        },
+        "abort": {
+          "entry_gone": "Cette entrée d'intégration n'existe plus."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Échec de la connexion — {brand}",
       "description": "Home Assistant n'a pas pu se connecter à votre compte {brand} — généralement un mot de passe incorrect ou modifié, mais un blocage temporaire peut y ressembler.\n\nParamètres → Appareils et services → VW Group Connect → ⋮ → Reconfigurer pour saisir à nouveau vos identifiants."

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Fonte: {source}"
+      },
+      "data_stale": {
+        "name": "Dati obsoleti"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "API ufficiale Škoda — aggiungi la tua chiave API",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Aggiungi una chiave API MyŠkoda",
+            "description": "Home Assistant non è riuscito a creare automaticamente una chiave API ufficiale Škoda per questa auto. Creane una nell'app MyŠkoda, poi scegli il veicolo e incolla qui la chiave. La creazione automatica continua a provare in background — questa è solo l'alternativa manuale.",
+            "data": {
+              "vin": "Veicolo",
+              "api_key": "Chiave API MyŠkoda (inizia con msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Incolla la tua chiave API MyŠkoda."
+        },
+        "abort": {
+          "entry_gone": "Quella voce di integrazione non esiste più."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Accesso non riuscito — {brand}",
       "description": "Home Assistant non è riuscito ad accedere al tuo account {brand} — di solito una password errata o modificata, anche se un blocco temporaneo può sembrare uguale.\n\nImpostazioni → Dispositivi e servizi → VW Group Connect → ⋮ → Riconfigura per reinserire le credenziali."

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Kilde: {source}"
+      },
+      "data_stale": {
+        "name": "Data er utdatert"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Škoda offisielt API — legg til API-nøkkelen din",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Legg til en MyŠkoda API-nøkkel",
+            "description": "Home Assistant kunne ikke opprette en offisiell Škoda API-nøkkel for denne bilen automatisk. Opprett en i MyŠkoda-appen, velg deretter kjøretøyet og lim inn nøkkelen her. Den automatiske opprettelsen fortsetter å prøve i bakgrunnen — dette er bare den manuelle løsningen.",
+            "data": {
+              "vin": "Kjøretøy",
+              "api_key": "MyŠkoda API-nøkkel (starter med msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Lim inn MyŠkoda API-nøkkelen din."
+        },
+        "abort": {
+          "entry_gone": "Den integrasjonsoppføringen finnes ikke lenger."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Innlogging mislyktes — {brand}",
       "description": "Home Assistant kunne ikke logge inn på {brand}-kontoen din — vanligvis feil eller endret passord, men en midlertidig blokkering kan se lik ut.\n\nInnstillinger → Enheter og tjenester → VW Group Connect → ⋮ → Rekonfigurer for å oppgi påloggingsinformasjonen på nytt."

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Bron: {source}"
+      },
+      "data_stale": {
+        "name": "Gegevens verouderd"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Officiële Škoda-API — voeg je API-sleutel toe",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Een MyŠkoda API-sleutel toevoegen",
+            "description": "Home Assistant kon niet automatisch een officiële Škoda API-sleutel voor deze auto aanmaken. Maak er een aan in de MyŠkoda-app, kies vervolgens het voertuig en plak de sleutel hier. Het automatisch aanmaken blijft op de achtergrond proberen — dit is alleen de handmatige terugvaloptie.",
+            "data": {
+              "vin": "Voertuig",
+              "api_key": "MyŠkoda API-sleutel (begint met msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Plak je MyŠkoda API-sleutel."
+        },
+        "abort": {
+          "entry_gone": "Die integratievermelding bestaat niet meer."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Aanmelden mislukt — {brand}",
       "description": "Home Assistant kon niet inloggen op je {brand}-account — meestal een onjuist of gewijzigd wachtwoord, al kan een tijdelijke blokkade er hetzelfde uitzien.\n\nInstellingen → Apparaten en diensten → VW Group Connect → ⋮ → Herconfigureren om je inloggegevens opnieuw in te voeren."

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Źródło: {source}"
+      },
+      "data_stale": {
+        "name": "Nieaktualne dane"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Oficjalne API Škoda — dodaj swój klucz API",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Dodaj klucz API MyŠkoda",
+            "description": "Home Assistant nie mógł automatycznie utworzyć oficjalnego klucza API Škoda dla tego samochodu. Utwórz go w aplikacji MyŠkoda, następnie wybierz pojazd i wklej tutaj klucz. Automatyczne tworzenie nadal działa w tle — to tylko opcja ręczna.",
+            "data": {
+              "vin": "Pojazd",
+              "api_key": "Klucz API MyŠkoda (zaczyna się od msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Wklej swój klucz API MyŠkoda."
+        },
+        "abort": {
+          "entry_gone": "Ten wpis integracji już nie istnieje."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Logowanie nie powiodło się — {brand}",
       "description": "Home Assistant nie mógł zalogować się do konta {brand} — zwykle błędne lub zmienione hasło, ale tymczasowa blokada może wyglądać tak samo.\n\nUstawienia → Urządzenia i usługi → VW Group Connect → ⋮ → Rekonfiguruj, aby ponownie wprowadzić dane logowania."

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1738,6 +1738,9 @@
       },
       "data_source": {
         "name": "Källa: {source}"
+      },
+      "data_stale": {
+        "name": "Data föråldrad"
       }
     },
     "switch": {
@@ -1940,6 +1943,27 @@
     }
   },
   "issues": {
+    "skoda_official_manual_key": {
+      "title": "Škodas officiella API — lägg till din API-nyckel",
+      "fix_flow": {
+        "step": {
+          "enter_key": {
+            "title": "Lägg till en MyŠkoda API-nyckel",
+            "description": "Home Assistant kunde inte automatiskt skapa en officiell Škoda API-nyckel för den här bilen. Skapa en i MyŠkoda-appen, välj sedan fordonet och klistra in nyckeln här. Den automatiska skapelsen fortsätter att försöka i bakgrunden — det här är bara det manuella alternativet.",
+            "data": {
+              "vin": "Fordon",
+              "api_key": "MyŠkoda API-nyckel (börjar med msk_)"
+            }
+          }
+        },
+        "error": {
+          "key_required": "Klistra in din MyŠkoda API-nyckel."
+        },
+        "abort": {
+          "entry_gone": "Den integrationsposten finns inte längre."
+        }
+      }
+    },
     "invalid_credentials": {
       "title": "Inloggning misslyckades — {brand}",
       "description": "Home Assistant kunde inte logga in på ditt {brand}-konto — vanligtvis fel eller ändrat lösenord, men en tillfällig spärr kan se likadan ut.\n\nInställningar → Enheter och tjänster → VW Group Connect → ⋮ → Konfigurera om för att ange dina inloggningsuppgifter igen."

--- a/custom_components/vag_connect/trigger_detect.py
+++ b/custom_components/vag_connect/trigger_detect.py
@@ -110,8 +110,8 @@ class VehicleTransitionDetector:
             if lvin is None or lvin == vin:
                 try:
                     cb(payload)
-                except Exception:  # noqa: BLE001 — a listener must never break polling
+                except Exception as exc:  # noqa: BLE001 — a listener must never break polling
                     _LOGGER.debug(
-                        "vehicle transition listener for %s raised", event_key,
-                        exc_info=True,
+                        "vehicle transition listener for %s raised (%s)",
+                        event_key, type(exc).__name__,
                     )

--- a/tests/test_1340_connectivity_orphan_cleanup.py
+++ b/tests/test_1340_connectivity_orphan_cleanup.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1340 — one-time entity-registry cleanup of orphaned connectivity sensors.
+
+The per-source connectivity binary_sensors are created dynamically, one per armed
+read channel (unique_id ``{vin}_connectivity_{token}``). When an account's channel
+set changes across versions/reconfigures, the old sensor is never re-created and
+lingers in the registry as a permanent ``unknown``/``unavailable`` leftover
+(cyrano330 had to delete ``connectivity_eu_data_act`` by hand). ``_reconcile_
+connectivity_entities`` prunes any connectivity entity whose token is no longer in
+the vehicle's current ``channel_status`` — conservatively, and scoped to this entry.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+VIN = "WVGZZZ1KZAW123456"
+VIN2 = "WAUZZZ8K9BA654321"
+
+
+def _entry(entity_id: str, unique_id: str):
+    e = MagicMock()
+    e.entity_id = entity_id
+    e.unique_id = unique_id
+    return e
+
+
+def _coord(vehicles: dict):
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c.hass = MagicMock()
+    c.entry = MagicMock()
+    c.entry.entry_id = "cfg1"
+    c.vehicles = vehicles
+    return c
+
+
+def _run(coord, entries):
+    registry = MagicMock()
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get", return_value=registry
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+        return_value=entries,
+    ):
+        coord._reconcile_connectivity_entities()
+    return [call.args[0] for call in registry.async_remove.call_args_list]
+
+
+def test_orphaned_connectivity_entity_is_removed():
+    # The car's current channels are the brand primary + eu_data_act supplementary.
+    coord = _coord({
+        VIN: {"channel_status": {
+            "audi": {"armed": True},
+            "eu_data_act": {"armed": True},
+        }},
+    })
+    kept = _entry(
+        "binary_sensor.audi_connectivity_eu_data_act",
+        f"{VIN}_connectivity_eu_data_act",
+    )
+    orphan = _entry(
+        "binary_sensor.audi_connectivity_website_authproxy",
+        f"{VIN}_connectivity_website_authproxy",
+    )
+    unrelated = _entry("sensor.audi_battery_level", f"{VIN}_battery_level")
+
+    removed = _run(coord, [kept, orphan, unrelated])
+
+    assert orphan.entity_id in removed          # channel no longer armed → pruned
+    assert kept.entity_id not in removed        # still armed → kept
+    assert unrelated.entity_id not in removed   # not a connectivity sensor → untouched
+
+
+def test_vin_without_channel_status_is_left_untouched():
+    # A VIN whose poll has not populated channel_status: its valid set is unknown,
+    # so NOTHING is pruned for it (conservative — never remove on a failed poll).
+    coord = _coord({VIN: {"battery_level": 55}})
+    orphan_looking = _entry(
+        "binary_sensor.audi_connectivity_website_authproxy",
+        f"{VIN}_connectivity_website_authproxy",
+    )
+    removed = _run(coord, [orphan_looking])
+    assert removed == []
+
+
+def test_only_the_matching_vin_is_reconciled():
+    # Two cars; only VIN's channels are known. A connectivity entity belonging to
+    # VIN2 (unknown channel set) must not be touched by VIN's reconcile.
+    coord = _coord({
+        VIN: {"channel_status": {"audi": {"armed": True}}},
+        VIN2: {"battery_level": 60},  # no channel_status
+    })
+    vin_orphan = _entry(
+        "binary_sensor.a_connectivity_eu_data_act",
+        f"{VIN}_connectivity_eu_data_act",
+    )
+    vin2_entity = _entry(
+        "binary_sensor.b_connectivity_eu_data_act",
+        f"{VIN2}_connectivity_eu_data_act",
+    )
+    removed = _run(coord, [vin_orphan, vin2_entity])
+    assert vin_orphan.entity_id in removed       # not armed on VIN → pruned
+    assert vin2_entity.entity_id not in removed  # VIN2 channel set unknown → skipped
+
+
+def test_registry_failure_is_swallowed():
+    # entity_registry.async_get blowing up must never propagate into the poll.
+    coord = _coord({VIN: {"channel_status": {"audi": {"armed": True}}}})
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get",
+        side_effect=RuntimeError("boom"),
+    ):
+        coord._reconcile_connectivity_entities()  # must not raise

--- a/tests/test_1465_data_stale_binary.py
+++ b/tests/test_1465_data_stale_binary.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#465 — automatable ``data_stale`` binary_sensor (device_class=PROBLEM).
+
+The stale-data signal already exists as ``portal_health=stale`` + a 72 h Repair;
+this adds a boolean a user can drive an automation off, brand-agnostic and gated on
+a populated capture timestamp so it self-hides for reads that carry none. The flag
+itself is set in the coordinator from the SAME capture-age + threshold as the
+Repair, so the two can never disagree.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.vag_connect.binary_sensor import VagDataStaleSensor
+
+VIN = "WVWZZZTESTVIN0001"
+
+
+def _sensor(vehicle: dict) -> VagDataStaleSensor:
+    coord = MagicMock()
+    coord.data = {VIN: vehicle}
+    return VagDataStaleSensor(coord, VIN)
+
+
+def test_is_on_maps_the_flag() -> None:
+    assert _sensor({"data_stale": True}).is_on is True
+    assert _sensor({"data_stale": False}).is_on is False
+    assert _sensor({"data_stale": None}).is_on is None   # no capture ts → unknown
+    assert _sensor({}).is_on is None                     # absent → unknown
+
+
+def test_attributes_surface_age_and_health_when_present() -> None:
+    s = _sensor({
+        "data_stale": True,
+        "minutes_since_last_snapshot": 4800,
+        "portal_health": "stale",
+    })
+    attrs = s._platform_attributes()
+    assert attrs is not None
+    assert attrs["minutes_since_last_snapshot"] == 4800
+    assert attrs["portal_health"] == "stale"
+
+
+def test_attributes_none_when_no_portal_signals() -> None:
+    # a Škoda-native/BFF read carries data_stale but no portal_health/age → no attrs
+    assert _sensor({"data_stale": True})._platform_attributes() is None

--- a/tests/test_1465_portal_5xx_backoff.py
+++ b/tests/test_1465_portal_5xx_backoff.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Escalating EU-DA portal 5xx backoff (adopted from TommiG1: 5/15/30 min).
+
+During a SUSTAINED VW-side portal outage the drop-anchored scheduler collapses to
+``_DROP_RETRY_S`` (~60 s), so we hammered VW's portal every minute for hours. This
+layers an escalating backoff on top: consecutive ``portal_error`` polls widen the
+minimum sleep 5→15→30 min, and any healthy/empty/non-portal poll resets it.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.coordinator import (
+    _PORTAL_5XX_BACKOFF_S,
+    _portal_5xx_backoff_s,
+    VagConnectCoordinator,
+)
+
+
+def test_backoff_curve() -> None:
+    assert _portal_5xx_backoff_s(0) == 0.0        # no outage → no floor raised
+    assert _portal_5xx_backoff_s(1) == 300.0      # 5 min
+    assert _portal_5xx_backoff_s(2) == 900.0      # 15 min
+    assert _portal_5xx_backoff_s(3) == 1800.0     # 30 min
+    assert _portal_5xx_backoff_s(4) == 1800.0     # saturates
+    assert _portal_5xx_backoff_s(99) == 1800.0
+    assert _portal_5xx_backoff_s(-1) == 0.0       # defensive
+
+
+def test_streak_increments_and_saturates_then_resets() -> None:
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c._consecutive_portal_5xx = 0
+    # sustained outage → 1, 2, 3, then saturates at len(_PORTAL_5XX_BACKOFF_S)
+    cap = len(_PORTAL_5XX_BACKOFF_S)
+    for expected in (1, 2, 3, cap, cap):
+        c._note_portal_outage(True)
+        assert c._consecutive_portal_5xx == expected
+    # a healthy (or empty / non-portal) poll resets the streak
+    c._note_portal_outage(False)
+    assert c._consecutive_portal_5xx == 0
+    # the backoff floor tracks the streak
+    c._note_portal_outage(True)
+    assert _portal_5xx_backoff_s(c._consecutive_portal_5xx) == 300.0
+
+
+def test_streak_survives_uninitialised_instance() -> None:
+    # __new__ without __init__ (the MagicMock test pattern) must not crash.
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c._note_portal_outage(True)
+    assert c._consecutive_portal_5xx == 1
+    c._note_portal_outage(False)
+    assert c._consecutive_portal_5xx == 0

--- a/tests/test_1465_portal_terms_auto_accept.py
+++ b/tests/test_1465_portal_terms_auto_accept.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""EU Data Act portal — auto-accept the legal terms-and-conditions interstitial.
+
+Adopted from TommiG1/HA_VAG-EU-Data-Act (verified byte-exact): consent and T&C are
+the SAME Auth0 signin-service form-POST (hidden ``_csrf`` / ``relayState`` /
+``hmac``); they differ only in the landing marker. We already auto-accept the OAuth
+consent grant (#527); this mirrors that for the T&C wall — the user has already
+authenticated and asked the integration to read their OWN car's data (Art. 4), so
+accepting an updated-terms interstitial completes exactly the flow they requested.
+
+Bounded to ONE attempt: if the T&C form cannot be parsed (or the accept re-lands on
+a T&C page), login falls through to the typed ``TermsAndConditionsError`` Repair —
+no silent loop. The wrong-CLIENT T&C artefact (#1340) is already gone at the source
+via the per-brand portal client_ids, so this only clears a genuine account-level
+T&C update.
+
+HTTP is mocked exactly like test_v2155_portal_consent_accept.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import EUDataActConnector
+from custom_components.vag_connect.cariad.exceptions import TermsAndConditionsError
+
+_SIGNIN_HTML = (
+    '<form action="/signin-service/v1/CLIENT/login/identifier">'
+    '<input type="hidden" name="hmac" value="email_hmac">'
+    '<input type="hidden" name="_csrf" value="csrf1">'
+    '<input type="hidden" name="relayState" value="rs1">'
+    '</form>'
+)
+_PASSWORD_HTML = (
+    '<script>window._IDK = {templateModel: '
+    '{"hmac":"fresh_pw_hmac","relayState":"rs1",'
+    '"postAction":"/signin-service/v1/CLIENT/login/authenticate"}, '
+    'csrf_token: "csrf2"};</script>'
+)
+# A scrapeable T&C page: hidden _csrf/relayState/hmac + an explicit accept action.
+_TERMS_FORM_HTML = (
+    '<script>window._IDK = {templateModel: {"template":"termsAndConditions",'
+    '"hmac":"terms_hmac","relayState":"rs1"}, csrf_token: "csrf_t"};</script>'
+    '<form action="/signin-service/v1/CLIENT/terms-and-conditions">'
+    '<input type="hidden" name="_csrf" value="csrf_t">'
+    '<input type="hidden" name="relayState" value="rs1">'
+    '<input type="hidden" name="hmac" value="terms_hmac">'
+    '<button type="submit">Accept</button>'
+    '</form>'
+)
+# A T&C page with NO usable form fields → auto-accept must bail → typed Repair.
+_TERMS_NOFORM_HTML = (
+    '<script>window._IDK = {templateModel: {"template":"termsAndConditions"}};</script>'
+)
+
+_TERMS_LANDING = (
+    "https://identity.vwgroup.io/signin-service/v1/CLIENT/terms-and-conditions"
+)
+_PORTAL_OK_LANDING = "https://eu-data-act.drivesomethinggreater.com/dashboard"
+_PORTAL_OK_HTML = "<html>logged in</html>"
+
+
+class _FakeResp:
+    def __init__(self, url: str, *, status: int = 200, text: str = "") -> None:
+        self.url = url
+        self.status = status
+        self._text = text
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+    async def text(self, errors: str | None = None) -> str:
+        return self._text
+
+
+class _TermsLoginSession:
+    """prime → authorize → identifier → credential POST (→ T&C page) → T&C accept."""
+
+    def __init__(
+        self,
+        *,
+        cred_landing: tuple[str, int, str],
+        accept_landing: tuple[str, int, str] | None = None,
+    ) -> None:
+        self._cred = cred_landing
+        self._accept = accept_landing
+        self.accept_posts = 0
+
+    def get(self, url: str, **kw: Any) -> _FakeResp:
+        if url.endswith("/") and "drivesomethinggreater" in url:
+            return _FakeResp(url, text="<html>portal</html>")
+        if "authorize" in url:
+            return _FakeResp(
+                "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/"
+                "identifier",
+                text=_SIGNIN_HTML,
+            )
+        raise AssertionError(f"unmatched GET {url}")
+
+    def post(self, url: str, **kw: Any) -> _FakeResp:
+        if url.endswith("/login/identifier"):
+            return _FakeResp(
+                "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/"
+                "authenticate?relayState=rs1",
+                text=_PASSWORD_HTML,
+            )
+        if "/login/authenticate" in url:
+            u, s, h = self._cred
+            return _FakeResp(u, status=s, text=h)
+        if "terms-and-conditions" in url:
+            self.accept_posts += 1
+            assert self._accept is not None, "unexpected T&C accept POST"
+            u, s, h = self._accept
+            return _FakeResp(u, status=s, text=h)
+        raise AssertionError(f"unmatched POST {url}")
+
+
+# ── (a) REAL adoption: auto-accept the T&C page → login completes ────────────
+
+@pytest.mark.asyncio
+async def test_terms_page_auto_accepted_login_completes() -> None:
+    session = _TermsLoginSession(
+        cred_landing=(_TERMS_LANDING, 200, _TERMS_FORM_HTML),
+        accept_landing=(_PORTAL_OK_LANDING, 200, _PORTAL_OK_HTML),
+    )
+    conn = EUDataActConnector(session)  # type: ignore[arg-type]
+    await conn.login("user@example.com", "secret")  # must NOT raise
+    assert conn.logged_in is True
+    assert session.accept_posts == 1  # accepted exactly once
+
+
+# ── (b) FALLBACK: unparseable T&C form → typed Repair, no silent loop ────────
+
+@pytest.mark.asyncio
+async def test_terms_page_without_form_falls_through_to_repair() -> None:
+    session = _TermsLoginSession(
+        cred_landing=(_TERMS_LANDING, 200, _TERMS_NOFORM_HTML),
+        accept_landing=None,  # accept must never be POSTed (no fields to send)
+    )
+    conn = EUDataActConnector(session)  # type: ignore[arg-type]
+    with pytest.raises(TermsAndConditionsError):
+        await conn.login("user@example.com", "secret")
+    assert session.accept_posts == 0
+
+
+# ── (c) FALLBACK: accept re-lands on a T&C page → typed Repair (no loop) ──────
+
+@pytest.mark.asyncio
+async def test_terms_accept_that_reloops_raises_repair() -> None:
+    session = _TermsLoginSession(
+        cred_landing=(_TERMS_LANDING, 200, _TERMS_FORM_HTML),
+        # the accept POST lands on ANOTHER T&C page → we accept once, then classify
+        accept_landing=(_TERMS_LANDING, 200, _TERMS_FORM_HTML),
+    )
+    conn = EUDataActConnector(session)  # type: ignore[arg-type]
+    with pytest.raises(TermsAndConditionsError):
+        await conn.login("user@example.com", "secret")
+    assert session.accept_posts == 1  # exactly once, then fell through
+
+
+# ── (d) unit: the T&C landing detector ───────────────────────────────────────
+
+def test_is_terms_landing_detects_only_terms() -> None:
+    conn = EUDataActConnector(object())  # type: ignore[arg-type]
+    assert conn._is_terms_landing(_TERMS_LANDING, _TERMS_FORM_HTML) is True
+    assert conn._is_terms_landing(_PORTAL_OK_LANDING, _PORTAL_OK_HTML) is False
+    # a plain signin/authenticate landing is not a T&C wall
+    assert conn._is_terms_landing(
+        "https://identity.vwgroup.io/signin-service/v1/CLIENT/login/authenticate",
+        _PASSWORD_HTML,
+    ) is False

--- a/tests/test_b15_security_hardening.py
+++ b/tests/test_b15_security_hardening.py
@@ -83,6 +83,23 @@ def test_not_anonymous_when_a_real_session_cookie_is_present() -> None:
     assert c._portal_session_is_anonymous() is False
 
 
+def test_not_anonymous_when_auth_cookie_is_parent_domain_scoped() -> None:
+    # a real session cookie scoped to the PARENT domain (.drivesomethinggreater.com)
+    # is still sent to the portal host → must count, must NOT false-flag anonymous.
+    # (guards the substring-match bug the release-readiness pass caught)
+    c = _connector([
+        _Cookie("affinity", _PORTAL),
+        _Cookie("ath", ".drivesomethinggreater.com"),
+    ])
+    assert c._portal_session_is_anonymous() is False
+
+
+def test_anonymous_when_only_lb_cookie_at_parent_domain() -> None:
+    # affinity at the parent domain is still infra-only → anonymous
+    c = _connector([_Cookie("affinity", ".drivesomethinggreater.com")])
+    assert c._portal_session_is_anonymous() is True
+
+
 def test_not_anonymous_when_no_portal_domain_cookie() -> None:
     # no cookie on the portal domain at all → ambiguous, do NOT flag (never raise
     # on an empty set — only on the confirmed affinity-only signature)

--- a/tests/test_cariad.py
+++ b/tests/test_cariad.py
@@ -1534,7 +1534,10 @@ class TestBaseClientHardening:
                     client._request("GET", "https://example.com/api")
                 )
         assert exc.value.status == 0
-        assert "transient" in str(exc.value).lower()
+        # #1355 redaction — str(APIError) no longer embeds the body, so the
+        # "transient" marker now lives on the raw ``body`` attribute (which the
+        # classifiers read), not in the human-facing message.
+        assert "transient" in exc.value.body.lower()
 
     def test_refresh_storm_protection_raises_after_threshold(self):
         """More than 3 refresh attempts in 1h must raise AuthenticationError."""

--- a/tests/test_skoda_manual_key_repair.py
+++ b/tests/test_skoda_manual_key_repair.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1286 — manual Škoda official-API key fallback. Auto-mint stays the primary
+path; when it can't create a key (non-native login, or the keygen rejects the
+request), an interactive repair asks the user to paste a MyŠkoda API key + VIN.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.vag_connect.const import CONF_SKODA_OFFICIAL_KEYS
+
+
+def _flow(entry_id="e1", vins=("VIN1",)):
+    from custom_components.vag_connect.repairs import _SkodaOfficialKeyRepairFlow
+    f = _SkodaOfficialKeyRepairFlow(entry_id, list(vins))
+    f.flow_id = "t"  # satisfy FlowHandler.async_show_form / async_create_entry
+    f.handler = "vag_connect"
+    return f
+
+
+# ── the repair flow ───────────────────────────────────────────────────────────
+
+def test_flow_stores_key_and_reloads():
+    f = _flow()
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {"brand": "skoda"}
+    hass.config_entries.async_get_entry.return_value = entry
+    hass.config_entries.async_reload = AsyncMock()
+    f.hass = hass
+    res = asyncio.run(f.async_step_enter_key({"vin": "vin1", "api_key": "  msk_ABC  "}))
+    upd = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    # whitespace stripped, VIN upper-cased, stored like a minted key
+    assert upd[CONF_SKODA_OFFICIAL_KEYS]["VIN1"] == {
+        "key": "msk_ABC", "id": "manual", "validUntil": "",
+    }
+    hass.config_entries.async_reload.assert_awaited_once_with("e1")
+    assert res["type"] == "create_entry"
+
+
+def test_flow_empty_key_is_an_error():
+    f = _flow()
+    hass = MagicMock()
+    hass.config_entries.async_get_entry.return_value = MagicMock(data={})
+    f.hass = hass
+    res = asyncio.run(f.async_step_enter_key({"vin": "VIN1", "api_key": "   "}))
+    hass.config_entries.async_update_entry.assert_not_called()
+    assert res["errors"] == {"api_key": "key_required"}
+
+
+def test_flow_aborts_if_entry_gone():
+    f = _flow()
+    hass = MagicMock()
+    hass.config_entries.async_get_entry.return_value = None
+    f.hass = hass
+    res = asyncio.run(f.async_step_enter_key({"vin": "VIN1", "api_key": "msk_x"}))
+    assert res["type"] == "abort"
+    assert res["reason"] == "entry_gone"
+
+
+def test_form_shown_without_input():
+    f = _flow()
+    f.hass = MagicMock()
+    res = asyncio.run(f.async_step_enter_key(None))
+    assert res["type"] == "form"
+    assert res["step_id"] == "enter_key"
+
+
+# ── factory routing ───────────────────────────────────────────────────────────
+
+def test_factory_routes_manual_key_and_splits_vins():
+    from custom_components.vag_connect.repairs import (
+        _AuthRepairFlow,
+        _SkodaOfficialKeyRepairFlow,
+        async_create_fix_flow,
+    )
+    flow = asyncio.run(async_create_fix_flow(
+        MagicMock(), "e1_skoda_official_manual_key",
+        {"entry_id": "e1", "reason": "skoda_official_manual_key", "vins": "VIN1,VIN2"},
+    ))
+    assert isinstance(flow, _SkodaOfficialKeyRepairFlow)
+    assert flow._vins == ["VIN1", "VIN2"]
+    # any other reason still goes to the generic auth repair
+    other = asyncio.run(async_create_fix_flow(
+        MagicMock(), "e1_invalid_credentials",
+        {"entry_id": "e1", "reason": "invalid_credentials"},
+    ))
+    assert isinstance(other, _AuthRepairFlow)
+
+
+# ── coordinator reconcile: raise when missing, clear when covered ──────────────
+
+def _coord(entry_data):
+    from custom_components.vag_connect.coordinator import VagConnectCoordinator
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c.hass = MagicMock()
+    c.entry = MagicMock()
+    c.entry.entry_id = "e1"
+    c.entry.data = dict(entry_data)
+    return c
+
+
+def test_reconcile_raises_when_a_vin_has_no_key():
+    c = _coord({})
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_manual_key"
+    ) as raise_, patch(
+        "custom_components.vag_connect.repairs.clear_issue_skoda_official_manual_key"
+    ) as clear_:
+        c._reconcile_skoda_manual_key_repair(["VIN1", "VIN2"])
+    raise_.assert_called_once()
+    assert raise_.call_args.args[2] == ["VIN1", "VIN2"]
+    clear_.assert_not_called()
+
+
+def test_reconcile_clears_when_all_vins_have_keys():
+    c = _coord({CONF_SKODA_OFFICIAL_KEYS: {"VIN1": {"key": "k"}}})
+    with patch(
+        "custom_components.vag_connect.repairs.raise_issue_skoda_official_manual_key"
+    ) as raise_, patch(
+        "custom_components.vag_connect.repairs.clear_issue_skoda_official_manual_key"
+    ) as clear_:
+        c._reconcile_skoda_manual_key_repair(["VIN1"])
+    clear_.assert_called_once()
+    raise_.assert_not_called()

--- a/tests/test_v2120_eu_data_act_connector.py
+++ b/tests/test_v2120_eu_data_act_connector.py
@@ -593,3 +593,113 @@ async def test_get_vehicle_data_listing_401_still_raises() -> None:
     conn = EUDataActConnector(_List401Session())  # type: ignore[arg-type]
     with pytest.raises(AuthenticationError):
         await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+
+
+# ── newest→oldest dataset fallback on a transient download (adopted TommiG1) ──
+
+
+@pytest.mark.asyncio
+async def test_download_falls_back_to_older_dataset_on_transient() -> None:
+    """Newest dataset 503s → parse the next-older listed dataset, not skip the poll.
+
+    Array order is the tiebreak when files carry no delivery ts, so the LAST-listed
+    file is treated as newest (data_new.zip). It 503s; the older data_old.zip 200s
+    and is parsed — a real poll instead of a wasted one during a partial outage.
+    """
+    class _FallbackSession:
+        def __init__(self) -> None:
+            self.download_calls = 0
+
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, json_data={"identifier": "ID123"})
+            if url.endswith("/list"):
+                return _FakeResp(
+                    url,
+                    json_data=[{"name": "data_old.zip"}, {"name": "data_new.zip"}],
+                )
+            if url.endswith("/download"):
+                self.download_calls += 1
+                if kw["headers"]["filename"] == "data_new.zip":
+                    return _FakeResp(url, status=503)
+                return _FakeResp(url, body=_build_dataset_zip())
+            raise AssertionError(f"unmatched GET {url}")
+
+    sess = _FallbackSession()
+    conn = EUDataActConnector(sess)  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    assert d.battery_soc == 77          # parsed from the OLDER dataset
+    assert d.connection_state == "online"
+    assert d.no_data is False
+    assert conn.last_no_data_reason != "portal_error"
+    assert sess.download_calls == 2     # newest (503) then older (200)
+
+
+@pytest.mark.asyncio
+async def test_all_datasets_transient_still_graceful() -> None:
+    """Every candidate 503s → the existing "no data this poll" outcome is kept."""
+    class _AllFailSession:
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, json_data={"identifier": "ID123"})
+            if url.endswith("/list"):
+                return _FakeResp(url, json_data=[{"name": "a.zip"}, {"name": "b.zip"}])
+            if url.endswith("/download"):
+                return _FakeResp(url, status=503)
+            raise AssertionError(f"unmatched GET {url}")
+
+    conn = EUDataActConnector(_AllFailSession())  # type: ignore[arg-type]
+    d = await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    assert d.battery_soc is None
+    assert d.connection_state is None
+    assert conn.last_no_data_reason == "portal_error"
+
+
+@pytest.mark.asyncio
+async def test_download_401_raises_without_falling_back() -> None:
+    """A 401 on the download = session expired → raise, never chase older files."""
+    class _Dl401Session:
+        def __init__(self) -> None:
+            self.download_calls = 0
+
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, json_data={"identifier": "ID123"})
+            if url.endswith("/list"):
+                return _FakeResp(url, json_data=[{"name": "new.zip"}, {"name": "old.zip"}])
+            if url.endswith("/download"):
+                self.download_calls += 1
+                return _FakeResp(url, status=401)
+            raise AssertionError(f"unmatched GET {url}")
+
+    sess = _Dl401Session()
+    conn = EUDataActConnector(sess)  # type: ignore[arg-type]
+    with pytest.raises(AuthenticationError):
+        await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    assert sess.download_calls == 1     # 401 → no fallback to the older dataset
+
+
+@pytest.mark.asyncio
+async def test_download_fallback_is_capped() -> None:
+    """A long all-503 listing does not hammer the portal — capped attempts."""
+    class _ManyFailSession:
+        def __init__(self) -> None:
+            self.download_calls = 0
+
+        def get(self, url: str, **kw: Any) -> _FakeResp:
+            if "metadata" in url:
+                return _FakeResp(url, json_data={"identifier": "ID123"})
+            if url.endswith("/list"):
+                return _FakeResp(
+                    url, json_data=[{"name": f"d{i}.zip"} for i in range(6)]
+                )
+            if url.endswith("/download"):
+                self.download_calls += 1
+                return _FakeResp(url, status=503)
+            raise AssertionError(f"unmatched GET {url}")
+
+    sess = _ManyFailSession()
+    conn = EUDataActConnector(sess)  # type: ignore[arg-type]
+    await conn.get_vehicle_data("WVWZZZTESTVIN0001")
+    assert sess.download_calls == 3     # _MAX_DATASET_FALLBACK, not 6
+    assert conn.last_no_data_reason == "portal_error"


### PR DESCRIPTION
Beta release. Full detail in CHANGELOG.

### Added
- Škoda official API: manual-key fallback repair when auto-enrollment cannot mint a key (paste a MyŠkoda app key + VIN).
- EU Data Act portal: auto-accept the terms-and-conditions interstitial the same way we already accept the data-consent page; the typed repair stays the fallback.
- `data_stale` binary_sensor (device_class=PROBLEM) off the same capture-age + threshold as the stale-data repair (report #465).
- Read a VW mask-variant of the instrument-cluster active-warnings field into the existing raw-dashboard-warnings diagnostic (report #1358).

### Fixed
- Portal login check no longer false-flags a valid parent-domain session.
- One-time cleanup of orphaned per-source connectivity entities left in the registry when an account channel set changes (report #1340).
- EU Data Act portal resilience: escalating 5xx backoff (5/15/30 min) during a sustained outage instead of a ~60 s tight-retry, plus a newest→oldest dataset fallback on a transient download error.

### Changed
- Integration-wide log-redaction hardening: URLs, response bodies and raw exception strings kept out of debug logs and error messages across every channel.

Full test suite green (5851 passed, 15 skipped); ruff + mypy-strict clean.