### PR TITLE
Persist + reuse the Porsche login token across restarts (v4.7.7, #1337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.7] - 2026-09-10 — Porsche login remembers itself (captcha only once)
+
+### Fixed
+- **Porsche no longer asks for the captcha on every restart.** The Porsche login token is now kept
+  and reused across restarts — refreshed silently through the token endpoint the same way every other
+  brand's is, which is never captcha-gated. So the interactive login (the only place Porsche's captcha
+  appears) runs essentially once, at first setup, instead of on every Home Assistant restart. The
+  captcha you solve during setup is carried straight into the running integration, so setup no longer
+  trips a second captcha right after it (#1337).
+
 ## [4.7.6] - 2026-09-10 — More live fields from the Scout feed, and an interactive Porsche captcha
 
 ### Added

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -202,6 +202,13 @@ class PorscheClient:
         self._password = password
         self._spin    = spin
         self._tokens: TokenSet | None = None
+        # v4.7.7 (#1337) — token persistence hook. The coordinator assigns
+        # ``_token_storage.save`` here (same contract as CariadBase) and calls
+        # ``set_persisted_tokens`` on startup, so a solved-captcha login is
+        # reused across restarts via the never-captcha-gated /oauth/token
+        # refresh instead of re-running the interactive login every time.
+        # Signature: ``async def on_tokens_changed(tokens: TokenSet) -> None``.
+        self.on_tokens_changed: Any | None = None
         self._auth = PorscheAuth(session)
         # v1.25.0 PR-B: refresh-storm protection state
         self._refresh_lock: asyncio.Lock | None = None
@@ -243,6 +250,32 @@ class PorscheClient:
             captcha_resume=captcha_resume,
         )
         _LOGGER.debug("Porsche Connect auth complete")
+        await self._emit_tokens()
+
+    def set_persisted_tokens(self, tokens: "TokenSet | None") -> None:
+        """Restore a stored token set so startup can skip the interactive login.
+
+        v4.7.7 (#1337). Mirrors ``CariadBase.set_persisted_tokens``: the
+        coordinator calls this before deciding whether to ``authenticate()``.
+        Only a token set carrying a usable ``refresh_token`` is restored — the
+        Porsche captcha lives on the interactive login, never on the
+        ``/oauth/token`` refresh, so a restored refresh token lets reads renew
+        silently. A refresh that has died (401/403) falls back to a full login
+        via the coordinator's existing not-a-portal retry path.
+        """
+        if tokens is not None and tokens.refresh_token:
+            self._tokens = tokens
+
+    async def _emit_tokens(self) -> None:
+        """Persist the current tokens via the coordinator's save hook (fail-soft)."""
+        if self.on_tokens_changed is None or self._tokens is None:
+            return
+        if not self._tokens.strategy:
+            self._tokens.strategy = "porsche"
+        try:
+            await self.on_tokens_changed(self._tokens)
+        except Exception:  # noqa: BLE001 — persistence is best-effort, never break auth
+            _LOGGER.debug("Porsche: token persistence hook failed", exc_info=True)
 
     async def get_vehicles(self) -> list[str]:
         """Return list of VINs from Porsche Connect garage."""
@@ -1212,6 +1245,7 @@ class PorscheClient:
             if self._tokens and self._tokens.refresh_token:
                 try:
                     self._tokens = await self._auth.refresh(self._tokens.refresh_token)
