### PR TITLE
Interactive Porsche captcha in the config flow (#1337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
-## [4.7.6] - 2026-09-10 — More live fields from the Scout feed
+## [4.7.6] - 2026-09-10 — More live fields from the Scout feed, and an interactive Porsche captcha
 
 ### Added
 - **GPS position, heading, short-term consumption and an engine-starts count from the live Scout
@@ -50,6 +50,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
   the car's GPS position (it does send coordinates under `persLocation`), its heading, the short-term
   average electric consumption and a total engine-starts counter now come through as sensors, and the
   trip id is consumed for correlation. Grounded on real Škoda Elroq and Audi captures (#1378, #1375).
+- **Porsche login now gets past the captcha wall — solve it right in the setup dialog.** Porsche's
+  login can put up an Auth0 captcha; the integration now shows it inline during setup,
+  re-authentication and reconfigure so you can type it and continue. The login also stops declaring
+  passkey support (matching a proven reference client), which keeps Porsche on the solvable captcha
+  path instead of bouncing to the unclearable `my.porsche.com` consent wall some accounts hit before —
+  confirmed working end-to-end on a real account. A captcha shown after the password step is replayed
+  to the exact screen that presented it (pinned to Porsche's own domain). Retries are bounded (too many
+  can lock a Porsche account), the challenge you enter never leaves your Home Assistant instance, and
+  any login that still can't be cleared gives an honest message plus a one-click report link with
+  auto-redacted diagnostics (#1337).
 
 ### Fixed
 - **Battery % right after plugging in: two more source fields covered.** The v4.7.5 fix that stops the

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -224,6 +224,7 @@ class PorscheClient:
         captcha_code: str | None = None,
         resume_state: str | None = None,
         resume_verifier: str | None = None,
+        captcha_resume: dict | None = None,
     ) -> None:
         """Auth0 PKCE login.
 
@@ -231,12 +232,15 @@ class PorscheClient:
         that was interrupted by :class:`PorscheCaptchaRequiredError` — see
         ``PorscheAuth.authenticate`` for why the state/verifier must be the
         ones captured when the captcha was first raised, not fresh ones.
+        ``captcha_resume`` (G5, #1337) carries the replay descriptor for a
+        post-password captcha; it is forwarded verbatim.
         """
         self._tokens = await self._auth.authenticate(
             self._email, self._password,
             captcha_code=captcha_code,
             resume_state=resume_state,
             resume_verifier=resume_verifier,
+            captcha_resume=captcha_resume,
         )
         _LOGGER.debug("Porsche Connect auth complete")
 

--- a/custom_components/vag_connect/cariad/auth/porsche.py
+++ b/custom_components/vag_connect/cariad/auth/porsche.py
@@ -205,6 +205,7 @@ class PorscheAuth:
         captcha_code: str | None = None,
         resume_state: str | None = None,
         resume_verifier: str | None = None,
+        captcha_resume: dict | None = None,
     ) -> TokenSet:
         """Full PKCE flow → access_token + refresh_token.
 
@@ -220,7 +221,17 @@ class PorscheAuth:
         state/verifier captured when the captcha was first raised, rather
         than starting a brand new transaction that would produce a
         ``code_verifier`` mismatch at the final token exchange.
+
+        ``captcha_resume`` (G5, #1337) resumes a captcha that appeared LATER
+        than the identifier step — in the post-password redirect chain, which
+        the identifier re-drive above cannot reach. It replays the solved
+        captcha to the exact ACUL screen that presented it (``_resume_acul_
+        captcha``) and continues to the code from there.
         """
+        if captcha_code and captcha_resume:
+            return await self._resume_acul_captcha(
+                captcha_code, captcha_resume, resume_verifier or "",
+            )
         if captcha_code and resume_state and resume_verifier:
             verifier = resume_verifier
             auth0_state = resume_state
@@ -275,13 +286,22 @@ class PorscheAuth:
         # (possibly new/chained) captcha challenge (b19, CJNE-comparison §1.5)
         # — neither is the generic "wall" case.
         login_url = f"https://{_AUTH_SERVER}/u/login/identifier?state={auth0_state}"
+        # #1337 — match the identifier-POST field shape CJNE/pyporscheconnectapi
+        # uses (verified against their oauth2.py). We previously declared WebAuthn
+        # support (`webauthn-available: true`), which routed enrolled accounts into
+        # the passkey-enrollment screen and on to the unclearable my.porsche.com
+        # wall (@Hollywoodchaos, #1337). Declaring NO WebAuthn keeps Auth0 on the
+        # identifier/captcha path, where a captcha surfaces as a solvable HTTP 400
+        # the config-flow captcha step can show — instead of the post-password
+        # wall. Reference, not a code copy (that library has separate PKCE/state/
+        # plaintext-password issues we don't want).
         identifier_data = {
             "state":       auth0_state,
             "username":    email,
             "js-available":"true",
-            "webauthn-available": "true",
+            "webauthn-available": "false",
             "is-brave":    "false",
-            "webauthn-platform-authenticator-available": "false",
+            "webauthn-platform-available": "false",
             "action":      "default",
         }
         if captcha_code:
@@ -330,6 +350,10 @@ class PorscheAuth:
                 raise AuthenticationError("Porsche auth failed — wrong credentials")
             location = resp.headers.get("Location", "")
             status = resp.status
+            # G5 (#1337) — read the rendered page only when it did NOT redirect,
+            # so a captcha shown DIRECTLY at the password step (not just later in
+            # the redirect chain) is solvable rather than a dead wall.
+            body = "" if location else await resp.text()
         # b11 (#1337 Hollywoodchaos) — the Porsche auth path emitted zero log
         # lines, so a user's debug capture showed nothing but the final warning.
         # Log status + whether a redirect was handed back (hostnames/statuses
@@ -342,6 +366,19 @@ class PorscheAuth:
                  "captcha/consent step the headless flow can't clear)",
         )
 
+        # G5 (#1337) — a captcha rendered as the DIRECT body of the password POST
+        # (no redirect). Surface it for solving if we can replay it; otherwise
+        # step 4 below turns the empty location into the honest wall.
+        if body:
+            image = self._extract_captcha_image(body)
+            if image:
+                resume = self._acul_captcha_resume(password_url, body)
+                if resume is not None:
+                    raise PorscheCaptchaRequiredError(
+                        image, resume["form"].get("state", ""), verifier,
+                        resume=resume,
+                    )
+
         # Step 4: follow the Auth0 redirect chain to the code.
         #
         # In Auth0's Identifier-First flow the password POST does NOT redirect
@@ -351,7 +388,7 @@ class PorscheAuth:
         # required the callback immediately, so it ALWAYS fell through to
         # "wrong credentials or captcha" even with correct credentials — a
         # self-inflicted failure independent of the Porsche One migration.
-        code = await self._follow_to_code(location, password_url)
+        code = await self._follow_to_code(location, password_url, verifier)
         if not code:
             # b23 (#1337) — the identifier + password were ACCEPTED above (a 401/
             # 400 there already raised the "wrong credentials" error); reaching
@@ -452,7 +489,9 @@ class PorscheAuth:
             parts.append("markers=" + ",".join(markers))
         return "; ".join(parts) if parts else "no title/markers"
 
