### PR TITLE
docs: sharpen v4.7.0 Audi/Porsche attestation note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,12 +66,15 @@ land on top of the betas:
 - The "add a read channel" options (Volkswagen.de / EU Data Act portal / Tibber) now read
   "Add/refresh…" instead of "Add a…", so it's clearer they're one-shot actions you can re-run, not
   on/off state toggles (#950).
-- **Audi & Porsche app login now fails with an honest message instead of a cryptic error.** VW and
-  Porsche moved these brands' app sign-in to a new login (Auth0) that requires on-device app
-  verification, so the passwordless / browser login can no longer complete — the final token step
-  is attestation-gated and can't be done headlessly (confirmed on real accounts; even an
-  interactive browser login can't pass it). The setup wizard now says so plainly and points Audi
-  owners at the read-only EU Data Act Portal, instead of showing a raw failure (#1364, #1337).
+- **Audi & Porsche app login: both have now hit the manufacturer's attestation wall — for now,
+  read-only Portal only.** VW and Porsche have both moved these brands' app sign-in to a new login
+  (Auth0) with on-device app verification. This was already visible in the app a few weeks ago as a
+  staged migration; it has now landed and taken the login down with it. The passwordless / browser
+  login can no longer complete: the final token step is attestation-gated and can't be done
+  headlessly — confirmed on real accounts, where even a fully completed interactive browser login
+  can't pass it. Until we find a way through, **Audi is available read-only via the EU Data Act
+  Portal** and Porsche stays blocked; the setup wizard now says so plainly instead of showing a raw
+  failure (#1364, #1337).
 
 ### Docs
 - The README now covers the opt-in monthly meters, and documents what to do on a brand-new or UK


### PR DESCRIPTION
Post-release CHANGELOG clarification: both Audi and Porsche hit the app attestation wall (Auth0 migration landed); read-only EU Data Act Portal is the only Audi path for now, Porsche blocked. No code change (#1364, #1337).