### PR TITLE
feat: per-VIN read-source priority — prefer live vw.de over the EU-DA portal (#1357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- **Choose which data source wins per car (EU Data Act portal vs live vw.de).** When a car reads over
+  both the EU Data Act portal and the live vw.de channel, the portal (a batched feed) wins every
+  shared field by default — which on some cars means slower, occasionally stale data even though the
+  live vw.de channel has a fresher value. A new per-car **"Data source priority"** option (in the
+  integration's options, shown when a vw.de channel is configured) lets you pick **"Prefer live
+  vw.de data"** for that car, so the live channel wins the fields it carries and the portal keeps
+  filling the rest. Default is **Automatic** — existing setups are unchanged (#1357).
+
 ## [4.7.3] - 2026-09-09 — Porsche login clarity + finding the command gate on newer VW cars
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/_channel_merge.py
+++ b/custom_components/vag_connect/cariad/_channel_merge.py
@@ -259,6 +259,7 @@ async def gather_and_merge(
     primary_name: str,
     primary: "VehicleData",
     suppliers: list[tuple[str, Awaitable["VehicleData | None"]]],
+    preferred: str | None = None,
 ) -> "VehicleData":
     """Read supplementary channels concurrently and merge them onto ``primary``.
 
@@ -288,4 +289,20 @@ async def gather_and_merge(
             sources.append((name, res))
     if len(sources) == 1:
         return primary
+    # #1357 — per-VIN read priority. The per-field winner is the ORDER of this
+    # list (merge_channels keeps sources[0] highest-trust and lets lower channels
+    # only fill gaps). When the caller names a ``preferred`` channel, stable-sort
+    # it to the front so it wins every field it carries while the others keep
+    # filling the rest. ``list.sort`` is stable, so every other tie-break — and
+    # thus the whole merge — is byte-for-byte identical to today when ``preferred``
+    # is None/"auto" or names the channel already at the front.
+    #
+    # NOTE: the preference reorders EVERY field the channel carries, INCLUDING
+    # position (lat/lon). The winning channel's ``position_captured_at`` travels
+    # with it, so freshness is still surfaced — but a caller that prefers a channel
+    # whose position is staler than another's will show the preferred channel's
+    # older fix (the whole point of the option is "trust this channel", so this is
+    # intended; the motivating case prefers the FRESHER channel).
+    if preferred and preferred != "auto":
+        sources.sort(key=lambda s: 0 if s[0] == preferred else 1)
     return merge_channels(sources)

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -2467,6 +2467,7 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
             # fresh one on the next update. Takes precedence over the key fields on
             # the same submit, so a re-save with the key still pre-filled clears.
             from .const import (  # noqa: PLC0415
+                CONF_READ_PRIORITY,
                 CONF_SKODA_OFFICIAL_API_KEY,
                 CONF_SKODA_OFFICIAL_KEYS,
             )
@@ -2509,6 +2510,37 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                         continue  # unchanged
                     _off_map[_vin] = {"key": _val, "source": "manual"}
                 user_input[CONF_SKODA_OFFICIAL_KEYS] = _off_map
+            # #1357 — fold the transient read_priority_<VIN> fields into the
+            # CONF_READ_PRIORITY map {VIN: mode}. The value is a plain enum that
+            # always renders, so a field set (back) to "auto" DROPS that VIN's entry
+            # (returns it to the default) — unlike the official keys, blanking here
+            # is a deliberate reset, not a lost secret.
+            _rp_fields = [
+                _k for _k in list(user_input.keys())
+                if _k.startswith(f"{CONF_READ_PRIORITY}_")
+            ]
+            if _rp_fields:
+                from .const import (  # noqa: PLC0415
+                    READ_PRIORITY_DEFAULT,
+                    READ_PRIORITY_MODES,
+                )
+                _stored_rp = (
+                    self._config_entry.options.get(CONF_READ_PRIORITY)
+                    or self._config_entry.data.get(CONF_READ_PRIORITY)
+                )
+                _rp_map = dict(_stored_rp) if isinstance(_stored_rp, dict) else {}
+                for _k in _rp_fields:
+                    _vin = _k[len(CONF_READ_PRIORITY) + 1:].strip().upper()
+                    _val = str(user_input.pop(_k) or "").strip()
+                    if (
+                        _val
+                        and _val != READ_PRIORITY_DEFAULT
+                        and _val in READ_PRIORITY_MODES
+                    ):
+                        _rp_map[_vin] = _val
+                    else:
+                        _rp_map.pop(_vin, None)  # auto/blank → back to the default
+                user_input[CONF_READ_PRIORITY] = _rp_map
             # b1/C1 — if the user ticked "add vw.de read channel", branch into
             # the login sub-flow; the remaining options are saved when it
             # completes. Default-False so untouched submits behave exactly as
@@ -2966,6 +2998,42 @@ class VagConnectOptionsFlow(config_entries.OptionsFlow):
                     f"{CONF_SKODA_OFFICIAL_KEYS}_{_vin}",
                     default=str(_cur_key),
                 )] = _PASSWORD_SELECTOR
+        # #1357 (Ra72xx) — per-VIN read-source priority. When a car reads over BOTH
+        # the EU Data Act portal and the live vw.de channel, the portal (batch) feed
+        # wins every shared field by default; this lets the user flip that PER car so
+        # the live vw.de channel wins the fields it carries and EU-DA fills the rest.
+        # Shown only when a vw.de channel is configured (else the reorder is a no-op).
+        # Options-then-data default (options-trap safe); folded into CONF_READ_PRIORITY
+        # on submit. "auto" for a VIN removes its entry (back to the default).
+        _has_vwde = bool(
+            current_data.get(CONF_SUPPLEMENTARY_AUTHPROXY)
+            or current_data.get(CONF_WEBSITE_AUTHPROXY)
+        )
+        if _has_vwde and isinstance(_vehicles, dict) and _vehicles:
+            from .const import (  # noqa: PLC0415
+                CONF_READ_PRIORITY,
+                READ_PRIORITY_DEFAULT,
+                READ_PRIORITY_MODES,
+            )
+            _rp_map = current_options.get(
+                CONF_READ_PRIORITY, current_data.get(CONF_READ_PRIORITY)
+            )
+            if not isinstance(_rp_map, dict):
+                _rp_map = {}
+            for _vin in _vehicles:
+                _cur_rp = str(
+                    _rp_map.get(_vin) or _rp_map.get(str(_vin).upper())
+                    or READ_PRIORITY_DEFAULT
+                )
+                if _cur_rp not in READ_PRIORITY_MODES:
+                    _cur_rp = READ_PRIORITY_DEFAULT
+                schema[vol.Optional(
+                    f"{CONF_READ_PRIORITY}_{_vin}", default=_cur_rp,
+                )] = SelectSelector(SelectSelectorConfig(
+                    options=list(READ_PRIORITY_MODES),
+                    mode=SelectSelectorMode.DROPDOWN,
+                    translation_key=CONF_READ_PRIORITY,
+                ))
         # v2.26.0 — companion (ADB) advanced opt-ins, surfaced only for a
         # companion entry (both default OFF: each TAPS the phone, so a user opts
         # in only after confirming the flow on their own device).

--- a/custom_components/vag_connect/const.py
+++ b/custom_components/vag_connect/const.py
@@ -331,6 +331,20 @@ SKODA_OFFICIAL_MODES: tuple[str, ...] = (
 )
 SKODA_OFFICIAL_MODE_DEFAULT = "auto"
 
+# Per-VIN read-source priority (#1357 @Ra72xx). On a car with more than one read
+# channel (EU Data Act portal + live vw.de), the per-field winner is the channel
+# ORDER handed to the merge, not the freshest value — so a portal-primary car has
+# the (slower, batch) EU-DA feed win every field the live vw.de channel also
+# carries. This lets a user flip that PER CAR so the live vw.de channel wins every
+# field it has while EU-DA keeps filling the fields only it provides.
+#   auto                      → today's behaviour (primary channel wins), default
+#   prefer_website_authproxy  → the live vw.de channel wins; EU-DA fills the gaps
+# Stored as a ``{VIN: mode}`` map (per-VIN, like CONF_SKODA_OFFICIAL_KEYS). Only
+# reorders the read merge; command routing / reconcile / write paths are untouched.
+CONF_READ_PRIORITY               = "read_priority"
+READ_PRIORITY_MODES: tuple[str, ...] = ("auto", "prefer_website_authproxy")
+READ_PRIORITY_DEFAULT = "auto"
+
 # v2.15.0b3 — "hide entities without data" (default ON). When enabled, data
 # sensors / binary sensors whose value hasn't arrived are not created, so a
 # device isn't flooded with dozens of "unknown" entities. The per-id dynamic

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2745,6 +2745,34 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         )
         return mode if mode in SKODA_OFFICIAL_MODES else SKODA_OFFICIAL_MODE_DEFAULT
 
+    def _read_priority_channel(self, vin: str) -> str | None:
+        """#1357 — the preferred READ channel for ``vin`` (per-VIN), or None for
+        the ``auto`` default. Reads the ``{VIN: mode}`` map options-then-data
+        (never options-only — the update listener folds options into data and
+        blanks options, so an options-only read would lose a saved map). Returns
+        the channel name the merge should sort to the front (``website_authproxy``
+        for ``prefer_website_authproxy``), else None so ``gather_and_merge`` keeps
+        today's primary-first order untouched."""
+        from .const import (  # noqa: PLC0415
+            CONF_READ_PRIORITY,
+            READ_PRIORITY_DEFAULT,
+            READ_PRIORITY_MODES,
+        )
+        entry = getattr(self, "entry", None)
+        if entry is None or not vin:
+            return None
+        raw = entry.options.get(
+            CONF_READ_PRIORITY, entry.data.get(CONF_READ_PRIORITY)
+        )
+        if not isinstance(raw, dict):
+            return None
+        mode = str(
+            raw.get(vin) or raw.get(str(vin).upper()) or READ_PRIORITY_DEFAULT
+        )
+        if mode not in READ_PRIORITY_MODES:
+            mode = READ_PRIORITY_DEFAULT
+        return "website_authproxy" if mode == "prefer_website_authproxy" else None
+
     def _push_official_mode(self, client: Any = None) -> None:
         """Push the configured source mode onto the Škoda client so its primary-read
         routing (``official_only``) reflects a live options change. Must run before
@@ -3393,6 +3421,7 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         try:
             merged = await gather_and_merge(
                 self._primary_channel_name(), primary, suppliers,
+                preferred=self._read_priority_channel(vin),
             )
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -2123,6 +2123,12 @@
         "official_only": "Official API only",
         "mysmob_only": "Standard channel only"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatic (recommended)",
+        "prefer_website_authproxy": "Prefer live vw.de data"
+      }
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -2345,6 +2345,12 @@
         "official_only": "Pouze oficiální API",
         "mysmob_only": "Pouze standardní kanál"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automaticky (doporučeno)",
+        "prefer_website_authproxy": "Upřednostnit živá data z vw.de"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -2345,6 +2345,12 @@
         "official_only": "Kun officielt API",
         "mysmob_only": "Kun standardkanal"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatisk (anbefalet)",
+        "prefer_website_authproxy": "Foretræk live vw.de-data"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -2123,6 +2123,12 @@
         "official_only": "Nur offizielle API",
         "mysmob_only": "Nur Standard-Kanal"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatisch (empfohlen)",
+        "prefer_website_authproxy": "Live-vw.de-Daten bevorzugen"
+      }
     }
   },
   "services": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -2345,6 +2345,12 @@
         "official_only": "Official API only",
         "mysmob_only": "Standard channel only"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatic (recommended)",
+        "prefer_website_authproxy": "Prefer live vw.de data"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -2345,6 +2345,12 @@
         "official_only": "Solo API oficial",
         "mysmob_only": "Solo canal estándar"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automático (recomendado)",
+        "prefer_website_authproxy": "Preferir datos en vivo de vw.de"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -2345,6 +2345,12 @@
         "official_only": "Vain virallinen API",
         "mysmob_only": "Vain vakiokanava"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automaattinen (suositus)",
+        "prefer_website_authproxy": "Suosi vw.de-livedataa"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -2345,6 +2345,12 @@
         "official_only": "API officielle uniquement",
         "mysmob_only": "Canal standard uniquement"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatique (recommandé)",
+        "prefer_website_authproxy": "Préférer les données en direct de vw.de"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -2345,6 +2345,12 @@
         "official_only": "Solo API ufficiale",
         "mysmob_only": "Solo canale standard"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatico (consigliato)",
+        "prefer_website_authproxy": "Preferisci i dati live di vw.de"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -2345,6 +2345,12 @@
         "official_only": "Kun offisielt API",
         "mysmob_only": "Kun standardkanal"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatisk (anbefalt)",
+        "prefer_website_authproxy": "Foretrekk sanntidsdata fra vw.de"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -2345,6 +2345,12 @@
         "official_only": "Alleen officiële API",
         "mysmob_only": "Alleen standaardkanaal"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatisch (aanbevolen)",
+        "prefer_website_authproxy": "Live vw.de-gegevens verkiezen"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -2345,6 +2345,12 @@
         "official_only": "Tylko oficjalne API",
         "mysmob_only": "Tylko kanał standardowy"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatycznie (zalecane)",
+        "prefer_website_authproxy": "Preferuj dane na żywo z vw.de"
+      }
     }
   },
   "triggers": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -2345,6 +2345,12 @@
         "official_only": "Endast officiellt API",
         "mysmob_only": "Endast standardkanal"
       }
+    },
+    "read_priority": {
+      "options": {
+        "auto": "Automatiskt (rekommenderas)",
+        "prefer_website_authproxy": "Föredra livedata från vw.de"
+      }
     }
   },
   "triggers": {

--- a/tests/test_1357_read_priority.py
+++ b/tests/test_1357_read_priority.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1357 (@Ra72xx) — per-VIN read-source priority.
+
+The per-field merge winner is the ORDER of the channel list, not the freshest
+value — so a portal-primary car has the (batch) EU Data Act feed win every field
+the live vw.de channel also carries. ``prefer_website_authproxy`` flips that PER
+VIN: the live vw.de channel is stable-sorted to the front so it wins every field
+it has, while EU-DA keeps filling the fields only it provides. ``auto`` (default)
+is byte-for-byte identical to today. Only the read merge order changes — reconcile,
+command routing and the write paths are untouched.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from custom_components.vag_connect.cariad._channel_merge import gather_and_merge
+from custom_components.vag_connect.cariad.models import VehicleData
+from custom_components.vag_connect.const import (
+    CONF_READ_PRIORITY,
+    READ_PRIORITY_DEFAULT,
+)
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+VIN = "WVWZZZAUZFW805377"
+
+
+def _supp(name: str, vd: VehicleData):
+    """(name, awaitable→vd) supplier tuple, matching gather_and_merge's contract."""
+    async def _read() -> VehicleData:
+        return vd
+    return (name, _read())
+
+
+def _merge(primary_name, primary, suppliers, preferred=None):
+    return asyncio.run(
+        gather_and_merge(primary_name, primary, suppliers, preferred=preferred)
+    )
+
+
+# ── the 49/8 flip: prefer vw.de reorders the winner ─────────────────────────
+def test_auto_default_keeps_primary_winning() -> None:
+    """No preferred → today's behaviour: the EU-DA primary wins the shared field."""
+    primary = VehicleData(vin=VIN)
+    primary.model = "portal-model"
+    supp = VehicleData(vin=VIN)
+    supp.model = "vwde-model"
+    merged = _merge("eu_data_act", primary, [_supp("website_authproxy", supp)])
+    assert merged.model == "portal-model"
+    assert merged.field_sources.get("model") == "eu_data_act"
+
+
+def test_prefer_vwde_flips_the_shared_field_to_vwde() -> None:
+    """prefer_website_authproxy → the live vw.de value wins + is stamped as such."""
+    primary = VehicleData(vin=VIN)
+    primary.model = "portal-model"
+    supp = VehicleData(vin=VIN)
+    supp.model = "vwde-model"
+    merged = _merge("eu_data_act", primary, [_supp("website_authproxy", supp)],
+                    preferred="website_authproxy")
+    assert merged.model == "vwde-model"
+    assert merged.field_sources.get("model") == "website_authproxy"
+
+
+def test_eu_da_only_field_still_comes_from_eu_da_when_preferring_vwde() -> None:
+    """The ~49 fields only EU-DA carries must keep coming from EU-DA (gap-fill),
+    so preferring vw.de improves freshness without losing portal-only data."""
+    primary = VehicleData(vin=VIN)
+    primary.model = "portal-model"          # shared with vw.de below
+    primary.service_km = 12345              # EU-DA-only here
+    supp = VehicleData(vin=VIN)
+    supp.model = "vwde-model"   # no service_km
+    merged = _merge("eu_data_act", primary, [_supp("website_authproxy", supp)],
+                    preferred="website_authproxy")
+    assert merged.model == "vwde-model"                       # flipped
+    assert merged.service_km == 12345                         # portal-only kept
+    assert merged.field_sources.get("service_km") == "eu_data_act"
+
+
+def test_preferred_auto_is_a_noop() -> None:
+    primary = VehicleData(vin=VIN)
+    primary.model = "portal-model"
+    supp = VehicleData(vin=VIN)
+    supp.model = "vwde-model"
+    merged = _merge("eu_data_act", primary, [_supp("website_authproxy", supp)],
+                    preferred="auto")
+    assert merged.model == "portal-model"
+
+
+def test_single_channel_car_is_untouched_by_preference() -> None:
+    """No supplier → gather_and_merge returns the primary verbatim, no crash."""
+    primary = VehicleData(vin=VIN)
+    primary.model = "only"
+    merged = _merge("eu_data_act", primary, [], preferred="website_authproxy")
+    assert merged.model == "only"
+
+
+def test_prefer_missing_channel_is_a_noop() -> None:
+    """Preferring a channel that isn't present must not reorder anything."""
+    primary = VehicleData(vin=VIN)
+    primary.model = "portal-model"
+    supp = VehicleData(vin=VIN)
+    supp.model = "vwde-model"
+    merged = _merge("eu_data_act", primary, [_supp("website_authproxy", supp)],
+                    preferred="tibber")  # not in sources
+    assert merged.model == "portal-model"  # order unchanged
+
+
+# ── the coordinator reader: per-VIN, options-then-data, unknown → None ──────
+def _reader(entry) -> object:
+    c = VagConnectCoordinator.__new__(VagConnectCoordinator)
+    c.entry = entry
+    return c
+
+
+def test_reader_returns_channel_for_prefer_vwde() -> None:
+    entry = SimpleNamespace(
+        options={},  # options are always {} at read time (listener folds → data)
+        data={CONF_READ_PRIORITY: {VIN: "prefer_website_authproxy"}},
+    )
+    assert VagConnectCoordinator._read_priority_channel(_reader(entry), VIN) \
+        == "website_authproxy"
+
+
+def test_reader_is_per_vin() -> None:
+    entry = SimpleNamespace(
+        options={},
+        data={CONF_READ_PRIORITY: {"OTHERVIN00000000X": "prefer_website_authproxy"}},
+    )
+    # the queried VIN has no entry → auto → None (other VINs unaffected)
+    assert VagConnectCoordinator._read_priority_channel(_reader(entry), VIN) is None
+
+
+def test_reader_auto_and_unknown_and_missing_map_all_give_none() -> None:
+    for data in (
+        {CONF_READ_PRIORITY: {VIN: READ_PRIORITY_DEFAULT}},   # explicit auto
+        {CONF_READ_PRIORITY: {VIN: "garbage"}},               # unknown mode
+        {CONF_READ_PRIORITY: {}},                             # empty map
+        {},                                                   # no map at all
+    ):
+        c = _reader(SimpleNamespace(options={}, data=data))
+        assert VagConnectCoordinator._read_priority_channel(c, VIN) is None
+
+
+def test_reader_matches_vin_case_insensitively() -> None:
+    entry = SimpleNamespace(
+        options={},
+        data={CONF_READ_PRIORITY: {VIN.upper(): "prefer_website_authproxy"}},
+    )
+    assert VagConnectCoordinator._read_priority_channel(_reader(entry), VIN.lower()) \
+        == "website_authproxy"

--- a/tests/test_966_persist_after_every_refresh.py
+++ b/tests/test_966_persist_after_every_refresh.py
@@ -30,7 +30,7 @@ def _coord(readers_return):
 def test_persist_runs_after_a_successful_supplementary_read(monkeypatch):
     from custom_components.vag_connect.cariad import _channel_merge as cm
 
-    async def _fake_gather(name, primary, suppliers):
+    async def _fake_gather(name, primary, suppliers, preferred=None):
         return primary  # a real read here would rotate the cookie jar
 
     monkeypatch.setattr(cm, "gather_and_merge", _fake_gather)
@@ -58,7 +58,7 @@ def test_persist_still_runs_is_guarded_idempotent(monkeypatch):
     # equality no-op is covered by the _persist_supplementary_cookies unit tests.
     from custom_components.vag_connect.cariad import _channel_merge as cm
 
-    async def _fake_gather(name, primary, suppliers):
+    async def _fake_gather(name, primary, suppliers, preferred=None):
         return primary
 
     monkeypatch.setattr(cm, "gather_and_merge", _fake_gather)

--- a/tests/test_v2150c1_wiring.py
+++ b/tests/test_v2150c1_wiring.py
@@ -202,7 +202,10 @@ def _coord_stub(client: Any, entry_data: dict[str, Any]) -> Any:
     stub._cariad_client = client
     stub.entry = MagicMock()
     stub.entry.data = entry_data
+    stub.entry.options = {}
     stub._primary_channel_name = VagConnectCoordinator._primary_channel_name.__get__(stub)
+    # #1357 — _merge_supplementary consults the per-VIN read-priority reader.
+    stub._read_priority_channel = VagConnectCoordinator._read_priority_channel.__get__(stub)
     return stub
 
 

--- a/tests/test_v2162_authproxy_parity.py
+++ b/tests/test_v2162_authproxy_parity.py
@@ -40,8 +40,15 @@ def _coord_stub(client: Any) -> Any:
     stub._cariad_client = client
     stub.entry = MagicMock()
     stub.entry.data = {}
+    stub.entry.options = {}
     stub._primary_channel_name = (
         VagConnectCoordinator._primary_channel_name.__get__(stub)
+    )
+    # #1357 — _merge_supplementary now consults the per-VIN read-priority reader;
+    # the minimal stub must bind it too (no read_priority config → returns None →
+    # today's primary-first order, so these parity tests are unaffected).
+    stub._read_priority_channel = (
+        VagConnectCoordinator._read_priority_channel.__get__(stub)
     )
     stub._merge_supplementary = (
         VagConnectCoordinator._merge_supplementary.__get__(stub)


### PR DESCRIPTION
## What this adds (#1357, @Ra72xx)

When a car reads over **both** the EU Data Act portal and the live vw.de channel, the per-field merge winner is the channel **order**, not the freshest value — so a portal-primary car (e.g. Ra72xx's ID.3: 49 of 57 fields from `eu_data_act`, 8 from vw.de) has the batched portal feed win every shared field, even when the live vw.de channel has a fresher value and the portal has gone stale.

This adds a **per-VIN "Data source priority"** option (integration options, shown when a vw.de channel is configured):
- **Automatic** (default) — today's behaviour, byte-for-byte unchanged.
- **Prefer live vw.de data** — the live channel wins every field it carries; the portal keeps filling the fields only it provides.

## How

- `_channel_merge.gather_and_merge` gains a `preferred` param and a **stable re-sort** of the merge `sources` list (the one place that decides the per-field winner). Default/auto early-returns before the sort → existing setups identical.
- `coordinator._read_priority_channel(vin)` reads a per-VIN `{VIN: mode}` map options-then-data (options-trap safe) and passes the preferred channel into the per-VIN `_merge_supplementary`.
- Mirrors the shipped Škoda `official_source` policy pattern end to end: const enum + reader + config_flow per-VIN select + 13-language selector labels.
- **Scoped to the read merge only** — command routing, `reconcile`, and the write paths never consult the source order and are untouched.

## Notes
- Position follows the preferred channel too; its `position_captured_at` travels with it, so freshness stays surfaced. (The motivating case prefers the *fresher* channel.)

## Tests
- New `tests/test_1357_read_priority.py` (10 cases: the 49/8 flip, EU-DA-only gap-fill kept, auto/None no-op, missing-channel no-op, per-VIN isolation, case-insensitive lookup, options-then-data reader).
- Full suite green (5971 passed).
