### PR TITLE
fix(porsche): correct get_status measurement inner-value keys against a real capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   electric-range sensor stayed empty and SoC/odometer fell back to the slower EU Data Act portal feed.
   Those reads now carry the same `gdc` + host the already-working warning-lights read uses, so the
   vw.de channel supplies range, SoC and odometer directly (#1357).
+- **Porsche electric range, odometer and service intervals now actually populate.** The Porsche
+  `measurements` reads were pulling the inner value under the wrong key names (guessed from the
+  measurement enum names), so battery range, the odometer and the service intervals came through
+  empty. Corrected against a real Taycan capture — they now read the `kilometers` member the backend
+  actually sends (E_RANGE, MILEAGE and the service ranges).
 
 ### Added
 - **Test cohort: a measurements-range + usable-capacity probe (diagnostics only).** For opt-in test

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -258,15 +258,18 @@ class PorscheClient:
             # 911 Cayenne EV) + PHEV (Cayenne E-Hybrid, Panamera
             # E-Hybrid) join the parity.
             #
-            # PPA measurement keys (verified per pcommit/iccarus +
-            # porsche-connect-cli traces):
-            # - E_RANGE.distance → battery-only range in km
-            # - FUEL_LEVEL.distanceToEmpty → combustion-only range in km
-            #
-            # The existing aggregate range_km keeps its or-fallback
-            # for back-compat (Porsche users on this sensor today
-            # see no change).
-            electric_range = v(m, "E_RANGE", "distance")
+            # PPA measurement keys — CORRECTED against a real Taycan mf capture
+            # (a public CJNE ha-porscheconnect paste, corroborated across every
+            # measurement and matching CJNE's own parsing). The value member is
+            # ``kilometers``, not ``distance``/``mileage``, which those reads
+            # guessed from the androguard enum NAMES — so electric range and the
+            # odometer were never actually populated on a real Porsche.
+            #   - E_RANGE.kilometers → battery-only range in km
+            #   - MILEAGE.kilometers → odometer
+            # FUEL_LEVEL was absent on that BEV capture, so its combustion-range
+            # / percent members stay as-is (still unverified) rather than being
+            # changed on a guess.
+            electric_range = v(m, "E_RANGE", "kilometers")
             combustion_range = v(m, "FUEL_LEVEL", "distanceToEmpty")
             if isinstance(electric_range, (int, float)):
                 d.electric_range_km = int(electric_range)
@@ -274,7 +277,7 @@ class PorscheClient:
                 d.combustion_range_km = int(combustion_range)
             d.range_km      = electric_range or combustion_range
             d.fuel_level    = v(m, "FUEL_LEVEL", "percent")
-            d.odometer_km   = drop_odometer_sentinel(v(m, "MILEAGE", "mileage"))
+            d.odometer_km   = drop_odometer_sentinel(v(m, "MILEAGE", "kilometers"))
 
             # Charging
             ch = m.get("CHARGING_SUMMARY", {})
@@ -284,11 +287,17 @@ class PorscheClient:
                 d.is_charging = d.charging_state.upper() in (
                     "CHARGING", "CHARGING_AC", "CHARGING_DC"
                 )
-            d.charging_power_kw = v(ch, "chargingPower")
-            plug_state = v(ch, "plugState")
-            if isinstance(plug_state, str):
-                d.plug_connected = plug_state.upper() == "CONNECTED"
-                d.plug_state = plug_state
+            # chargingPower lives on CHARGING_RATE, not CHARGING_SUMMARY (real
+            # capture: CHARGING_RATE={"chargingPower","chargingRate"}) — the old
+            # read from CHARGING_SUMMARY never returned a value.
+            d.charging_power_kw = v(m, "CHARGING_RATE", "chargingPower")
+            # Plug — CHARGING_SUMMARY.plugState does not exist. The real capture
+            # carries a combined status enum ("CHARGING"/"NOT_PLUGGED"/…) on
+            # CHARGING_SUMMARY.status; derive plug-connected from it (a BEV only
+            # reports non-"NOT_PLUGGED" states while the cable is connected).
+            if isinstance(d.charging_state, str):
+                d.plug_connected = d.charging_state.upper() != "NOT_PLUGGED"
+                d.plug_state = d.charging_state
 
             # b19 (CJNE-comparison #3.3) — target-SoC precedence chain ported
             # from CJNE's ``_update_vehicle_data`` (Apache-2.0): which field
@@ -320,43 +329,62 @@ class PorscheClient:
                 target_soc = 100
             d.target_soc = target_soc
 
-            # Lock — v2.0.1 (#131 follow-up): defensive parsing.
-            # Only assign when the source is an actual string; otherwise
-            # leave the dataclass default ``None`` so the entity stays
-            # "unknown" instead of falsely reporting "Unlocked".
-            lock = v(m, "LOCK_STATE_VEHICLE", "lockState")
-            if isinstance(lock, str):
-                d.doors_locked = lock.upper() == "LOCKED"
+            # Lock — real capture: LOCK_STATE_VEHICLE={"isLocked": bool}, not a
+            # ``lockState`` string. Only assign when the bool is actually
+            # present so the entity stays "unknown" rather than "unlocked".
+            lock = v(m, "LOCK_STATE_VEHICLE", "isLocked")
+            if isinstance(lock, bool):
+                d.doors_locked = lock
 
-            # Doors — v2.0.1: only assign when at least one door
-            # actually publishes its openState. PPA sometimes returns
-            # the LOCK_STATE_VEHICLE block but skips the per-door blocks
-            # for a few minutes after wake (observed against Taycan).
+            # Doors / lids / sunroof — real capture: {"isOpen": bool} (not the
+            # ``openState`` string these guessed). Only assign when at least one
+            # door publishes its state; PPA can return LOCK_STATE_VEHICLE but
+            # skip the per-door blocks for a few minutes after wake (Taycan).
             door_states = [
-                v(m, f"OPEN_STATE_DOOR_{pos}", "openState")
+                v(m, f"OPEN_STATE_DOOR_{pos}", "isOpen")
                 for pos in ("FRONT_LEFT", "FRONT_RIGHT", "REAR_LEFT", "REAR_RIGHT")
             ]
-            if any(isinstance(s, str) for s in door_states):
-                d.doors_open = any(
-                    isinstance(s, str) and s.upper() == "OPEN" for s in door_states
-                )
-            d.hood_open   = v(m, "OPEN_STATE_LID_FRONT",  "openState") == "OPEN"
-            d.trunk_open  = v(m, "OPEN_STATE_LID_REAR",   "openState") == "OPEN"
-            d.sunroof_open = v(m, "OPEN_STATE_SUNROOF",   "openState") == "OPEN"
+            if any(isinstance(s, bool) for s in door_states):
+                d.doors_open = any(s is True for s in door_states)
+            hood = v(m, "OPEN_STATE_LID_FRONT", "isOpen")
+            if isinstance(hood, bool):
+                d.hood_open = hood
+            trunk = v(m, "OPEN_STATE_LID_REAR", "isOpen")
+            if isinstance(trunk, bool):
+                d.trunk_open = trunk
+            sunroof = v(m, "OPEN_STATE_SUNROOF", "isOpen")
+            if isinstance(sunroof, bool):
+                d.sunroof_open = sunroof
 
-            # Climate
+            # Climate — real capture: CLIMATIZER_STATE={"isOn": bool,
+            # "targetTemperature": <Kelvin>, ...}, not a ``climatisationState``
+            # string. (targetTemperature is available for a future sensor.)
             clim = m.get("CLIMATIZER_STATE", {})
-            d.climatisation_state  = v(clim, "climatisationState")
-            d.climatisation_active = d.climatisation_state not in (None, "OFF")
+            clim_on = v(clim, "isOn")
+            if isinstance(clim_on, bool):
+                d.climatisation_active = clim_on
+                d.climatisation_state = "ON" if clim_on else "OFF"
 
-            # GPS
+            # GPS — real capture: GPS_LOCATION={"location":"<lat>,<lng>",
+            # "direction":int}, one comma-separated string, not separate
+            # latitude/longitude members.
             gps = m.get("GPS_LOCATION", {})
-            d.latitude  = v(gps, "latitude")
-            d.longitude = v(gps, "longitude")
+            loc = v(gps, "location")
+            if isinstance(loc, str) and "," in loc:
+                lat_str, _, lng_str = loc.partition(",")
+                try:
+                    d.latitude = float(lat_str.strip())
+                    d.longitude = float(lng_str.strip())
+                except ValueError:
+                    pass
+            direction = v(gps, "direction")
+            if isinstance(direction, (int, float)) and not isinstance(direction, bool):
+                d.heading = int(direction)
 
-            # Service
-            d.service_km    = v(m, "MAIN_SERVICE_RANGE", "distance")
-            d.oil_service_km = v(m, "OIL_SERVICE_RANGE", "distance")
+            # Service — real capture: *_SERVICE_RANGE={"kilometers": int}, not
+            # ``distance``.
+            d.service_km    = v(m, "MAIN_SERVICE_RANGE", "kilometers")
+            d.oil_service_km = v(m, "OIL_SERVICE_RANGE", "kilometers")
 
             # ── TPMS ───────────────────────────────────────────────────────
             # b20 (2026-09-08, androguard enum dump of the real

--- a/tests/test_porsche_measurement_keys.py
+++ b/tests/test_porsche_measurement_keys.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Porsche get_status measurement inner-value keys — corrected against a real
+Taycan mf capture (a public CJNE ha-porscheconnect issue paste, corroborated
+across every measurement and matching CJNE's own parsing).
+
+The shipped parser guessed the value member names from the androguard enum
+NAMES (which give the measurement KEYS, not the value members), so it read
+``openState`` / ``lockState`` / ``distance`` / ``mileage`` / separate
+lat+long — none of which exist. On a real Porsche those reads returned nothing
+and the core sensors (doors, lock, odometer, range, GPS, climate, charge
+power) were silently empty. The real shapes are ``{"isOpen": bool}`` /
+``{"isLocked": bool}`` / ``{"kilometers": int}`` / ``{"isOn": bool}`` /
+``{"location": "<lat>,<lng>", "direction": int}`` and chargingPower on
+CHARGING_RATE.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.porsche import PorscheClient
+
+_VIN = "WP0ZZZ99ZTS300001"
+
+
+def _client() -> PorscheClient:
+    return PorscheClient.__new__(PorscheClient)
+
+
+async def _status(measurements: list[dict]) -> object:
+    c = _client()
+    c._get = AsyncMock(return_value={"measurements": measurements})
+    return await c.get_status(_VIN)
+
+
+# A representative slice of a real capture's shapes (synthetic values, no PII).
+_REAL = [
+    {"key": "BATTERY_LEVEL", "value": {"percent": 87}},
+    {"key": "E_RANGE", "value": {"kilometers": 326}},
+    {"key": "MILEAGE", "value": {"kilometers": 87966}},
+    {"key": "LOCK_STATE_VEHICLE", "value": {"isLocked": True}},
+    {"key": "OPEN_STATE_DOOR_FRONT_LEFT", "value": {"isOpen": False}},
+    {"key": "OPEN_STATE_DOOR_FRONT_RIGHT", "value": {"isOpen": True}},
+    {"key": "OPEN_STATE_LID_FRONT", "value": {"isOpen": False}},
+    {"key": "OPEN_STATE_LID_REAR", "value": {"isOpen": True}},
+    {"key": "OPEN_STATE_SUNROOF", "value": {"isOpen": False}},
+    {"key": "CLIMATIZER_STATE", "value": {"isOn": True, "targetTemperature": 293.15}},
+    {"key": "GPS_LOCATION", "value": {"location": "48.137154,11.576124", "direction": 249}},
+    {"key": "CHARGING_SUMMARY", "value": {"status": "CHARGING", "mode": "DIRECT", "targetSoC": 85}},
+    {"key": "CHARGING_RATE", "value": {"chargingPower": 6.45, "chargingRate": 0.4}},
+    {"key": "MAIN_SERVICE_RANGE", "value": {"kilometers": 29934}},
+]
+
+
+class TestRealShapesParse:
+    @pytest.mark.asyncio
+    async def test_ranges_and_odometer(self) -> None:
+        d = await _status(_REAL)
+        assert d.battery_soc == 87
+        assert d.electric_range_km == 326
+        assert d.range_km == 326
+        assert d.odometer_km == 87966
+        assert d.service_km == 29934
+
+    @pytest.mark.asyncio
+    async def test_lock_and_openings(self) -> None:
+        d = await _status(_REAL)
+        assert d.doors_locked is True
+        assert d.doors_open is True          # front-right is open
+        assert d.hood_open is False
+        assert d.trunk_open is True
+        assert d.sunroof_open is False
+
+    @pytest.mark.asyncio
+    async def test_climate(self) -> None:
+        d = await _status(_REAL)
+        assert d.climatisation_active is True
+        assert d.climatisation_state == "ON"
+
+    @pytest.mark.asyncio
+    async def test_gps_location_string_split(self) -> None:
+        d = await _status(_REAL)
+        assert d.latitude == pytest.approx(48.137154)
+        assert d.longitude == pytest.approx(11.576124)
+        assert d.heading == 249
+
+    @pytest.mark.asyncio
+    async def test_charging(self) -> None:
+        d = await _status(_REAL)
+        assert d.charging_state == "CHARGING"
+        assert d.is_charging is True
+        assert d.charging_power_kw == 6.45     # from CHARGING_RATE, not CHARGING_SUMMARY
+        assert d.plug_connected is True
+        assert d.plug_state == "CHARGING"
+        assert d.target_soc == 85
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_not_plugged_status(self) -> None:
+        d = await _status([
+            {"key": "CHARGING_SUMMARY", "value": {"status": "NOT_PLUGGED"}},
+        ])
+        assert d.plug_connected is False
+        assert d.is_charging is False
+
+    @pytest.mark.asyncio
+    async def test_missing_openings_leave_none_not_false(self) -> None:
+        # No open-state blocks at all → the fields must stay unknown, not be
+        # falsely reported as closed (the old ``== "OPEN"`` set them False).
+        d = await _status([{"key": "BATTERY_LEVEL", "value": {"percent": 50}}])
+        assert d.doors_open is None
+        assert d.hood_open is None
+        assert d.trunk_open is None
+        assert d.sunroof_open is None
+        assert d.doors_locked is None
+
+    @pytest.mark.asyncio
+    async def test_old_openstate_shape_is_ignored(self) -> None:
+        # A payload in the OLD guessed shape must NOT produce a reading — proves
+        # the parser no longer reads the non-existent string members.
+        d = await _status([
+            {"key": "OPEN_STATE_DOOR_FRONT_LEFT", "value": {"openState": "OPEN"}},
+            {"key": "LOCK_STATE_VEHICLE", "value": {"lockState": "LOCKED"}},
+            {"key": "MILEAGE", "value": {"mileage": 12345}},
+        ])
+        assert d.doors_open is None
+        assert d.doors_locked is None
+        assert d.odometer_km is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_gps_does_not_crash(self) -> None:
+        d = await _status([{"key": "GPS_LOCATION", "value": {"location": "not-a-coord"}}])
+        assert d.latitude is None
+        assert d.longitude is None

--- a/tests/test_v1242_porsche_vw_na_parity.py
+++ b/tests/test_v1242_porsche_vw_na_parity.py
@@ -83,27 +83,30 @@ _PORSCHE_OVERVIEW_HAPPY: dict = {
     "vin": "WP0ZZZ99ZTS300001",
     "modelName": "Taycan 4S",
     "modelType": {"year": 2024, "engine": "BEV"},
+    # Value member names are the REAL ones from a Taycan mf capture (public CJNE
+    # ha-porscheconnect paste): isOpen / isLocked / kilometers / location string
+    # — not the openState/lockState/distance/mileage/lat+long the parser once
+    # guessed from the androguard enum names.
     "measurements": [
         {"key": "BATTERY_LEVEL", "value": {"percent": 78}},
-        {"key": "E_RANGE", "value": {"distance": 312}},
-        {"key": "MILEAGE", "value": {"mileage": 14250}},
+        {"key": "E_RANGE", "value": {"kilometers": 312}},
+        {"key": "MILEAGE", "value": {"kilometers": 14250}},
         {"key": "CHARGING_SUMMARY", "value": {
-            "status": "NOT_CHARGING",
-            "plugState": "DISCONNECTED",
-            "targetSoc": 80,
+            "status": "NOT_PLUGGED",
+            "targetSoC": 80,
         }},
-        {"key": "LOCK_STATE_VEHICLE", "value": {"lockState": "LOCKED"}},
-        {"key": "OPEN_STATE_DOOR_FRONT_LEFT",  "value": {"openState": "CLOSED"}},
-        {"key": "OPEN_STATE_DOOR_FRONT_RIGHT", "value": {"openState": "CLOSED"}},
-        {"key": "OPEN_STATE_DOOR_REAR_LEFT",   "value": {"openState": "CLOSED"}},
-        {"key": "OPEN_STATE_DOOR_REAR_RIGHT",  "value": {"openState": "CLOSED"}},
-        {"key": "OPEN_STATE_LID_FRONT", "value": {"openState": "CLOSED"}},
-        {"key": "OPEN_STATE_LID_REAR",  "value": {"openState": "CLOSED"}},
-        {"key": "OPEN_STATE_SUNROOF",   "value": {"openState": "CLOSED"}},
-        {"key": "GPS_LOCATION", "value": {"latitude": 47.3769, "longitude": 8.5417}},
-        {"key": "MAIN_SERVICE_RANGE", "value": {"distance": 18000}},
-        {"key": "OIL_SERVICE_RANGE",  "value": {"distance": 12500}},
-        {"key": "CLIMATIZER_STATE", "value": {"climatisationState": "OFF"}},
+        {"key": "LOCK_STATE_VEHICLE", "value": {"isLocked": True}},
+        {"key": "OPEN_STATE_DOOR_FRONT_LEFT",  "value": {"isOpen": False}},
+        {"key": "OPEN_STATE_DOOR_FRONT_RIGHT", "value": {"isOpen": False}},
+        {"key": "OPEN_STATE_DOOR_REAR_LEFT",   "value": {"isOpen": False}},
+        {"key": "OPEN_STATE_DOOR_REAR_RIGHT",  "value": {"isOpen": False}},
+        {"key": "OPEN_STATE_LID_FRONT", "value": {"isOpen": False}},
+        {"key": "OPEN_STATE_LID_REAR",  "value": {"isOpen": False}},
+        {"key": "OPEN_STATE_SUNROOF",   "value": {"isOpen": False}},
+        {"key": "GPS_LOCATION", "value": {"location": "47.3769,8.5417", "direction": 90}},
+        {"key": "MAIN_SERVICE_RANGE", "value": {"kilometers": 18000}},
+        {"key": "OIL_SERVICE_RANGE",  "value": {"kilometers": 12500}},
+        {"key": "CLIMATIZER_STATE", "value": {"isOn": False}},
     ],
 }
 
@@ -127,7 +130,7 @@ class TestPorscheParserHappy:
         assert d.battery_soc == 78
         assert d.range_km == 312
         assert d.odometer_km == 14250
-        assert d.charging_state == "NOT_CHARGING"
+        assert d.charging_state == "NOT_PLUGGED"
         assert d.is_charging is False
         assert d.plug_connected is False
         assert d.target_soc == 80


### PR DESCRIPTION
## Context

Companion to #1370. A real Taycan `mf` capture (a public CJNE ha-porscheconnect issue paste, corroborated across every measurement in it and matching CJNE's own parsing) surfaced that the shipped Porsche `get_status` parser reads value member names that **don't exist** — they were guessed from the androguard enum NAMES (which give the measurement *keys*, not the value *members*). On a real Porsche those reads returned nothing, so the core sensors were silently empty. Nobody caught it because the login was blocked until v4.7.1, so no real parse output was ever seen.

## Corrections (all grounded on the capture)

| field | was (member that doesn't exist) | real |
| --- | --- | --- |
| doors / lids / sunroof | `openState` string `== "OPEN"` | `{"isOpen": bool}` |
| doors_locked | `LOCK_STATE_VEHICLE.lockState` | `{"isLocked": bool}` |
| odometer | `MILEAGE.mileage` | `{"kilometers": int}` |
| electric range | `E_RANGE.distance` | `{"kilometers": int}` |
| service_km / oil_service_km | `*_SERVICE_RANGE.distance` | `{"kilometers": int}` |
| climatisation | `CLIMATIZER_STATE.climatisationState` | `{"isOn": bool}` (+ `targetTemperature` in Kelvin) |
| GPS | separate `latitude` / `longitude` | one `{"location": "<lat>,<lng>", "direction": int}` string |
| charging power | `CHARGING_SUMMARY.chargingPower` | `CHARGING_RATE.chargingPower` |
| plug | `CHARGING_SUMMARY.plugState` (does not exist) | derived from `CHARGING_SUMMARY.status` (`"NOT_PLUGGED"`/…) |

Missing open-state blocks now leave the fields `None` (unknown) instead of a false "closed" — the old `== "OPEN"` set them `False` when a door block was simply absent.

## Not changed (deliberately)

- **FUEL_LEVEL** — absent on that BEV capture, so its combustion-range / percent members are left as-is (still unverified) rather than changed on a guess.
- **OIL_LEVEL / TPMS** — disabled on the capture, so their inner shapes stay unverified (TPMS is a separate, already-shipped guess).

## Tests

- New `tests/test_porsche_measurement_keys.py` — the real shapes parse; missing blocks stay `None`; the OLD guessed shapes no longer parse; malformed GPS doesn't crash.
- The existing Porsche parity fixture is updated to the real shapes.
- Full suite green; ruff + mypy strict clean.