-    async def _follow_to_code(self, location: str, base_url: str) -> str | None:
+    async def _follow_to_code(
+        self, location: str, base_url: str, verifier: str = "",
+    ) -> str | None:
         """Walk the redirect chain from the password POST to the auth code.
 
         Each ``Location`` may be relative (``/authorize/resume?...``) or
@@ -520,10 +559,31 @@ class PorscheAuth:
                         "(stale state or unparseable context) — stopping",
                     )
                     return None
-                if self._extract_captcha_image(html):
+                image = self._extract_captcha_image(html)
+                if image:
+                    # G5 (#1337) — a captcha AFTER the password step. CJNE never
+                    # reaches this (their login completes), so there is no
+                    # reference to copy: the robust move is to replay the solved
+                    # captcha back to THIS exact screen. If the ACUL context is
+                    # parseable we hand the config flow everything it needs to do
+                    # that (``resume``); if it is not, we cannot replay it safely,
+                    # so we fall through to the honest wall + the report link
+                    # rather than guess at a screen we can't read.
+                    resume = self._acul_captcha_resume(target, html)
+                    if resume is not None:
+                        _LOGGER.debug(
+                            "Porsche auth: hop rendered a solvable CAPTCHA screen "
+                            "(host=%s) — surfacing it to the setup dialog",
+                            urlsplit(target).hostname or "?",
+                        )
+                        raise PorscheCaptchaRequiredError(
+                            image, resume["form"].get("state", ""), verifier,
+                            resume=resume,
+                        )
                     _LOGGER.debug(
-                        "Porsche auth: hop rendered a CAPTCHA screen (host=%s) — "
-                        "cannot be solved inside the redirect chain; no code",
+                        "Porsche auth: hop rendered a CAPTCHA screen (host=%s) "
+                        "with no parseable ACUL context — cannot replay it; no "
+                        "code",
                         urlsplit(target).hostname or "?",
                     )
                     return None
@@ -562,6 +622,10 @@ class PorscheAuth:
         state = context.get("transaction", {}).get("state")
         if not state:
             return None
+        if not self._is_porsche_host(url):
+            # G5/#1337 (privacy) — never POST the seeded ACUL form off Porsche's
+            # own domain, even to decline passkey enrollment.
+            return None
         data = dict(context.get("untrustedData", {}).get("submittedFormData") or {})
         data.update({
             "state": state,
@@ -582,6 +646,121 @@ class PorscheAuth:
             if resp.status not in (301, 302, 303, 307, 308):
                 return None
             return resp.headers.get("Location", "")
+
+    @staticmethod
+    def _is_porsche_host(url: str) -> bool:
+        """True only for an ``https`` URL on Porsche's own domain.
+
+        G5/#1337 (privacy, defense-in-depth) — the ACUL replay POSTs a seeded
+        form (the screen's own ``submittedFormData`` + the solved captcha) back
+        to the host that rendered the screen. That host comes from a redirect
+        ``Location`` header, so pin it to Porsche's own Auth0 domain before any
+        such POST: a subverted redirect chain must never divert the
+        credential-adjacent POST off-domain.
+        """
+        parts = urlsplit(url)
+        host = (parts.hostname or "").lower()
+        return parts.scheme == "https" and (
+            host == _AUTH_SERVER or host.endswith(".porsche.com")
+        )
+
+    def _acul_captcha_resume(self, url: str, html: str) -> dict | None:
+        """Build the replay descriptor for a post-password ACUL captcha screen.
+
+        G5 (#1337). Reads the same base64 ``atob("...")`` ACUL context the other
+        screen helpers use: ``transaction.state`` (required — without it the
+        screen cannot be POSTed back) plus any ``untrustedData.submittedFormData``
+        the page carried (seeded first, like ``_skip_passkey_enrollment``, in
+        case an ACUL version validates that expected fields are present). Returns
+        ``{"url": <this screen's POST url>, "form": {...submittedFormData,
+        "state": <state>}}``, or ``None`` when there is no parseable context /
+        state, or the screen is not on Porsche's own domain — the caller then
+        treats it as an unreplayable wall.
+        """
+        if not self._is_porsche_host(url):
+            return None
+        match = re.search(r'atob\("([A-Za-z0-9+/=]+)"', html)
+        if not match:
+            return None
+        try:
+            context = json.loads(base64.b64decode(match.group(1)).decode("utf-8"))
+        except (ValueError, json.JSONDecodeError):
+            return None
+        if not isinstance(context, dict):
+            return None
+        transaction = context.get("transaction")
+        state = transaction.get("state") if isinstance(transaction, dict) else None
+        if not isinstance(state, str) or not state:
+            return None
+        untrusted = context.get("untrustedData")
+        submitted = untrusted.get("submittedFormData") if isinstance(untrusted, dict) else None
+        form = dict(submitted) if isinstance(submitted, dict) else {}
+        form["state"] = state
+        return {"url": url, "form": form}
+
+    async def _resume_acul_captcha(
+        self, captcha_code: str, resume: dict, verifier: str,
+    ) -> TokenSet:
+        """Replay a solved post-password captcha to the screen that showed it.
+
+        G5 (#1337). POSTs the captcha back to ``resume["url"]`` with the seeded
+        ACUL form data (``resume["form"]`` carries the screen ``state``), the
+        solved ``captcha`` and ``action=default``, then continues down the
+        redirect chain to the authorization code and exchanges it — reusing the
+        ORIGINAL PKCE ``verifier`` so the token exchange still matches. A chained
+        captcha (another one comes back) re-raises
+        :class:`PorscheCaptchaRequiredError` so the config flow loops; anything
+        else that is not a redirect toward a code is the honest wall.
+
+        NOT LIVE-VERIFIED — no account here has produced a post-password captcha;
+        the shape mirrors ``_skip_passkey_enrollment`` (the one ACUL replay CJNE
+        does confirm) and any misfire surfaces through the in-flow report link.
+        """
+        url = str(resume.get("url") or "")
+        if not self._is_porsche_host(url):
+            # The descriptor is built with the same guard, so this should be
+            # unreachable; keep it as a hard stop against ever POSTing the
+            # seeded form off Porsche's domain.
+            raise PorscheLoginWallError()
+        form = dict(resume.get("form") or {})
+        form.update({
+            "captcha":  captcha_code,
+            "action":   "default",
+            "acul-sdk": "@auth0/auth0-acul-js@1.2.0",
+        })
+        async with self._session.post(
+            url,
+            timeout=_AUTH_TIMEOUT,
+            data=form,
+            headers={
+                "User-Agent":   _USER_AGENT,
+                "X-Client-ID":  _X_CLIENT,
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            allow_redirects=False,
+        ) as resp:
+            status = resp.status
+            location = resp.headers.get("Location", "")
+            body = "" if status in (301, 302, 303, 307, 308) else await resp.text()
+        if status in (301, 302, 303, 307, 308) and location:
+            code = await self._follow_to_code(location, url, verifier)
+            if not code:
+                raise PorscheLoginWallError()
+            return await self._exchange_code(code, verifier)
+        if status == 200:
+            # The screen re-rendered instead of advancing: another captcha
+            # (chain it so the config flow can show the fresh one) or a wall.
+            image = self._extract_captcha_image(body)
+            if image:
+                nxt = self._acul_captcha_resume(url, body)
+                if nxt is not None:
+                    raise PorscheCaptchaRequiredError(
+                        image, nxt["form"].get("state", ""), verifier, resume=nxt,
+                    )
+            raise PorscheLoginWallError()
+        raise AuthenticationError(
+            f"Porsche captcha resume failed (HTTP {status})"
+        )
 
     async def refresh(self, refresh_token: str) -> TokenSet:
         """Refresh tokens using refresh_token.

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -415,23 +415,37 @@ class PorscheCaptchaRequiredError(AuthenticationError):
     """b19 (#1337, CJNE-comparison #12a) — Porsche's Auth0 tenant rendered a
     captcha challenge instead of continuing the login redirect chain.
 
-    Carries what a future interactive config-flow step would need to resume
-    the SAME PKCE transaction after the user solves it (the verifier cannot
-    be regenerated — it is bound to the original ``/authorize`` request), the
-    same way CJNE/pyporscheconnectapi's ``PorscheCaptchaRequiredError`` does.
-    No solving path exists yet; this only lets a captcha wall be distinguished
-    from wrong credentials in logs/diagnostics.
+    Carries what the interactive config-flow step needs to resume the SAME PKCE
+    transaction after the user solves it (the verifier cannot be regenerated —
+    it is bound to the original ``/authorize`` request), the same way
+    CJNE/pyporscheconnectapi's ``PorscheCaptchaRequiredError`` does.
+
+    ``resume`` (G5, #1337) is present only for a captcha that appears LATER in
+    the flow than the identifier step — i.e. in the post-password redirect chain
+    (which CJNE never sees, because their login completes). It is an opaque
+    descriptor ``{"url": <screen POST url>, "form": <ACUL submittedFormData +
+    state>}`` that lets the resume replay the solved captcha back to the exact
+    ACUL screen that presented it, instead of re-driving identifier + password.
+    ``None`` means the classic identifier-step captcha, which resumes by
+    re-POSTing the identifier with the ``captcha`` field (unchanged).
     """
 
-    def __init__(self, captcha_image: str, state: str, code_verifier: str) -> None:
+    def __init__(
+        self,
+        captcha_image: str,
+        state: str,
+        code_verifier: str,
+        resume: dict | None = None,
+    ) -> None:
         super().__init__(
-            "Porsche requires a captcha to be solved — not yet solvable "
-            "automatically. Sign in manually in the Porsche app once, or "
-            "wait for interactive captcha support."
+            "Porsche requires a captcha to be solved — the interactive setup "
+            "step will show it. If it cannot be cleared, sign in once in the "
+            "Porsche app from the same network."
         )
         self.captcha_image = captcha_image
         self.state = state
         self.code_verifier = code_verifier
+        self.resume = resume
 
 
 class PorscheLoginWallError(AuthenticationError):

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -190,6 +190,7 @@ async def _validate_credentials(
     captcha_code: str | None = None,
     captcha_state: str | None = None,
     captcha_verifier: str | None = None,
+    captcha_resume: dict | None = None,
 ) -> None:
     """Validate credentials by authenticating with the CARIAD API.
 
@@ -233,6 +234,7 @@ async def _validate_credentials(
                     captcha_code=captcha_code,
                     resume_state=captcha_state,
                     resume_verifier=captcha_verifier,
+                    captcha_resume=captcha_resume,
                 )
             else:
                 await client.authenticate(mfa_code=mfa_code)
@@ -417,7 +419,16 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         self._porsche_captcha_image: str = ""
         self._porsche_captcha_state: str = ""
         self._porsche_captcha_verifier: str = ""
-        self._porsche_captcha_return: str = ""  # "email_password" | "reauth"
+        # G5 (#1337) — replay descriptor for a post-password captcha (None for a
+        # classic identifier-step captcha, which resumes via the identifier POST).
+        self._porsche_captcha_resume: dict | None = None
+        self._porsche_captcha_return: str = ""  # "email_password"|"reauth"|"reconfigure"
+        # #1337 — bound the captcha loop: Auth0 can chain challenge after
+        # challenge, and repeated failed attempts have LOCKED Porsche accounts
+        # (ha-porscheconnect#199). After this many submits we stop and hand the
+        # user a one-click GitHub report instead of letting them hammer on.
+        self._porsche_captcha_attempts: int = 0
+        self._porsche_reconfigure_entry_id: str = ""
         self._porsche_reauth_entry_id: str = ""
         self._porsche_reauth_spin: str = ""
         self._porsche_reauth_country: str = "us"
@@ -761,6 +772,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 self._porsche_captcha_image    = err.captcha_image
                 self._porsche_captcha_state    = err.state
                 self._porsche_captcha_verifier = err.code_verifier
+                self._porsche_captcha_resume   = err.resume
                 return await self.async_step_porsche_captcha()
             except ValueError as err:
                 err_str = str(err)
@@ -771,6 +783,18 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                     self._pending_entry_data = self._build_entry_data(brand, username, password, user_input)
                     self._pending_user_input = dict(user_input)
                     return await self.async_step_mfa()
+                if err_str == "porsche_login_wall":
+                    # #1337 — the login got past the password but hit a Porsche
+                    # wall we can't clear headless. Stop cleanly and offer a
+                    # one-click report so we capture which screen it was.
+                    return self.async_abort(
+                        reason="porsche_login_wall",
+                        description_placeholders={
+                            "report_url": self._porsche_report_url(
+                                "email_password", "porsche_login_wall"
+                            ),
+                        },
+                    )
                 errors["base"] = _map_error(err_str)
             else:
                 portal_data = self._build_entry_data(
@@ -1926,6 +1950,44 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         )
 
     @staticmethod
+    def _porsche_report_url(step: str, reason: str, screen: str = "") -> str:
+        """Build a PII-FREE pre-filled GitHub issue URL for a Porsche login wall.
+
+        #1337 — when the headless login hits a screen we can't clear (captcha /
+        consent / an unknown Auth0 ACUL screen), we don't yet know WHICH screen
+        it is for that account. Rather than wait for a reporter to volunteer a
+        capture, the setup dialog hands the user a one-click "report this" link
+        so we get the decisive datapoint cleanly.
+
+        Privacy: the query string carries ONLY non-identifying context — which
+        step failed, the error key, and the Auth0 screen name if known. It must
+        NEVER contain a VIN, e-mail, password, token, captcha text, or any full
+        auth URL (those carry ``state``/``code``). Everything sensitive stays in
+        the auto-redacted diagnostics the body asks the user to attach — never in
+        the URL. (Redaction-gate: no secrets/PII in query strings.)
+        """
+        from urllib.parse import urlencode  # noqa: PLC0415
+
+        title = f"[Porsche login] {reason}"
+        body = (
+            "Auto-filled by the VW Group Connect setup dialog.\n\n"
+            f"- Step: {step}\n"
+            f"- Error: {reason}\n"
+            f"- Auth0 screen: {screen or 'unknown'}\n\n"
+            "What happened (optional):\n\n\n"
+            "Please attach your diagnostics: Settings -> Devices & Services -> "
+            "VW Group Connect -> three-dots menu -> Download diagnostics "
+            "(it is automatically redacted). If you can, also enable debug "
+            "logging first, reproduce, and paste any 'Porsche auth:' log lines "
+            "-- they name the exact screen this got stuck on.\n"
+        )
+        query = urlencode({"labels": "porsche,auth", "title": title, "body": body})
+        return (
+            "https://github.com/its-me-prash/vwgroup-connect-ha/issues/new?"
+            + query
+        )
+
+    @staticmethod
     def _porsche_captcha_img_html(data_uri: str) -> str:
         """Resize a tiny inline captcha SVG for visibility.
 
@@ -1974,64 +2036,132 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
         errors: dict[str, str] = {}
         from .cariad.exceptions import PorscheCaptchaRequiredError  # noqa: PLC0415
 
+        # #1337 — one report link for every give-up path in this step, so a user
+        # who hits a wall we can't clear can hand us the decisive datapoint.
+        def _abort_report(reason: str) -> config_entries.ConfigFlowResult:
+            return self.async_abort(
+                reason=reason,
+                description_placeholders={
+                    "report_url": self._porsche_report_url(
+                        self._porsche_captcha_return or "porsche_captcha", reason
+                    ),
+                },
+            )
+
         if user_input is not None:
             code = str(user_input.get(CONF_CAPTCHA_CODE, "")).strip()
-            country = (
-                self._porsche_reauth_country
-                if self._porsche_captcha_return == "reauth"
-                else self._pending_entry_data.get(CONF_COUNTRY, "us")
-            )
-            try:
-                await _validate_credentials(
-                    self.hass, "porsche",
-                    self._pending_username, self._pending_password,
-                    country=country,
-                    captcha_code=code,
-                    captcha_state=self._porsche_captcha_state,
-                    captcha_verifier=self._porsche_captcha_verifier,
-                )
-            except PorscheCaptchaRequiredError as err:
-                # Chained captcha (CJNE-comparison #12 — ha-porscheconnect
-                # handles this the same way): Auth0 rendered ANOTHER one
-                # rather than accepting or cleanly rejecting the solution.
-                # Update state and re-show the form with the new image.
-                self._porsche_captcha_image    = err.captcha_image
-                self._porsche_captcha_state    = err.state
-                self._porsche_captcha_verifier = err.code_verifier
-            except ValueError as err:
-                mapped = _map_error(str(err))
-                if mapped == "porsche_login_wall":
-                    # b23 (#1337) — the captcha was accepted but the login then
-                    # hit the post-password captcha/consent wall. Re-showing the
-                    # now-consumed captcha would just invite a lockout-risking
-                    # retry (repeated failures have locked Porsche accounts), so
-                    # stop cleanly with the honest reason instead.
-                    return self.async_abort(reason="porsche_login_wall")
-                errors["base"] = mapped
+            if not code:
+                # Blank submit — nothing was consumed, so re-show the SAME image
+                # (no fresh challenge fetched → no extra hit on Porsche's Auth0).
+                errors["base"] = "missing_captcha"
             else:
                 if self._porsche_captcha_return == "reauth":
-                    reauth_entry = self.hass.config_entries.async_get_entry(
-                        self._porsche_reauth_entry_id
+                    country = self._porsche_reauth_country
+                elif self._porsche_captcha_return == "reconfigure":
+                    country = self._pending_user_input.get(CONF_COUNTRY, "us")
+                else:
+                    country = self._pending_entry_data.get(CONF_COUNTRY, "us")
+                try:
+                    await _validate_credentials(
+                        self.hass, "porsche",
+                        self._pending_username, self._pending_password,
+                        country=country,
+                        captcha_code=code,
+                        captcha_state=self._porsche_captcha_state,
+                        captcha_verifier=self._porsche_captcha_verifier,
+                        captcha_resume=self._porsche_captcha_resume,
                     )
-                    if reauth_entry is None:
-                        return self.async_abort(reason="reauth_failed")
-                    self.hass.config_entries.async_update_entry(
-                        reauth_entry,
-                        data={
-                            **reauth_entry.data,
-                            CONF_PASSWORD: self._pending_password,
-                            CONF_SPIN: self._porsche_reauth_spin,
-                        },
+                except PorscheCaptchaRequiredError as err:
+                    # Chained captcha (CJNE-comparison #12 — ha-porscheconnect
+                    # handles this the same way): Auth0 rendered ANOTHER one
+                    # rather than accepting or cleanly rejecting the solution.
+                    # Bound the loop — repeated failed attempts have LOCKED
+                    # Porsche accounts (ha-porscheconnect#199), so after a few
+                    # tries we stop and offer a report instead of hammering.
+                    self._porsche_captcha_attempts += 1
+                    if self._porsche_captcha_attempts >= 3:
+                        return _abort_report("porsche_captcha_cooldown")
+                    # Fresh image/state/verifier — never re-show a consumed one.
+                    self._porsche_captcha_image    = err.captcha_image
+                    self._porsche_captcha_state    = err.state
+                    self._porsche_captcha_verifier = err.code_verifier
+                    self._porsche_captcha_resume   = err.resume
+                    errors["base"] = "captcha_retry"
+                except ValueError as err:
+                    mapped = _map_error(str(err))
+                    if mapped == "porsche_login_wall":
+                        # b23 (#1337) — the captcha was accepted but the login
+                        # then hit the post-password captcha/consent wall.
+                        # Re-showing the now-consumed captcha would just invite a
+                        # lockout-risking retry, so stop cleanly + offer a report.
+                        return _abort_report("porsche_login_wall")
+                    if mapped == "cannot_connect":
+                        # Transient — the challenge may still be valid, so let the
+                        # user retry rather than forcing a full restart.
+                        errors["base"] = "cannot_connect"
+                    else:
+                        # Auth0 rejected without re-challenging: the captcha is
+                        # consumed and dead. Don't loop on a stale image — stop
+                        # cleanly; a fresh login gets a fresh transaction.
+                        return _abort_report("porsche_captcha_failed")
+                else:
+                    self._porsche_captcha_attempts = 0
+                    if self._porsche_captcha_return == "reauth":
+                        reauth_entry = self.hass.config_entries.async_get_entry(
+                            self._porsche_reauth_entry_id
+                        )
+                        if reauth_entry is None:
+                            return self.async_abort(reason="reauth_failed")
+                        self.hass.config_entries.async_update_entry(
+                            reauth_entry,
+                            data={
+                                **reauth_entry.data,
+                                CONF_PASSWORD: self._pending_password,
+                                CONF_SPIN: self._porsche_reauth_spin,
+                            },
+                        )
+                        await self.hass.config_entries.async_reload(
+                            reauth_entry.entry_id
+                        )
+                        return self.async_abort(reason="reauth_successful")
+                    if self._porsche_captcha_return == "reconfigure":
+                        # G1 (#1337) — a captcha hit during Reconfigure. Mirror
+                        # async_step_reconfigure's in-place update (Porsche is
+                        # never MBB-eligible, so no command-channel chain here).
+                        entry = self.hass.config_entries.async_get_entry(
+                            self._porsche_reconfigure_entry_id
+                        )
+                        if entry is None:
+                            return self.async_abort(reason="reconfigure_failed")
+                        brand = self._pending_brand
+                        username = self._pending_username
+                        password = self._pending_password
+                        new_unique_id = f"{brand}_{username}"
+                        await self.async_set_unique_id(new_unique_id)
+                        if new_unique_id != entry.unique_id:
+                            self._abort_if_unique_id_configured()
+                        base = self._build_entry_data(
+                            brand, username, password, self._pending_user_input
+                        )
+                        merged = (
+                            base if new_unique_id != entry.unique_id
+                            else {**entry.data, **base}
+                        )
+                        self.hass.config_entries.async_update_entry(
+                            entry,
+                            title=f"{_brand_label(brand)} — {username}",
+                            unique_id=new_unique_id,
+                            data=merged,
+                        )
+                        await self.hass.config_entries.async_reload(entry.entry_id)
+                        return self.async_abort(reason="reconfigure_successful")
+                    # "email_password" — Porsche is never MBB-eligible (VW/Audi
+                    # only), so the non-captcha path's plain create-entry branch
+                    # is the only outcome here.
+                    return self.async_create_entry(
+                        title=f"{_brand_label(self._pending_brand)} — {self._pending_username}",
+                        data=self._pending_entry_data,
                     )
-                    await self.hass.config_entries.async_reload(reauth_entry.entry_id)
-                    return self.async_abort(reason="reauth_successful")
-                # "email_password" — Porsche is never MBB-eligible (VW/Audi
-                # only), so the non-captcha path's plain create-entry branch
-                # is the only outcome here.
-                return self.async_create_entry(
-                    title=f"{_brand_label(self._pending_brand)} — {self._pending_username}",
-                    data=self._pending_entry_data,
-                )
 
         return self.async_show_form(
             step_id="porsche_captcha",
@@ -2040,6 +2170,10 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             description_placeholders={
                 "captcha_img": self._porsche_captcha_img_html(
                     self._porsche_captcha_image
+                ),
+                "report_url": self._porsche_report_url(
+                    self._porsche_captcha_return or "porsche_captcha",
+                    "porsche_captcha",
                 ),
             },
         )
@@ -2094,8 +2228,18 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 self._porsche_captcha_image    = err.captcha_image
                 self._porsche_captcha_state    = err.state
                 self._porsche_captcha_verifier = err.code_verifier
+                self._porsche_captcha_resume   = err.resume
                 return await self.async_step_porsche_captcha()
             except ValueError as err:
+                if str(err) == "porsche_login_wall":
+                    return self.async_abort(
+                        reason="porsche_login_wall",
+                        description_placeholders={
+                            "report_url": self._porsche_report_url(
+                                "reauth", "porsche_login_wall"
+                            ),
+                        },
+                    )
                 errors["base"] = _map_error(str(err))
             else:
                 self.hass.config_entries.async_update_entry(
@@ -2237,11 +2381,39 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             password = user_input[CONF_PASSWORD]
             country  = user_input.get(CONF_COUNTRY, "us")
 
+            from .cariad.exceptions import PorscheCaptchaRequiredError  # noqa: PLC0415
+
             try:
                 await _validate_credentials(
                     self.hass, brand, username, password, country=country
                 )
+            except PorscheCaptchaRequiredError as err:
+                # G1 (#1337) — a Porsche captcha during Reconfigure used to
+                # propagate uncaught here (only ValueError was handled) and crash
+                # the flow. Route it through the shared captcha step; the success
+                # branch there updates THIS entry in place.
+                self._pending_brand    = brand
+                self._pending_username = username
+                self._pending_password = password
+                self._pending_user_input = dict(user_input)
+                self._porsche_captcha_return = "reconfigure"
+                self._porsche_reconfigure_entry_id = entry.entry_id
+                self._porsche_captcha_attempts = 0
+                self._porsche_captcha_image    = err.captcha_image
+                self._porsche_captcha_state    = err.state
+                self._porsche_captcha_verifier = err.code_verifier
+                self._porsche_captcha_resume   = err.resume
+                return await self.async_step_porsche_captcha()
             except ValueError as err:
+                if str(err) == "porsche_login_wall":
+                    return self.async_abort(
+                        reason="porsche_login_wall",
+                        description_placeholders={
+                            "report_url": self._porsche_report_url(
+                                "reconfigure", "porsche_login_wall"
+                            ),
+                        },
+                    )
                 errors["base"] = _map_error(str(err))
             else:
                 new_unique_id = f"{brand}_{username}"

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha required",
-        "description": "Porsche needs you to solve a captcha to continue signing in.\n\n{captcha_img}\n\nOnly solve this once with your best guess — repeated failed attempts have caused Porsche to lock accounts for suspicious activity.",
+        "description": "Porsche needs you to solve a captcha to continue signing in.\n\n{captcha_img}\n\nOnly solve this once with your best guess — repeated failed attempts have caused Porsche to lock accounts for suspicious activity.\n\nNothing you enter here leaves your Home Assistant instance. If the image will not load or you keep getting errors, you can report it (attach diagnostics): {report_url}",
         "data": {
           "captcha_code": "Captcha Code"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet.",
       "companion_agent_token_too_short": "The agent token is too short. Paste the random token the agent app generated (at least 32 characters).",
-      "companion_host_required": "Enter the phone's IP address — or tick the companion agent option if the phone calls Home Assistant instead."
+      "companion_host_required": "Enter the phone's IP address — or tick the companion agent option if the phone calls Home Assistant instead.",
+      "missing_captcha": "Please type the characters shown in the image above.",
+      "captcha_retry": "Please solve the captcha shown above to continue."
     },
     "abort": {
       "already_configured": "This account is already configured.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Your vehicle isn't eligible for the MBB durable login — the backend returned \"Unknown user\". This means it's a newer ID / MEB model (ID.3/4/5, e-up, etc.) that was never enrolled in the legacy Car-Net/MBB system, so the durable login + remote commands can't reach it. Use the EU Data Act portal channel (or the Email + Password login) for these vehicles instead. The MBB login is for older Car-Net cars (most PHEV / combustion models).",
       "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
       "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here.",
-      "porsche_login_wall": "Your credentials are fine — the login got past the password step but stopped at a Porsche captcha/consent screen it can't complete automatically (seen at my.porsche.com). This is a Porsche-side wall, tracked in #1337, not a wrong password. Don't retry in a loop — repeated attempts have locked Porsche accounts."
+      "porsche_login_wall": "Your credentials are fine — the login got past the password step but stopped at a Porsche captcha/consent screen it can't complete automatically (seen at my.porsche.com). This is a Porsche-side wall, tracked in #1337, not a wrong password. Don't retry in a loop — repeated attempts have locked Porsche accounts. If you can, please report it so we can fix it (attach diagnostics): {report_url}",
+      "porsche_captcha_failed": "That captcha could not be verified and it is now used up. Please close this dialog and start the Porsche login again to get a fresh one. If you can, please report it so we can fix it (attach diagnostics): {report_url}",
+      "porsche_captcha_cooldown": "Too many captcha attempts. Repeated tries can make Porsche temporarily lock the account or flag your network, so this stopped to keep your account safe. Wait a few minutes before trying again. If you can, please report it so we can fix it (attach diagnostics): {report_url}",
+      "reconfigure_failed": "Reconfigure failed: the configuration entry could not be found. Please try again.",
+      "reauth_failed": "Re-authentication failed: the configuration entry could not be found. Please try again."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Vyžadována captcha",
-        "description": "Porsche vyžaduje vyřešení captchy pro pokračování v přihlášení.\n\n{captcha_img}\n\nVyřešte to jen jednou podle svého nejlepšího odhadu — opakované neúspěšné pokusy již vedly k zablokování účtu Porsche kvůli podezřelé aktivitě.",
+        "description": "Porsche vyžaduje vyřešení captchy pro pokračování v přihlášení.\n\n{captcha_img}\n\nVyřešte to jen jednou podle svého nejlepšího odhadu — opakované neúspěšné pokusy již vedly k zablokování účtu Porsche kvůli podezřelé aktivitě.\n\nNic, co sem zadáš, neopustí tvou instanci Home Assistant. Pokud se obrázek nenačte nebo se stále objevují chyby, můžeš to nahlásit (přilož diagnostiku): {report_url}",
         "data": {
           "captcha_code": "Kód captcha"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Připojení k telefonu proběhlo, ale aplikace značky na něm není nainstalovaná.",
       "companion_unknown_brand": "Pro tuto značku zatím není k dispozici žádná přednastavená konfigurace doprovodného telefonu.",
       "companion_agent_token_too_short": "Token agenta je příliš krátký. Vložte náhodný token vygenerovaný aplikací agenta (nejméně 32 znaků).",
-      "companion_host_required": "Zadejte IP adresu telefonu — nebo zaškrtněte volbu agenta, pokud telefon volá Home Assistant."
+      "companion_host_required": "Zadejte IP adresu telefonu — nebo zaškrtněte volbu agenta, pokud telefon volá Home Assistant.",
+      "missing_captcha": "Zadej znaky zobrazené na obrázku výše.",
+      "captcha_retry": "Pro pokračování vyřeš captcha zobrazenou výše."
     },
     "abort": {
       "already_configured": "Tento účet je již nastaven.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Vaše vozidlo není způsobilé pro trvalé přihlášení MBB — backend vrátil „Unknown user“. Jde o novější model ID / MEB (ID.3/4/5, e-up apod.), který nikdy nebyl registrován ve starém systému Car-Net/MBB, takže trvalé přihlášení a vzdálené příkazy se k němu nedostanou. Pro taková vozidla použijte kanál portálu EU Data Act (nebo přihlášení e-mailem a heslem). Přihlášení MBB je pro starší vozy Car-Net (většina plug-in hybridních / spalovacích modelů).",
       "mbb_fallback_armed": "Záložní připojení je nastaveno. Pokud normální připojení vašeho Audi někdy přestane přijímat dálkové příkazy, zamykání/odemykání, klimatizace a nabíjení se automaticky přepnou na zálohu. V běžném provozu se nic nemění.",
       "no_devicegrant_audi": "Nebylo nalezeno žádné odpovídající Audi. Tato záloha platí jen pro Audi přidané přihlášením přes QR / aplikaci, které ji ještě nemá. Nejprve takto přidejte své Audi a pak se sem vraťte.",
-      "porsche_login_wall": "Tvoje přihlašovací údaje jsou v pořádku — přihlášení prošlo krokem s heslem, ale zastavilo se na obrazovce captcha/souhlasu Porsche, kterou nelze dokončit automaticky (pozorováno na my.porsche.com). Jde o překážku na straně Porsche, sledovanou v #1337, ne o špatné heslo. Nezkoušej to opakovaně ve smyčce — opakované pokusy zablokovaly účty Porsche."
+      "porsche_login_wall": "Tvoje přihlašovací údaje jsou v pořádku — přihlášení prošlo krokem s heslem, ale zastavilo se na obrazovce captcha/souhlasu Porsche, kterou nelze dokončit automaticky (pozorováno na my.porsche.com). Jde o překážku na straně Porsche, sledovanou v #1337, ne o špatné heslo. Nezkoušej to opakovaně ve smyčce — opakované pokusy zablokovaly účty Porsche. Pokud můžeš, nahlas to prosím, ať to můžeme opravit (přilož diagnostiku): {report_url}",
+      "porsche_captcha_failed": "Captcha se nepodařilo ověřit a je nyní neplatná. Zavři toto okno a spusť přihlášení Porsche znovu pro získání nové. Pokud můžeš, nahlas to prosím, ať to můžeme opravit (přilož diagnostiku): {report_url}",
+      "porsche_captcha_cooldown": "Příliš mnoho pokusů o captcha. Opakované pokusy mohou vést k tomu, že Porsche účet dočasně zablokuje nebo označí tvou síť, proto bylo přihlašování zastaveno kvůli ochraně účtu. Než to zkusíš znovu, počkej několik minut. Pokud můžeš, nahlas to prosím, ať to můžeme opravit (přilož diagnostiku): {report_url}",
+      "reconfigure_failed": "Změna konfigurace selhala: konfigurační záznam nebyl nalezen. Zkus to prosím znovu.",
+      "reauth_failed": "Opětovné ověření selhalo: konfigurační záznam nebyl nalezen. Zkus to prosím znovu."
     },
     "progress": {
       "awaiting_browser_login": "Otevřete {verification_uri} v libovolném prohlížeči, přihlaste se pomocí účtu Brand ID a potvrďte kód {user_code}.",

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha påkrævet",
-        "description": "Porsche kræver, at du løser en captcha for at fortsætte login.\n\n{captcha_img}\n\nLøs det kun én gang efter bedste evne — gentagne mislykkede forsøg har fået Porsche til at spærre konti for mistænkelig aktivitet.",
+        "description": "Porsche kræver, at du løser en captcha for at fortsætte login.\n\n{captcha_img}\n\nLøs det kun én gang efter bedste evne — gentagne mislykkede forsøg har fået Porsche til at spærre konti for mistænkelig aktivitet.\n\nDet, du indtaster her, forlader ikke din Home Assistant-instans. Hvis billedet ikke indlæses, eller du bliver ved med at få fejl, kan du rapportere det (vedhæft diagnostik): {report_url}",
         "data": {
           "captcha_code": "Captcha-kode"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Der blev oprettet forbindelse til telefonen, men mærkets app er ikke installeret på den.",
       "companion_unknown_brand": "Det mærke har endnu ingen forudindstilling for hjælpetelefon.",
       "companion_agent_token_too_short": "Agent-tokenet er for kort. Indsæt det tilfældige token, agent-appen har genereret (mindst 32 tegn).",
-      "companion_host_required": "Angiv telefonens IP-adresse — eller sæt flueben ved agent-muligheden, hvis telefonen ringer til Home Assistant."
+      "companion_host_required": "Angiv telefonens IP-adresse — eller sæt flueben ved agent-muligheden, hvis telefonen ringer til Home Assistant.",
+      "missing_captcha": "Indtast de tegn, der vises i billedet ovenfor.",
+      "captcha_retry": "Løs den viste captcha ovenfor for at fortsætte."
     },
     "abort": {
       "already_configured": "Denne konto er allerede konfigureret.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Dit køretøj er ikke egnet til det vedvarende MBB-login — backendet returnerede \"Unknown user\". Det betyder, at det er en nyere ID/MEB-model (ID.3/4/5, e-up osv.), der aldrig blev registreret i det ældre Car-Net/MBB-system, så det vedvarende login + fjernkommandoerne kan ikke nå det. Brug EU Data Act-portalkanalen (eller login med e-mail + adgangskode) til disse køretøjer i stedet. MBB-loginet er til ældre Car-Net-biler (de fleste PHEV-/forbrændingsmodeller).",
       "mbb_fallback_armed": "Reserveforbindelse oprettet. Hvis din Audis normale forbindelse en dag holder op med at tage imod fjernkommandoer, skifter lås/lås op, klima og opladning automatisk til reserven. I hverdagen ændrer der sig ingenting.",
       "no_devicegrant_audi": "Ingen passende Audi fundet. Denne reserve gælder kun for en Audi, du har tilføjet med QR-/app-login, og som ikke allerede har den. Tilføj din Audi på den måde først, og kom så tilbage hertil.",
-      "porsche_login_wall": "Dine loginoplysninger er i orden — loginnet kom forbi adgangskodetrinnet, men stoppede ved en Porsche captcha-/samtykkeskærm, som det ikke kan gennemføre automatisk (set på my.porsche.com). Det er en blokering på Porsches side, fulgt i #1337, ikke en forkert adgangskode. Prøv ikke igen i en løkke — gentagne forsøg har låst Porsche-konti."
+      "porsche_login_wall": "Dine loginoplysninger er i orden — loginnet kom forbi adgangskodetrinnet, men stoppede ved en Porsche captcha-/samtykkeskærm, som det ikke kan gennemføre automatisk (set på my.porsche.com). Det er en blokering på Porsches side, fulgt i #1337, ikke en forkert adgangskode. Prøv ikke igen i en løkke — gentagne forsøg har låst Porsche-konti. Hvis du kan, så rapportér det, så vi kan rette det (vedhæft diagnostik): {report_url}",
+      "porsche_captcha_failed": "Captchaen kunne ikke bekræftes og er nu brugt. Luk denne dialog, og start Porsche-loginet igen for at få en ny. Hvis du kan, så rapportér det, så vi kan rette det (vedhæft diagnostik): {report_url}",
+      "porsche_captcha_cooldown": "For mange captcha-forsøg. Gentagne forsøg kan få Porsche til midlertidigt at låse kontoen eller markere dit netværk, så processen blev stoppet for at beskytte din konto. Vent et par minutter, før du prøver igen. Hvis du kan, så rapportér det, så vi kan rette det (vedhæft diagnostik): {report_url}",
+      "reconfigure_failed": "Genkonfiguration mislykkedes: konfigurationsposten blev ikke fundet. Prøv igen.",
+      "reauth_failed": "Gengodkendelse mislykkedes: konfigurationsposten blev ikke fundet. Prøv igen."
     },
     "progress": {
       "awaiting_browser_login": "Åbn {verification_uri} i en hvilken som helst browser, log ind med din Brand ID-konto, og bekræft koden {user_code}.",

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha erforderlich",
-        "description": "Porsche verlangt die Lösung eines Captchas, um mit der Anmeldung fortzufahren.\n\n{captcha_img}\n\nLöse es nur einmal mit deiner besten Vermutung — wiederholte Fehlversuche haben bei Porsche schon zu Konto-Sperrungen wegen verdächtiger Aktivität geführt.",
+        "description": "Porsche verlangt die Lösung eines Captchas, um mit der Anmeldung fortzufahren.\n\n{captcha_img}\n\nLöse es nur einmal mit deiner besten Vermutung — wiederholte Fehlversuche haben bei Porsche schon zu Konto-Sperrungen wegen verdächtiger Aktivität geführt.\n\nWas du hier eingibst, verlässt deine Home-Assistant-Instanz nicht. Wenn das Bild nicht lädt oder du immer wieder Fehler bekommst, kannst du es melden (Diagnose anhängen): {report_url}",
         "data": {
           "captcha_code": "Captcha-Code"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Verbindung zum Smartphone hergestellt, aber die Marken-App ist darauf nicht installiert.",
       "companion_unknown_brand": "Für diese Marke gibt es noch keine Begleit-Voreinstellung.",
       "companion_agent_token_too_short": "Das Agent-Token ist zu kurz. Füge das Zufalls-Token aus der Agent-App ein (mindestens 32 Zeichen).",
-      "companion_host_required": "Bitte die IP-Adresse des Handys eingeben — oder die Companion-Agent-Option aktivieren, wenn das Handy Home Assistant anruft."
+      "companion_host_required": "Bitte die IP-Adresse des Handys eingeben — oder die Companion-Agent-Option aktivieren, wenn das Handy Home Assistant anruft.",
+      "missing_captcha": "Bitte gib die im Bild oben gezeigten Zeichen ein.",
+      "captcha_retry": "Bitte löse das oben gezeigte Captcha, um fortzufahren."
     },
     "abort": {
       "already_configured": "Dieses Konto ist bereits eingerichtet.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Dein Fahrzeug ist für den dauerhaften MBB-Login nicht geeignet — das Backend meldet „Unknown user\". Das heisst, es ist ein neueres ID-/MEB-Modell (ID.3/4/5, e-up usw.), das nie im alten Car-Net/MBB-System registriert war — der dauerhafte Login + die Fernbefehle erreichen es daher nicht. Nutze für solche Fahrzeuge den EU-Data-Act-Kanal (oder den E-Mail-+-Passwort-Login). Der MBB-Login ist für ältere Car-Net-Autos (die meisten PHEV-/Verbrenner-Modelle).",
       "mbb_fallback_armed": "Reserve-Verbindung eingerichtet. Falls die normale Verbindung deines Audi je keine Fernbefehle mehr annimmt, wechseln Ver-/Entriegeln, Klima und Laden automatisch auf die Reserve. Im Alltag ändert sich nichts.",
       "no_devicegrant_audi": "Kein passender Audi gefunden. Diese Reserve gilt nur für einen Audi, den du per QR-/App-Login hinzugefügt hast und der sie noch nicht hat. Füge deinen Audi zuerst so hinzu, dann komm hierher zurück.",
-      "porsche_login_wall": "Deine Zugangsdaten sind in Ordnung — die Anmeldung kam am Passwort-Schritt vorbei, blieb dann aber an einem Porsche-Captcha-/Zustimmungs-Bildschirm hängen, den sie nicht automatisch abschließen kann (auf my.porsche.com beobachtet). Das ist eine Porsche-seitige Sperre (verfolgt unter #1337), kein falsches Passwort. Nicht in einer Schleife wiederholen — wiederholte Versuche haben schon zu Porsche-Konto-Sperrungen geführt."
+      "porsche_login_wall": "Deine Zugangsdaten sind in Ordnung — die Anmeldung kam am Passwort-Schritt vorbei, blieb dann aber an einem Porsche-Captcha-/Zustimmungs-Bildschirm hängen, den sie nicht automatisch abschließen kann (auf my.porsche.com beobachtet). Das ist eine Porsche-seitige Sperre (verfolgt unter #1337), kein falsches Passwort. Nicht in einer Schleife wiederholen — wiederholte Versuche haben schon zu Porsche-Konto-Sperrungen geführt. Wenn möglich, melde es bitte, damit wir es beheben können (Diagnose anhängen): {report_url}",
+      "porsche_captcha_failed": "Das Captcha konnte nicht bestätigt werden und ist jetzt verbraucht. Bitte schließe diesen Dialog und starte die Porsche-Anmeldung neu, um ein frisches zu erhalten. Wenn möglich, melde es bitte, damit wir es beheben können (Diagnose anhängen): {report_url}",
+      "porsche_captcha_cooldown": "Zu viele Captcha-Versuche. Wiederholte Versuche können dazu führen, dass Porsche das Konto vorübergehend sperrt oder dein Netzwerk markiert – daher wurde hier gestoppt, um dein Konto zu schützen. Warte ein paar Minuten, bevor du es erneut versuchst. Wenn möglich, melde es bitte, damit wir es beheben können (Diagnose anhängen): {report_url}",
+      "reconfigure_failed": "Neukonfiguration fehlgeschlagen: Der Konfigurationseintrag wurde nicht gefunden. Bitte versuche es erneut.",
+      "reauth_failed": "Erneute Anmeldung fehlgeschlagen: Der Konfigurationseintrag wurde nicht gefunden. Bitte versuche es erneut."
     },
     "progress": {
       "awaiting_browser_login": "Öffne {verification_uri} in einem Browser, melde dich mit deinem Brand-ID-Konto an und bestätige den Code {user_code}.",

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha required",
-        "description": "Porsche needs you to solve a captcha to continue signing in.\n\n{captcha_img}\n\nOnly solve this once with your best guess — repeated failed attempts have caused Porsche to lock accounts for suspicious activity.",
+        "description": "Porsche needs you to solve a captcha to continue signing in.\n\n{captcha_img}\n\nOnly solve this once with your best guess — repeated failed attempts have caused Porsche to lock accounts for suspicious activity.\n\nNothing you enter here leaves your Home Assistant instance. If the image will not load or you keep getting errors, you can report it (attach diagnostics): {report_url}",
         "data": {
           "captcha_code": "Captcha Code"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Connected to the phone, but the brand app is not installed on it.",
       "companion_unknown_brand": "That brand has no companion preset yet.",
       "companion_agent_token_too_short": "The agent token is too short. Paste the random token the agent app generated (at least 32 characters).",
-      "companion_host_required": "Enter the phone's IP address — or tick the companion agent option if the phone calls Home Assistant instead."
+      "companion_host_required": "Enter the phone's IP address — or tick the companion agent option if the phone calls Home Assistant instead.",
+      "missing_captcha": "Please type the characters shown in the image above.",
+      "captcha_retry": "Please solve the captcha shown above to continue."
     },
     "abort": {
       "already_configured": "This account is already configured.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Your vehicle isn't eligible for the MBB durable login — the backend returned \"Unknown user\". This means it's a newer ID / MEB model (ID.3/4/5, e-up, etc.) that was never enrolled in the legacy Car-Net/MBB system, so the durable login + remote commands can't reach it. Use the EU Data Act portal channel (or the Email + Password login) for these vehicles instead. The MBB login is for older Car-Net cars (most PHEV / combustion models).",
       "mbb_fallback_armed": "Backup connection set up. If your Audi's normal connection ever stops accepting remote commands, lock/unlock, climate and charging switch to the backup automatically. Nothing changes day to day.",
       "no_devicegrant_audi": "No matching Audi found. This backup only applies to an Audi you added with the QR / app login that doesn't already have it. Add your Audi that way first, then come back here.",
-      "porsche_login_wall": "Your credentials are fine — the login got past the password step but stopped at a Porsche captcha/consent screen it can't complete automatically (seen at my.porsche.com). This is a Porsche-side wall, tracked in #1337, not a wrong password. Don't retry in a loop — repeated attempts have locked Porsche accounts."
+      "porsche_login_wall": "Your credentials are fine — the login got past the password step but stopped at a Porsche captcha/consent screen it can't complete automatically (seen at my.porsche.com). This is a Porsche-side wall, tracked in #1337, not a wrong password. Don't retry in a loop — repeated attempts have locked Porsche accounts. If you can, please report it so we can fix it (attach diagnostics): {report_url}",
+      "porsche_captcha_failed": "That captcha could not be verified and it is now used up. Please close this dialog and start the Porsche login again to get a fresh one. If you can, please report it so we can fix it (attach diagnostics): {report_url}",
+      "porsche_captcha_cooldown": "Too many captcha attempts. Repeated tries can make Porsche temporarily lock the account or flag your network, so this stopped to keep your account safe. Wait a few minutes before trying again. If you can, please report it so we can fix it (attach diagnostics): {report_url}",
+      "reconfigure_failed": "Reconfigure failed: the configuration entry could not be found. Please try again.",
+      "reauth_failed": "Re-authentication failed: the configuration entry could not be found. Please try again."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in any browser, sign in with your Brand ID account, and confirm the code {user_code}.",

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha necesario",
-        "description": "Porsche requiere resolver un captcha para continuar con el inicio de sesión.\n\n{captcha_img}\n\nResuélvelo solo una vez con tu mejor intento — los intentos fallidos repetidos han provocado que Porsche bloquee cuentas por actividad sospechosa.",
+        "description": "Porsche requiere resolver un captcha para continuar con el inicio de sesión.\n\n{captcha_img}\n\nResuélvelo solo una vez con tu mejor intento — los intentos fallidos repetidos han provocado que Porsche bloquee cuentas por actividad sospechosa.\n\nLo que introduces aquí no sale de tu instancia de Home Assistant. Si la imagen no se carga o sigues recibiendo errores, puedes notificarlo (adjunta los diagnósticos): {report_url}",
         "data": {
           "captcha_code": "Código captcha"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Se conectó con el teléfono, pero la aplicación de la marca no está instalada en él.",
       "companion_unknown_brand": "Esa marca aún no tiene una preconfiguración de teléfono auxiliar.",
       "companion_agent_token_too_short": "El token del agente es demasiado corto. Pegue el token aleatorio que generó la app de agente (al menos 32 caracteres).",
-      "companion_host_required": "Introduzca la dirección IP del teléfono — o marque la opción de agente si es el teléfono el que llama a Home Assistant."
+      "companion_host_required": "Introduzca la dirección IP del teléfono — o marque la opción de agente si es el teléfono el que llama a Home Assistant.",
+      "missing_captcha": "Escribe los caracteres que se muestran en la imagen de arriba.",
+      "captcha_retry": "Resuelve el captcha que se muestra arriba para continuar."
     },
     "abort": {
       "already_configured": "Esta cuenta ya está configurada.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Tu vehículo no es apto para el inicio de sesión duradero MBB — el backend devolvió «Unknown user». Es un modelo ID / MEB más reciente (ID.3/4/5, e-up, etc.) que nunca se registró en el antiguo sistema Car-Net/MBB, por lo que el inicio de sesión duradero y los comandos remotos no pueden alcanzarlo. Usa el canal del portal EU Data Act (o el inicio de sesión con correo + contraseña) para estos vehículos. El inicio de sesión MBB es para coches Car-Net antiguos (la mayoría de modelos híbridos enchufables / de combustión).",
       "mbb_fallback_armed": "Conexión de reserva configurada. Si la conexión normal de tu Audi deja alguna vez de aceptar comandos remotos, el bloqueo/desbloqueo, la climatización y la carga pasan a la de reserva automáticamente. En el día a día no cambia nada.",
       "no_devicegrant_audi": "No se encontró ningún Audi compatible. Esta reserva solo se aplica a un Audi que hayas añadido con el inicio de sesión por QR / app y que aún no la tenga. Añade primero tu Audi de esa forma y luego vuelve aquí.",
-      "porsche_login_wall": "Tus credenciales son correctas — el inicio de sesión superó el paso de la contraseña, pero se detuvo en una pantalla de captcha/consentimiento de Porsche que no puede completar automáticamente (vista en my.porsche.com). Es un bloqueo del lado de Porsche, registrado en #1337, no una contraseña incorrecta. No lo reintentes en bucle — los intentos repetidos han bloqueado cuentas de Porsche."
+      "porsche_login_wall": "Tus credenciales son correctas — el inicio de sesión superó el paso de la contraseña, pero se detuvo en una pantalla de captcha/consentimiento de Porsche que no puede completar automáticamente (vista en my.porsche.com). Es un bloqueo del lado de Porsche, registrado en #1337, no una contraseña incorrecta. No lo reintentes en bucle — los intentos repetidos han bloqueado cuentas de Porsche. Si puedes, notifícalo para que podamos solucionarlo (adjunta los diagnósticos): {report_url}",
+      "porsche_captcha_failed": "No se pudo verificar el captcha y ya está caducado. Cierra este diálogo y vuelve a iniciar el acceso de Porsche para obtener uno nuevo. Si puedes, notifícalo para que podamos solucionarlo (adjunta los diagnósticos): {report_url}",
+      "porsche_captcha_cooldown": "Demasiados intentos de captcha. Los intentos repetidos pueden hacer que Porsche bloquee temporalmente la cuenta o marque tu red, por lo que se detuvo para proteger tu cuenta. Espera unos minutos antes de volver a intentarlo. Si puedes, notifícalo para que podamos solucionarlo (adjunta los diagnósticos): {report_url}",
+      "reconfigure_failed": "Error al reconfigurar: no se encontró la entrada de configuración. Inténtalo de nuevo.",
+      "reauth_failed": "Error en la reautenticación: no se encontró la entrada de configuración. Inténtalo de nuevo."
     },
     "progress": {
       "awaiting_browser_login": "Abre {verification_uri} en cualquier navegador, inicia sesión con tu cuenta Brand ID y confirma el código {user_code}.",

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha vaaditaan",
-        "description": "Porsche vaatii captchan ratkaisemista kirjautumisen jatkamiseksi.\n\n{captcha_img}\n\nRatkaise tämä vain kerran parhaan arviosi mukaan — toistuvat epäonnistuneet yritykset ovat johtaneet Porschen tilien lukitsemiseen epäilyttävän toiminnan vuoksi.",
+        "description": "Porsche vaatii captchan ratkaisemista kirjautumisen jatkamiseksi.\n\n{captcha_img}\n\nRatkaise tämä vain kerran parhaan arviosi mukaan — toistuvat epäonnistuneet yritykset ovat johtaneet Porschen tilien lukitsemiseen epäilyttävän toiminnan vuoksi.\n\nMitään tähän syöttämääsi ei lähetetä Home Assistant -instanssistasi. Jos kuva ei lataudu tai saat jatkuvasti virheitä, voit ilmoittaa siitä (liitä diagnostiikka): {report_url}",
         "data": {
           "captcha_code": "Captcha-koodi"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Yhteys puhelimeen muodostettiin, mutta merkin sovellusta ei ole asennettu siihen.",
       "companion_unknown_brand": "Kyseiselle merkille ei ole vielä apupuhelimen esiasetusta.",
       "companion_agent_token_too_short": "Agentin tunnus on liian lyhyt. Liitä agenttisovelluksen luoma satunnainen tunnus (vähintään 32 merkkiä).",
-      "companion_host_required": "Anna puhelimen IP-osoite — tai valitse agenttivaihtoehto, jos puhelin soittaa Home Assistantille."
+      "companion_host_required": "Anna puhelimen IP-osoite — tai valitse agenttivaihtoehto, jos puhelin soittaa Home Assistantille.",
+      "missing_captcha": "Kirjoita yllä olevassa kuvassa näkyvät merkit.",
+      "captcha_retry": "Ratkaise yllä näkyvä captcha jatkaaksesi."
     },
     "abort": {
       "already_configured": "Tämä tili on jo määritetty.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Ajoneuvosi ei sovellu pysyvään MBB-kirjautumiseen — taustajärjestelmä palautti ”Unknown user”. Tämä tarkoittaa, että se on uudempi ID- / MEB-malli (ID.3/4/5, e-up jne.), jota ei koskaan liitetty vanhaan Car-Net/MBB-järjestelmään, joten pysyvä kirjautuminen + etäkomennot eivät tavoita sitä. Käytä näille ajoneuvoille EU Data Act -portaalikanavaa (tai sähköposti + salasana -kirjautumista) sen sijaan. MBB-kirjautuminen on tarkoitettu vanhemmille Car-Net-autoille (useimmat PHEV- / polttomoottorimallit).",
       "mbb_fallback_armed": "Varayhteys otettu käyttöön. Jos Audisi tavallinen yhteys joskus lakkaa hyväksymästä etäkomentoja, lukitus/avaus, ilmastointi ja lataus siirtyvät automaattisesti varayhteyteen. Arjessa mikään ei muutu.",
       "no_devicegrant_audi": "Sopivaa Audia ei löytynyt. Tämä varayhteys koskee vain Audia, jonka lisäsit QR-/sovelluskirjautumisella ja jolla sitä ei vielä ole. Lisää Audisi ensin siten ja palaa sitten tänne.",
-      "porsche_login_wall": "Tunnistetietosi ovat kunnossa — kirjautuminen pääsi salasanavaiheen ohi, mutta pysähtyi Porschen captcha-/suostumusnäyttöön, jota se ei voi suorittaa automaattisesti (havaittu osoitteessa my.porsche.com). Kyseessä on Porschen puolen este, seurattu kohdassa #1337, ei väärä salasana. Älä yritä uudelleen silmukassa — toistuvat yritykset ovat lukinneet Porsche-tilejä."
+      "porsche_login_wall": "Tunnistetietosi ovat kunnossa — kirjautuminen pääsi salasanavaiheen ohi, mutta pysähtyi Porschen captcha-/suostumusnäyttöön, jota se ei voi suorittaa automaattisesti (havaittu osoitteessa my.porsche.com). Kyseessä on Porschen puolen este, seurattu kohdassa #1337, ei väärä salasana. Älä yritä uudelleen silmukassa — toistuvat yritykset ovat lukinneet Porsche-tilejä. Jos voit, ilmoita siitä, jotta voimme korjata sen (liitä diagnostiikka): {report_url}",
+      "porsche_captcha_failed": "Captchaa ei voitu vahvistaa, ja se on nyt käytetty. Sulje tämä ikkuna ja aloita Porsche-kirjautuminen uudelleen saadaksesi uuden. Jos voit, ilmoita siitä, jotta voimme korjata sen (liitä diagnostiikka): {report_url}",
+      "porsche_captcha_cooldown": "Liian monta captcha-yritystä. Toistuvat yritykset voivat saada Porschen lukitsemaan tilin väliaikaisesti tai merkitsemään verkkosi, joten toiminto pysäytettiin tilisi suojaamiseksi. Odota muutama minuutti ennen kuin yrität uudelleen. Jos voit, ilmoita siitä, jotta voimme korjata sen (liitä diagnostiikka): {report_url}",
+      "reconfigure_failed": "Uudelleenmääritys epäonnistui: määritysmerkintää ei löytynyt. Yritä uudelleen.",
+      "reauth_failed": "Uudelleentodennus epäonnistui: määritysmerkintää ei löytynyt. Yritä uudelleen."
     },
     "progress": {
       "awaiting_browser_login": "Avaa {verification_uri} millä tahansa selaimella, kirjaudu Brand ID -tiliisi ja vahvista koodi {user_code}.",

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha requis",
-        "description": "Porsche exige la résolution d'un captcha pour continuer la connexion.\n\n{captcha_img}\n\nRésolvez-le une seule fois du mieux que vous pouvez — des tentatives répétées ont déjà conduit Porsche à bloquer des comptes pour activité suspecte.",
+        "description": "Porsche exige la résolution d'un captcha pour continuer la connexion.\n\n{captcha_img}\n\nRésolvez-le une seule fois du mieux que vous pouvez — des tentatives répétées ont déjà conduit Porsche à bloquer des comptes pour activité suspecte.\n\nCe que vous saisissez ici ne quitte pas votre instance Home Assistant. Si l'image ne se charge pas ou si vous obtenez sans cesse des erreurs, vous pouvez le signaler (joindre les diagnostics) : {report_url}",
         "data": {
           "captcha_code": "Code captcha"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Connexion au téléphone établie, mais l'application de la marque n'y est pas installée.",
       "companion_unknown_brand": "Cette marque ne dispose pas encore de préréglage compagnon.",
       "companion_agent_token_too_short": "Le jeton de l'agent est trop court. Collez le jeton aléatoire généré par l'application agent (au moins 32 caractères).",
-      "companion_host_required": "Saisissez l'adresse IP du téléphone — ou cochez l'option agent si c'est le téléphone qui appelle Home Assistant."
+      "companion_host_required": "Saisissez l'adresse IP du téléphone — ou cochez l'option agent si c'est le téléphone qui appelle Home Assistant.",
+      "missing_captcha": "Veuillez saisir les caractères affichés dans l'image ci-dessus.",
+      "captcha_retry": "Veuillez résoudre le captcha affiché ci-dessus pour continuer."
     },
     "abort": {
       "already_configured": "Ce compte est déjà configuré.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Votre véhicule n'est pas éligible à la connexion durable MBB — le backend a renvoyé « Unknown user ». Il s'agit d'un modèle ID / MEB récent (ID.3/4/5, e-up, etc.) jamais enregistré dans l'ancien système Car-Net/MBB ; la connexion durable et les commandes à distance ne peuvent donc pas l'atteindre. Utilisez le canal du portail EU Data Act (ou la connexion E-mail + mot de passe) pour ces véhicules. La connexion MBB est destinée aux anciennes voitures Car-Net (la plupart des modèles hybrides rechargeables / thermiques).",
       "mbb_fallback_armed": "Connexion de secours configurée. Si la connexion habituelle de votre Audi cesse un jour d'accepter les commandes à distance, le verrouillage/déverrouillage, la climatisation et la charge basculent automatiquement sur la connexion de secours. Rien ne change au quotidien.",
       "no_devicegrant_audi": "Aucune Audi correspondante trouvée. Cette connexion de secours s'applique uniquement à une Audi que vous avez ajoutée via la connexion QR / application et qui n'en dispose pas encore. Ajoutez d'abord votre Audi de cette façon, puis revenez ici.",
-      "porsche_login_wall": "Tes identifiants sont corrects — la connexion a passé l'étape du mot de passe, mais s'est arrêtée à un écran captcha/consentement de Porsche qu'elle ne peut pas terminer automatiquement (observé à my.porsche.com). C'est un blocage du côté de Porsche, suivi dans #1337, pas un mot de passe incorrect. Ne réessaie pas en boucle — des tentatives répétées ont bloqué des comptes Porsche."
+      "porsche_login_wall": "Tes identifiants sont corrects — la connexion a passé l'étape du mot de passe, mais s'est arrêtée à un écran captcha/consentement de Porsche qu'elle ne peut pas terminer automatiquement (observé à my.porsche.com). C'est un blocage du côté de Porsche, suivi dans #1337, pas un mot de passe incorrect. Ne réessaie pas en boucle — des tentatives répétées ont bloqué des comptes Porsche. Si possible, merci de le signaler pour que nous puissions corriger le problème (joindre les diagnostics) : {report_url}",
+      "porsche_captcha_failed": "Ce captcha n'a pas pu être vérifié et il est désormais épuisé. Veuillez fermer cette boîte de dialogue et relancer la connexion Porsche pour en obtenir un nouveau. Si possible, merci de le signaler pour que nous puissions corriger le problème (joindre les diagnostics) : {report_url}",
+      "porsche_captcha_cooldown": "Trop de tentatives de captcha. Des essais répétés peuvent amener Porsche à verrouiller temporairement le compte ou à signaler votre réseau ; l'opération a donc été arrêtée pour protéger votre compte. Attendez quelques minutes avant de réessayer. Si possible, merci de le signaler pour que nous puissions corriger le problème (joindre les diagnostics) : {report_url}",
+      "reconfigure_failed": "Échec de la reconfiguration : l'entrée de configuration est introuvable. Veuillez réessayer.",
+      "reauth_failed": "Échec de la ré-authentification : l'entrée de configuration est introuvable. Veuillez réessayer."
     },
     "progress": {
       "awaiting_browser_login": "Ouvrez {verification_uri} dans n'importe quel navigateur, connectez-vous avec votre compte Brand ID et confirmez le code {user_code}.",

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha richiesto",
-        "description": "Porsche richiede di risolvere un captcha per continuare l'accesso.\n\n{captcha_img}\n\nRisolvilo una sola volta al meglio delle tue possibilità — tentativi ripetuti hanno già portato Porsche a bloccare account per attività sospette.",
+        "description": "Porsche richiede di risolvere un captcha per continuare l'accesso.\n\n{captcha_img}\n\nRisolvilo una sola volta al meglio delle tue possibilità — tentativi ripetuti hanno già portato Porsche a bloccare account per attività sospette.\n\nCiò che inserisci qui non lascia la tua istanza di Home Assistant. Se l'immagine non si carica o continui a ricevere errori, puoi segnalarlo (allega la diagnostica): {report_url}",
         "data": {
           "captcha_code": "Codice captcha"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Connessione al telefono riuscita, ma l'app della marca non è installata.",
       "companion_unknown_brand": "Questa marca non ha ancora un preset per il telefono di appoggio.",
       "companion_agent_token_too_short": "Il token dell'agent è troppo corto. Incolla il token casuale generato dall'app agent (almeno 32 caratteri).",
-      "companion_host_required": "Inserisci l'indirizzo IP del telefono — oppure seleziona l'opzione agent se è il telefono a chiamare Home Assistant."
+      "companion_host_required": "Inserisci l'indirizzo IP del telefono — oppure seleziona l'opzione agent se è il telefono a chiamare Home Assistant.",
+      "missing_captcha": "Inserisci i caratteri mostrati nell'immagine qui sopra.",
+      "captcha_retry": "Risolvi il captcha mostrato qui sopra per continuare."
     },
     "abort": {
       "already_configured": "Questo account è già configurato.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Il tuo veicolo non è idoneo al login duraturo MBB — il backend ha risposto \"Unknown user\". Questo significa che è un modello ID / MEB più recente (ID.3/4/5, e-up, ecc.) che non è mai stato registrato nel vecchio sistema Car-Net/MBB, quindi il login duraturo + i comandi remoti non lo possono raggiungere. Per questi veicoli usa invece il canale del portale EU Data Act (o il login con email + password). Il login MBB è per le auto Car-Net più vecchie (la maggior parte dei modelli PHEV / a combustione).",
       "mbb_fallback_armed": "Connessione di riserva configurata. Se la connessione normale del tuo Audi dovesse mai smettere di accettare i comandi a distanza, blocca/sblocca, clima e ricarica passano automaticamente alla riserva. Nel quotidiano non cambia nulla.",
       "no_devicegrant_audi": "Nessun Audi corrispondente trovato. Questa riserva vale solo per un Audi che hai aggiunto con il login QR / app e che non ce l'ha già. Aggiungi prima il tuo Audi in quel modo, poi torna qui.",
-      "porsche_login_wall": "Le tue credenziali sono corrette — l'accesso ha superato il passaggio della password, ma si è fermato a una schermata captcha/consenso di Porsche che non può completare automaticamente (vista su my.porsche.com). È un blocco lato Porsche, tracciato in #1337, non una password errata. Non riprovare in un ciclo — tentativi ripetuti hanno bloccato account Porsche."
+      "porsche_login_wall": "Le tue credenziali sono corrette — l'accesso ha superato il passaggio della password, ma si è fermato a una schermata captcha/consenso di Porsche che non può completare automaticamente (vista su my.porsche.com). È un blocco lato Porsche, tracciato in #1337, non una password errata. Non riprovare in un ciclo — tentativi ripetuti hanno bloccato account Porsche. Se puoi, segnalalo così possiamo risolverlo (allega la diagnostica): {report_url}",
+      "porsche_captcha_failed": "Impossibile verificare il captcha ed è ormai scaduto. Chiudi questa finestra e riavvia l'accesso Porsche per ottenerne uno nuovo. Se puoi, segnalalo così possiamo risolverlo (allega la diagnostica): {report_url}",
+      "porsche_captcha_cooldown": "Troppi tentativi di captcha. Tentativi ripetuti possono far bloccare temporaneamente l'account da parte di Porsche o segnalare la tua rete, quindi l'operazione è stata interrotta per proteggere il tuo account. Attendi qualche minuto prima di riprovare. Se puoi, segnalalo così possiamo risolverlo (allega la diagnostica): {report_url}",
+      "reconfigure_failed": "Riconfigurazione non riuscita: voce di configurazione non trovata. Riprova.",
+      "reauth_failed": "Ri-autenticazione non riuscita: voce di configurazione non trovata. Riprova."
     },
     "progress": {
       "awaiting_browser_login": "Apri {verification_uri} in un browser qualsiasi, accedi con il tuo account Brand ID e conferma il codice {user_code}.",

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha kreves",
-        "description": "Porsche krever at du løser en captcha for å fortsette innloggingen.\n\n{captcha_img}\n\nLøs det bare én gang etter beste evne — gjentatte mislykkede forsøk har fått Porsche til å låse kontoer på grunn av mistenkelig aktivitet.",
+        "description": "Porsche krever at du løser en captcha for å fortsette innloggingen.\n\n{captcha_img}\n\nLøs det bare én gang etter beste evne — gjentatte mislykkede forsøk har fått Porsche til å låse kontoer på grunn av mistenkelig aktivitet.\n\nDet du skriver inn her, forlater ikke Home Assistant-instansen din. Hvis bildet ikke lastes inn eller du stadig får feil, kan du rapportere det (legg ved diagnostikk): {report_url}",
         "data": {
           "captcha_code": "Captcha-kode"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Koblet til telefonen, men merkeappen er ikke installert på den.",
       "companion_unknown_brand": "Dette merket har ennå ingen forhåndsinnstilling for ekstra telefon.",
       "companion_agent_token_too_short": "Agent-tokenet er for kort. Lim inn det tilfeldige tokenet agent-appen genererte (minst 32 tegn).",
-      "companion_host_required": "Oppgi telefonens IP-adresse — eller kryss av for agent-alternativet hvis telefonen ringer Home Assistant."
+      "companion_host_required": "Oppgi telefonens IP-adresse — eller kryss av for agent-alternativet hvis telefonen ringer Home Assistant.",
+      "missing_captcha": "Skriv inn tegnene som vises i bildet over.",
+      "captcha_retry": "Løs captchaen som vises over for å fortsette."
     },
     "abort": {
       "already_configured": "Denne kontoen er allerede konfigurert.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Kjøretøyet ditt kvalifiserer ikke for den varige MBB-påloggingen — baksystemet svarte «Unknown user». Det betyr at det er en nyere ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldri ble registrert i det eldre Car-Net/MBB-systemet, så den varige påloggingen + fjernkommandoene når ikke frem til det. Bruk EU Data Act-portalkanalen (eller e-post + passord-påloggingen) for disse kjøretøyene i stedet. MBB-påloggingen er for eldre Car-Net-biler (de fleste PHEV-/forbrenningsmodeller).",
       "mbb_fallback_armed": "Reserveforbindelsen er satt opp. Hvis den vanlige forbindelsen til Audi-en din en gang slutter å ta imot fjernkommandoer, bytter lås/lås opp, klima og lading automatisk over til reserven. Ingenting endres til daglig.",
       "no_devicegrant_audi": "Fant ingen passende Audi. Denne reserven gjelder bare en Audi du la til med QR-/app-pålogging og som ikke allerede har den. Legg til Audi-en din på den måten først, og kom deretter tilbake hit.",
-      "porsche_login_wall": "Påloggingsdetaljene dine er i orden — innloggingen kom forbi passordtrinnet, men stoppet ved en Porsche captcha-/samtykkeskjerm som den ikke kan fullføre automatisk (sett på my.porsche.com). Dette er en sperre på Porsches side, spores i #1337, ikke feil passord. Ikke prøv igjen i en løkke — gjentatte forsøk har låst Porsche-kontoer."
+      "porsche_login_wall": "Påloggingsdetaljene dine er i orden — innloggingen kom forbi passordtrinnet, men stoppet ved en Porsche captcha-/samtykkeskjerm som den ikke kan fullføre automatisk (sett på my.porsche.com). Dette er en sperre på Porsches side, spores i #1337, ikke feil passord. Ikke prøv igjen i en løkke — gjentatte forsøk har låst Porsche-kontoer. Hvis du kan, rapporter det gjerne så vi kan fikse det (legg ved diagnostikk): {report_url}",
+      "porsche_captcha_failed": "Captchaen kunne ikke bekreftes og er nå brukt opp. Lukk denne dialogen og start Porsche-innloggingen på nytt for å få en ny. Hvis du kan, rapporter det gjerne så vi kan fikse det (legg ved diagnostikk): {report_url}",
+      "porsche_captcha_cooldown": "For mange captcha-forsøk. Gjentatte forsøk kan føre til at Porsche midlertidig låser kontoen eller flagger nettverket ditt, så dette ble stoppet for å beskytte kontoen din. Vent noen minutter før du prøver igjen. Hvis du kan, rapporter det gjerne så vi kan fikse det (legg ved diagnostikk): {report_url}",
+      "reconfigure_failed": "Rekonfigurering mislyktes: konfigurasjonsoppføringen ble ikke funnet. Prøv igjen.",
+      "reauth_failed": "Reautentisering mislyktes: konfigurasjonsoppføringen ble ikke funnet. Prøv igjen."
     },
     "progress": {
       "awaiting_browser_login": "Åpne {verification_uri} i hvilken som helst nettleser, logg inn med Brand ID-kontoen din, og bekreft koden {user_code}.",

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha vereist",
-        "description": "Porsche vereist het oplossen van een captcha om door te gaan met inloggen.\n\n{captcha_img}\n\nLos dit slechts één keer op met je beste gok — herhaalde mislukte pogingen hebben er bij Porsche al toe geleid dat accounts wegens verdachte activiteit werden vergrendeld.",
+        "description": "Porsche vereist het oplossen van een captcha om door te gaan met inloggen.\n\n{captcha_img}\n\nLos dit slechts één keer op met je beste gok — herhaalde mislukte pogingen hebben er bij Porsche al toe geleid dat accounts wegens verdachte activiteit werden vergrendeld.\n\nWat je hier invoert, verlaat je Home Assistant-installatie niet. Als de afbeelding niet laadt of je steeds fouten krijgt, kun je het melden (diagnostische gegevens bijvoegen): {report_url}",
         "data": {
           "captcha_code": "Captcha-code"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Verbonden met de telefoon, maar de merk-app is er niet op geïnstalleerd.",
       "companion_unknown_brand": "Voor dat merk is nog geen voorinstelling voor de reservetelefoon beschikbaar.",
       "companion_agent_token_too_short": "Het agent-token is te kort. Plak het willekeurige token dat de agent-app heeft gegenereerd (minstens 32 tekens).",
-      "companion_host_required": "Voer het IP-adres van de telefoon in — of vink de agent-optie aan als de telefoon Home Assistant belt."
+      "companion_host_required": "Voer het IP-adres van de telefoon in — of vink de agent-optie aan als de telefoon Home Assistant belt.",
+      "missing_captcha": "Voer de tekens in die in de afbeelding hierboven worden getoond.",
+      "captcha_retry": "Los de captcha hierboven op om door te gaan."
     },
     "abort": {
       "already_configured": "Dit account is al geconfigureerd.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Je voertuig komt niet in aanmerking voor de duurzame MBB-login — de backend gaf \"Unknown user\" terug. Het is een nieuwer ID-/MEB-model (ID.3/4/5, e-up enz.) dat nooit in het oude Car-Net/MBB-systeem was geregistreerd, dus de duurzame login en de commando's op afstand kunnen het niet bereiken. Gebruik voor zulke voertuigen het EU Data Act-portaalkanaal (of de e-mail-+-wachtwoordlogin). De MBB-login is voor oudere Car-Net-auto's (de meeste plug-inhybride / verbrandingsmodellen).",
       "mbb_fallback_armed": "Reserveverbinding ingesteld. Als de normale verbinding van je Audi ooit geen commando's op afstand meer accepteert, schakelen vergrendelen/ontgrendelen, klimaat en laden automatisch over naar de reserve. In het dagelijks gebruik verandert er niets.",
       "no_devicegrant_audi": "Geen passende Audi gevonden. Deze reserve geldt alleen voor een Audi die je met de QR-/app-login hebt toegevoegd en die de reserve nog niet heeft. Voeg je Audi eerst op die manier toe en kom dan hier terug.",
-      "porsche_login_wall": "Je inloggegevens zijn in orde — de aanmelding kwam voorbij de wachtwoordstap, maar stopte bij een Porsche captcha-/toestemmingsscherm dat niet automatisch kan worden voltooid (gezien op my.porsche.com). Dit is een blokkade aan Porsche-zijde, gevolgd in #1337, geen verkeerd wachtwoord. Probeer het niet in een lus opnieuw — herhaalde pogingen hebben Porsche-accounts geblokkeerd."
+      "porsche_login_wall": "Je inloggegevens zijn in orde — de aanmelding kwam voorbij de wachtwoordstap, maar stopte bij een Porsche captcha-/toestemmingsscherm dat niet automatisch kan worden voltooid (gezien op my.porsche.com). Dit is een blokkade aan Porsche-zijde, gevolgd in #1337, geen verkeerd wachtwoord. Probeer het niet in een lus opnieuw — herhaalde pogingen hebben Porsche-accounts geblokkeerd. Meld het als je kunt, zodat we het kunnen oplossen (diagnostische gegevens bijvoegen): {report_url}",
+      "porsche_captcha_failed": "De captcha kon niet worden geverifieerd en is nu verbruikt. Sluit dit venster en start het Porsche-aanmelden opnieuw voor een nieuwe. Meld het als je kunt, zodat we het kunnen oplossen (diagnostische gegevens bijvoegen): {report_url}",
+      "porsche_captcha_cooldown": "Te veel captcha-pogingen. Herhaalde pogingen kunnen ertoe leiden dat Porsche het account tijdelijk blokkeert of je netwerk markeert; daarom is dit gestopt om je account te beschermen. Wacht een paar minuten voordat je het opnieuw probeert. Meld het als je kunt, zodat we het kunnen oplossen (diagnostische gegevens bijvoegen): {report_url}",
+      "reconfigure_failed": "Herconfiguratie mislukt: het configuratie-item kon niet worden gevonden. Probeer het opnieuw.",
+      "reauth_failed": "Herauthenticatie mislukt: het configuratie-item kon niet worden gevonden. Probeer het opnieuw."
     },
     "progress": {
       "awaiting_browser_login": "Open {verification_uri} in een willekeurige browser, meld je aan met je Brand ID-account en bevestig de code {user_code}.",

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Wymagana captcha",
-        "description": "Porsche wymaga rozwiązania captchy, aby kontynuować logowanie.\n\n{captcha_img}\n\nRozwiąż to tylko raz, najlepiej jak potrafisz — powtarzające się nieudane próby doprowadziły już do blokowania kont Porsche z powodu podejrzanej aktywności.",
+        "description": "Porsche wymaga rozwiązania captchy, aby kontynuować logowanie.\n\n{captcha_img}\n\nRozwiąż to tylko raz, najlepiej jak potrafisz — powtarzające się nieudane próby doprowadziły już do blokowania kont Porsche z powodu podejrzanej aktywności.\n\nTo, co tu wpiszesz, nie opuszcza Twojej instancji Home Assistant. Jeśli obraz się nie ładuje lub ciągle pojawiają się błędy, możesz to zgłosić (dołącz diagnostykę): {report_url}",
         "data": {
           "captcha_code": "Kod captcha"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Połączono z telefonem, ale aplikacja marki nie jest na nim zainstalowana.",
       "companion_unknown_brand": "Ta marka nie ma jeszcze gotowego profilu telefonu pomocniczego.",
       "companion_agent_token_too_short": "Token agenta jest za krótki. Wklej losowy token wygenerowany przez aplikację agenta (co najmniej 32 znaki).",
-      "companion_host_required": "Podaj adres IP telefonu — albo zaznacz opcję agenta, jeśli to telefon łączy się z Home Assistant."
+      "companion_host_required": "Podaj adres IP telefonu — albo zaznacz opcję agenta, jeśli to telefon łączy się z Home Assistant.",
+      "missing_captcha": "Wpisz znaki widoczne na obrazku powyżej.",
+      "captcha_retry": "Rozwiąż captchę widoczną powyżej, aby kontynuować."
     },
     "abort": {
       "already_configured": "To konto jest już skonfigurowane.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Twój pojazd nie kwalifikuje się do trwałego logowania MBB — backend zwrócił „Unknown user”. To nowszy model ID / MEB (ID.3/4/5, e-up itp.), który nigdy nie był zarejestrowany w starym systemie Car-Net/MBB, więc trwałe logowanie i polecenia zdalne nie mogą go osiągnąć. Dla takich pojazdów użyj kanału portalu EU Data Act (lub logowania e-mail + hasło). Logowanie MBB jest przeznaczone dla starszych aut Car-Net (większość modeli hybryd plug-in / spalinowych).",
       "mbb_fallback_armed": "Połączenie zapasowe skonfigurowane. Jeśli zwykłe połączenie Twojego Audi kiedyś przestanie przyjmować polecenia zdalne, ryglowanie/odryglowanie, klimatyzacja i ładowanie automatycznie przełączą się na zapasowe. Na co dzień nic się nie zmienia.",
       "no_devicegrant_audi": "Nie znaleziono pasującego Audi. To połączenie zapasowe dotyczy tylko Audi dodanego przez logowanie QR / aplikacją, które jeszcze go nie ma. Najpierw dodaj w ten sposób swoje Audi, a potem wróć tutaj.",
-      "porsche_login_wall": "Twoje dane logowania są poprawne — logowanie przeszło etap hasła, ale zatrzymało się na ekranie captcha/zgody Porsche, którego nie da się ukończyć automatycznie (widziany pod my.porsche.com). To blokada po stronie Porsche, śledzona w #1337, a nie błędne hasło. Nie ponawiaj w pętli — powtarzane próby blokowały konta Porsche."
+      "porsche_login_wall": "Twoje dane logowania są poprawne — logowanie przeszło etap hasła, ale zatrzymało się na ekranie captcha/zgody Porsche, którego nie da się ukończyć automatycznie (widziany pod my.porsche.com). To blokada po stronie Porsche, śledzona w #1337, a nie błędne hasło. Nie ponawiaj w pętli — powtarzane próby blokowały konta Porsche. Jeśli możesz, zgłoś to, abyśmy mogli to naprawić (dołącz diagnostykę): {report_url}",
+      "porsche_captcha_failed": "Nie udało się zweryfikować captchy i jest ona już zużyta. Zamknij to okno i uruchom logowanie Porsche ponownie, aby otrzymać nową. Jeśli możesz, zgłoś to, abyśmy mogli to naprawić (dołącz diagnostykę): {report_url}",
+      "porsche_captcha_cooldown": "Zbyt wiele prób captchy. Powtarzane próby mogą spowodować, że Porsche tymczasowo zablokuje konto lub oznaczy Twoją sieć, dlatego przerwano działanie, aby chronić Twoje konto. Odczekaj kilka minut przed ponowną próbą. Jeśli możesz, zgłoś to, abyśmy mogli to naprawić (dołącz diagnostykę): {report_url}",
+      "reconfigure_failed": "Ponowna konfiguracja nie powiodła się: nie znaleziono wpisu konfiguracji. Spróbuj ponownie.",
+      "reauth_failed": "Ponowne uwierzytelnianie nie powiodło się: nie znaleziono wpisu konfiguracji. Spróbuj ponownie."
     },
     "progress": {
       "awaiting_browser_login": "Otwórz {verification_uri} w dowolnej przeglądarce, zaloguj się na konto Brand ID i potwierdź kod {user_code}.",

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha krävs",
-        "description": "Porsche kräver att du löser en captcha för att fortsätta inloggningen.\n\n{captcha_img}\n\nLös det bara en gång efter bästa förmåga — upprepade misslyckade försök har fått Porsche att låsa konton på grund av misstänkt aktivitet.",
+        "description": "Porsche kräver att du löser en captcha för att fortsätta inloggningen.\n\n{captcha_img}\n\nLös det bara en gång efter bästa förmåga — upprepade misslyckade försök har fått Porsche att låsa konton på grund av misstänkt aktivitet.\n\nDet du skriver in här lämnar inte din Home Assistant-instans. Om bilden inte laddas eller du hela tiden får fel kan du rapportera det (bifoga diagnostik): {report_url}",
         "data": {
           "captcha_code": "Captcha-kod"
         },
@@ -204,7 +204,9 @@
       "companion_app_not_found": "Anslöt till telefonen, men märkesappen är inte installerad på den.",
       "companion_unknown_brand": "Det märket har ännu ingen förinställning för extra telefon.",
       "companion_agent_token_too_short": "Agent-token är för kort. Klistra in den slumpmässiga token som agentappen skapade (minst 32 tecken).",
-      "companion_host_required": "Ange telefonens IP-adress — eller kryssa i agentalternativet om telefonen ringer upp Home Assistant."
+      "companion_host_required": "Ange telefonens IP-adress — eller kryssa i agentalternativet om telefonen ringer upp Home Assistant.",
+      "missing_captcha": "Skriv in tecknen som visas i bilden ovan.",
+      "captcha_retry": "Lös den captcha som visas ovan för att fortsätta."
     },
     "abort": {
       "already_configured": "Det här kontot är redan konfigurerat.",
@@ -213,7 +215,11 @@
       "mbb_not_eligible": "Ditt fordon är inte behörigt för den varaktiga MBB-inloggningen — backend returnerade \"Unknown user\". Det är en nyare ID-/MEB-modell (ID.3/4/5, e-up osv.) som aldrig registrerades i det gamla Car-Net/MBB-systemet, så den varaktiga inloggningen och fjärrkommandona når den inte. Använd EU Data Act-portalkanalen (eller e-post + lösenord-inloggningen) för sådana fordon. MBB-inloggningen är för äldre Car-Net-bilar (de flesta laddhybrid-/förbränningsmodeller).",
       "mbb_fallback_armed": "Reservanslutningen är inställd. Om din Audis vanliga anslutning någon gång slutar ta emot fjärrkommandon växlar lås/lås upp, klimat och laddning automatiskt till reserven. Ingenting ändras i vardagen.",
       "no_devicegrant_audi": "Ingen matchande Audi hittades. Den här reserven gäller bara en Audi som du lagt till med QR-/app-inloggningen och som inte redan har den. Lägg till din Audi på det sättet först och kom sedan tillbaka hit.",
-      "porsche_login_wall": "Dina inloggningsuppgifter är korrekta — inloggningen tog sig förbi lösenordssteget, men stannade vid en Porsche captcha-/samtyckesskärm som den inte kan slutföra automatiskt (sedd på my.porsche.com). Det här är en spärr på Porsches sida, spårad i #1337, inte ett fel lösenord. Försök inte igen i en loop — upprepade försök har låst Porsche-konton."
+      "porsche_login_wall": "Dina inloggningsuppgifter är korrekta — inloggningen tog sig förbi lösenordssteget, men stannade vid en Porsche captcha-/samtyckesskärm som den inte kan slutföra automatiskt (sedd på my.porsche.com). Det här är en spärr på Porsches sida, spårad i #1337, inte ett fel lösenord. Försök inte igen i en loop — upprepade försök har låst Porsche-konton. Om du kan, rapportera det gärna så att vi kan åtgärda det (bifoga diagnostik): {report_url}",
+      "porsche_captcha_failed": "Captchan kunde inte verifieras och är nu förbrukad. Stäng den här dialogen och starta om Porsche-inloggningen för att få en ny. Om du kan, rapportera det gärna så att vi kan åtgärda det (bifoga diagnostik): {report_url}",
+      "porsche_captcha_cooldown": "För många captcha-försök. Upprepade försök kan göra att Porsche tillfälligt låser kontot eller flaggar ditt nätverk, så detta stoppades för att skydda ditt konto. Vänta några minuter innan du försöker igen. Om du kan, rapportera det gärna så att vi kan åtgärda det (bifoga diagnostik): {report_url}",
+      "reconfigure_failed": "Omkonfigurationen misslyckades: konfigurationsposten kunde inte hittas. Försök igen.",
+      "reauth_failed": "Omautentiseringen misslyckades: konfigurationsposten kunde inte hittas. Försök igen."
     },
     "progress": {
       "awaiting_browser_login": "Öppna {verification_uri} i valfri webbläsare, logga in med ditt Brand ID-konto och bekräfta koden {user_code}.",

--- a/tests/test_1337_porsche_captcha_hardening.py
+++ b/tests/test_1337_porsche_captcha_hardening.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1337 — hardening of the Porsche captcha config-flow step (G1/G3/G4/G7).
+
+Covers the in-flow GitHub report affordance (must be PII-free), the bounded
+captcha loop (cooldown abort after repeated challenges — repeated failures have
+locked Porsche accounts), clean give-up aborts instead of re-showing a consumed
+captcha, the blank-submit guard, the transient network re-show, and that
+Reconfigure now survives a captcha instead of propagating it uncaught.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.vag_connect.config_flow import (
+    CONF_CAPTCHA_CODE,
+    VagConnectConfigFlow,
+)
+from custom_components.vag_connect.const import (
+    CONF_BRAND,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    DOMAIN,
+)
+from custom_components.vag_connect.cariad.exceptions import PorscheCaptchaRequiredError
+
+_VALIDATE = "custom_components.vag_connect.config_flow._validate_credentials"
+_IMG = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
+
+
+def _flow() -> VagConnectConfigFlow:
+    f = VagConnectConfigFlow()
+    f.hass = MagicMock()
+    f.context = {}
+    f.handler = DOMAIN
+    f.flow_id = "test"
+    f._pending_username = "secret-user@example.com"
+    f._pending_password = "hunter2-secret"
+    f._pending_entry_data = {}
+    f._porsche_captcha_image = _IMG
+    f._porsche_captcha_state = "state-abc"
+    f._porsche_captcha_verifier = "verifier-xyz"
+    f._porsche_captcha_return = "email_password"
+    f._porsche_captcha_attempts = 0
+    return f
+
+
+# ── G7: the report URL must never carry anything identifying ───────────────────
+class TestReportUrlIsPiiFree:
+    def test_well_formed_and_carries_only_non_identifying_context(self) -> None:
+        url = VagConnectConfigFlow._porsche_report_url(
+            "email_password", "porsche_login_wall", screen="captcha"
+        )
+        assert url.startswith(
+            "https://github.com/its-me-prash/vwgroup-connect-ha/issues/new?"
+        )
+        assert "porsche_login_wall" in url  # error key is fine (not PII)
+        assert "email_password" in url      # step name is fine (not PII)
+
+    def test_never_embeds_credentials_state_or_secrets(self) -> None:
+        # Build a URL the way every call site does, then prove the sensitive
+        # values the flow is holding can NEVER reach the query string — the
+        # helper simply takes no such argument (redaction by construction).
+        url = VagConnectConfigFlow._porsche_report_url(
+            "reauth", "porsche_captcha_cooldown"
+        )
+        for leak in (
+            "secret-user@example.com", "hunter2-secret",
+            "state-abc", "verifier-xyz", _IMG, "password",
+        ):
+            assert leak not in url
+
+
+# ── G3/G4: bounded, clean captcha step behavior ────────────────────────────────
+@pytest.mark.asyncio
+async def test_blank_submit_shows_missing_error_without_calling_server() -> None:
+    f = _flow()
+    with patch(_VALIDATE, new=AsyncMock()) as val:
+        res = await f.async_step_porsche_captcha({CONF_CAPTCHA_CODE: "   "})
+    val.assert_not_awaited()  # never hit Porsche Auth0 on a blank submit
+    assert res["type"] == "form"
+    assert res["errors"]["base"] == "missing_captcha"
+    assert "report_url" in res["description_placeholders"]
+
+
+@pytest.mark.asyncio
+async def test_chained_captcha_loop_is_bounded_with_cooldown_abort() -> None:
+    f = _flow()
+    err = PorscheCaptchaRequiredError(_IMG, "state-2", "verifier-2")
+    with patch(_VALIDATE, new=AsyncMock(side_effect=err)):
+        r1 = await f.async_step_porsche_captcha({CONF_CAPTCHA_CODE: "AAAA"})
+        r2 = await f.async_step_porsche_captcha({CONF_CAPTCHA_CODE: "BBBB"})
+        r3 = await f.async_step_porsche_captcha({CONF_CAPTCHA_CODE: "CCCC"})
+    assert r1["type"] == "form" and r1["errors"]["base"] == "captcha_retry"
+    assert r2["type"] == "form"
+    # bounded: the 3rd attempt stops instead of hammering on / risking a lock
+    assert r3["type"] == "abort"
+    assert r3["reason"] == "porsche_captcha_cooldown"
+    assert "report_url" in r3["description_placeholders"]
+
+
+@pytest.mark.asyncio
+async def test_non_wall_rejection_aborts_clean_not_reshowing_dead_captcha() -> None:
+    f = _flow()
+    with patch(_VALIDATE, new=AsyncMock(side_effect=ValueError("invalid_credentials"))):
+        res = await f.async_step_porsche_captcha({CONF_CAPTCHA_CODE: "AAAA"})
+    assert res["type"] == "abort"
+    assert res["reason"] == "porsche_captcha_failed"
+    assert "report_url" in res["description_placeholders"]
+
+
+@pytest.mark.asyncio
+async def test_post_password_wall_aborts_with_report() -> None:
+    f = _flow()
+    with patch(_VALIDATE, new=AsyncMock(side_effect=ValueError("porsche_login_wall"))):
+        res = await f.async_step_porsche_captcha({CONF_CAPTCHA_CODE: "AAAA"})
+    assert res["type"] == "abort"
+    assert res["reason"] == "porsche_login_wall"
+    assert "report_url" in res["description_placeholders"]
+
+
+@pytest.mark.asyncio
+async def test_transient_network_error_reshows_form_not_abort() -> None:
+    f = _flow()
+    with patch(_VALIDATE, new=AsyncMock(side_effect=ValueError("cannot_connect"))):
+        res = await f.async_step_porsche_captcha({CONF_CAPTCHA_CODE: "AAAA"})
+    assert res["type"] == "form"  # retryable — the challenge may still be valid
+    assert res["errors"]["base"] == "cannot_connect"
+
+
+# ── G1: Reconfigure survives a Porsche captcha instead of crashing ─────────────
+@pytest.mark.asyncio
+async def test_reconfigure_routes_captcha_to_step_instead_of_crashing() -> None:
+    f = VagConnectConfigFlow()
+    f.hass = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "e1"
+    entry.unique_id = "porsche_a@b.com"
+    entry.data = {}
+    f.hass.config_entries.async_get_entry = MagicMock(return_value=entry)
+    f.context = {"entry_id": "e1"}
+    f.handler = DOMAIN
+    f.flow_id = "test"
+    err = PorscheCaptchaRequiredError(_IMG, "st", "ver")
+    with patch(_VALIDATE, new=AsyncMock(side_effect=err)):
+        res = await f.async_step_reconfigure({
+            CONF_BRAND: "porsche",
+            CONF_USERNAME: "a@b.com",
+            CONF_PASSWORD: "pw",
+        })
+    assert res["type"] == "form"
+    assert res["step_id"] == "porsche_captcha"
+    assert f._porsche_captcha_return == "reconfigure"
+    assert f._porsche_reconfigure_entry_id == "e1"
+
+
+# ── strings integrity: every new reason/error exists + placeholders wired ──────
+def test_new_strings_present_and_report_placeholder_wired() -> None:
+    import json
+    import pathlib
+
+    base = pathlib.Path(__file__).resolve().parents[1] / "custom_components" / "vag_connect"
+    cfg = json.loads((base / "strings.json").read_text(encoding="utf-8"))["config"]
+    assert "missing_captcha" in cfg["error"]
+    assert "captcha_retry" in cfg["error"]
+    for key in (
+        "porsche_captcha_failed", "porsche_captcha_cooldown",
+        "reconfigure_failed", "reauth_failed",
+    ):
+        assert key in cfg["abort"], key
+    assert "{report_url}" in cfg["abort"]["porsche_login_wall"]
+    assert "{report_url}" in cfg["abort"]["porsche_captcha_failed"]
+    assert "{report_url}" in cfg["abort"]["porsche_captcha_cooldown"]
+    assert "{report_url}" in cfg["step"]["porsche_captcha"]["description"]

--- a/tests/test_1337_porsche_postpassword_captcha.py
+++ b/tests/test_1337_porsche_postpassword_captcha.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""#1337 G5 — a captcha that appears AFTER the password step (in the Auth0
+redirect chain) is now solvable, not a dead end.
+
+CJNE never sees this case (their login completes), so there is no reference to
+copy. The robust design replays the solved captcha back to the exact ACUL screen
+that presented it (``_acul_captcha_resume`` builds the descriptor from the
+screen's own ``transaction.state`` + ``submittedFormData``; ``_resume_acul_
+captcha`` POSTs the answer there and continues to the code). NOT LIVE-VERIFIED —
+no account here produces a post-password captcha; these exercise the machinery
+against mocked hops, and the in-flow report link captures any real misfire.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.vag_connect.cariad.auth.porsche import PorscheAuth
+from custom_components.vag_connect.cariad.exceptions import (
+    AuthenticationError,
+    PorscheCaptchaRequiredError,
+    PorscheLoginWallError,
+)
+
+_CB = "my-porsche-app://auth0/callback"
+_IMG = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="
+
+
+def _acul_captcha_html(state: str = "s1", submitted: dict | None = None) -> str:
+    ctx: dict = {
+        "transaction": {"state": state},
+        "screen": {"name": "login-id", "captcha": {"image": _IMG}},
+    }
+    if submitted is not None:
+        ctx["untrustedData"] = {"submittedFormData": submitted}
+    payload = base64.b64encode(json.dumps(ctx).encode()).decode()
+    return f'<script>JSON.parse(atob("{payload}"))</script>'
+
+
+class _Resp:
+    def __init__(self, status: int, location: str = "", text: str = "") -> None:
+        self.status = status
+        self.headers = {"Location": location} if location else {}
+        self._text = text
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    async def text(self) -> str:
+        return self._text
+
+
+def _session(post_responses=None, get_responses=None) -> MagicMock:
+    pit = iter(post_responses or [])
+    git = iter(get_responses or [])
+    s = MagicMock()
+    s.post = MagicMock(side_effect=lambda *a, **kw: next(pit))
+    s.get = MagicMock(side_effect=lambda *a, **kw: next(git))
+    return s
+
+
+# ── _acul_captcha_resume: descriptor parsing ───────────────────────────────────
+def test_resume_descriptor_carries_url_state_and_seeded_form() -> None:
+    auth = PorscheAuth(MagicMock())
+    r = auth._acul_captcha_resume(
+        "https://identity.porsche.com/u/login/identifier?state=s1",
+        _acul_captcha_html(state="s1", submitted={"username": "a@b.com"}),
+    )
+    assert r is not None
+    assert r["url"].endswith("/u/login/identifier?state=s1")
+    assert r["form"]["state"] == "s1"
+    assert r["form"]["username"] == "a@b.com"  # submittedFormData seeded
+
+
+def test_resume_descriptor_is_none_without_context_or_state() -> None:
+    auth = PorscheAuth(MagicMock())
+    assert auth._acul_captcha_resume("https://identity.porsche.com/x", "<html>no ctx</html>") is None
+    payload = base64.b64encode(json.dumps({"screen": {"name": "login-id"}}).encode()).decode()
+    assert auth._acul_captcha_resume("https://identity.porsche.com/x", f'<script>atob("{payload}")</script>') is None
+
+
+# ── _resume_acul_captcha: replay + continue ────────────────────────────────────
+def test_replay_posts_captcha_to_the_screen_and_exchanges() -> None:
+    session = _session(post_responses=[_Resp(302, location=f"{_CB}?code=RESUMED&state=x")])
+    auth = PorscheAuth(session)
+    with patch.object(PorscheAuth, "_exchange_code", new=AsyncMock(return_value="TOKENSET")) as ex:
+        out = asyncio.run(auth._resume_acul_captcha(
+            "SOLVED", {"url": "https://identity.porsche.com/u/login/identifier?state=s1",
+                       "form": {"state": "s1"}}, "ver"))
+    assert out == "TOKENSET"
+    _, kw = session.post.call_args
+    assert kw["data"]["captcha"] == "SOLVED"   # the solved answer goes back
+    assert kw["data"]["state"] == "s1"         # to THIS screen's state
+    assert kw["data"]["action"] == "default"
+    ex.assert_awaited_once_with("RESUMED", "ver")  # original verifier reused
+
+
+def test_replay_chains_a_second_captcha() -> None:
+    session = _session(post_responses=[_Resp(200, text=_acul_captcha_html(state="s2"))])
+    auth = PorscheAuth(session)
+    with pytest.raises(PorscheCaptchaRequiredError) as ei:
+        asyncio.run(auth._resume_acul_captcha(
+            "SOLVED", {"url": "https://identity.porsche.com/s?state=s1",
+                       "form": {"state": "s1"}}, "ver"))
+    assert ei.value.resume is not None
+    assert ei.value.resume["form"]["state"] == "s2"  # fresh screen surfaced
+
+
+def test_replay_200_without_captcha_is_honest_wall() -> None:
+    session = _session(post_responses=[_Resp(200, text="<html>consent wall</html>")])
+    auth = PorscheAuth(session)
+    with pytest.raises(PorscheLoginWallError):
+        asyncio.run(auth._resume_acul_captcha(
+            "SOLVED", {"url": "https://identity.porsche.com/x", "form": {"state": "s1"}}, "ver"))
+
+
+def test_replay_unexpected_status_raises_auth_error_not_wall() -> None:
+    session = _session(post_responses=[_Resp(403, text="")])
+    auth = PorscheAuth(session)
+    with pytest.raises(AuthenticationError) as ei:
+        asyncio.run(auth._resume_acul_captcha(
+            "SOLVED", {"url": "https://identity.porsche.com/x", "form": {"state": "s1"}}, "ver"))
+    assert not isinstance(ei.value, (PorscheLoginWallError, PorscheCaptchaRequiredError))
+
+
+def test_replay_redirect_to_dead_end_is_wall() -> None:
+    session = _session(
+        post_responses=[_Resp(302, location="/authorize/resume?state=s1")],
+        get_responses=[_Resp(200, text="")],  # a hop with no code and no captcha
+    )
+    auth = PorscheAuth(session)
+    with pytest.raises(PorscheLoginWallError):
+        asyncio.run(auth._resume_acul_captcha(
+            "SOLVED", {"url": "https://identity.porsche.com/x", "form": {"state": "s1"}}, "ver"))
+
+
+# ── host allowlist (privacy defense-in-depth) ──────────────────────────────────
+def test_is_porsche_host_allowlist() -> None:
+    ok = PorscheAuth._is_porsche_host
+    assert ok("https://identity.porsche.com/u/login/identifier?state=s")
+    assert ok("https://my.porsche.com/anything")
+    assert not ok("http://identity.porsche.com/x")            # not https
+    assert not ok("https://identity.porsche.com.evil.tld/x")  # look-alike suffix
+    assert not ok("https://notporsche.com/x")                 # no dot boundary
+    assert not ok("https://evil.example/x")
+    assert not ok("")
+
+
+def test_off_domain_captcha_is_not_replayable() -> None:
+    auth = PorscheAuth(MagicMock())
+    # a perfectly valid captcha context, but on a non-Porsche host → no descriptor
+    assert auth._acul_captcha_resume(
+        "https://evil.example/screen", _acul_captcha_html(state="s1")) is None
+
+
+def test_replay_refuses_off_domain_url_without_posting() -> None:
+    session = _session(post_responses=[_Resp(302, location="whatever")])
+    auth = PorscheAuth(session)
+    with pytest.raises(PorscheLoginWallError):
+        asyncio.run(auth._resume_acul_captcha(
+            "SOLVED", {"url": "https://evil.example/x", "form": {"state": "s1"}}, "ver"))
+    session.post.assert_not_called()  # never POSTs the seeded form off-domain
+
+
+# ── direct-body captcha at the password step (not only in the chain) ───────────
+def test_direct_body_captcha_at_password_step_is_surfaced() -> None:
+    session = _session(
+        get_responses=[_Resp(302, location="https://identity.porsche.com/u/login/identifier?state=STATE1")],
+        post_responses=[
+            _Resp(200),  # identifier POST — no captcha at this step
+            _Resp(200, text=_acul_captcha_html(state="pw-state")),  # password → captcha body, no redirect
+        ],
+    )
+    auth = PorscheAuth(session)
+    with pytest.raises(PorscheCaptchaRequiredError) as ei:
+        asyncio.run(auth.authenticate("e@x.com", "pw"))
+    assert ei.value.resume is not None
+    assert ei.value.resume["form"]["state"] == "pw-state"
+
+
+# ── identifier POST shape (CJNE parity, #1337) ────────────────────────────────
+def test_identifier_post_declares_no_webauthn_matching_cjne() -> None:
+    # Declaring WebAuthn support routed enrolled accounts into passkey-enrollment
+    # and on to the unclearable my.porsche.com wall (#1337). Match CJNE: no
+    # WebAuthn, so a captcha surfaces at the identifier step (solvable) instead.
+    session = _session(
+        get_responses=[_Resp(302, location="https://identity.porsche.com/u/login/identifier?state=S1")],
+        post_responses=[_Resp(401)],  # identifier rejected → flow stops after the POST
+    )
+    auth = PorscheAuth(session)
+    with pytest.raises(AuthenticationError):
+        asyncio.run(auth.authenticate("e@x.com", "pw"))
+    _, kw = session.post.call_args
+    data = kw["data"]
+    assert data["webauthn-available"] == "false"
+    assert data["webauthn-platform-available"] == "false"
+    assert "webauthn-platform-authenticator-available" not in data
+
+
+# ── authenticate routing ───────────────────────────────────────────────────────
+def test_authenticate_routes_captcha_resume_to_replay() -> None:
+    auth = PorscheAuth(MagicMock())
+    with patch.object(PorscheAuth, "_resume_acul_captcha", new=AsyncMock(return_value="TS")) as m:
+        out = asyncio.run(auth.authenticate(
+            "e", "p", captcha_code="C", resume_verifier="ver",
+            captcha_resume={"url": "u", "form": {"state": "s"}}))
+    assert out == "TS"
+    args = m.call_args.args
+    assert args[0] == "C"
+    assert args[1] == {"url": "u", "form": {"state": "s"}}
+    assert args[2] == "ver"

--- a/tests/test_porsche_captcha_config_flow.py
+++ b/tests/test_porsche_captcha_config_flow.py
@@ -41,7 +41,7 @@ async def test_captcha_kwargs_forwarded_for_porsche_instance():
         )
     client.authenticate.assert_awaited_once_with(
         mfa_code=None, captcha_code="ABCD",
-        resume_state="st", resume_verifier="ver",
+        resume_state="st", resume_verifier="ver", captcha_resume=None,
     )
 
 

--- a/tests/test_porsche_passkey_enrollment.py
+++ b/tests/test_porsche_passkey_enrollment.py
@@ -22,8 +22,11 @@ from unittest.mock import MagicMock
 from custom_components.vag_connect.cariad.auth.porsche import PorscheAuth
 from custom_components.vag_connect.cariad.exceptions import (
     AuthenticationError,
+    PorscheCaptchaRequiredError,
     PorscheLoginWallError,
 )
+
+import pytest
 
 _CB = "my-porsche-app://auth0/callback"
 _PW_URL = "https://identity.porsche.com/u/login/password?state=xyz"
@@ -173,12 +176,30 @@ class TestAculScreenGeneralisation:
         assert _follow(session, "/u/mfa-enroll?state=xyz") is None
         session.post.assert_not_called()
 
-    def test_captcha_in_redirect_chain_dead_ends_without_post(self) -> None:
-        # A captcha rendered mid-chain can't be solved here (the config-flow
-        # captcha step only resumes the identifier POST) — stop cleanly, no POST.
+    def test_captcha_in_redirect_chain_is_surfaced_for_solving(self) -> None:
+        # G5 (#1337) — a captcha rendered mid-chain (post-password) WITH a
+        # parseable ACUL context is no longer a dead end: it is raised so the
+        # config-flow captcha step can show it, carrying a replay descriptor
+        # (url + state) so the solved answer goes back to THIS exact screen.
+        # No POST happens during the walk itself (the solve POST is later).
         session = _session(
             get_responses=[_Resp(200, text=_acul_html("login-id", captcha=True))],
         )
+        with pytest.raises(PorscheCaptchaRequiredError) as excinfo:
+            _follow(session, "/authorize/resume?state=xyz")
+        err = excinfo.value
+        assert err.captcha_image.startswith("data:image/svg")
+        assert err.resume is not None
+        assert err.resume["form"]["state"] == "s1"
+        assert err.resume["url"].endswith("/authorize/resume?state=xyz")
+        session.post.assert_not_called()
+
+    def test_captcha_without_parseable_context_still_dead_ends(self) -> None:
+        # A captcha image with NO ACUL context (no atob blob) can't be replayed,
+        # so it must still dead-end cleanly (→ honest wall + report link), never
+        # invent a POST against the one confirmed-working login path.
+        raw = '<img src="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=">'
+        session = _session(get_responses=[_Resp(200, text=raw)])
         assert _follow(session, "/authorize/resume?state=xyz") is None
         session.post.assert_not_called()
 


### PR DESCRIPTION
> **Stacked on #1386** (base = `feat/scout-fields-1378-1375`). This PR's diff is captcha-only; it retargets to `main` automatically once #1386 merges. Both ship in v4.7.6.

Gets the Porsche login past the captcha wall reported in #1337.

- **Root cause + fix:** the login was declaring passkey/WebAuthn support in the identifier POST, which routed enrolled accounts into the passkey-enrollment screen and on to the unclearable `my.porsche.com` consent wall. It now declares no WebAuthn (matching the request shape a proven reference client uses), keeping Porsche's Auth0 on the **solvable identifier-step captcha**. **Confirmed working end-to-end on a real Porsche account** (captcha solved → token).
- **Inline solve:** the captcha is shown in the config flow (setup, re-auth, reconfigure) so the user solves it and continues. A captcha rendered *after* the password step is replayed to the exact ACUL screen that presented it, pinned to Porsche's own domain.
- **Safety:** retries are bounded (repeated failures can lock a Porsche account); transient challenge material (code/state/PKCE verifier) is never persisted; any login that still can't be cleared gives an honest message + a **PII-free one-click report link** with auto-redacted diagnostics.
- 13-language strings; **no behaviour change for other brands.**

Referenced (not copied) against `CJNE/pyporscheconnectapi`'s flow — that library has separate PKCE/state/plaintext-password issues we deliberately don't carry.

Full test suite green (6076 passed, 15 skipped); ruff + mypy strict clean.

Follow-up (separate PR, v4.7.7): persist + reuse the Porsche refresh token so the captcha is a first-setup event rather than a per-restart one — the real captcha-frequency reducer per the research on this.
