### PR TITLE
Release 4.7.5 — correct battery % on portal cars while charging (#1195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.5] - 2026-09-09 — Correct battery % on portal cars while charging
+
+### Fixed
+- **No more wrong battery % right after you plug in (VW-EU portal cars).** VW's EU Data Act portal
+  sends the battery state-of-charge twice — the live value and a separate "SoC at the moment charging
+  started" snapshot — and it stamps that snapshot as freshly updated whenever a charge begins. The
+  integration could then briefly show the stale charge-start figure instead of the real one (e.g. 37%
+  when the car was actually at 24%). The known charge-start reading is now kept apart, so the live
+  battery % always wins. Thanks to @hangout6690 for tracking it down to the exact source fields (#1195).
+
 ## [4.7.4] - 2026-09-09 — Fresher VW-EU data, richer Porsche readings, per-car source priority
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -760,6 +760,21 @@ _MAPPED_UUIDS: frozenset[str] = frozenset({
     "30cc36fd-71ca-3c09-9296-e94ebd47bd2b",  # odometer fallback
 })
 
+# #1195 (hangout6690, ID.3) — the EU Data Act portal ships TWO
+# ``battery_state_report.soc`` points under DIFFERENT content-UUIDs: the live SoC
+# and a "SoC at charge start" snapshot (confirmed against the official EU Data Act
+# data dictionary, Continuous Data V6.0). The charge-start leaf is only updated —
+# and re-stamped with a fresh capture time — when a charging session BEGINS, so
+# the freshness resolver lets its stale value win the live SoC right after a
+# charge starts (his car: charge-start 37% beating the live 24%). These UUIDs are
+# the known charge-start-SoC datums; the walker remaps them onto a distinct leaf
+# so they never compete for the live ``battery_state_report.soc``. The live SoC
+# UUID (506cb83e) keeps the canonical leaf and wins. More UUIDs can be added here
+# as reporters surface them; inert for any car that never ships this UUID.
+_CHARGE_START_SOC_UUIDS: frozenset[str] = frozenset({
+    "93b55324-6628-36df-8f76-8eba797fc59c",  # "SoC at charge start" (#1195)
+})
+
 # #1022 — charge_power is emitted under the SAME dataFieldName
 # (battery_state_report.charge_power) by several dict UUIDs with DIFFERENT units,
 # so the UUID (not the value's fractional part) is the true scale discriminator.
@@ -1051,6 +1066,20 @@ def _walk_fields(
                         break
             # data-point shape: {dataFieldName|name: X, value: Y}
             fname = node.get("dataFieldName") or node.get("name")
+            # #1195 — a battery_state_report.soc point keyed by a known
+            # "SoC at charge start" UUID must NOT feed the live-SoC pool (its stale
+            # value is re-stamped fresh at charge start and would out-freshen the
+            # live reading). Remap it onto a distinct leaf: the value is still kept
+            # (never suppressed), just no longer mistaken for the live SoC, so the
+            # live battery_state_report.soc (UUID 506cb83e) wins cleanly.
+            _sc_key = node.get("key")
+            if (
+                isinstance(fname, str)
+                and fname.strip().lower() == "battery_state_report.soc"
+                and isinstance(_sc_key, str)
+                and _sc_key.strip().lower() in _CHARGE_START_SOC_UUIDS
+            ):
+                fname = "battery_state_report.soc_at_charge_start"
             if fname is not None and "value" in node:
                 add(fname, node.get("value"), ts, ts_real, ts_inh)
                 # v2.17.4/v2.17.5 — when the leaf name is a GENERIC token, also key

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.4"
+  "version": "4.7.5"
 }

--- a/tests/test_1195_charge_start_soc.py
+++ b/tests/test_1195_charge_start_soc.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1195 (hangout6690, ID.3) — the EU Data Act portal ships
+``battery_state_report.soc`` under TWO content-UUIDs: the live SoC and a
+"SoC at charge start" snapshot (per the official EU Data Act data dictionary).
+The charge-start leaf is re-stamped with a fresh capture time whenever a charge
+begins, so the freshness resolver let its stale value win the live SoC right
+after a charge started (his car: charge-start 37% beating the live 24%).
+
+The walker now remaps the known charge-start-SoC UUID onto a distinct leaf
+(``battery_state_report.soc_at_charge_start``) so it never competes for the live
+``battery_state_report.soc``. The value is kept (never suppressed), just no
+longer mistaken for the live reading.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    _CHARGE_START_SOC_UUIDS,
+    _walk_fields,
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+_LIVE_UUID = "506cb83e-f99f-3af3-bbeb-0429b69a78d9"
+_CHARGE_START_UUID = "93b55324-6628-36df-8f76-8eba797fc59c"
+
+
+def _soc_point(value: str, key: str) -> dict:
+    return {"dataFieldName": "battery_state_report.soc", "value": value, "key": key}
+
+
+def test_charge_start_soc_does_not_win_the_live_soc() -> None:
+    # live 24% + charge-start 37% (the stale one) in one export.
+    fields = _walk_fields({"data": [
+        _soc_point("24", _LIVE_UUID),
+        _soc_point("37", _CHARGE_START_UUID),
+    ]})
+    assert fields["battery_state_report.soc"] == "24"
+    # kept under its own name — not suppressed
+    assert fields["battery_state_report.soc_at_charge_start"] == "37"
+
+
+def test_charge_start_remapped_even_when_it_is_the_last_append() -> None:
+    # last-append would otherwise win inside the ZIP (#529) — the remap must fire
+    # regardless of order, so the live SoC still wins.
+    fields = _walk_fields({"data": [
+        _soc_point("37", _CHARGE_START_UUID),
+        _soc_point("24", _LIVE_UUID),
+    ]})
+    assert fields["battery_state_report.soc"] == "24"
+
+
+def test_normal_single_soc_is_unaffected() -> None:
+    # a car that ships one soc point (any/no charge-start UUID) is untouched.
+    fields = _walk_fields({"data": [
+        {"dataFieldName": "battery_state_report.soc", "value": "55",
+         "key": "some-other-uuid"},
+    ]})
+    assert fields["battery_state_report.soc"] == "55"
+    assert "battery_state_report.soc_at_charge_start" not in fields
+
+
+def test_known_charge_start_uuid_is_registered() -> None:
+    assert _CHARGE_START_UUID in _CHARGE_START_SOC_UUIDS
+
+
+def test_end_to_end_battery_soc_is_the_live_value() -> None:
+    # end to end: the mapper must set battery_soc to the live 24, not 37.
+    fields = _walk_fields({"data": [
+        _soc_point("24", _LIVE_UUID),
+        _soc_point("37", _CHARGE_START_UUID),
+    ]})
+    d = map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+    assert d.battery_soc == 24


### PR DESCRIPTION
## v4.7.5 — correct battery % on portal cars while charging (#1195)

VW's EU Data Act portal sends `battery_state_report.soc` under **two** content-UUIDs — the live SoC (`506cb83e…`) and a separate **"SoC at charge start"** snapshot (`93b55324…`, confirmed against the official EU Data Act data dictionary). The charge-start leaf is re-stamped with a fresh capture time whenever a charge begins, so the freshness resolver could let its stale value win the live SoC right after plugging in (@hangout6690's ID.3: charge-start **37%** beating the live **24%**).

The walker now remaps the known charge-start UUID onto a distinct leaf so it never competes for the live `battery_state_report.soc` — the value is kept (never suppressed), just no longer mistaken for the live reading. More UUIDs can be added as reporters surface them; inert for any car that never ships it.

Grounded on @hangout6690's exact source fields + dictionary reference. New `tests/test_1195_charge_start_soc.py` (5 cases); full suite green (6039).
