### PR TITLE
Release 4.7.4 — Fresher VW-EU data, richer Porsche readings, per-car source priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.4] - 2026-09-09 — Fresher VW-EU data, richer Porsche readings, per-car source priority
+
 ### Fixed
 - **vw.de channel now delivers electric range (and fresher SoC/odometer) on ID./MEB cars.** The
   vw.de charging and maintenance reads were the only live-status calls sent without the per-platform

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.3"
+  "version": "4.7.4"
 }


### PR DESCRIPTION
## v4.7.4 — collected release

Bundles the four features merged to `main` since v4.7.3 (they were sitting in `[Unreleased]`):

### Fixed
- **vw.de channel delivers electric range + fresher SoC/odometer on ID./MEB cars** — the charging/maintenance reads now carry the per-platform `gdc` + VCF host, so the live vw.de backend fills range/SoC/odometer instead of falling back to the slower portal feed (#1372, #1357).
- **Porsche electric range, odometer and service intervals populate** — the `measurements` reads were parsing the inner value under the wrong keys; corrected against a real Taycan capture to read the `kilometers` member (#1374).

### Added
- **Test-cohort measurements-range + usable-capacity probe** (diagnostics only, no sensor fed until a live capture confirms) (#1372).
- **More Porsche vehicle data** — windows, spoiler, charge/service flaps, parking brake & light, oil level, service interval, wired from the already-fetched `mf` measurements, Taycan-grounded, fail-soft (#1370).
- **Per-car "Data source priority"** — pick "Prefer live vw.de data" per VIN so the live channel wins the fields it carries while the portal fills the rest; default Automatic, existing setups unchanged (#1376, #1357).

Full suite green on `main`.
