### PR TITLE
Scout live-feed fields + charge-start SoC follow-up (v4.7.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.6] - 2026-09-10 — More live fields from the Scout feed
+
+### Added
+- **GPS position, heading, short-term consumption and an engine-starts count from the live Scout
+  feed.** The portal's continuous feed carries several fields the integration wasn't surfacing yet:
+  the car's GPS position (it does send coordinates under `persLocation`), its heading, the short-term
+  average electric consumption and a total engine-starts counter now come through as sensors, and the
+  trip id is consumed for correlation. Grounded on real Škoda Elroq and Audi captures (#1378, #1375).
+
+### Fixed
+- **Battery % right after plugging in: two more source fields covered.** The v4.7.5 fix that stops the
+  "SoC at charge start" snapshot from briefly beating the live battery % now also covers two more
+  portal content fields that carry that snapshot, so a poll that includes only one of them can't
+  re-latch the stale value either. Thanks again to @hangout6690 (#1380).
+
 ## [4.7.5] - 2026-09-09 — Correct battery % on portal cars while charging
 
 ### Fixed

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -773,6 +773,11 @@ _MAPPED_UUIDS: frozenset[str] = frozenset({
 # as reporters surface them; inert for any car that never ships this UUID.
 _CHARGE_START_SOC_UUIDS: frozenset[str] = frozenset({
     "93b55324-6628-36df-8f76-8eba797fc59c",  # "SoC at charge start" (#1195)
+    # #1380 (hangout6690) — his ID.3 ships two MORE charge-start-SoC UUIDs under
+    # the same battery_state_report.soc leaf; a file that carries only one of
+    # these (no live 506cb83e) otherwise re-latched the stale charge-start value.
+    "7bddd5e7-43a4-3878-bd63-9502782f77a5",  # "SoC at charge start" (#1380)
+    "bd4b6d50-b574-31e6-8141-8787ca5fec8c",  # "SoC at charge start" (#1380)
 })
 
 # #1022 — charge_power is emitted under the SAME dataFieldName
@@ -1244,6 +1249,41 @@ def _to_float(raw: str | None) -> float | None:
 def _to_int(raw: str | None) -> int | None:
     f = _to_float(raw)
     return int(f) if f is not None else None
+
+
+def _parse_pers_location(value: Any) -> tuple[float | None, float | None]:
+    """#1378/#923 — parse the MEB portal ``persLocation`` leaf into a validated
+    ``(lat, lon)``. Škoda Elroq (and other MEB cars) DO ship the vehicle position
+    in the continuous feed under ``persLocation`` = ``"[50.799918, 4.408567]"`` —
+    the sample #923 was waiting for (the position module's docstring assumed the
+    continuous feed carried none). Returns ``(None, None)`` unless the value is a
+    two-element numeric pair inside real-world bounds and not the null-island
+    ``0,0`` sentinel — so a malformed value, a charging/destination coordinate, or
+    a placeholder can never be mistaken for the car's position. Conservative by
+    design: it only trusts a well-formed, in-range pair.
+    """
+    pair: Any = value
+    if isinstance(value, str):
+        s = value.strip()
+        try:
+            pair = json.loads(s)
+        except (ValueError, TypeError):
+            parts = [p.strip() for p in s.strip("[]").split(",")]
+            pair = parts if len(parts) == 2 else None
+    if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+        return (None, None)
+    try:
+        lat = float(pair[0])
+        lon = float(pair[1])
+    except (ValueError, TypeError):
+        return (None, None)
+    if (
+        -90.0 <= lat <= 90.0
+        and -180.0 <= lon <= 180.0
+        and not (lat == 0.0 and lon == 0.0)
+    ):
+        return (lat, lon)
+    return (None, None)
 
 
 def _dur_to_min(raw: str | None) -> int | None:
@@ -1731,6 +1771,50 @@ def map_dataset_to_vehicle_data(
         # v3.0.2 (#1122) — _GLOBAL_SENTINELS drops the RAW uint32 sentinel here,
         # but not its 0.1-km-scaled form (429_496_729); the shared guard does.
         d.odometer_km = drop_odometer_sentinel(odo)
+
+    # #1378/#923 — MEB portal cars (Skoda Elroq …) ship the vehicle position in
+    # the CONTINUOUS feed under ``persLocation`` ("[lat, lon]") — the sample #923
+    # had been waiting for. Parse it defensively (validated pair, in-range, not
+    # 0/0; a charging/destination coord or a placeholder can't pass) and map the
+    # companion ``heading``. Cars that don't ship persLocation are unaffected —
+    # their position keeps coming from the brand-native parkingposition path.
+    _pers_lat, _pers_lon = _parse_pers_location(first("persLocation"))
+    if _pers_lat is not None and _pers_lon is not None:
+        d.latitude = _pers_lat
+        d.longitude = _pers_lon
+        # Pair the coordinates with THEIR OWN capture time, exactly like the
+        # brand-native / vw.de position writers. Without it a multi-channel merge
+        # (e.g. a prefer-vw.de or prefer-eu-data car, #1376) would gap-fill
+        # position_captured_at from a DIFFERENT channel's fix and misjudge the
+        # persLocation pin's staleness.
+        if field_ts and "persLocation" in field_ts:
+            _pos_iso = _epoch_or_iso(str(field_ts["persLocation"]))
+            if _pos_iso:
+                d.position_captured_at = _pos_iso
+    _heading = _to_int(first("heading"))
+    if _heading is not None and 0 <= _heading <= 360:
+        d.heading = _heading % 360
+
+    # #1378 (Škoda Elroq) — short-term (recent) average electric consumption. The
+    # portal ships it WITH a unit ("15.8 kWh/100km"), so take the leading number.
+    # Only trust it as an ELECTRIC figure when the unit says so (kWh/Wh); a PHEV
+    # that ships this leaf as a fuel value (l/100km) must not be mislabelled into
+    # the electric sensor. Distinct from the per-trip average; feeds its own sensor.
+    _stc_raw = str(first("shortTermAverageConsumption") or "")
+    _stc_parts = _stc_raw.split()
+    _stc = _to_float(_stc_parts[0]) if _stc_parts else None
+    if _stc is not None and _stc >= 0 and "wh" in _stc_raw.lower():
+        d.short_term_avg_electric_consumption_kwh_100km = _stc
+
+    # #1375 (Audi S6 TDI) — SCR/AdBlue engine-start counter (diagnostic).
+    _scr = _to_int(first("scr_number_of_engine_starts"))
+    if _scr is not None and _scr >= 0:
+        d.engine_starts_count = _scr
+
+    # #1378 — ``tripId`` is a per-trip UUID (identifier only, no sensor value).
+    # Consume it so the Scout stops re-reporting it as an "undiscovered field"
+    # every poll; it is metadata, not a suppressed reading.
+    first("tripId")
 
     # #465 (zdravac) — vehicleIsStandingStill (dict UUID 0010398f-5fda-39af-9e7a-
     # 25db8c2e623a, cluster "Parking Data", boolean "current motion state").

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1551,6 +1551,11 @@ class VehicleData:
     last_trip_avg_speed_kmh: float | None = None
     last_trip_avg_fuel_consumption_l_100km: float | None = None
     last_trip_avg_electric_consumption_kwh_100km: float | None = None
+    # #1378 (Škoda Elroq) — the EU Data Act portal's short-term (recent) average
+    # electric consumption, distinct from the per-trip figure above.
+    short_term_avg_electric_consumption_kwh_100km: float | None = None
+    # #1375 (Audi S6 TDI) — SCR/AdBlue system engine-start counter (diagnostic).
+    engine_starts_count: int | None = None
     last_trip_timestamp: str | None = None
     # v2.10.0 - last-trip reset timestamp. audi_connect_ha v2.1.0 surfaces
     # this as `shortterm_reset`. Read-only: records WHEN the user last

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.5"
+  "version": "4.7.6"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1577,6 +1577,29 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         condition="electric",
     ),
 
+    # #1378 (Škoda Elroq) — short-term (recent) average electric consumption.
+    VagSensorDescription(
+        key="short_term_avg_electric_consumption_kwh_100km",
+        translation_key="short_term_avg_electric_consumption_kwh_100km",
+        data_key="short_term_avg_electric_consumption_kwh_100km",
+        native_unit_of_measurement="kWh/100 km",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:lightning-bolt-outline",
+        suggested_display_precision=1,
+        condition="electric",
+    ),
+
+    # #1375 (Audi S6 TDI) — SCR/AdBlue engine-start counter (diagnostic).
+    VagSensorDescription(
+        key="engine_starts_count",
+        translation_key="engine_starts_count",
+        data_key="engine_starts_count",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        icon="mdi:engine",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+
     VagSensorDescription(
         key="api_observer_findings",
         translation_key="api_observer_findings",

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -1478,6 +1478,12 @@
       },
       "readiness_software_update_status": {
         "name": "Software update status"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Short Term Average Electric Consumption"
+      },
+      "engine_starts_count": {
+        "name": "Engine Starts"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Stav aktualizace softwaru"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Krátkodobá průměrná spotřeba elektřiny"
+      },
+      "engine_starts_count": {
+        "name": "Starty motoru"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Softwareopdateringsstatus"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Kortsigtet gennemsnitligt elforbrug"
+      },
+      "engine_starts_count": {
+        "name": "Motorstarter"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Software-Update-Status"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Kurzzeit-Durchschnittsverbrauch (elektrisch)"
+      },
+      "engine_starts_count": {
+        "name": "Motorstarts"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Software update status"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Short Term Average Electric Consumption"
+      },
+      "engine_starts_count": {
+        "name": "Engine Starts"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Estado de actualización de software"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Consumo eléctrico medio a corto plazo"
+      },
+      "engine_starts_count": {
+        "name": "Arranques del motor"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Ohjelmistopäivityksen tila"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Lyhyen aikavälin keskimääräinen sähkönkulutus"
+      },
+      "engine_starts_count": {
+        "name": "Moottorin käynnistykset"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "État de la mise à jour logicielle"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Consommation électrique moyenne à court terme"
+      },
+      "engine_starts_count": {
+        "name": "Démarrages moteur"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Stato aggiornamento software"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Consumo elettrico medio a breve termine"
+      },
+      "engine_starts_count": {
+        "name": "Avviamenti motore"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Status for programvareoppdatering"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Kortsiktig gjennomsnittlig strømforbruk"
+      },
+      "engine_starts_count": {
+        "name": "Motorstarter"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Status software-update"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Kortetermijn gemiddeld elektriciteitsverbruik"
+      },
+      "engine_starts_count": {
+        "name": "Motorstarts"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Stan aktualizacji oprogramowania"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Krótkoterminowe średnie zużycie energii"
+      },
+      "engine_starts_count": {
+        "name": "Uruchomienia silnika"
       }
     },
     "binary_sensor": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -1445,6 +1445,12 @@
       },
       "readiness_software_update_status": {
         "name": "Status för programuppdatering"
+      },
+      "short_term_avg_electric_consumption_kwh_100km": {
+        "name": "Kortsiktig genomsnittlig elförbrukning"
+      },
+      "engine_starts_count": {
+        "name": "Motorstarter"
       }
     },
     "binary_sensor": {

--- a/tests/test_1195_charge_start_soc.py
+++ b/tests/test_1195_charge_start_soc.py
@@ -64,6 +64,29 @@ def test_known_charge_start_uuid_is_registered() -> None:
     assert _CHARGE_START_UUID in _CHARGE_START_SOC_UUIDS
 
 
+# #1380 (hangout6690) — his ID.3 ships two MORE charge-start-SoC UUIDs; a file
+# carrying only one of them (no live 506cb83e) re-latched the stale value.
+_CHARGE_START_UUIDS_1380 = (
+    "7bddd5e7-43a4-3878-bd63-9502782f77a5",
+    "bd4b6d50-b574-31e6-8141-8787ca5fec8c",
+)
+
+
+def test_all_1380_charge_start_uuids_are_registered() -> None:
+    for u in _CHARGE_START_UUIDS_1380:
+        assert u in _CHARGE_START_SOC_UUIDS
+
+
+def test_1380_charge_start_only_file_yields_no_live_soc_to_carry_forward() -> None:
+    # a poll whose ONLY soc point is a charge-start UUID must NOT become the live
+    # SoC — battery_state_report.soc is left empty so the last-known live value
+    # carries forward, instead of the stale charge-start figure winning.
+    for uuid in (_CHARGE_START_UUID, *_CHARGE_START_UUIDS_1380):
+        fields = _walk_fields({"data": [_soc_point("37", uuid)]})
+        assert "battery_state_report.soc" not in fields
+        assert fields["battery_state_report.soc_at_charge_start"] == "37"
+
+
 def test_end_to_end_battery_soc_is_the_live_value() -> None:
     # end to end: the mapper must set battery_soc to the live 24, not 37.
     fields = _walk_fields({"data": [

--- a/tests/test_1195_partial_dataset_soc_hold.py
+++ b/tests/test_1195_partial_dataset_soc_hold.py
@@ -57,14 +57,19 @@ def test_partial_polls_hold_the_hv_soc_not_the_frozen_leaf() -> None:
     assert seq == [66, 66, 66, 55], seq
 
 
-def test_each_dataset_parsed_alone_shows_the_bug_source() -> None:
-    # Sanity: parsed in isolation, the partial datasets DO surface the frozen leaf
-    # (67) — which is exactly why the cross-poll hold in reconcile is needed.
+def test_charge_start_leaf_is_discarded_at_parse_time() -> None:
+    # v4.7.6 (#1380) — the frozen leaf in the partial datasets is a "SoC at charge
+    # start" snapshot (dataset_13's soc point is keyed 7bddd5e7, a charge-start
+    # UUID). The parser now discards those UUIDs OUTRIGHT, so a charge-start-only
+    # poll yields NO battery_soc at all (None) — reconcile then carries the last
+    # live value forward. That is a cleaner fix than only relying on the
+    # cross-poll hold: the stale 67 never even reaches reconcile.
     assert _parse("dataset_12_20260818181316Z.json")["battery_soc"] == 66
-    assert _parse("dataset_13_20260818182550Z.json")["battery_soc"] == 67
+    assert _parse("dataset_13_20260818182550Z.json")["battery_soc"] is None
     assert _parse("dataset_15_20260818185540Z.json")["battery_soc"] == 55
     assert _parse("dataset_12_20260818181316Z.json")["battery_soc_from_hv"] is True
-    assert _parse("dataset_13_20260818182550Z.json")["battery_soc_from_hv"] is False
+    # charge-start-only poll → no SoC surfaced at all, so no HV provenance is set
+    assert _parse("dataset_13_20260818182550Z.json")["battery_soc_from_hv"] is None
 
 
 # ── the reconcile guard in isolation ──────────────────────────────────────────

--- a/tests/test_1378_1375_scout_sensors.py
+++ b/tests/test_1378_1375_scout_sensors.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1378 (Škoda Elroq) + #1375 (Audi S6 TDI) — new EU Data Act portal fields the
+Vehicle Data Scout surfaced: short-term average electric consumption and the
+SCR/AdBlue engine-start counter. Both are now mapped onto their own sensors; the
+trip-id metadata leaf is consumed so it stops re-reporting as undiscovered.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    _walk_fields,
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(points: list[dict]) -> VehicleData:
+    fields = _walk_fields({"data": points})
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_short_term_consumption_is_parsed_from_unit_string() -> None:
+    d = _map([{"dataFieldName": "shortTermAverageConsumption",
+               "value": "15.8 kWh/100km", "key": "k"}])
+    assert d.short_term_avg_electric_consumption_kwh_100km == 15.8
+
+
+def test_fuel_consumption_is_not_mislabelled_as_electric() -> None:
+    # a PHEV/ICE shipping this leaf as l/100km must NOT land in the electric field
+    # (the unit guard requires kWh/Wh).
+    d = _map([{"dataFieldName": "shortTermAverageConsumption",
+               "value": "5.2 l/100km", "key": "k"}])
+    assert d.short_term_avg_electric_consumption_kwh_100km is None
+
+
+def test_engine_starts_counter_is_parsed() -> None:
+    d = _map([{"dataFieldName": "scr_number_of_engine_starts", "value": "7",
+               "key": "k"}])
+    assert d.engine_starts_count == 7
+
+
+def test_engine_starts_zero_is_kept() -> None:
+    d = _map([{"dataFieldName": "scr_number_of_engine_starts", "value": "0",
+               "key": "k"}])
+    assert d.engine_starts_count == 0
+
+
+def test_tripId_is_handled_without_inventing_a_sensor() -> None:
+    # a bare trip identifier must not crash the mapper and must not invent any
+    # field; the parser just consumes it (first("tripId")) so the Scout stops
+    # re-reporting it every poll.
+    d = _map([{"dataFieldName": "tripId", "value": "abc-123", "key": "k"}])
+    assert d.short_term_avg_electric_consumption_kwh_100km is None
+    assert d.engine_starts_count is None
+
+
+def test_absent_scout_fields_are_inert() -> None:
+    d = _map([{"dataFieldName": "battery_state_report.soc", "value": "50",
+               "key": "k"}])
+    assert d.short_term_avg_electric_consumption_kwh_100km is None
+    assert d.engine_starts_count is None

--- a/tests/test_1378_scout_perslocation.py
+++ b/tests/test_1378_scout_perslocation.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1378 / #923 — MEB portal cars (Škoda Elroq …) ship the vehicle position in
+the CONTINUOUS EU Data Act feed under ``persLocation`` = "[lat, lon]" (the sample
+#923 was waiting for), plus a ``heading``. The parser now reads them defensively
+into latitude/longitude/heading — validated, in-range, not the 0/0 sentinel, so a
+charging/destination coordinate or a placeholder can never be mistaken for the
+car's own position.
+"""
+from __future__ import annotations
+
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    _parse_pers_location,
+    _walk_fields,
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+
+
+def _map(points: list[dict]) -> VehicleData:
+    fields = _walk_fields({"data": points})
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+# ── the parser helper ───────────────────────────────────────────────────────
+def test_parse_pers_location_accepts_a_valid_pair() -> None:
+    assert _parse_pers_location("[50.799918, 4.408567]") == (50.799918, 4.408567)
+    assert _parse_pers_location("50.8,4.4") == (50.8, 4.4)
+    assert _parse_pers_location([50.8, 4.4]) == (50.8, 4.4)
+
+
+def test_parse_pers_location_rejects_junk_and_sentinels() -> None:
+    for bad in ("", "garbage", "[0, 0]", "[999, 4]", "[50]", "[50,4,9]", None,
+                "[abc, def]", "0,0"):
+        assert _parse_pers_location(bad) == (None, None)
+
+
+# ── end to end ──────────────────────────────────────────────────────────────
+def test_persLocation_populates_latitude_longitude() -> None:
+    d = _map([
+        {"dataFieldName": "persLocation", "value": "[50.799918, 4.408567]",
+         "key": "k1"},
+        {"dataFieldName": "heading", "value": "326", "key": "k2"},
+    ])
+    assert d.latitude == 50.799918
+    assert d.longitude == 4.408567
+    assert d.heading == 326
+
+
+def test_heading_wraps_360_to_0() -> None:
+    d = _map([{"dataFieldName": "heading", "value": "360", "key": "k"}])
+    assert d.heading == 0
+
+
+def test_bad_persLocation_leaves_position_unset() -> None:
+    d = _map([{"dataFieldName": "persLocation", "value": "[0, 0]", "key": "k"}])
+    assert d.latitude is None
+    assert d.longitude is None
+
+
+def test_no_position_leaves_are_inert() -> None:
+    d = _map([{"dataFieldName": "battery_state_report.soc", "value": "50",
+               "key": "k"}])
+    assert d.latitude is None
+    assert d.heading is None


### PR DESCRIPTION
Maps several fields from the continuous Scout portal feed onto sensors, and extends the v4.7.5 charge-start SoC fix.

### Added
- **Scout live-feed fields:** GPS position (from `persLocation`), heading, short-term average electric consumption, an engine-starts counter, and trip-id correlation — surfaced from the portal's continuous feed. Grounded on real Škoda Elroq and Audi captures (#1378, #1375).

### Fixed
- **Charge-start SoC follow-up (#1380):** two more portal content UUIDs added to the #1195 guard that keeps the "SoC at charge start" snapshot from beating the live battery %, so a partial poll carrying only one of them can't re-latch the stale value. Thanks again to @hangout6690.

Bumps `manifest.json` to 4.7.6 and adds the CHANGELOG entry. Full test suite green.
