### PR TITLE
v4.7.2 — phantom battery-0% fix + vw.de charging telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,23 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.2] - 2026-09-08 — No more phantom "battery 0%", richer vw.de charging data
+
+### Fixed
+- **No more false "battery 0%" low-battery alerts on cars without a traction battery.** VW's EU Data
+  Act portal always sends the 12V/auxiliary battery reading as `0` — it's a placeholder, never a real
+  value (a car that can still talk to the cloud is never at a true 0%). Home Assistant treats that as
+  a battery and fired low-battery notifications, most visibly on plain combustion cars that have no
+  high-voltage battery at all (e.g. a petrol Arteon). The always-zero reading is now suppressed, so
+  the phantom "12V battery" sensor and its notifications go away (#923). Grounded on 53 real
+  diagnostics where this field was 0 every single time.
+
+### Added
+- **The vw.de channel now reads AC/DC charge type and HV battery cell temperatures.** If you use the
+  supplementary vw.de channel, it now also delivers the charge type (AC vs DC) and the high-voltage
+  battery's minimum/maximum cell temperature — the same fields VW's own backend exposes, which the EU
+  Data Act portal feed never carries. They feed the existing sensors, so nothing new to set up.
+
 ## [4.7.1] - 2026-09-08 — Porsche: login, commands, vehicle data, and real two-way control
 
 A from-the-ground-up pass on Porsche, grounded against a full read-through of the real app's own

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -3213,9 +3213,16 @@ def map_dataset_to_vehicle_data(
         d.parking_lights_state = {
             2: "off", 3: "left", 4: "right", 5: "both",
         }.get(_plights)
-    # bem_level — auxiliary/12V battery energy management level (%).
+    # bem_level — auxiliary/12V battery energy management level (%). Across every
+    # captured diagnostic (53 vehicles, combustion + PHEV) this leaf only ever
+    # arrives as 0 — a "no reading" placeholder, never a real 12V charge (a car
+    # that can still report telemetry is never at a true 0%). Left through, the
+    # BATTERY-device-class sensor publishes 0% and fires Home Assistant's
+    # low-battery notifications on cars with no HV pack at all (#923, dtech77pl's
+    # petrol Arteon "battery 0%"). Treat 0 as the unsupported-field sentinel; a
+    # genuine non-zero reading (if a car ever ships one) still comes through.
     _bem = _to_int(first("bem_level"))
-    if _bem is not None:
+    if _bem:
         d.aux_battery_energy_pct = _bem
     # bem_alert_time — 12V battery BEM level-2 pre-warning alert time. #897
     # (SparkyDan555) carried an absolute ISO timestamp, but the dict type is

--- a/custom_components/vag_connect/cariad/auth/_website_authproxy.py
+++ b/custom_components/vag_connect/cariad/auth/_website_authproxy.py
@@ -255,6 +255,22 @@ def map_charging_to_vehicle_data(payload: Any, d: VehicleData) -> VehicleData:
     if btemp is not None:
         d.battery_temp_c = btemp
 
+    # v4.7.2 — HV battery min/max cell temperature, the same leaves the BFF reads
+    # (batteryStatus.value.{minTemperature_K,maxTemperature_K}); the authproxy body
+    # carries them without the ``.value`` wrapper. Fail-soft: absent → unchanged.
+    # These feed the existing hv_battery_{min,max}_temperature_c sensors, so the
+    # vw.de channel now delivers cell temperatures the portal feed never carries.
+    _bmin = _kelvin_to_celsius(
+        battery.get("minTemperature_K") or battery.get("temperatureMin_K")
+    )
+    if _bmin is not None:
+        d.hv_battery_min_temperature_c = _bmin
+    _bmax = _kelvin_to_celsius(
+        battery.get("maxTemperature_K") or battery.get("temperatureMax_K")
+    )
+    if _bmax is not None:
+        d.hv_battery_max_temperature_c = _bmax
+
     state = drop_charge_sentinel(charging.get("chargingState"))  # #923-sweep
     if isinstance(state, str) and state:
         d.charging_state = state
@@ -275,6 +291,12 @@ def map_charging_to_vehicle_data(payload: Any, d: VehicleData) -> VehicleData:
     mode = charging.get("chargeMode")
     if isinstance(mode, str) and mode:
         d.charge_mode = mode
+
+    # v4.7.2 — AC/DC charge type, same leaf the BFF reads
+    # (chargingStatus.value.chargeType). Sentinel-guarded, fail-soft.
+    ctype = drop_charge_sentinel(charging.get("chargeType"))
+    if isinstance(ctype, str) and ctype:
+        d.charging_type = ctype
 
     plug_state = plug.get("plugConnectionState")
     if isinstance(plug_state, str) and plug_state:

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.1"
+  "version": "4.7.2"
 }

--- a/tests/test_v2140_website_authproxy.py
+++ b/tests/test_v2140_website_authproxy.py
@@ -81,6 +81,37 @@ def test_charging_mapping_populates_ev_fields() -> None:
     assert d.external_power is True
 
 
+def test_charging_mapping_reads_charge_type_and_hv_cell_temps() -> None:
+    """v4.7.2 — the vw.de charging body also carries AC/DC charge type and HV
+    battery min/max cell temperature (same leaves the BFF reads); the authproxy
+    channel now feeds the existing sensors. Fail-soft when absent."""
+    payload = {
+        "data": {
+            "batteryStatus": {
+                "currentSOC_pct": 60,
+                "minTemperature_K": 288.15,   # 15.0 °C
+                "maxTemperature_K": 298.15,   # 25.0 °C
+            },
+            "chargingStatus": {
+                "chargingState": "charging",
+                "chargeType": "dc",
+            },
+        }
+    }
+    d = map_charging_to_vehicle_data(payload, VehicleData(vin="WVWZZZTEST0000009"))
+    assert d.charging_type == "dc"
+    assert d.hv_battery_min_temperature_c == 15.0
+    assert d.hv_battery_max_temperature_c == 25.0
+    # absent → untouched (fail-soft)
+    d2 = map_charging_to_vehicle_data(
+        {"data": {"batteryStatus": {"currentSOC_pct": 60}, "chargingStatus": {}}},
+        VehicleData(vin="WVWZZZTEST0000010"),
+    )
+    assert d2.charging_type is None
+    assert d2.hv_battery_min_temperature_c is None
+    assert d2.hv_battery_max_temperature_c is None
+
+
 def test_charging_mapping_not_charging_when_disconnected() -> None:
     """A 'notConnected' plug + 'readyForCharging' state map to not-charging."""
     payload = {

--- a/tests/test_v2153_eu_new_fields.py
+++ b/tests/test_v2153_eu_new_fields.py
@@ -194,6 +194,16 @@ def test_aux_battery_energy_pct() -> None:
     assert _map({"bem_level": "57"}).aux_battery_energy_pct == 57
 
 
+def test_aux_battery_energy_pct_zero_is_suppressed() -> None:
+    # #923 (dtech77pl) — bem_level only ever ships 0 across every captured
+    # diagnostic (a "no reading" placeholder). A 0 must NOT reach the
+    # BATTERY-device-class sensor, or it publishes 0% and triggers Home Assistant
+    # low-battery notifications on combustion cars with no HV pack.
+    assert _map({"bem_level": "0"}).aux_battery_energy_pct is None
+    # a genuine non-zero reading still comes through unchanged
+    assert _map({"bem_level": "80"}).aux_battery_energy_pct == 80
+
+
 def test_dashboard_warnings_raw_passthrough_no_decode() -> None:
     # We surface the raw hex/interpreted value ONLY — no invented enum decode.
     d = _map({"active_warnings_in_instrument_cluster_feff_filtered": "0x1A"})


### PR DESCRIPTION
Small maintenance release off the back of the #923 comment sweep.

## Fixed
- **Phantom "battery 0%" alerts** (#923). The EU Data Act portal always ships the 12V/aux battery
  reading as `0` (a placeholder, never a real value), which fired Home Assistant low-battery
  notifications on cars with no HV pack at all — e.g. dtech77pl's petrol Arteon. The always-zero
  reading is now suppressed. Grounded on 53 real diagnostics (0 every time).

## Added
- **vw.de channel: AC/DC charge type + HV battery cell min/max temperature.** The same leaves the
  CARIAD BFF already reads, ported to the supplementary vw.de authproxy channel — fields the EU Data
  Act portal feed never carries. Feeds existing sensors; fail-soft when absent.

Full test suite green (5939). No entity/translation changes.