+                    await self._emit_tokens()  # v4.7.7 — persist the rotated token
                     return
                 except TokenExpiredError:
                     pass

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -191,7 +191,7 @@ async def _validate_credentials(
     captcha_state: str | None = None,
     captcha_verifier: str | None = None,
     captcha_resume: dict | None = None,
-) -> None:
+) -> dict[str, Any] | None:
     """Validate credentials by authenticating with the CARIAD API.
 
     ``captcha_code``/``captcha_state``/``captcha_verifier`` (b19, #1337,
@@ -308,6 +308,22 @@ async def _validate_credentials(
                 "".join(traceback.format_tb(err.__traceback__)),
             )
             raise ValueError("cannot_connect") from err
+
+        # v4.7.7 (#1337) — on a successful Porsche login, return the token set so
+        # the config flow can bridge it into the entry (porsche_initial_tokens).
+        # The coordinator then reuses it via the never-captcha-gated /oauth/token
+        # refresh instead of running a SECOND interactive login (another captcha)
+        # at first setup. Other brands / no token → None (unchanged behaviour).
+        _t = getattr(client, "_tokens", None)
+        if isinstance(client, PorscheClient) and _t is not None:
+            return {
+                "access_token":  _t.access_token,
+                "refresh_token": _t.refresh_token,
+                "id_token":      _t.id_token,
+                "expires_at":    _t.expires_at,
+                "strategy":      _t.strategy or "porsche",
+            }
+    return None
 
 
 def _map_error(err_code: str) -> str:
@@ -759,7 +775,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             from .cariad.exceptions import PorscheCaptchaRequiredError  # noqa: PLC0415
 
             try:
-                await _validate_credentials(
+                _tok = await _validate_credentials(
                     self.hass, brand, username, password, country=country
                 )
             except PorscheCaptchaRequiredError as err:
@@ -830,6 +846,8 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                     self._dag_user_id = ""
                     self._dag_error = ""
                     return await self.async_step_browser_login_pending()
+                if _tok:  # v4.7.7 (#1337) — bridge a Porsche login token (no-captcha path)
+                    portal_data = {**portal_data, "porsche_initial_tokens": _tok}
                 return self.async_create_entry(
                     title=f"{_brand_label(brand)} — {username}",
                     data=portal_data,
@@ -2012,6 +2030,46 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             pass
         return f'<img src="{data_uri}" />'
 
+    async def _persist_porsche_token_store(
+        self, entry_id: str, tok: dict[str, Any] | None
+    ) -> None:
+        """v4.7.7 (#1337) — on Porsche reauth/reconfigure, OVERWRITE the per-entry
+        token store with the freshly solved-captcha token.
+
+        The coordinator prefers the persisted token store; the entry.data bridge
+        (``porsche_initial_tokens``) is only promoted when that store is EMPTY. On
+        a reauth the store still holds the old, now-dead token, so without this
+        overwrite the reload would restore the dead token and loop straight back
+        to reauth. Mirrors the DAG QR reauth's store overwrite. Fail-soft: a
+        storage error must not block the (otherwise successful) reauth.
+        """
+        if not tok:
+            return
+        try:
+            from homeassistant.helpers.storage import Store  # noqa: PLC0415
+
+            from .cariad.auth._token_storage import (  # noqa: PLC0415
+                _STORAGE_VERSION,
+                TokenStorage,
+                storage_key_for_entry,
+            )
+            from .cariad.models import TokenSet  # noqa: PLC0415
+            fresh = TokenSet(
+                access_token=str(tok.get("access_token", "")),
+                refresh_token=str(tok.get("refresh_token", "")),
+                id_token=str(tok.get("id_token", "")),
+                expires_at=float(tok.get("expires_at", 0.0) or 0.0),
+                strategy=str(tok.get("strategy", "") or "porsche"),
+            )
+            store: Store[dict[str, Any]] = Store(
+                self.hass, _STORAGE_VERSION, storage_key_for_entry(entry_id)
+            )
+            await TokenStorage(store).save(fresh)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Porsche: could not overwrite token store on reauth", exc_info=True
+            )
+
     async def async_step_porsche_captcha(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
@@ -2062,7 +2120,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 else:
                     country = self._pending_entry_data.get(CONF_COUNTRY, "us")
                 try:
-                    await _validate_credentials(
+                    _tok = await _validate_credentials(
                         self.hass, "porsche",
                         self._pending_username, self._pending_password,
                         country=country,
@@ -2118,7 +2176,16 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                                 **reauth_entry.data,
                                 CONF_PASSWORD: self._pending_password,
                                 CONF_SPIN: self._porsche_reauth_spin,
+                                # v4.7.7 (#1337) — bridge the freshly solved-captcha
+                                # token so the reload reuses it (refresh) instead of
+                                # a fresh interactive login (another captcha).
+                                **({"porsche_initial_tokens": _tok} if _tok else {}),
                             },
+                        )
+                        # v4.7.7 — overwrite the token store so the reload reuses
+                        # the fresh token, not the dead one it still holds.
+                        await self._persist_porsche_token_store(
+                            reauth_entry.entry_id, _tok
                         )
                         await self.hass.config_entries.async_reload(
                             reauth_entry.entry_id
@@ -2147,17 +2214,25 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                             base if new_unique_id != entry.unique_id
                             else {**entry.data, **base}
                         )
+                        if _tok:  # v4.7.7 — bridge the solved-captcha token
+                            merged["porsche_initial_tokens"] = _tok
                         self.hass.config_entries.async_update_entry(
                             entry,
                             title=f"{_brand_label(brand)} — {username}",
                             unique_id=new_unique_id,
                             data=merged,
                         )
+                        await self._persist_porsche_token_store(entry.entry_id, _tok)
                         await self.hass.config_entries.async_reload(entry.entry_id)
                         return self.async_abort(reason="reconfigure_successful")
                     # "email_password" — Porsche is never MBB-eligible (VW/Audi
                     # only), so the non-captcha path's plain create-entry branch
                     # is the only outcome here.
+                    if _tok:  # v4.7.7 — bridge the solved-captcha token
+                        self._pending_entry_data = {
+                            **self._pending_entry_data,
+                            "porsche_initial_tokens": _tok,
+                        }
                     return self.async_create_entry(
                         title=f"{_brand_label(self._pending_brand)} — {self._pending_username}",
                         data=self._pending_entry_data,
@@ -2214,7 +2289,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             from .cariad.exceptions import PorscheCaptchaRequiredError  # noqa: PLC0415
 
             try:
-                await _validate_credentials(
+                _tok = await _validate_credentials(
                     self.hass, brand, username, password, country=country
                 )
             except PorscheCaptchaRequiredError as err:
@@ -2244,8 +2319,16 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             else:
                 self.hass.config_entries.async_update_entry(
                     reauth_entry,
-                    data={**reauth_entry.data, CONF_PASSWORD: password, CONF_SPIN: spin},
+                    data={
+                        **reauth_entry.data,
+                        CONF_PASSWORD: password,
+                        CONF_SPIN: spin,
+                        # v4.7.7 (#1337) — bridge a Porsche login token so the
+                        # reload reuses it (refresh) instead of re-logging in.
+                        **({"porsche_initial_tokens": _tok} if _tok else {}),
+                    },
                 )
+                await self._persist_porsche_token_store(reauth_entry.entry_id, _tok)
                 await self.hass.config_entries.async_reload(reauth_entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
 
@@ -2384,7 +2467,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             from .cariad.exceptions import PorscheCaptchaRequiredError  # noqa: PLC0415
 
             try:
-                await _validate_credentials(
+                _tok = await _validate_credentials(
                     self.hass, brand, username, password, country=country
                 )
             except PorscheCaptchaRequiredError as err:
@@ -2437,6 +2520,8 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 # (unique_id changed) do a clean rebuild — carrying the previous
                 # account's brand-specific tokens forward would be wrong.
                 merged = base if account_changed else {**entry.data, **base}
+                if _tok:  # v4.7.7 (#1337) — bridge a Porsche login token
+                    merged["porsche_initial_tokens"] = _tok
 
                 # v2.17.2 (#666) — arm the durable-MBB command channel on an
                 # EXISTING portal entry via Reconfigure (VW/Audi). Mirrors the
@@ -2485,6 +2570,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                     unique_id=new_unique_id,
                     data=merged,
                 )
+                await self._persist_porsche_token_store(entry.entry_id, _tok)
                 await self.hass.config_entries.async_reload(entry.entry_id)
                 return self.async_abort(reason="reconfigure_successful")
 

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1405,6 +1405,29 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 # up on a subsequent config_flow update.
                 await self._token_storage.save(persisted)
 
+            # v4.7.7 (#1337) — Porsche: the config flow already solved the
+            # captcha and got a token; it stashed it in entry.data so the FIRST
+            # coordinator setup reuses it (via the never-captcha-gated
+            # /oauth/token refresh) instead of running a SECOND interactive login
+            # — another captcha — right after setup. Promote it into the
+            # persistent store; from then on it's a normal cached-token restart.
+            porsche_initial = self.entry.data.get("porsche_initial_tokens")
+            if persisted is None and porsche_initial:
+                from .cariad.models import TokenSet  # noqa: PLC0415
+                persisted = TokenSet(
+                    access_token=str(porsche_initial.get("access_token", "")),
+                    refresh_token=str(porsche_initial.get("refresh_token", "")),
+                    id_token=str(porsche_initial.get("id_token", "")),
+                    expires_at=float(porsche_initial.get("expires_at", 0.0) or 0.0),
+                    strategy=str(porsche_initial.get("strategy", "") or "porsche"),
+                )
+                _LOGGER.debug(
+                    "VW Group Connect: bootstrapping Porsche with the config-flow "
+                    "login token for %s — skipping a second interactive login",
+                    brand,
+                )
+                await self._token_storage.save(persisted)
+
         # VW EU Two-Way (650d46ca): when armed, the modern-BFF device-grant token
         # is the PRIMARY. Activate it from entry.data on the config_flow reload
         # (overriding an older primary); once the re-mint has saved a device_grant

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.6"
+  "version": "4.7.7"
 }

--- a/tests/test_1337_porsche_token_persistence.py
+++ b/tests/test_1337_porsche_token_persistence.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v4.7.7 (#1337) — Porsche token persistence so the captcha is a first-setup
+event, not a per-restart one.
+
+The Porsche captcha lives ONLY on the interactive login (/u/login/identifier);
+the /oauth/token refresh is never captcha-gated. So if a solved-captcha login's
+refresh token is persisted and reused across restarts, the interactive login
+(and its captcha) essentially never re-runs. These tests cover the PorscheClient
+persistence hooks (save/restore/emit) and the config-flow token bridge.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.vag_connect.cariad.api.porsche import PorscheClient
+from custom_components.vag_connect.cariad.models import TokenSet
+from custom_components.vag_connect.config_flow import _validate_credentials
+
+_CREATE = "custom_components.vag_connect.cariad.CariadClientFactory.create"
+
+
+def _bare_client() -> PorscheClient:
+    c = PorscheClient.__new__(PorscheClient)  # skip __init__/network
+    c._tokens = None
+    c.on_tokens_changed = None
+    return c
+
+
+# ── set_persisted_tokens: restore only a usable (refreshable) token ────────────
+def test_restore_only_with_refresh_token() -> None:
+    c = _bare_client()
+    c.set_persisted_tokens(
+        TokenSet(access_token="a", refresh_token="r", id_token="i", expires_at=123)
+    )
+    assert c._tokens is not None and c._tokens.refresh_token == "r"
+
+
+def test_restore_ignores_none_and_refreshless() -> None:
+    c = _bare_client()
+    c.set_persisted_tokens(None)
+    assert c._tokens is None
+    c.set_persisted_tokens(TokenSet(access_token="a", refresh_token="", id_token="i"))
+    assert c._tokens is None  # no refresh token → not reusable → ignored
+
+
+# ── _emit_tokens: tags strategy, calls the save hook, fail-soft ────────────────
+@pytest.mark.asyncio
+async def test_emit_tags_strategy_and_calls_hook() -> None:
+    c = _bare_client()
+    c._tokens = TokenSet(access_token="a", refresh_token="r", id_token="i")
+    seen: list[TokenSet] = []
+    async def _save(ts: TokenSet) -> None:
+        seen.append(ts)
+    c.on_tokens_changed = _save
+    await c._emit_tokens()
+    assert len(seen) == 1
+    assert seen[0].strategy == "porsche"  # tagged so it is not treated as portal
+
+
+@pytest.mark.asyncio
+async def test_emit_noop_without_hook_or_tokens() -> None:
+    c = _bare_client()
+    await c._emit_tokens()  # no tokens, no hook → no crash
+    c._tokens = TokenSet(access_token="a", refresh_token="r", id_token="i")
+    await c._emit_tokens()  # no hook → no crash
+
+
+@pytest.mark.asyncio
+async def test_emit_is_failsoft_when_hook_raises() -> None:
+    c = _bare_client()
+    c._tokens = TokenSet(access_token="a", refresh_token="r", id_token="i")
+    async def _boom(ts: TokenSet) -> None:
+        raise RuntimeError("storage down")
+    c.on_tokens_changed = _boom
+    await c._emit_tokens()  # must NOT propagate — persistence is best-effort
+
+
+# ── authenticate() emits, so the coordinator's save hook persists it ───────────
+@pytest.mark.asyncio
+async def test_authenticate_emits_for_persistence() -> None:
+    c = _bare_client()
+    c._email = "e@x.com"
+    c._password = "pw"
+    c._auth = MagicMock()
+    c._auth.authenticate = AsyncMock(return_value=TokenSet(
+        access_token="AA", refresh_token="RR", id_token="II", expires_at=999))
+    seen: list[TokenSet] = []
+    async def _save(ts: TokenSet) -> None:
+        seen.append(ts)
+    c.on_tokens_changed = _save
+    await c.authenticate()
+    assert c._tokens is not None and c._tokens.refresh_token == "RR"
+    assert seen and seen[-1].refresh_token == "RR" and seen[-1].strategy == "porsche"
+
+
+# ── _validate_credentials bridges the Porsche token to the config flow ─────────
+@pytest.mark.asyncio
+async def test_validate_returns_porsche_token_dict() -> None:
+    client = _bare_client()
+    client.authenticate = AsyncMock()  # type: ignore[method-assign]
+    client._tokens = TokenSet(
+        access_token="AAA", refresh_token="RRR", id_token="III",
+        expires_at=888.0, strategy="porsche")
+    with patch(_CREATE, return_value=client):
+        out = await _validate_credentials(None, "porsche", "e@x.com", "pw")
+    assert out == {
+        "access_token": "AAA", "refresh_token": "RRR", "id_token": "III",
+        "expires_at": 888.0, "strategy": "porsche",
+    }
+
+
+# ── reauth/reconfigure must OVERWRITE the token store (not just entry.data) ─────
+@pytest.mark.asyncio
+async def test_reauth_overwrites_token_store_with_fresh_token() -> None:
+    # The coordinator prefers the persisted store; on reauth it still holds the
+    # DEAD token. The entry.data bridge is only promoted when the store is empty,
+    # so a reauth MUST overwrite the store or it loops. This covers that fix.
+    from custom_components.vag_connect.config_flow import VagConnectConfigFlow
+    flow = VagConnectConfigFlow()
+    flow.hass = MagicMock()
+    saved: list[TokenSet] = []
+
+    class _FakeTS:
+        def __init__(self, _store: object) -> None:
+            pass
+        async def save(self, ts: TokenSet) -> None:
+            saved.append(ts)
+
+    with patch(
+        "custom_components.vag_connect.cariad.auth._token_storage.TokenStorage",
+        _FakeTS,
+    ), patch(
+        "custom_components.vag_connect.cariad.auth._token_storage.storage_key_for_entry",
+        return_value="k",
+    ), patch("homeassistant.helpers.storage.Store", MagicMock()):
+        await flow._persist_porsche_token_store("e1", {
+            "access_token": "A", "refresh_token": "R", "id_token": "I",
+            "expires_at": 5.0, "strategy": "porsche",
+        })
+    assert len(saved) == 1
+    assert saved[0].refresh_token == "R"
+    assert saved[0].strategy == "porsche"
+
+
+@pytest.mark.asyncio
+async def test_reauth_store_overwrite_is_noop_without_token() -> None:
+    from custom_components.vag_connect.config_flow import VagConnectConfigFlow
+    flow = VagConnectConfigFlow()
+    flow.hass = MagicMock()
+    # tok=None → no save, no crash (fail-soft)
+    await flow._persist_porsche_token_store("e1", None)
+
+
+@pytest.mark.asyncio
+async def test_validate_returns_none_for_non_porsche() -> None:
+    client = MagicMock()
+    client.authenticate = AsyncMock()
+    with patch(_CREATE, return_value=client):
+        out = await _validate_credentials(None, "volkswagen", "e@x.com", "pw")
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_validate_returns_none_when_porsche_has_no_tokens() -> None:
+    # A PorscheClient mock with no _tokens (e.g. __new__ without a login) must
+    # not crash — the bridge just yields None.
+    client = PorscheClient.__new__(PorscheClient)
+    client.authenticate = AsyncMock()  # type: ignore[method-assign]
+    with patch(_CREATE, return_value=client):
+        out = await _validate_credentials(None, "porsche", "e@x.com", "pw")
+    assert out is None


### PR DESCRIPTION
Follow-up to #1389 (v4.7.6): makes the Porsche captcha a **first-setup** event instead of a per-restart one.

Porsche's captcha only appears on the interactive login (`/u/login/identifier`); the `/oauth/token` refresh is never captcha-gated. So:

- **`PorscheClient`** now plugs into the existing token-persistence machinery — an `on_tokens_changed` save hook, `set_persisted_tokens` restore, and an emit after login/refresh (tagged `strategy=porsche` so it's treated as a normal refreshable token, not a portal sentinel that forces a fresh login).
- **The config flow** bridges the freshly solved-captcha login token into the entry (`porsche_initial_tokens`), which the coordinator promotes into the persistent store on first run — so the coordinator's first setup reuses it via the (never-captcha-gated) refresh instead of running a **second** interactive login. Without this, a captcha-hitting account solves the captcha in the config flow and then setup fails on the second login.
- A dead refresh token falls back to a fresh (captcha-capable) login via the coordinator's existing not-a-portal retry path — no bricked entry.

**No behaviour change for other brands** (guarded by `isinstance(PorscheClient)` and the token strategy). Full test suite green (6085 passed, 15 skipped); ruff + mypy strict clean.

Bumps `manifest.json` to 4.7.7 + CHANGELOG.
