### PR TITLE
Porsche login done the reference way + lifecycle, Scout and merge fixes (v4.7.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,60 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.8] - 2026-09-11 — Porsche login done the reference way, and a round of honesty fixes
+
+### Fixed
+- **Porsche: the login now pauses briefly after the password step, exactly like the proven
+  reference client does.** That client waits a moment before following Porsche's redirect chain;
+  we didn't, and on accounts with a car attached the chain kept landing on the `my.porsche.com`
+  wall even after the captcha was solved right. The client also now identifies itself plainly as
+  this integration instead of borrowing a phone's identity — the same thing the reference client
+  does, and it has been stable for years. When a wall still appears, the message and the pre-filled
+  report link now name the exact Porsche screen it stopped on, so a report is actionable on the
+  first try (#1337, #1400).
+- **Porsche: a dead refresh token now asks you to sign in again instead of failing quietly.** If
+  every car read fails authentication, the integration opens the re-authentication dialog rather
+  than retrying a token Porsche has already thrown away. Setup also no longer signs in twice on the
+  first retry, and the solved-captcha token handed over from setup is only reused when it actually
+  carries a refresh token, and the hand-over copy is always removed from the entry afterwards. A hiccup
+  of Porsche's token endpoint (a 5xx) is no longer mistaken for a dead token, several cars sharing one
+  login now refresh it once instead of once per car, and re-authentication is only requested after two
+  consecutive polls in which every car failed authentication (#1337).
+- **Porsche: "everything is empty" is now visible instead of silent.** When Porsche's status
+  endpoint refuses a car, that's logged once as a warning per car, and a new diagnostic
+  *Connect Contract Active* binary sensor shows whether Porsche reports an active Connect
+  contract at all — the usual reason a Porsche shows up with no data (#1337).
+- **Portal: the "session expired" repair finally goes away once you're signed in again.** It was
+  raised by setup, the data-request kickoff and the historical export, but never cleared — so it
+  outlived the re-login it asked for. It now clears the moment data flows through the portal again.
+- **Scout feed: short-term consumption on combustion cars, engine starts, and the charge-report
+  battery %.** The short-term consumption leaf arrives as l/100 km on ICE and plug-in hybrids —
+  v4.7.6 read it and then dropped it. It now feeds its own *Short Term Average Fuel Consumption*
+  sensor. The SCR engine-starts counter only shows up on combustion cars (every EV was getting a
+  disabled "Engine Starts" entity), and its two status codes (14/15) are no longer recorded as a
+  count. The "battery % at the last charge report" snapshot gets a disabled-by-default diagnostic
+  sensor, so the Scout stops re-reporting it every poll and it can't shadow the live battery %
+  (#1195, #1380, #1382–#1401).
+- **Scout feed: anti-theft alarm reason (CUPRA Raval).** The portal's `dwa_alarm_reason` leaf (e.g.
+  "ALARM_REASON_DRIVERSDOOROPEN") now feeds a diagnostic *Alarm Reason* sensor, kept verbatim. The
+  bare `data` leaf that came with it is a small DER-encoded export envelope (two timestamps, no
+  reading) and is recognised as such instead of being reported as a new field every poll (#1396).
+- **Position: the freshest fix wins when a car has more than one data channel.** Merging used to
+  take the primary channel's coordinates first and only fill gaps from the others, so a stale pin
+  could beat a newer fix from the second channel. Position, heading and capture time now come from
+  whichever channel reported most recently.
+- **Trip sensors on VW-EU portal cars are no longer hidden by a capability the car doesn't need.**
+  The "no trip-statistics capability" gate hid trip sensors even when the EU Data Act feed had
+  already delivered the values. It now only applies when the car has no trip value at all
+  (#923, thanks @guiumb).
+- **Options flow: the "Terms & Conditions" sign-in message showed as a raw key** in the re-login
+  dialog; it now has its text in all 12 translations.
+
+### Changed
+- **Captcha dialog wording is now accurate.** The v4.7.6 text said the captcha answer "never leaves
+  your Home Assistant instance" — that was wrong: it is sent to Porsche's login service (and nowhere
+  else). The dialog now says exactly that. The v4.7.6 notes below were corrected the same way.
+
 ## [4.7.7] - 2026-09-10 — Porsche login remembers itself (captcha only once)
 
 ### Fixed
@@ -57,19 +111,25 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 ### Added
 - **GPS position, heading, short-term consumption and an engine-starts count from the live Scout
   feed.** The portal's continuous feed carries several fields the integration wasn't surfacing yet:
-  the car's GPS position (it does send coordinates under `persLocation`), its heading, the short-term
-  average electric consumption and a total engine-starts counter now come through as sensors, and the
-  trip id is consumed for correlation. Grounded on real Škoda Elroq and Audi captures (#1378, #1375).
-- **Porsche login now gets past the captcha wall — solve it right in the setup dialog.** Porsche's
-  login can put up an Auth0 captcha; the integration now shows it inline during setup,
-  re-authentication and reconfigure so you can type it and continue. The login also stops declaring
-  passkey support (matching a proven reference client), which keeps Porsche on the solvable captcha
-  path instead of bouncing to the unclearable `my.porsche.com` consent wall some accounts hit before —
-  confirmed working end-to-end on a real account. A captcha shown after the password step is replayed
-  to the exact screen that presented it (pinned to Porsche's own domain). Retries are bounded (too many
-  can lock a Porsche account), the challenge you enter never leaves your Home Assistant instance, and
-  any login that still can't be cleared gives an honest message plus a one-click report link with
-  auto-redacted diagnostics (#1337).
+  on cars whose feed includes `persLocation` (seen on a Škoda Elroq) the GPS position and heading,
+  plus the short-term average electric consumption and the SCR engine-starts counter now come
+  through as sensors. The per-trip id is recognised as metadata so it stops being reported as an
+  undiscovered field. Grounded on real Škoda Elroq and Audi captures (#1378, #1375).
+  *(Corrected in 4.7.8: the original note implied every car sends `persLocation` and that the trip
+  id is used for correlation — neither is the case.)*
+- **Porsche's captcha can now be solved right in the setup dialog.** Porsche's login can put up an
+  Auth0 captcha; the integration now shows it inline during setup, re-authentication and reconfigure
+  so you can type it and continue. The login also stops declaring passkey support (matching a proven
+  reference client), which keeps Porsche on the solvable captcha path instead of bouncing straight
+  to the `my.porsche.com` wall — confirmed on a real account without a vehicle attached; accounts
+  with a car could still hit that wall after the password step, which 4.7.8 addresses. A captcha
+  Porsche presents after the password step is answered on the screen that showed it (pinned to
+  Porsche's own domain). Retries are bounded (too many can lock a Porsche account), what you type is
+  sent only to Porsche's login service, and any login that still can't be cleared gives an honest
+  message plus a pre-filled report link (no personal data in it) that tells you which log lines to
+  attach (#1337).
+  *(Corrected in 4.7.8: the original note claimed the answer "never leaves your Home Assistant
+  instance" and that the link attaches diagnostics automatically — both were wrong.)*
 
 ### Fixed
 - **Battery % right after plugging in: two more source fields covered.** The v4.7.5 fix that stops the

--- a/custom_components/vag_connect/binary_sensor.py
+++ b/custom_components/vag_connect/binary_sensor.py
@@ -53,6 +53,16 @@ BINARY_DESCRIPTIONS: tuple[VagBinarySensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:car-key",
     ),
+    # v4.7.8 (#1337) — Porsche Connect contract state. A lapsed contract leaves
+    # the car enumerated but every reading blank (@mps222, 3 cars) with nothing
+    # telling the user why; this names it. None (not reported) → no entity.
+    VagBinarySensorDescription(
+        key="connect_contract_active",
+        translation_key="connect_contract_active",
+        data_key="connect_contract_active",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:file-certificate-outline",
+    ),
     VagBinarySensorDescription(
         key="windows_open",
         translation_key="windows_open",

--- a/custom_components/vag_connect/cariad/_channel_merge.py
+++ b/custom_components/vag_connect/cariad/_channel_merge.py
@@ -33,6 +33,7 @@ import copy
 import logging
 from collections.abc import Awaitable
 from dataclasses import fields
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -182,6 +183,42 @@ def merge_channels(
                     field_sources[f_name] = nm
                     contributors.add(nm)
                     break
+
+    # v4.7.8 (#923/#1378) — position: FRESHEST capture wins, not merge order.
+    # The EU-DA batch feed can now carry a pin (``persLocation``), and with the
+    # portal as PRIMARY its 15-min-old pin would outrank a live vw.de fix via
+    # plain gap-fill (position is deliberately outside the live-supersede set:
+    # capture AGE, not channel class, is the right judge). Among every source
+    # that has a pin AND a parseable capture time, take the newest; a source
+    # without a timestamp can't win over one that has one.
+    _best_nm: str | None = None
+    _best_vd: VehicleData | None = None
+    _best_ts: datetime | None = None
+    for nm, vd in sources:
+        lat = getattr(vd, "latitude", None)
+        lon = getattr(vd, "longitude", None)
+        ts_raw = getattr(vd, "position_captured_at", None)
+        if lat is None or lon is None or not ts_raw:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        if _best_ts is None or ts > _best_ts:
+            _best_nm, _best_vd, _best_ts = nm, vd, ts
+    if (
+        _best_nm is not None
+        and _best_vd is not None
+        and field_sources.get("latitude") != _best_nm
+    ):
+        for f_name in ("latitude", "longitude", "position_captured_at", "heading"):
+            val = getattr(_best_vd, f_name, None)
+            if val is not None:
+                setattr(merged, f_name, copy.deepcopy(val))
+                field_sources[f_name] = _best_nm
+        contributors.add(_best_nm)
 
     _merge_drivetrain(merged, sources)
 

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -28,7 +28,10 @@ _LOGGER = logging.getLogger(__name__)
 
 _API_BASE   = "https://api.ppa.porsche.com"
 _X_CLIENT   = "41843fb4-691d-4970-85c7-2673e8ecef40"
-_USER_AGENT = "My Porsche/2.1.0 (iPhone; iOS 17.0; Scale/3.00)"
+# #1337 (v4.7.8) — same plain library User-Agent the auth layer now sends (the
+# reference client uses ONE lib UA for both login and API reads); keep them
+# identical so Porsche sees a single consistent client.
+_USER_AGENT = "vag-connect-ha/4.7.8 (+https://github.com/its-me-prash/vwgroup-connect-ha)"
 
 # v1.25.0 PR-B: storm-protection constants (mirror of base.py)
 _REFRESH_MAX_PER_HOUR = 3
@@ -202,6 +205,10 @@ class PorscheClient:
         self._password = password
         self._spin    = spin
         self._tokens: TokenSet | None = None
+        # v4.7.8 (#1337) — diagnostics-visible outcome of the last vehicle
+        # status read + once-per-VIN WARNING latch (see ``get_status``).
+        self.probe_outcomes: dict[str, str] = {}
+        self._status_warned: set[str] = set()
         # v4.7.7 (#1337) — token persistence hook. The coordinator assigns
         # ``_token_storage.save`` here (same contract as CariadBase) and calls
         # ``set_persisted_tokens`` on startup, so a solved-captcha login is
@@ -314,7 +321,41 @@ class PorscheClient:
                 f"{_API_BASE}/app/connect/v1/vehicles/{vin}", params=params,
             )
         except Exception as err:  # noqa: BLE001 — never crash a poll on one bad read
-            _LOGGER.debug("Porsche get_status failed: %s", type(err).__name__)
+            # v4.7.8 (#1337) — a silently empty VehicleData looked exactly like
+            # "this car has no data" (@mps222: 3 Porsches, every sensor blank,
+            # no clue why). Record the outcome for diagnostics and say it ONCE
+            # per VIN at WARNING; later polls stay at DEBUG.
+            _kind = type(err).__name__
+            _status = getattr(err, "status", None)
+            # Lazy-init: tests (and the raw-response capture below) build the
+            # client via __new__ without __init__.
+            if not hasattr(self, "probe_outcomes"):
+                self.probe_outcomes = {}
+            if not hasattr(self, "_status_warned"):
+                self._status_warned = set()
+            self.probe_outcomes["porsche_status"] = (
+                f"{_kind}:{_status}" if _status else _kind
+            )
+            # An auth failure is NOT "one bad read": ``_request`` has already
+            # refreshed + retried (and fallen back to a full login) before it
+            # raises this, so the token is dead. Let it reach the coordinator,
+            # which escalates to re-authentication when every car says so —
+            # swallowing it here left users with silently empty entities and an
+            # interactive login re-run up to 3x/hour with no prompt (#1337).
+            if isinstance(err, AuthenticationError):
+                _LOGGER.debug("Porsche get_status: authentication failed (%s)", _kind)
+                raise
+            if vin not in self._status_warned:
+                self._status_warned.add(vin)
+                _LOGGER.warning(
+                    "Porsche ***%s: vehicle status read failed (%s%s) — its "
+                    "entities stay empty until a read succeeds. If this persists "
+                    "check the car's Porsche Connect contract and attach "
+                    "diagnostics to an issue.",
+                    vin[-6:], _kind, f" HTTP {_status}" if _status else "",
+                )
+            else:
+                _LOGGER.debug("Porsche get_status failed: %s", _kind)
             return d
 
         # v3.0.0 — capture the raw Porsche response for the Scout + diagnostics.
@@ -349,6 +390,22 @@ class PorscheClient:
                 and item.get("key")
                 and v(item, "status", "isEnabled", default=True)
             }
+
+            # v4.7.8 (#1337) — Porsche Connect contract state. Requested all along
+            # but never parsed: a car whose contract lapsed reports its identity
+            # and NO enabled measurements (@mps222, 3 cars, every sensor blank,
+            # no clue why). An ENABLED CONNECT_CONTRACT measurement = active;
+            # present-but-disabled = inactive; absent = unknown. Its value shape
+            # is unverified on a live car, so only the enabled flag is read.
+            _cc_raw = next(
+                (it for it in raw_measurements
+                 if isinstance(it, dict) and it.get("key") == "CONNECT_CONTRACT"),
+                None,
+            )
+            d.connect_contract_active = (
+                bool(v(_cc_raw, "status", "isEnabled", default=True))
+                if _cc_raw is not None else None
+            )
 
             d.battery_soc   = v(m, "BATTERY_LEVEL", "percent")
             # v2.2.1 Phase 8 PR #3 — split electric / combustion range
@@ -1131,10 +1188,11 @@ class PorscheClient:
         # eating one wasted round trip every natural expiry cycle. Only on
         # the first attempt, so a mid-retry-chain call doesn't re-trigger it.
         if _attempt == 0 and retry and self._tokens.needs_refresh():
-            await self._refresh()
+            await self._refresh(stale_access_token=self._tokens.access_token)
+        _used_token = self._tokens.access_token
         headers = kwargs.pop("headers", {})
         headers.update({
-            "Authorization": f"Bearer {self._tokens.access_token}",
+            "Authorization": f"Bearer {_used_token}",
             "X-Client-ID":   _X_CLIENT,
             "User-Agent":    _USER_AGENT,
             "Accept":        "application/json",
@@ -1145,7 +1203,7 @@ class PorscheClient:
                 timeout=ClientTimeout(total=30), **kwargs,
             ) as resp:
                 if resp.status == 401 and retry:
-                    await self._refresh()
+                    await self._refresh(stale_access_token=_used_token)
                     return await self._request(method, url, retry=False, **kwargs)
                 if resp.status == 429 and _attempt < 3:
                     # b19 (CJNE-comparison #5) — honor a server-sent
@@ -1216,7 +1274,7 @@ class PorscheClient:
                 continue
             setattr(self, attr, value)
 
-    async def _refresh(self) -> None:
+    async def _refresh(self, stale_access_token: str | None = None) -> None:
         """Refresh tokens with storm protection (v1.25.0 PR-B parity).
 
         Pre-v1.25.0 there was no throttle — repeated 401s would spam refresh
@@ -1228,6 +1286,18 @@ class PorscheClient:
         if self._refresh_lock is None:
             self._refresh_lock = asyncio.Lock()
         async with self._refresh_lock:
+            # v4.7.8 — coalesce: N per-VIN reads that all saw the same expiring
+            # or rejected token queue here; the first one refreshes, the rest
+            # find a NEWER token when they get the lock and must not refresh
+            # again. Without this a 3-car account burned the whole 3/h budget
+            # in one poll and, with a dead refresh token, ran N interactive
+            # logins per poll (#1337).
+            if (
+                stale_access_token is not None
+                and self._tokens is not None
+                and self._tokens.access_token != stale_access_token
+            ):
+                return
             now = time.monotonic()
             cutoff = now - _REFRESH_WINDOW_S
             self._refresh_history = [t for t in self._refresh_history if t > cutoff]

--- a/custom_components/vag_connect/cariad/auth/_eu_data_act.py
+++ b/custom_components/vag_connect/cariad/auth/_eu_data_act.py
@@ -1694,6 +1694,12 @@ def map_dataset_to_vehicle_data(
         else None
     )
 
+    # v4.7.8 (#1195/#1380) — the charge-report SoC leaf the walker splits off
+    # (the SoC at the last charge start/stop report, NOT live). Surfaced as its
+    # own reading so the Scout stops re-reporting it as "undiscovered" on every
+    # poll (11 auto-issues in one day) — Scout policy: map, never suppress.
+    d.battery_soc_charge_report = _to_int(first("battery_state_report.soc_at_charge_start"))
+
     # #465 — SoC is the one field observed to ship under disagreeing aliases
     # (a stale 57 vs the fresh 81); resolve it by capture time, not list order.
     _leaf_soc = _to_int(first_freshest("battery_state_report.soc", "soc", "stateOfChargeInPercent",
@@ -1803,18 +1809,45 @@ def map_dataset_to_vehicle_data(
     _stc_raw = str(first("shortTermAverageConsumption") or "")
     _stc_parts = _stc_raw.split()
     _stc = _to_float(_stc_parts[0]) if _stc_parts else None
-    if _stc is not None and _stc >= 0 and "wh" in _stc_raw.lower():
-        d.short_term_avg_electric_consumption_kwh_100km = _stc
+    _stc_unit = _stc_parts[1].lower() if len(_stc_parts) > 1 else ""
+    if _stc is not None and _stc >= 0:
+        if "wh" in _stc_unit:
+            d.short_term_avg_electric_consumption_kwh_100km = _stc
+        elif _stc_unit.startswith("l"):
+            # v4.7.8 — the data dictionary names this leaf "short term FUEL
+            # consumption", so l/100km is its DOCUMENTED shape, not an edge case.
+            # v4.7.6 consumed it here and then dropped it (a Scout no-suppression
+            # violation on every ICE/PHEV car); it gets its own fuel sensor.
+            d.short_term_avg_fuel_consumption_l_100km = _stc
 
     # #1375 (Audi S6 TDI) — SCR/AdBlue engine-start counter (diagnostic).
+    # v4.7.8 — per the dictionary "<=13 number of restarts, ==14 driveability,
+    # ==15 no_driveability": 14/15 are STATUS codes, not a count. Recording
+    # them as a TOTAL_INCREASING value made HA's statistics see a meter reset
+    # when the real count came back; only the count range is a count.
     _scr = _to_int(first("scr_number_of_engine_starts"))
-    if _scr is not None and _scr >= 0:
+    if _scr is not None and 0 <= _scr <= 13:
         d.engine_starts_count = _scr
 
     # #1378 — ``tripId`` is a per-trip UUID (identifier only, no sensor value).
     # Consume it so the Scout stops re-reporting it as an "undiscovered field"
     # every poll; it is metadata, not a suppressed reading.
     first("tripId")
+
+    # v4.7.8 (#1396, CUPRA Raval) — anti-theft alarm reason (``dwa`` = Diebstahl-
+    # warnanlage), e.g. "ALARM_REASON_DRIVERSDOOROPEN". Kept verbatim: the enum
+    # set is not documented, so no value is rewritten or dropped.
+    _dwa = first("dwa_alarm_reason")
+    if _dwa is not None and str(_dwa).strip():
+        d.alarm_reason = str(_dwa).strip()
+
+    # v4.7.8 (#1396, CUPRA Raval) — a bare ``data`` leaf carrying a base64 DER
+    # packet. Decoded it holds two GeneralizedTime stamps ten minutes apart plus
+    # small counters — an export ENVELOPE (poll window), not a vehicle reading;
+    # the same class as the v2.18.1 envelope carve-out (tripId precedent).
+    # Consumed so the Scout stops re-reporting it every poll; nothing here is a
+    # value a sensor could show. Revisit if a decoded shape ever carries data.
+    first("data")
 
     # #465 (zdravac) — vehicleIsStandingStill (dict UUID 0010398f-5fda-39af-9e7a-
     # 25db8c2e623a, cluster "Parking Data", boolean "current motion state").

--- a/custom_components/vag_connect/cariad/auth/porsche.py
+++ b/custom_components/vag_connect/cariad/auth/porsche.py
@@ -112,6 +112,7 @@ Old flow based on CJNE/pyporscheconnectapi (Apache-2.0), aiohttp reimpl.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -124,6 +125,7 @@ from urllib.parse import parse_qs, urljoin, urlsplit
 from aiohttp import ClientTimeout, ClientSession
 
 from ..exceptions import (
+    APIError,
     AuthenticationError,
     PorscheCaptchaRequiredError,
     PorscheLoginWallError,
@@ -142,7 +144,16 @@ _TOKEN_URL     = f"https://{_AUTH_SERVER}/oauth/token"
 _CLIENT_ID     = "XhygisuebbrqQ80byOuU5VncxLIm8E6H"
 _REDIRECT_URI  = "my-porsche-app://auth0/callback"
 _AUDIENCE      = "https://api.porsche.com"
-_USER_AGENT    = "My Porsche/2.1.0 (iPhone; iOS 17.0; Scale/3.00)"
+# #1337 (v4.7.8) — a plain library User-Agent, the same CLASS the reference
+# client (CJNE/pyporscheconnectapi) authenticates and reads with. We previously
+# impersonated the iOS app; a native-app fingerprint without the app's device
+# context is the more suspicious of the two to Auth0's bot scoring and is one
+# of only two request-shape differences from the flow that demonstrably gets
+# vehicle-holding accounts through. Honest, ours, not the other project's string.
+_USER_AGENT    = "vag-connect-ha/4.7.8 (+https://github.com/its-me-prash/vwgroup-connect-ha)"
+# Reference-client settle delay between the password POST and the first resume
+# hop (see the comment at the call site in ``authenticate``).
+_POST_PASSWORD_SETTLE_S = 2.5
 # b19 (CJNE-comparison #4) — CJNE attaches this X-Client-ID to every Auth0-flow
 # request (identifier/password POSTs, resume hops, token exchange, refresh),
 # not just post-auth API calls. It is already used post-auth in api/porsche.py
@@ -196,6 +207,11 @@ class PorscheAuth:
 
     def __init__(self, session: ClientSession) -> None:
         self._session = session
+        # v4.7.8 (#1337) — the last unhandled wall screen (host/name) + its
+        # secret-free page marker, set by ``_follow_to_code``; carried on
+        # ``PorscheLoginWallError`` so the UI/report can name what was hit.
+        self._last_wall_screen: str = ""
+        self._last_wall_marker: str = ""
 
     async def authenticate(
         self,
@@ -228,6 +244,11 @@ class PorscheAuth:
         captcha to the exact ACUL screen that presented it (``_resume_acul_
         captcha``) and continues to the code from there.
         """
+        # v4.7.8 — a wall screen/marker belongs to THIS attempt only; the same
+        # PorscheAuth lives across polls, so a previous attempt's wall name must
+        # never leak into a later error.
+        self._last_wall_screen = ""
+        self._last_wall_marker = ""
         if captcha_code and captcha_resume:
             return await self._resume_acul_captcha(
                 captcha_code, captcha_resume, resume_verifier or "",
@@ -378,6 +399,26 @@ class PorscheAuth:
                         image, resume["form"].get("state", ""), verifier,
                         resume=resume,
                     )
+            # v4.7.8 — a rendered page with no replayable captcha IS the wall.
+            # Name it here: step 4 has no redirect to follow, so it would
+            # otherwise report "unknown". Host + ACUL screen name + the
+            # secret-free page marker only — never the URL/query/body.
+            self._last_wall_screen = (
+                f"{_AUTH_SERVER}/{self._acul_screen_name(password_url, body) or 'unknown'}"
+            )
+            self._last_wall_marker = self._page_marker(body)
+
+        # #1337 (v4.7.8) — settle delay before resuming. The reference client
+        # (CJNE/pyporscheconnectapi, ``login_with_identifier``) deliberately
+        # sleeps 2.5 s between the password POST and the first resume hop, and
+        # it is the ONE thing its flow did that ours did not. Porsche's backend
+        # needs a moment to commit the login; resuming immediately bounced
+        # vehicle-holding accounts to the unclearable ``my.porsche.com`` wall
+        # (@Hollywoodchaos, @mps222, @buhito81). mps222 called it exactly: his
+        # login "surprisingly" worked the moment DEBUG logging added latency.
+        # Matching the reference delay 1:1 keeps us on the code-yielding path.
+        if location:
+            await asyncio.sleep(_POST_PASSWORD_SETTLE_S)
 
         # Step 4: follow the Auth0 redirect chain to the code.
         #
@@ -396,7 +437,7 @@ class PorscheAuth:
             # code. Raise the distinct wall error so the config flow stops
             # mislabelling these verified-good credentials as "email/password
             # incorrect" (#1337 @Hollywoodchaos/@mps222 both hit exactly that).
-            raise PorscheLoginWallError()
+            raise PorscheLoginWallError(self._last_wall_screen, self._last_wall_marker)
 
         # Step 5: Exchange code for tokens
         return await self._exchange_code(code, verifier)
@@ -587,13 +628,21 @@ class PorscheAuth:
                         urlsplit(target).hostname or "?",
                     )
                     return None
+                marker = self._page_marker(html)
                 _LOGGER.debug(
                     "Porsche auth: hop returned HTTP %s — rendered screen '%s' "
                     "(host=%s; %s) we do not handle; no authorization code. The "
                     "screen name/marker is what grounding a fix for it needs.",
                     resp.status, screen or "unknown",
-                    urlsplit(target).hostname or "?", self._page_marker(html),
+                    urlsplit(target).hostname or "?", marker,
                 )
+                # v4.7.8 (#1337) — remember WHAT we hit so the wall error (and the
+                # config flow's abort text + one-click report) can name it. Every
+                # wall report so far said "screen: unknown" because this stayed
+                # DEBUG-only; secret-free by construction (host + screen name +
+                # title/keyword marker, never a URL/query/body).
+                self._last_wall_screen = f"{urlsplit(target).hostname or '?'}/{screen or 'unknown'}"
+                self._last_wall_marker = marker
                 return None
         return None
 
@@ -721,7 +770,7 @@ class PorscheAuth:
             # The descriptor is built with the same guard, so this should be
             # unreachable; keep it as a hard stop against ever POSTing the
             # seeded form off Porsche's domain.
-            raise PorscheLoginWallError()
+            raise PorscheLoginWallError(self._last_wall_screen, self._last_wall_marker)
         form = dict(resume.get("form") or {})
         form.update({
             "captcha":  captcha_code,
@@ -745,7 +794,7 @@ class PorscheAuth:
         if status in (301, 302, 303, 307, 308) and location:
             code = await self._follow_to_code(location, url, verifier)
             if not code:
-                raise PorscheLoginWallError()
+                raise PorscheLoginWallError(self._last_wall_screen, self._last_wall_marker)
             return await self._exchange_code(code, verifier)
         if status == 200:
             # The screen re-rendered instead of advancing: another captcha
@@ -757,7 +806,7 @@ class PorscheAuth:
                     raise PorscheCaptchaRequiredError(
                         image, nxt["form"].get("state", ""), verifier, resume=nxt,
                     )
-            raise PorscheLoginWallError()
+            raise PorscheLoginWallError(self._last_wall_screen, self._last_wall_marker)
         raise AuthenticationError(
             f"Porsche captcha resume failed (HTTP {status})"
         )
@@ -786,10 +835,16 @@ class PorscheAuth:
                 raise TokenExpiredError("Porsche refresh token expired")
             if resp.status != 200:
                 body = await resp.text()
-                raise AuthenticationError(
-                    f"Porsche token refresh failed {resp.status}: "
-                    f"{_oauth_error_code(body)}"
-                )
+                code = _oauth_error_code(body)
+                if resp.status == 400 and code == "invalid_grant":
+                    # OAuth's own "refresh token invalid/revoked" answer.
+                    raise TokenExpiredError("Porsche refresh token expired")
+                # v4.7.8 — anything else (5xx, 429, 4xx-other) is a token-
+                # ENDPOINT failure, not a dead token: only 401/403/invalid_grant
+                # mean the refresh token is gone. Raising AuthenticationError
+                # here turned an Auth0 hiccup into a full re-authentication
+                # (captcha again) once get_status stopped swallowing auth errors.
+                raise APIError(resp.status, _TOKEN_URL, code)
             data = await resp.json()
 
         return TokenSet(

--- a/custom_components/vag_connect/cariad/exceptions.py
+++ b/custom_components/vag_connect/cariad/exceptions.py
@@ -462,11 +462,20 @@ class PorscheLoginWallError(AuthenticationError):
     and instead names the real wall — mirroring how ``NorthAmericaAttestation
     Error`` rescued the VW-NA case. Carries no secret; the message is static."""
 
-    def __init__(self) -> None:
+    def __init__(self, screen: str = "", marker: str = "") -> None:
+        # v4.7.8 (#1337) — name WHAT was hit. ``screen`` is "host/acul-screen-
+        # name" (e.g. "my.porsche.com/unknown"), ``marker`` the secret-free page
+        # marker (title + keyword flags). Both are already-redacted by
+        # construction (no URL/query/body/token), so they may travel into the
+        # WARNING log line, the abort dialog and the one-click GitHub report —
+        # the datapoint every wall report so far was missing.
+        where = f" (screen: {screen}; {marker})" if screen or marker else ""
         super().__init__(
             "Porsche login reached a captcha/consent screen after the password "
-            "step that a headless login cannot complete — credentials are fine."
+            f"step that a headless login cannot complete — credentials are fine{where}."
         )
+        self.screen = screen
+        self.marker = marker
 
 
 class PortalInteractionRequiredError(AuthenticationError):

--- a/custom_components/vag_connect/cariad/models.py
+++ b/custom_components/vag_connect/cariad/models.py
@@ -1518,6 +1518,9 @@ class VehicleData:
     alarm_active: bool | None = None       # vehicleAlarm == "ALARM"
     siren_active: bool | None = None       # siren == "ACTIVE"
     last_alarm_at: Any | None = None       # ISO timestamp of last alarm
+    # v4.7.8 (#1396) — EU-DA portal anti-theft alarm reason, verbatim enum
+    # string (e.g. "ALARM_REASON_DRIVERSDOOROPEN"); None = not reported.
+    alarm_reason: str | None = None
 
     # v2.0.0 (Big-Bang) — Heat-source mode (issue #163, best-effort).
     # ID.x heat-pump models surface ``climatisationSettings.value.heaterSource``
@@ -1556,6 +1559,15 @@ class VehicleData:
     short_term_avg_electric_consumption_kwh_100km: float | None = None
     # #1375 (Audi S6 TDI) — SCR/AdBlue system engine-start counter (diagnostic).
     engine_starts_count: int | None = None
+    # v4.7.8 — fuel-unit shape of the short-term consumption leaf (Scout policy:
+    # never drop a value the feed sends).
+    short_term_avg_fuel_consumption_l_100km: float | None = None
+    # v4.7.8 — the portal's "SoC at the last charge start/stop report" leaf,
+    # kept apart from the live SoC (#1195/#1380) and now surfaced instead of
+    # being re-reported by the Scout every poll.
+    battery_soc_charge_report: int | None = None
+    # v4.7.8 (#1337) — Porsche Connect contract state; None = not reported.
+    connect_contract_active: bool | None = None
     last_trip_timestamp: str | None = None
     # v2.10.0 - last-trip reset timestamp. audi_connect_ha v2.1.0 surfaces
     # this as `shortterm_reset`. Read-only: records WHEN the user last

--- a/custom_components/vag_connect/config_flow.py
+++ b/custom_components/vag_connect/config_flow.py
@@ -283,7 +283,11 @@ async def _validate_credentials(
                 "wall past the password step (not a credentials problem): %s",
                 brand, err,
             )
-            raise ValueError("porsche_login_wall") from err
+            # v4.7.8 — carry the wall's screen/marker through the ValueError so
+            # the step handlers can put it into the one-click report.
+            raise ValueError(
+                f"porsche_login_wall:{err.screen}|{err.marker}"
+            ) from err
         except AuthenticationError as err:
             _LOGGER.warning("VW Group Connect auth failed (%s): %s", brand, err)
             raise ValueError("invalid_credentials") from err
@@ -315,7 +319,9 @@ async def _validate_credentials(
         # refresh instead of running a SECOND interactive login (another captcha)
         # at first setup. Other brands / no token → None (unchanged behaviour).
         _t = getattr(client, "_tokens", None)
-        if isinstance(client, PorscheClient) and _t is not None:
+        # v4.7.8 — bridge only a token that can actually be refreshed; a
+        # refresh-less one must fall back to the normal authenticate() path.
+        if isinstance(client, PorscheClient) and _t is not None and _t.refresh_token:
             return {
                 "access_token":  _t.access_token,
                 "refresh_token": _t.refresh_token,
@@ -326,8 +332,19 @@ async def _validate_credentials(
     return None
 
 
+def _wall_screen(err_str: str) -> str:
+    """v4.7.8 (#1337) — the ``<screen>`` carried on a ``porsche_login_wall:<screen>|<marker>``
+    ValueError (empty for any other error)."""
+    if not err_str.startswith("porsche_login_wall:"):
+        return ""
+    return err_str.partition(":")[2].partition("|")[0]
+
+
 def _map_error(err_code: str) -> str:
     """Map ValueError string to strings.json error key."""
+    # v4.7.8 — a ":detail" suffix (porsche_login_wall:<screen>|<marker>) rides
+    # along for the report link; the error KEY is the part before it.
+    err_code = err_code.split(":", 1)[0]
     return err_code if err_code in {
         "terms_and_conditions", "marketing_consent", "two_factor_required",
         "too_many_requests", "invalid_credentials", "missing_library",
@@ -799,15 +816,16 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                     self._pending_entry_data = self._build_entry_data(brand, username, password, user_input)
                     self._pending_user_input = dict(user_input)
                     return await self.async_step_mfa()
-                if err_str == "porsche_login_wall":
+                if err_str.startswith("porsche_login_wall"):
                     # #1337 — the login got past the password but hit a Porsche
                     # wall we can't clear headless. Stop cleanly and offer a
-                    # one-click report so we capture which screen it was.
+                    # one-click report that names which screen it was.
                     return self.async_abort(
                         reason="porsche_login_wall",
                         description_placeholders={
                             "report_url": self._porsche_report_url(
-                                "email_password", "porsche_login_wall"
+                                "email_password", "porsche_login_wall",
+                                _wall_screen(err_str),
                             ),
                         },
                     )
@@ -1993,11 +2011,14 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
             f"- Error: {reason}\n"
             f"- Auth0 screen: {screen or 'unknown'}\n\n"
             "What happened (optional):\n\n\n"
-            "Please attach your diagnostics: Settings -> Devices & Services -> "
-            "VW Group Connect -> three-dots menu -> Download diagnostics "
-            "(it is automatically redacted). If you can, also enable debug "
-            "logging first, reproduce, and paste any 'Porsche auth:' log lines "
-            "-- they name the exact screen this got stuck on.\n"
+            "Most useful: enable debug logging for VW Group Connect (Settings -> "
+            "Devices & Services -> VW Group Connect -> three-dots menu -> Enable "
+            "debug logging), reproduce once, then paste the 'Porsche auth:' lines "
+            "from the log -- they name the exact screen this got stuck on. "
+            "(If the setup itself failed there is no entry yet, so there is no "
+            "diagnostics file to download; the debug lines are the capture.) "
+            "If the integration IS set up, also attach Download diagnostics "
+            "(automatically redacted).\n"
         )
         query = urlencode({"labels": "porsche,auth", "title": title, "body": body})
         return (
@@ -2096,12 +2117,15 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
 
         # #1337 — one report link for every give-up path in this step, so a user
         # who hits a wall we can't clear can hand us the decisive datapoint.
-        def _abort_report(reason: str) -> config_entries.ConfigFlowResult:
+        def _abort_report(
+            reason: str, screen: str = ""
+        ) -> config_entries.ConfigFlowResult:
             return self.async_abort(
                 reason=reason,
                 description_placeholders={
                     "report_url": self._porsche_report_url(
-                        self._porsche_captcha_return or "porsche_captcha", reason
+                        self._porsche_captcha_return or "porsche_captcha", reason,
+                        screen,
                     ),
                 },
             )
@@ -2152,7 +2176,7 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                         # then hit the post-password captcha/consent wall.
                         # Re-showing the now-consumed captcha would just invite a
                         # lockout-risking retry, so stop cleanly + offer a report.
-                        return _abort_report("porsche_login_wall")
+                        return _abort_report("porsche_login_wall", _wall_screen(str(err)))
                     if mapped == "cannot_connect":
                         # Transient — the challenge may still be valid, so let the
                         # user retry rather than forcing a full restart.
@@ -2306,12 +2330,12 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 self._porsche_captcha_resume   = err.resume
                 return await self.async_step_porsche_captcha()
             except ValueError as err:
-                if str(err) == "porsche_login_wall":
+                if str(err).startswith("porsche_login_wall"):
                     return self.async_abort(
                         reason="porsche_login_wall",
                         description_placeholders={
                             "report_url": self._porsche_report_url(
-                                "reauth", "porsche_login_wall"
+                                "reauth", "porsche_login_wall", _wall_screen(str(err)),
                             ),
                         },
                     )
@@ -2488,12 +2512,13 @@ class VagConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 self._porsche_captcha_resume   = err.resume
                 return await self.async_step_porsche_captcha()
             except ValueError as err:
-                if str(err) == "porsche_login_wall":
+                if str(err).startswith("porsche_login_wall"):
                     return self.async_abort(
                         reason="porsche_login_wall",
                         description_placeholders={
                             "report_url": self._porsche_report_url(
-                                "reconfigure", "porsche_login_wall"
+                                "reconfigure", "porsche_login_wall",
+                                _wall_screen(str(err)),
                             ),
                         },
                     )

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -1412,7 +1412,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             # — another captcha — right after setup. Promote it into the
             # persistent store; from then on it's a normal cached-token restart.
             porsche_initial = self.entry.data.get("porsche_initial_tokens")
-            if persisted is None and porsche_initial:
+            # v4.7.8 — only a token WITH a refresh_token is worth bridging: the
+            # client silently ignores a refresh-less one while this code would
+            # still skip authenticate(), leaving the entry with no token at all.
+            if (
+                persisted is None
+                and porsche_initial
+                and porsche_initial.get("refresh_token")
+            ):
                 from .cariad.models import TokenSet  # noqa: PLC0415
                 persisted = TokenSet(
                     access_token=str(porsche_initial.get("access_token", "")),
@@ -1427,6 +1434,17 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     brand,
                 )
                 await self._token_storage.save(persisted)
+            # v4.7.8 — promoted or not (a reauth/reconfigure writes the store
+            # directly AND stashes a copy here), the entry.data copy is never
+            # the source of truth: strip it so no plaintext token lingers in
+            # core.config_entries and no stale copy can be re-promoted later
+            # (storage-version bump, corrupted file, .storage restore).
+            if "porsche_initial_tokens" in self.entry.data:
+                _cleaned = {
+                    k: v for k, v in self.entry.data.items()
+                    if k != "porsche_initial_tokens"
+                }
+                self.hass.config_entries.async_update_entry(self.entry, data=_cleaned)
 
         # VW EU Two-Way (650d46ca): when armed, the modern-BFF device-grant token
         # is the PRIMARY. Activate it from entry.data on the config_flow reload
@@ -1598,6 +1616,14 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 # original invalid_credentials behaviour (strict no-op).
                 try:
                     if persisted is None or persisted_is_portal:
+                        raise
+                    # v4.7.8 (#1337) — Porsche's client already falls back to a
+                    # fresh interactive login inside its own refresh path, so
+                    # reaching here means that login ALREADY failed (captcha or
+                    # dead credentials). A second identical attempt would only
+                    # submit the same credentials twice per restart — the exact
+                    # retry pressure that has locked Porsche accounts. Re-raise.
+                    if brand == "porsche":
                         raise
                     _LOGGER.info(
                         "VW Group Connect: persisted tokens for %s no longer "
@@ -1852,6 +1878,25 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                 type(err).__name__,
             )
             return False
+
+    def _porsche_auth_dead(self, vins: list[str], results: list[Any]) -> bool:
+        """v4.7.8 (#1337) — True when EVERY Porsche car read failed
+        authentication on two consecutive polls. One poll is not enough: a
+        token-endpoint hiccup surfaces as APIError (not auth) since 4.7.8, but
+        a single all-auth-fail poll can still be a blip; two in a row means the
+        refresh token is really dead and re-authentication is the only way out.
+        Brand-gated on purpose: other brands have their own auth paths.
+        """
+        from .cariad.exceptions import AuthenticationError  # noqa: PLC0415
+
+        if not vins or self.entry.data.get(CONF_BRAND) != "porsche":
+            return False
+        if results and all(isinstance(r, AuthenticationError) for r in results):
+            n = getattr(self, "_porsche_auth_fail_polls", 0) + 1
+            self._porsche_auth_fail_polls = n
+            return n >= 2
+        self._porsche_auth_fail_polls = 0
+        return False
 
     def _trigger_reauth(self, reason: str) -> None:
         """Stop the poll loop and ask HA to start the reauth flow.
@@ -2540,6 +2585,11 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         """
         from homeassistant.helpers import issue_registry as ir  # noqa: PLC0415
 
+        # v4.7.8 — remember that we raised it, so the per-poll repair refresh
+        # can clear it again once the portal session is demonstrably alive
+        # (data flowed). Before this the Repair was never deleted at all: a
+        # user who re-logged in kept seeing "session expired" forever.
+        self._data_act_session_expired_pending = True
         ir.async_create_issue(
             self.hass,
             DOMAIN,
@@ -2668,6 +2718,21 @@ class VagConnectCoordinator(DataUpdateCoordinator):
             self._portal_interaction_reason = ""
         issue_id = f"data_act_no_data_{self.entry.entry_id}"
         reason = getattr(portal, "last_no_data_reason", "") if portal else ""
+        # v4.7.8 — the "portal session expired" Repair (raised by setup, the
+        # kickoff and the historical export) was never cleared, so it outlived
+        # the re-login it asked for. Data flowing through the portal this poll
+        # is proof the session is alive again → clear it. Deliberately NOT
+        # cleared on a no-data poll: the kickoff can raise it mid-cycle and the
+        # same cycle's empty dataset must not immediately erase it.
+        if (
+            portal is not None
+            and not reason
+            and getattr(self, "_data_act_session_expired_pending", False)
+        ):
+            ir.async_delete_issue(
+                self.hass, DOMAIN, f"data_act_session_expired_{entry_id}"
+            )
+            self._data_act_session_expired_pending = False
         if portal is None or not reason:
             ir.async_delete_issue(self.hass, DOMAIN, issue_id)
             return
@@ -3804,6 +3869,18 @@ class VagConnectCoordinator(DataUpdateCoordinator):
                     *[_client.get_status(vin) for vin in vins],
                     return_exceptions=True,
                 )
+                # v4.7.8 (#1337) — Porsche: when EVERY car's read failed with an
+                # auth error, the refresh token is dead and the client's own
+                # fallback (a full interactive login) is failing on captcha /
+                # changed credentials. Before this the per-VIN failures were only
+                # counted, so the entry re-ran that interactive login up to 3x per
+                # hour indefinitely with no reauth prompt. Escalate to reauth.
+                # Brand-gated on purpose: other brands have their own auth paths.
+                if self._porsche_auth_dead(vins, list(results)):
+                    self._trigger_reauth(
+                        "every vehicle read failed authentication on two "
+                        "consecutive polls (refresh token dead)"
+                    )
                 fresh: dict[str, Any] = {}
                 any_success = False
                 # Lazy-initialise v1.8.7 tracking dicts so tests that bypass

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.7"
+  "version": "4.7.8"
 }

--- a/custom_components/vag_connect/sensor.py
+++ b/custom_components/vag_connect/sensor.py
@@ -1588,6 +1588,41 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         suggested_display_precision=1,
         condition="electric",
     ),
+    # v4.7.8 — the same portal leaf in its documented FUEL shape (l/100km);
+    # v4.7.6 consumed it and dropped it. Scout policy: never suppress a value.
+    VagSensorDescription(
+        key="short_term_avg_fuel_consumption_l_100km",
+        translation_key="short_term_avg_fuel_consumption_l_100km",
+        data_key="short_term_avg_fuel_consumption_l_100km",
+        native_unit_of_measurement="L/100 km",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:gas-station-outline",
+        suggested_display_precision=1,
+        condition="combustion",
+    ),
+    # v4.7.8 (#1195/#1380) — the "SoC at the last charge report" snapshot the
+    # portal ships beside the live SoC. Kept apart from battery_soc so the live
+    # value always wins; surfaced here so the Scout stops re-reporting it.
+    VagSensorDescription(
+        key="battery_soc_charge_report",
+        translation_key="battery_soc_charge_report",
+        data_key="battery_soc_charge_report",
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery-clock",
+        condition="electric",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    # v4.7.8 (#1396, CUPRA Raval) — anti-theft alarm reason from the portal
+    # feed (verbatim enum string). Diagnostic; only cars that report it get it.
+    VagSensorDescription(
+        key="alarm_reason",
+        translation_key="alarm_reason",
+        data_key="alarm_reason",
+        icon="mdi:alarm-light-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 
     # #1375 (Audi S6 TDI) — SCR/AdBlue engine-start counter (diagnostic).
     VagSensorDescription(
@@ -1596,6 +1631,9 @@ SENSOR_DESCRIPTIONS: tuple[VagSensorDescription, ...] = (
         data_key="engine_starts_count",
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:engine",
+        # v4.7.8 — SCR/AdBlue engine starts exist only on combustion cars;
+        # without this every EV got a (disabled) "Engine Starts" entity.
+        condition="combustion",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
@@ -4210,9 +4248,15 @@ async def async_setup_entry(
                 # trip data inline from their own get_status parse, so a missing
                 # tripStatistics cap must NOT hide their sensors; the hide-empty guard
                 # below already suppresses any field they don't fill.
-                if brand in ("audi", "volkswagen") and (
-                    coordinator.command_capability_supported(vin, "command_trip_stats")
+                # v4.7.8 (#923 guiumb) — ...but ONLY when the car has no trip
+                # value at all. A VW-EU portal car gets its trips from the EU Data
+                # Act feed, not the BFF; the "no tripStatistics capability" gate
+                # was hiding real data those cars already carried.
+                if (
+                    brand in ("audi", "volkswagen")
+                    and coordinator.command_capability_supported(vin, "command_trip_stats")
                     is False
+                    and vehicle.get(desc.data_key) is None
                 ):
                     continue
             # b3 — hide empty: skip data sensors with no value yet (reporters,

--- a/custom_components/vag_connect/strings.json
+++ b/custom_components/vag_connect/strings.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha required",
-        "description": "Porsche needs you to solve a captcha to continue signing in.\n\n{captcha_img}\n\nOnly solve this once with your best guess — repeated failed attempts have caused Porsche to lock accounts for suspicious activity.\n\nNothing you enter here leaves your Home Assistant instance. If the image will not load or you keep getting errors, you can report it (attach diagnostics): {report_url}",
+        "description": "Porsche needs you to solve a captcha to continue signing in.\n\n{captcha_img}\n\nSolve it once with your best guess — repeated failed attempts have caused Porsche to lock accounts for suspicious activity.\n\nYour answer goes only to Porsche's login service, never to any third party or to this project. If the image will not load or you keep getting errors, you can report it: {report_url}",
         "data": {
           "captcha_code": "Captcha Code"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Sign-in failed. Check your Volkswagen ID email and password.",
       "cannot_connect": "Could not reach Volkswagen. Please try again.",
       "vweu_mfa_unsupported": "This account needs an email or authenticator code, which VW EU Two-Way cannot handle yet. Use the read-only channels instead.",
-      "vweu_no_bff_data": "Signed in, but Volkswagen returned no live data for this car on the modern backend yet, so VW EU Two-Way was not enabled and your current channel is unchanged. Please try again later, or share a diagnostics so we can look into it."
+      "vweu_no_bff_data": "Signed in, but Volkswagen returned no live data for this car on the modern backend yet, so VW EU Two-Way was not enabled and your current channel is unchanged. Please try again later, or share a diagnostics so we can look into it.",
+      "terms_and_conditions": "Terms and conditions need to be accepted. Sign in to the app once and confirm."
     },
     "abort": {
       "not_volkswagen": "This channel is only available for Volkswagen.",
@@ -1490,6 +1491,15 @@
       },
       "engine_starts_count": {
         "name": "Engine Starts"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Short Term Average Fuel Consumption"
+      },
+      "battery_soc_charge_report": {
+        "name": "Battery Level at Last Charge Report"
+      },
+      "alarm_reason": {
+        "name": "Alarm Reason"
       }
     },
     "binary_sensor": {
@@ -1801,6 +1811,9 @@
       },
       "data_stale": {
         "name": "Data stale"
+      },
+      "connect_contract_active": {
+        "name": "Connect Contract Active"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/cs.json
+++ b/custom_components/vag_connect/translations/cs.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Vyžadována captcha",
-        "description": "Porsche vyžaduje vyřešení captchy pro pokračování v přihlášení.\n\n{captcha_img}\n\nVyřešte to jen jednou podle svého nejlepšího odhadu — opakované neúspěšné pokusy již vedly k zablokování účtu Porsche kvůli podezřelé aktivitě.\n\nNic, co sem zadáš, neopustí tvou instanci Home Assistant. Pokud se obrázek nenačte nebo se stále objevují chyby, můžeš to nahlásit (přilož diagnostiku): {report_url}",
+        "description": "Porsche vyžaduje vyřešení captcha pro pokračování přihlášení.\n\n{captcha_img}\n\nVyřeš ji jednou podle nejlepšího odhadu — opakované neúspěšné pokusy už u Porsche vedly k zablokování účtů kvůli podezřelé aktivitě.\n\nTvoje odpověď jde pouze do přihlašovací služby Porsche, nikdy třetím stranám ani tomuto projektu. Pokud se obrázek nenačte nebo se chyby opakují, můžeš to nahlásit: {report_url}",
         "data": {
           "captcha_code": "Kód captcha"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Přihlášení selhalo. Zkontrolujte e-mail a heslo svého Volkswagen ID.",
       "cannot_connect": "Volkswagen se nepodařilo kontaktovat. Zkuste to prosím znovu.",
       "vweu_mfa_unsupported": "Tento účet vyžaduje kód z e-mailu nebo z ověřovací aplikace, který VW EU Two-Way zatím neumí zpracovat. Použijte místo toho kanály jen pro čtení.",
-      "vweu_no_bff_data": "Přihlášení proběhlo, ale Volkswagen pro tento vůz na moderním backendu zatím nevrátil žádná živá data, takže VW EU Two-Way nebyl zapnut a váš stávající kanál zůstává beze změny. Zkuste to prosím později, nebo sdílejte diagnostiku, abychom se na to mohli podívat."
+      "vweu_no_bff_data": "Přihlášení proběhlo, ale Volkswagen pro tento vůz na moderním backendu zatím nevrátil žádná živá data, takže VW EU Two-Way nebyl zapnut a váš stávající kanál zůstává beze změny. Zkuste to prosím později, nebo sdílejte diagnostiku, abychom se na to mohli podívat.",
+      "terms_and_conditions": "Je nutné přijmout obchodní podmínky. Přihlaste se v aplikaci."
     },
     "abort": {
       "not_volkswagen": "Tento kanál je dostupný pouze pro Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Starty motoru"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Krátkodobá průměrná spotřeba paliva"
+      },
+      "battery_soc_charge_report": {
+        "name": "Stav baterie (poslední zpráva o nabíjení)"
+      },
+      "alarm_reason": {
+        "name": "Důvod alarmu"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Data zastaralá"
+      },
+      "connect_contract_active": {
+        "name": "Smlouva Connect aktivní"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/da.json
+++ b/custom_components/vag_connect/translations/da.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha påkrævet",
-        "description": "Porsche kræver, at du løser en captcha for at fortsætte login.\n\n{captcha_img}\n\nLøs det kun én gang efter bedste evne — gentagne mislykkede forsøg har fået Porsche til at spærre konti for mistænkelig aktivitet.\n\nDet, du indtaster her, forlader ikke din Home Assistant-instans. Hvis billedet ikke indlæses, eller du bliver ved med at få fejl, kan du rapportere det (vedhæft diagnostik): {report_url}",
+        "description": "Porsche kræver, at du løser en captcha for at fortsætte med at logge ind.\n\n{captcha_img}\n\nLøs den én gang med dit bedste bud — gentagne mislykkede forsøg har fået Porsche til at låse konti på grund af mistænkelig aktivitet.\n\nDit svar sendes kun til Porsches login-tjeneste, aldrig til tredjeparter eller til dette projekt. Hvis billedet ikke indlæses, eller du bliver ved med at få fejl, kan du rapportere det: {report_url}",
         "data": {
           "captcha_code": "Captcha-kode"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Login mislykkedes. Tjek din Volkswagen ID-e-mail og adgangskode.",
       "cannot_connect": "Kunne ikke få forbindelse til Volkswagen. Prøv venligst igen.",
       "vweu_mfa_unsupported": "Denne konto kræver en e-mail- eller authenticator-kode, som VW EU To-vejs endnu ikke kan håndtere. Brug de skrivebeskyttede kanaler i stedet.",
-      "vweu_no_bff_data": "Logget ind, men Volkswagen returnerede endnu ingen live-data for denne bil på det moderne backend, så VW EU To-vejs blev ikke aktiveret, og din nuværende kanal er uændret. Prøv venligst igen senere, eller del en diagnostikfil, så vi kan undersøge det."
+      "vweu_no_bff_data": "Logget ind, men Volkswagen returnerede endnu ingen live-data for denne bil på det moderne backend, så VW EU To-vejs blev ikke aktiveret, og din nuværende kanal er uændret. Prøv venligst igen senere, eller del en diagnostikfil, så vi kan undersøge det.",
+      "terms_and_conditions": "Vilkår og betingelser skal accepteres. Log ind i appen én gang, og bekræft."
     },
     "abort": {
       "not_volkswagen": "Denne kanal er kun tilgængelig for Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Motorstarter"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Gennemsnitligt brændstofforbrug (kort sigt)"
+      },
+      "battery_soc_charge_report": {
+        "name": "Batteriniveau (seneste opladningsrapport)"
+      },
+      "alarm_reason": {
+        "name": "Alarmårsag"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Data forældet"
+      },
+      "connect_contract_active": {
+        "name": "Connect-kontrakt aktiv"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/de.json
+++ b/custom_components/vag_connect/translations/de.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha erforderlich",
-        "description": "Porsche verlangt die Lösung eines Captchas, um mit der Anmeldung fortzufahren.\n\n{captcha_img}\n\nLöse es nur einmal mit deiner besten Vermutung — wiederholte Fehlversuche haben bei Porsche schon zu Konto-Sperrungen wegen verdächtiger Aktivität geführt.\n\nWas du hier eingibst, verlässt deine Home-Assistant-Instanz nicht. Wenn das Bild nicht lädt oder du immer wieder Fehler bekommst, kannst du es melden (Diagnose anhängen): {report_url}",
+        "description": "Porsche verlangt die Lösung eines Captchas, um mit der Anmeldung fortzufahren.\n\n{captcha_img}\n\nLöse es einmal mit deiner besten Vermutung — wiederholte Fehlversuche haben bei Porsche schon zu Konto-Sperrungen wegen verdächtiger Aktivität geführt.\n\nDeine Eingabe geht ausschließlich an den Porsche-Anmeldedienst, nie an Dritte oder an dieses Projekt. Wenn das Bild nicht lädt oder du immer wieder Fehler bekommst, kannst du es melden: {report_url}",
         "data": {
           "captcha_code": "Captcha-Code"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Anmeldung fehlgeschlagen. Prüfe E-Mail-Adresse und Passwort deiner Volkswagen ID.",
       "cannot_connect": "Volkswagen konnte nicht erreicht werden. Bitte erneut versuchen.",
       "vweu_mfa_unsupported": "Dieses Konto benötigt einen E-Mail- oder Authenticator-Code, den VW EU Two-Way noch nicht verarbeiten kann. Nutze stattdessen die nur-lesenden Kanäle.",
-      "vweu_no_bff_data": "Angemeldet, aber Volkswagen hat für dieses Auto auf dem modernen Backend noch keine Live-Daten geliefert. VW EU Two-Way wurde daher nicht aktiviert und dein aktueller Kanal bleibt unverändert. Bitte versuche es später erneut oder teile eine Diagnose, damit wir uns das ansehen können."
+      "vweu_no_bff_data": "Angemeldet, aber Volkswagen hat für dieses Auto auf dem modernen Backend noch keine Live-Daten geliefert. VW EU Two-Way wurde daher nicht aktiviert und dein aktueller Kanal bleibt unverändert. Bitte versuche es später erneut oder teile eine Diagnose, damit wir uns das ansehen können.",
+      "terms_and_conditions": "Nutzungsbedingungen müssen akzeptiert werden. Einmal in der App anmelden und bestätigen."
     },
     "abort": {
       "not_volkswagen": "Dieser Kanal ist nur für Volkswagen verfügbar.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Motorstarts"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Kurzzeit-Durchschnittsverbrauch Kraftstoff"
+      },
+      "battery_soc_charge_report": {
+        "name": "Akkustand (letzter Lade-Report)"
+      },
+      "alarm_reason": {
+        "name": "Alarmgrund"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Daten veraltet"
+      },
+      "connect_contract_active": {
+        "name": "Connect-Vertrag aktiv"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/en.json
+++ b/custom_components/vag_connect/translations/en.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha required",
-        "description": "Porsche needs you to solve a captcha to continue signing in.\n\n{captcha_img}\n\nOnly solve this once with your best guess — repeated failed attempts have caused Porsche to lock accounts for suspicious activity.\n\nNothing you enter here leaves your Home Assistant instance. If the image will not load or you keep getting errors, you can report it (attach diagnostics): {report_url}",
+        "description": "Porsche needs you to solve a captcha to continue signing in.\n\n{captcha_img}\n\nSolve it once with your best guess — repeated failed attempts have caused Porsche to lock accounts for suspicious activity.\n\nYour answer goes only to Porsche's login service, never to any third party or to this project. If the image will not load or you keep getting errors, you can report it: {report_url}",
         "data": {
           "captcha_code": "Captcha Code"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Sign-in failed. Check your Volkswagen ID email and password.",
       "cannot_connect": "Could not reach Volkswagen. Please try again.",
       "vweu_mfa_unsupported": "This account needs an email or authenticator code, which VW EU Two-Way cannot handle yet. Use the read-only channels instead.",
-      "vweu_no_bff_data": "Signed in, but Volkswagen returned no live data for this car on the modern backend yet, so VW EU Two-Way was not enabled and your current channel is unchanged. Please try again later, or share a diagnostics so we can look into it."
+      "vweu_no_bff_data": "Signed in, but Volkswagen returned no live data for this car on the modern backend yet, so VW EU Two-Way was not enabled and your current channel is unchanged. Please try again later, or share a diagnostics so we can look into it.",
+      "terms_and_conditions": "Terms and conditions need to be accepted. Sign in to the app once and confirm."
     },
     "abort": {
       "not_volkswagen": "This channel is only available for Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Engine Starts"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Short Term Average Fuel Consumption"
+      },
+      "battery_soc_charge_report": {
+        "name": "Battery Level at Last Charge Report"
+      },
+      "alarm_reason": {
+        "name": "Alarm Reason"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Data stale"
+      },
+      "connect_contract_active": {
+        "name": "Connect Contract Active"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/es.json
+++ b/custom_components/vag_connect/translations/es.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha necesario",
-        "description": "Porsche requiere resolver un captcha para continuar con el inicio de sesión.\n\n{captcha_img}\n\nResuélvelo solo una vez con tu mejor intento — los intentos fallidos repetidos han provocado que Porsche bloquee cuentas por actividad sospechosa.\n\nLo que introduces aquí no sale de tu instancia de Home Assistant. Si la imagen no se carga o sigues recibiendo errores, puedes notificarlo (adjunta los diagnósticos): {report_url}",
+        "description": "Porsche requiere resolver un captcha para continuar con el inicio de sesión.\n\n{captcha_img}\n\nResuélvelo una sola vez con tu mejor estimación: los intentos fallidos repetidos han provocado bloqueos de cuentas Porsche por actividad sospechosa.\n\nTu respuesta se envía únicamente al servicio de inicio de sesión de Porsche, nunca a terceros ni a este proyecto. Si la imagen no carga o sigues recibiendo errores, puedes informarlo: {report_url}",
         "data": {
           "captcha_code": "Código captcha"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Error al iniciar sesión. Comprueba el correo electrónico y la contraseña de tu Volkswagen ID.",
       "cannot_connect": "No se pudo contactar con Volkswagen. Inténtalo de nuevo.",
       "vweu_mfa_unsupported": "Esta cuenta necesita un código por correo electrónico o de la app de autenticación, que VW EU bidireccional aún no puede gestionar. Usa los canales de solo lectura en su lugar.",
-      "vweu_no_bff_data": "Sesión iniciada, pero Volkswagen aún no ha devuelto datos en vivo para este coche en el backend moderno, por lo que VW EU bidireccional no se ha activado y tu canal actual no cambia. Inténtalo de nuevo más tarde o comparte un diagnóstico para que podamos investigarlo."
+      "vweu_no_bff_data": "Sesión iniciada, pero Volkswagen aún no ha devuelto datos en vivo para este coche en el backend moderno, por lo que VW EU bidireccional no se ha activado y tu canal actual no cambia. Inténtalo de nuevo más tarde o comparte un diagnóstico para que podamos investigarlo.",
+      "terms_and_conditions": "Hay que aceptar los términos. Inicia sesión en la aplicación."
     },
     "abort": {
       "not_volkswagen": "Este canal solo está disponible para Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Arranques del motor"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Consumo medio de combustible (corto plazo)"
+      },
+      "battery_soc_charge_report": {
+        "name": "Nivel de batería (último informe de carga)"
+      },
+      "alarm_reason": {
+        "name": "Motivo de la alarma"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Datos obsoletos"
+      },
+      "connect_contract_active": {
+        "name": "Contrato Connect activo"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fi.json
+++ b/custom_components/vag_connect/translations/fi.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha vaaditaan",
-        "description": "Porsche vaatii captchan ratkaisemista kirjautumisen jatkamiseksi.\n\n{captcha_img}\n\nRatkaise tämä vain kerran parhaan arviosi mukaan — toistuvat epäonnistuneet yritykset ovat johtaneet Porschen tilien lukitsemiseen epäilyttävän toiminnan vuoksi.\n\nMitään tähän syöttämääsi ei lähetetä Home Assistant -instanssistasi. Jos kuva ei lataudu tai saat jatkuvasti virheitä, voit ilmoittaa siitä (liitä diagnostiikka): {report_url}",
+        "description": "Porsche vaatii captchan ratkaisemista kirjautumisen jatkamiseksi.\n\n{captcha_img}\n\nRatkaise se kerran parhaan arvauksesi mukaan — toistuvat epäonnistuneet yritykset ovat johtaneet Porsche-tilien lukitsemiseen epäilyttävän toiminnan vuoksi.\n\nVastauksesi lähetetään vain Porschen kirjautumispalveluun, ei koskaan kolmansille osapuolille tai tälle projektille. Jos kuva ei lataudu tai virheet toistuvat, voit ilmoittaa siitä: {report_url}",
         "data": {
           "captcha_code": "Captcha-koodi"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Kirjautuminen epäonnistui. Tarkista Volkswagen ID -sähköpostisi ja -salasanasi.",
       "cannot_connect": "Volkswageniin ei saatu yhteyttä. Yritä uudelleen.",
       "vweu_mfa_unsupported": "Tämä tili vaatii sähköposti- tai todennussovelluskoodin, jota VW EU Two-Way ei vielä osaa käsitellä. Käytä sen sijaan vain luku -kanavia.",
-      "vweu_no_bff_data": "Kirjautuminen onnistui, mutta Volkswagen ei vielä palauttanut tälle autolle live-tietoja modernissa taustajärjestelmässä, joten VW EU Two-Way ei aktivoitunut ja nykyinen kanavasi säilyy ennallaan. Yritä myöhemmin uudelleen tai jaa diagnostiikkatiedosto, jotta voimme selvittää asiaa."
+      "vweu_no_bff_data": "Kirjautuminen onnistui, mutta Volkswagen ei vielä palauttanut tälle autolle live-tietoja modernissa taustajärjestelmässä, joten VW EU Two-Way ei aktivoitunut ja nykyinen kanavasi säilyy ennallaan. Yritä myöhemmin uudelleen tai jaa diagnostiikkatiedosto, jotta voimme selvittää asiaa.",
+      "terms_and_conditions": "Käyttöehdot on hyväksyttävä. Kirjaudu sovellukseen kerran ja vahvista."
     },
     "abort": {
       "not_volkswagen": "Tämä kanava on käytettävissä vain Volkswagenille.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Moottorin käynnistykset"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Lyhyen aikavälin keskimääräinen polttoaineenkulutus"
+      },
+      "battery_soc_charge_report": {
+        "name": "Akun varaustaso (viimeisin latausraportti)"
+      },
+      "alarm_reason": {
+        "name": "Hälytyksen syy"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Tiedot vanhentuneet"
+      },
+      "connect_contract_active": {
+        "name": "Connect-sopimus aktiivinen"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/fr.json
+++ b/custom_components/vag_connect/translations/fr.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha requis",
-        "description": "Porsche exige la résolution d'un captcha pour continuer la connexion.\n\n{captcha_img}\n\nRésolvez-le une seule fois du mieux que vous pouvez — des tentatives répétées ont déjà conduit Porsche à bloquer des comptes pour activité suspecte.\n\nCe que vous saisissez ici ne quitte pas votre instance Home Assistant. Si l'image ne se charge pas ou si vous obtenez sans cesse des erreurs, vous pouvez le signaler (joindre les diagnostics) : {report_url}",
+        "description": "Porsche demande la résolution d'un captcha pour poursuivre la connexion.\n\n{captcha_img}\n\nRésolvez-le une seule fois avec votre meilleure estimation — des échecs répétés ont déjà entraîné le blocage de comptes Porsche pour activité suspecte.\n\nVotre réponse est envoyée uniquement au service de connexion Porsche, jamais à un tiers ni à ce projet. Si l'image ne se charge pas ou si les erreurs persistent, vous pouvez le signaler : {report_url}",
         "data": {
           "captcha_code": "Code captcha"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Échec de la connexion. Vérifiez l'e-mail et le mot de passe de votre Volkswagen ID.",
       "cannot_connect": "Impossible de joindre Volkswagen. Veuillez réessayer.",
       "vweu_mfa_unsupported": "Ce compte nécessite un code par e-mail ou d'une application d'authentification, que VW EU bidirectionnel ne prend pas encore en charge. Utilisez plutôt les canaux en lecture seule.",
-      "vweu_no_bff_data": "Connexion réussie, mais Volkswagen n'a pas encore renvoyé de données en direct pour cette voiture sur le backend moderne ; VW EU bidirectionnel n'a donc pas été activé et votre canal actuel reste inchangé. Veuillez réessayer plus tard, ou partagez un fichier de diagnostic pour que nous puissions examiner le problème."
+      "vweu_no_bff_data": "Connexion réussie, mais Volkswagen n'a pas encore renvoyé de données en direct pour cette voiture sur le backend moderne ; VW EU bidirectionnel n'a donc pas été activé et votre canal actuel reste inchangé. Veuillez réessayer plus tard, ou partagez un fichier de diagnostic pour que nous puissions examiner le problème.",
+      "terms_and_conditions": "Conditions d'utilisation à accepter. Connectez-vous dans l'application."
     },
     "abort": {
       "not_volkswagen": "Ce canal est disponible uniquement pour Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Démarrages moteur"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Consommation moyenne de carburant (court terme)"
+      },
+      "battery_soc_charge_report": {
+        "name": "Niveau de batterie (dernier rapport de charge)"
+      },
+      "alarm_reason": {
+        "name": "Cause de l'alarme"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Données obsolètes"
+      },
+      "connect_contract_active": {
+        "name": "Contrat Connect actif"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/it.json
+++ b/custom_components/vag_connect/translations/it.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha richiesto",
-        "description": "Porsche richiede di risolvere un captcha per continuare l'accesso.\n\n{captcha_img}\n\nRisolvilo una sola volta al meglio delle tue possibilità — tentativi ripetuti hanno già portato Porsche a bloccare account per attività sospette.\n\nCiò che inserisci qui non lascia la tua istanza di Home Assistant. Se l'immagine non si carica o continui a ricevere errori, puoi segnalarlo (allega la diagnostica): {report_url}",
+        "description": "Porsche richiede di risolvere un captcha per proseguire con l'accesso.\n\n{captcha_img}\n\nRisolvilo una sola volta con la tua ipotesi migliore: ripetuti tentativi falliti hanno già causato il blocco di account Porsche per attività sospetta.\n\nLa tua risposta viene inviata solo al servizio di accesso Porsche, mai a terzi né a questo progetto. Se l'immagine non si carica o continui a ricevere errori, puoi segnalarlo: {report_url}",
         "data": {
           "captcha_code": "Codice captcha"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Accesso non riuscito. Controlla l'email e la password del tuo Volkswagen ID.",
       "cannot_connect": "Impossibile raggiungere Volkswagen. Riprova.",
       "vweu_mfa_unsupported": "Questo account richiede un codice via email o dall'app di autenticazione, che VW EU Two-Way non è ancora in grado di gestire. Usa invece i canali in sola lettura.",
-      "vweu_no_bff_data": "Accesso riuscito, ma Volkswagen non ha ancora restituito dati in tempo reale per quest'auto sul backend moderno, quindi VW EU Two-Way non è stato attivato e il tuo canale attuale resta invariato. Riprova più tardi, oppure condividi una diagnostica così possiamo esaminarla."
+      "vweu_no_bff_data": "Accesso riuscito, ma Volkswagen non ha ancora restituito dati in tempo reale per quest'auto sul backend moderno, quindi VW EU Two-Way non è stato attivato e il tuo canale attuale resta invariato. Riprova più tardi, oppure condividi una diagnostica così possiamo esaminarla.",
+      "terms_and_conditions": "I termini e le condizioni devono essere accettati. Accedi una volta all'app e conferma."
     },
     "abort": {
       "not_volkswagen": "Questo canale è disponibile solo per Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Avviamenti motore"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Consumo medio carburante (breve termine)"
+      },
+      "battery_soc_charge_report": {
+        "name": "Livello batteria (ultimo rapporto di ricarica)"
+      },
+      "alarm_reason": {
+        "name": "Motivo dell'allarme"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Dati obsoleti"
+      },
+      "connect_contract_active": {
+        "name": "Contratto Connect attivo"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nb.json
+++ b/custom_components/vag_connect/translations/nb.json
@@ -33,7 +33,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha kreves",
-        "description": "Porsche krever at du løser en captcha for å fortsette innloggingen.\n\n{captcha_img}\n\nLøs det bare én gang etter beste evne — gjentatte mislykkede forsøk har fått Porsche til å låse kontoer på grunn av mistenkelig aktivitet.\n\nDet du skriver inn her, forlater ikke Home Assistant-instansen din. Hvis bildet ikke lastes inn eller du stadig får feil, kan du rapportere det (legg ved diagnostikk): {report_url}",
+        "description": "Porsche krever at du løser en captcha for å fortsette innloggingen.\n\n{captcha_img}\n\nLøs den én gang med ditt beste forsøk — gjentatte mislykkede forsøk har ført til at Porsche har låst kontoer på grunn av mistenkelig aktivitet.\n\nSvaret ditt sendes kun til Porsches innloggingstjeneste, aldri til tredjeparter eller til dette prosjektet. Hvis bildet ikke lastes eller du stadig får feil, kan du rapportere det: {report_url}",
         "data": {
           "captcha_code": "Captcha-kode"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Pålogging mislyktes. Sjekk e-postadressen og passordet til Volkswagen ID-en din.",
       "cannot_connect": "Kunne ikke nå Volkswagen. Prøv igjen.",
       "vweu_mfa_unsupported": "Denne kontoen krever en e-post- eller autentiseringskode, som VW EU Two-Way ikke kan håndtere ennå. Bruk de skrivebeskyttede kanalene i stedet.",
-      "vweu_no_bff_data": "Logget inn, men Volkswagen har ennå ikke returnert sanntidsdata for denne bilen på det moderne baksystemet, så VW EU Two-Way ble ikke aktivert og din nåværende kanal er uendret. Prøv igjen senere, eller del en diagnostikkfil så vi kan se nærmere på det."
+      "vweu_no_bff_data": "Logget inn, men Volkswagen har ennå ikke returnert sanntidsdata for denne bilen på det moderne baksystemet, så VW EU Two-Way ble ikke aktivert og din nåværende kanal er uendret. Prøv igjen senere, eller del en diagnostikkfil så vi kan se nærmere på det.",
+      "terms_and_conditions": "Vilkårene må godtas. Logg inn i appen én gang og bekreft."
     },
     "abort": {
       "not_volkswagen": "Denne kanalen er kun tilgjengelig for Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Motorstarter"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Gjennomsnittlig drivstofforbruk (kort sikt)"
+      },
+      "battery_soc_charge_report": {
+        "name": "Batterinivå (siste laderapport)"
+      },
+      "alarm_reason": {
+        "name": "Alarmårsak"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Data er utdatert"
+      },
+      "connect_contract_active": {
+        "name": "Connect-kontrakt aktiv"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/nl.json
+++ b/custom_components/vag_connect/translations/nl.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha vereist",
-        "description": "Porsche vereist het oplossen van een captcha om door te gaan met inloggen.\n\n{captcha_img}\n\nLos dit slechts één keer op met je beste gok — herhaalde mislukte pogingen hebben er bij Porsche al toe geleid dat accounts wegens verdachte activiteit werden vergrendeld.\n\nWat je hier invoert, verlaat je Home Assistant-installatie niet. Als de afbeelding niet laadt of je steeds fouten krijgt, kun je het melden (diagnostische gegevens bijvoegen): {report_url}",
+        "description": "Porsche vereist het oplossen van een captcha om verder te gaan met aanmelden.\n\n{captcha_img}\n\nLos het één keer op met je beste gok — herhaalde mislukte pogingen hebben bij Porsche al tot accountblokkeringen wegens verdachte activiteit geleid.\n\nJe antwoord gaat alleen naar de aanmeldservice van Porsche, nooit naar derden of naar dit project. Laadt de afbeelding niet of blijf je fouten krijgen, dan kun je het melden: {report_url}",
         "data": {
           "captcha_code": "Captcha-code"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Aanmelden mislukt. Controleer je Volkswagen ID-e-mailadres en -wachtwoord.",
       "cannot_connect": "Volkswagen niet bereikbaar. Probeer het opnieuw.",
       "vweu_mfa_unsupported": "Dit account vereist een e-mail- of authenticatorcode, die VW EU Two-Way nog niet aankan. Gebruik in plaats daarvan de alleen-lezen kanalen.",
-      "vweu_no_bff_data": "Aangemeld, maar Volkswagen leverde op de moderne backend nog geen live gegevens voor deze auto, dus VW EU Two-Way is niet ingeschakeld en je huidige kanaal blijft ongewijzigd. Probeer het later opnieuw of deel een diagnosebestand zodat we het kunnen onderzoeken."
+      "vweu_no_bff_data": "Aangemeld, maar Volkswagen leverde op de moderne backend nog geen live gegevens voor deze auto, dus VW EU Two-Way is niet ingeschakeld en je huidige kanaal blijft ongewijzigd. Probeer het later opnieuw of deel een diagnosebestand zodat we het kunnen onderzoeken.",
+      "terms_and_conditions": "Gebruiksvoorwaarden moeten worden geaccepteerd. Log eenmaal in via de app."
     },
     "abort": {
       "not_volkswagen": "Dit kanaal is alleen beschikbaar voor Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Motorstarts"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Gemiddeld brandstofverbruik (korte termijn)"
+      },
+      "battery_soc_charge_report": {
+        "name": "Accuniveau (laatste laadrapport)"
+      },
+      "alarm_reason": {
+        "name": "Alarmreden"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Gegevens verouderd"
+      },
+      "connect_contract_active": {
+        "name": "Connect-contract actief"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/pl.json
+++ b/custom_components/vag_connect/translations/pl.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Wymagana captcha",
-        "description": "Porsche wymaga rozwiązania captchy, aby kontynuować logowanie.\n\n{captcha_img}\n\nRozwiąż to tylko raz, najlepiej jak potrafisz — powtarzające się nieudane próby doprowadziły już do blokowania kont Porsche z powodu podejrzanej aktywności.\n\nTo, co tu wpiszesz, nie opuszcza Twojej instancji Home Assistant. Jeśli obraz się nie ładuje lub ciągle pojawiają się błędy, możesz to zgłosić (dołącz diagnostykę): {report_url}",
+        "description": "Porsche wymaga rozwiązania captcha, aby kontynuować logowanie.\n\n{captcha_img}\n\nRozwiąż je raz, najlepiej jak potrafisz — powtarzające się nieudane próby prowadziły już do blokady kont Porsche z powodu podejrzanej aktywności.\n\nTwoja odpowiedź trafia wyłącznie do usługi logowania Porsche, nigdy do osób trzecich ani do tego projektu. Jeśli obraz się nie ładuje lub błędy się powtarzają, możesz to zgłosić: {report_url}",
         "data": {
           "captcha_code": "Kod captcha"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Logowanie nieudane. Sprawdź adres e-mail i hasło do Volkswagen ID.",
       "cannot_connect": "Nie udało się połączyć z Volkswagenem. Spróbuj ponownie.",
       "vweu_mfa_unsupported": "To konto wymaga kodu z e-maila lub aplikacji uwierzytelniającej, czego VW EU Two-Way jeszcze nie obsługuje. Użyj zamiast tego kanałów tylko do odczytu.",
-      "vweu_no_bff_data": "Zalogowano, ale Volkswagen nie zwrócił jeszcze żadnych danych na żywo dla tego auta z nowoczesnego backendu, więc VW EU Two-Way nie został włączony, a Twój obecny kanał pozostaje bez zmian. Spróbuj ponownie później lub udostępnij plik diagnostyczny, abyśmy mogli się temu przyjrzeć."
+      "vweu_no_bff_data": "Zalogowano, ale Volkswagen nie zwrócił jeszcze żadnych danych na żywo dla tego auta z nowoczesnego backendu, więc VW EU Two-Way nie został włączony, a Twój obecny kanał pozostaje bez zmian. Spróbuj ponownie później lub udostępnij plik diagnostyczny, abyśmy mogli się temu przyjrzeć.",
+      "terms_and_conditions": "Warunki użytkowania muszą być zaakceptowane. Zaloguj się w aplikacji."
     },
     "abort": {
       "not_volkswagen": "Ten kanał jest dostępny wyłącznie dla Volkswagena.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Uruchomienia silnika"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Krótkoterminowe średnie zużycie paliwa"
+      },
+      "battery_soc_charge_report": {
+        "name": "Poziom baterii (ostatni raport ładowania)"
+      },
+      "alarm_reason": {
+        "name": "Powód alarmu"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Nieaktualne dane"
+      },
+      "connect_contract_active": {
+        "name": "Umowa Connect aktywna"
       }
     },
     "switch": {

--- a/custom_components/vag_connect/translations/sv.json
+++ b/custom_components/vag_connect/translations/sv.json
@@ -81,7 +81,7 @@
       },
       "porsche_captcha": {
         "title": "Captcha krävs",
-        "description": "Porsche kräver att du löser en captcha för att fortsätta inloggningen.\n\n{captcha_img}\n\nLös det bara en gång efter bästa förmåga — upprepade misslyckade försök har fått Porsche att låsa konton på grund av misstänkt aktivitet.\n\nDet du skriver in här lämnar inte din Home Assistant-instans. Om bilden inte laddas eller du hela tiden får fel kan du rapportera det (bifoga diagnostik): {report_url}",
+        "description": "Porsche kräver att du löser en captcha för att fortsätta inloggningen.\n\n{captcha_img}\n\nLös den en gång med din bästa gissning — upprepade misslyckade försök har fått Porsche att låsa konton på grund av misstänkt aktivitet.\n\nDitt svar skickas endast till Porsches inloggningstjänst, aldrig till tredje part eller till detta projekt. Om bilden inte laddas eller du fortsätter få fel kan du rapportera det: {report_url}",
         "data": {
           "captcha_code": "Captcha-kod"
         },
@@ -354,7 +354,8 @@
       "invalid_auth": "Inloggningen misslyckades. Kontrollera din Volkswagen ID-e-post och ditt lösenord.",
       "cannot_connect": "Kunde inte nå Volkswagen. Försök igen.",
       "vweu_mfa_unsupported": "Det här kontot kräver en e-post- eller autentiseringskod, som VW EU Two-Way inte kan hantera ännu. Använd de skrivskyddade kanalerna istället.",
-      "vweu_no_bff_data": "Inloggningen lyckades, men Volkswagen har ännu inte returnerat några live-data för den här bilen på det moderna backendet, så VW EU Two-Way aktiverades inte och din nuvarande kanal är oförändrad. Försök igen senare, eller dela en diagnostikfil så att vi kan titta på det."
+      "vweu_no_bff_data": "Inloggningen lyckades, men Volkswagen har ännu inte returnerat några live-data för den här bilen på det moderna backendet, så VW EU Two-Way aktiverades inte och din nuvarande kanal är oförändrad. Försök igen senare, eller dela en diagnostikfil så att vi kan titta på det.",
+      "terms_and_conditions": "Användarvillkor måste accepteras. Logga in i appen."
     },
     "abort": {
       "not_volkswagen": "Den här kanalen är endast tillgänglig för Volkswagen.",
@@ -1457,6 +1458,15 @@
       },
       "engine_starts_count": {
         "name": "Motorstarter"
+      },
+      "short_term_avg_fuel_consumption_l_100km": {
+        "name": "Genomsnittlig bränsleförbrukning (kort sikt)"
+      },
+      "battery_soc_charge_report": {
+        "name": "Batterinivå (senaste laddrapport)"
+      },
+      "alarm_reason": {
+        "name": "Larmorsak"
       }
     },
     "binary_sensor": {
@@ -1768,6 +1778,9 @@
       },
       "data_stale": {
         "name": "Data föråldrad"
+      },
+      "connect_contract_active": {
+        "name": "Connect-avtal aktivt"
       }
     },
     "switch": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,3 +78,14 @@ def pytest_configure(config):
         "markers",
         "ha_required: test needs the homeassistant package installed",
     )
+
+
+@pytest.fixture(autouse=True)
+def _no_porsche_settle_delay(monkeypatch):
+    """v4.7.8 (#1337) — the Porsche login sleeps 2.5 s after the password POST
+    (reference-client settle delay). Never pay that in unit tests."""
+    try:
+        from custom_components.vag_connect.cariad.auth import porsche as _p
+        monkeypatch.setattr(_p, "_POST_PASSWORD_SETTLE_S", 0, raising=False)
+    except Exception:  # noqa: BLE001 — module import problems surface elsewhere
+        pass

--- a/tests/test_1337_porsche_captcha_hardening.py
+++ b/tests/test_1337_porsche_captcha_hardening.py
@@ -156,6 +156,51 @@ async def test_reconfigure_routes_captcha_to_step_instead_of_crashing() -> None:
     assert f._porsche_reconfigure_entry_id == "e1"
 
 
+# ── v4.7.8: the wall names its screen (exception → ValueError → report) ───────
+def test_wall_error_carries_screen_and_marker_in_message() -> None:
+    from custom_components.vag_connect.cariad.exceptions import PorscheLoginWallError
+    err = PorscheLoginWallError("my.porsche.com/unknown", "title='Consent'; markers=consent")
+    assert err.screen == "my.porsche.com/unknown"
+    assert "my.porsche.com/unknown" in str(err)   # the WARNING line names it now
+    assert "consent" in str(err)
+    assert PorscheLoginWallError().screen == ""  # no-arg construction still fine
+
+
+def test_wall_screen_helper_and_map_error_tolerate_suffix() -> None:
+    from custom_components.vag_connect.config_flow import _map_error, _wall_screen
+    s = "porsche_login_wall:my.porsche.com/unknown|title='x'; markers=consent"
+    assert _wall_screen(s) == "my.porsche.com/unknown"
+    assert _map_error(s) == "porsche_login_wall"          # key survives the suffix
+    assert _wall_screen("invalid_credentials") == ""
+    assert _map_error("invalid_credentials") == "invalid_credentials"
+    assert _map_error("porsche_login_wall") == "porsche_login_wall"
+
+
+@pytest.mark.asyncio
+async def test_validate_credentials_threads_wall_screen_into_value_error() -> None:
+    from custom_components.vag_connect.cariad.api.porsche import PorscheClient
+    from custom_components.vag_connect.cariad.exceptions import PorscheLoginWallError
+    from custom_components.vag_connect.config_flow import _validate_credentials, _wall_screen
+    client = PorscheClient.__new__(PorscheClient)
+    client.authenticate = AsyncMock(  # type: ignore[method-assign]
+        side_effect=PorscheLoginWallError("my.porsche.com/consent", "markers=consent"))
+    with patch("custom_components.vag_connect.cariad.CariadClientFactory.create",
+               return_value=client), pytest.raises(ValueError) as ei:
+        await _validate_credentials(None, "porsche", "a@b.com", "pw")
+    assert _wall_screen(str(ei.value)) == "my.porsche.com/consent"
+
+
+def test_report_url_carries_the_screen_and_debug_guidance() -> None:
+    from urllib.parse import parse_qs, urlsplit
+    from custom_components.vag_connect.config_flow import VagConnectConfigFlow
+    url = VagConnectConfigFlow._porsche_report_url(
+        "email_password", "porsche_login_wall", "my.porsche.com/unknown")
+    body = parse_qs(urlsplit(url).query)["body"][0]
+    assert "Auth0 screen: my.porsche.com/unknown" in body
+    # a FAILED setup has no entry → no diagnostics: steer to the debug lines
+    assert "no entry yet" in body and "Porsche auth:" in body
+
+
 # ── strings integrity: every new reason/error exists + placeholders wired ──────
 def test_new_strings_present_and_report_placeholder_wired() -> None:
     import json

--- a/tests/test_478_porsche_reference_parity.py
+++ b/tests/test_478_porsche_reference_parity.py
@@ -1,0 +1,555 @@
+# Copyright 2026 Prash Balan (@its-me-prash) — GNU AGPL v3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""v4.7.8 — Porsche login 1:1 with the reference client (settle delay + plain
+library User-Agent), the lifecycle fixes around it (dead refresh token → reauth,
+solved-captcha hand-over hygiene, "session expired" repair that finally clears),
+and the Scout/merge corrections shipped in the same release.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.vag_connect.cariad import _channel_merge as merge_mod
+from custom_components.vag_connect.cariad.api import porsche as api_mod
+from custom_components.vag_connect.cariad.auth import porsche as auth_mod
+from custom_components.vag_connect.cariad.auth._eu_data_act import (
+    _walk_fields,
+    map_dataset_to_vehicle_data,
+)
+from custom_components.vag_connect.cariad.models import VehicleData
+from custom_components.vag_connect.const import CONF_BRAND
+from custom_components.vag_connect.coordinator import VagConnectCoordinator
+
+_CC = Path(__file__).resolve().parents[1] / "custom_components" / "vag_connect"
+_LANGS = ("cs", "da", "de", "en", "es", "fi", "fr", "it", "nb", "nl", "pl", "sv")
+
+
+class _Resp:
+    def __init__(self, status: int, location: str = "", text: str = "") -> None:
+        self.status = status
+        self.headers = {"Location": location} if location else {}
+        self._text = text
+
+    async def __aenter__(self) -> "_Resp":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    async def text(self) -> str:
+        return self._text
+
+
+def _session(post_responses=None, get_responses=None) -> MagicMock:
+    pit = iter(post_responses or [])
+    git = iter(get_responses or [])
+    s = MagicMock()
+    s.post = MagicMock(side_effect=lambda *a, **kw: next(pit))
+    s.get = MagicMock(side_effect=lambda *a, **kw: next(git))
+    return s
+
+
+# ── 1:1 with the reference client ─────────────────────────────────────────────
+
+def test_settle_delay_matches_reference_client_verbatim() -> None:
+    # CJNE/pyporscheconnectapi sleeps 2.5 s between the password POST and the
+    # first resume hop. Pin the constant in SOURCE: the conftest zeroes the live
+    # value for test speed, so the module attribute can't be asserted directly.
+    src = Path(auth_mod.__file__).read_text(encoding="utf-8")
+    assert "_POST_PASSWORD_SETTLE_S = 2.5" in src
+
+
+def test_settle_delay_sits_between_password_post_and_resume(monkeypatch) -> None:
+    monkeypatch.setattr(auth_mod, "_POST_PASSWORD_SETTLE_S", 0.123)
+    events: list[tuple] = []
+
+    async def fake_sleep(seconds):
+        events.append(("sleep", seconds))
+
+    async def fake_follow(self, location, referer, verifier=""):
+        events.append(("follow", location))
+        return "CODE"
+
+    async def fake_exchange(self, code, verifier):
+        events.append(("exchange", code))
+        return "TOKENS"
+
+    monkeypatch.setattr(auth_mod.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(auth_mod.PorscheAuth, "_follow_to_code", fake_follow)
+    monkeypatch.setattr(auth_mod.PorscheAuth, "_exchange_code", fake_exchange)
+    session = _session(
+        get_responses=[_Resp(302, location="https://identity.porsche.com/u/login/identifier?state=S1")],
+        post_responses=[
+            _Resp(200),                                       # identifier accepted
+            _Resp(302, location="/authorize/resume?state=S1"),  # password accepted
+        ],
+    )
+    out = asyncio.run(auth_mod.PorscheAuth(session).authenticate("a@b.com", "pw"))
+    assert out == "TOKENS"
+    # order is the whole point: password POST → settle → resume chain → exchange
+    assert events == [
+        ("sleep", 0.123),
+        ("follow", "/authorize/resume?state=S1"),
+        ("exchange", "CODE"),
+    ]
+
+
+def test_settle_delay_is_not_paid_on_a_wrong_password(monkeypatch) -> None:
+    events: list = []
+
+    async def fake_sleep(seconds):
+        events.append("sleep")
+
+    monkeypatch.setattr(auth_mod.asyncio, "sleep", fake_sleep)
+    session = _session(
+        get_responses=[_Resp(302, location="https://identity.porsche.com/u/login/identifier?state=S1")],
+        post_responses=[_Resp(200), _Resp(401)],
+    )
+    with pytest.raises(auth_mod.AuthenticationError):
+        asyncio.run(auth_mod.PorscheAuth(session).authenticate("a@b.com", "pw"))
+    assert events == []
+
+
+@pytest.mark.parametrize("ua", [auth_mod._USER_AGENT, api_mod._USER_AGENT])
+def test_user_agent_is_the_plain_library_identity(ua: str) -> None:
+    # The reference client identifies itself as a library and has been stable
+    # for years; borrowing a phone's identity buys nothing and reads as evasion.
+    assert ua.startswith("vag-connect-ha/")
+    assert "github.com/its-me-prash/vwgroup-connect-ha" in ua
+    for impersonation in ("okhttp", "Android", "iPhone", "Mozilla", "Dalvik"):
+        assert impersonation not in ua
+
+
+def test_both_layers_carry_the_same_user_agent() -> None:
+    assert auth_mod._USER_AGENT == api_mod._USER_AGENT
+
+
+# ── lifecycle around the login ────────────────────────────────────────────────
+
+def _coord_self(reason: str = "", *, pending: bool = True) -> SimpleNamespace:
+    portal = SimpleNamespace(last_login_interaction="", last_no_data_reason=reason)
+    client = SimpleNamespace(_eu_portal=portal, _supplementary_eu_portal=None)
+    entry = SimpleNamespace(entry_id="e1", data={CONF_BRAND: "skoda"})
+    return SimpleNamespace(
+        _cariad_client=client, entry=entry, hass=MagicMock(),
+        _portal_interaction_reason="",
+        _data_act_session_expired_pending=pending,
+    )
+
+
+def test_session_expired_repair_is_remembered_when_raised() -> None:
+    me = SimpleNamespace(
+        hass=MagicMock(), entry=SimpleNamespace(entry_id="e1", data={CONF_BRAND: "skoda"}),
+    )
+    with patch("homeassistant.helpers.issue_registry.async_create_issue") as create:
+        VagConnectCoordinator._raise_data_act_session_expired_repair(me)
+    create.assert_called_once()
+    assert "data_act_session_expired_e1" in str(create.call_args.args)
+    assert me._data_act_session_expired_pending is True
+
+
+def test_session_expired_repair_clears_once_data_flows_again() -> None:
+    me = _coord_self("", pending=True)
+    with patch("homeassistant.helpers.issue_registry.async_delete_issue") as delete, \
+            patch("homeassistant.helpers.issue_registry.async_create_issue"):
+        VagConnectCoordinator._update_data_act_no_data_repair(me)
+    assert any("data_act_session_expired_e1" in str(c.args) for c in delete.call_args_list)
+    assert me._data_act_session_expired_pending is False
+
+
+def test_session_expired_repair_survives_a_no_data_poll() -> None:
+    # the kickoff can raise it mid-cycle; the same cycle's empty dataset must
+    # not erase it straight away
+    me = _coord_self("empty", pending=True)
+    with patch("homeassistant.helpers.issue_registry.async_delete_issue") as delete, \
+            patch("homeassistant.helpers.issue_registry.async_create_issue"):
+        VagConnectCoordinator._update_data_act_no_data_repair(me)
+    assert not any("data_act_session_expired_e1" in str(c.args) for c in delete.call_args_list)
+    assert me._data_act_session_expired_pending is True
+
+
+def test_session_expired_repair_is_left_alone_when_never_raised() -> None:
+    me = _coord_self("", pending=False)
+    with patch("homeassistant.helpers.issue_registry.async_delete_issue") as delete, \
+            patch("homeassistant.helpers.issue_registry.async_create_issue"):
+        VagConnectCoordinator._update_data_act_no_data_repair(me)
+    assert not any("data_act_session_expired_e1" in str(c.args) for c in delete.call_args_list)
+
+
+def test_coordinator_source_carries_the_porsche_lifecycle_fixes() -> None:
+    src = (_CC / "coordinator.py").read_text(encoding="utf-8")
+    # M2 — every read failed auth → reauth instead of an endless interactive loop
+    assert "every vehicle read failed authentication" in src
+    # L1 — the solved-captcha hand-over is only promoted with a refresh token
+    assert 'porsche_initial.get("refresh_token")' in src
+    # L2 — and the hand-over key is stripped from entry.data afterwards
+    assert 'k != "porsche_initial_tokens"' in src
+
+
+# ── "everything is empty" made visible ────────────────────────────────────────
+
+def _overview(measurements: list) -> dict:
+    return {
+        "modelName": "Taycan",
+        "modelType": {"engine": "BEV", "year": 2021},
+        "measurements": measurements,
+    }
+
+
+def _status(overview) -> VehicleData:
+    client = api_mod.PorscheClient.__new__(api_mod.PorscheClient)
+    client._get = AsyncMock(return_value=overview)  # type: ignore[method-assign]
+    return asyncio.run(client.get_status("WP0X"))
+
+
+def test_connect_contract_enabled_is_active() -> None:
+    d = _status(_overview([{"key": "CONNECT_CONTRACT", "status": {"isEnabled": True}, "value": {}}]))
+    assert d.connect_contract_active is True
+
+
+def test_connect_contract_disabled_is_inactive() -> None:
+    d = _status(_overview([{"key": "CONNECT_CONTRACT", "status": {"isEnabled": False}, "value": {}}]))
+    assert d.connect_contract_active is False
+
+
+def test_connect_contract_absent_is_unknown() -> None:
+    d = _status(_overview([{"key": "BATTERY_LEVEL", "status": {"isEnabled": True}, "value": {}}]))
+    assert d.connect_contract_active is None
+
+
+def test_status_auth_failure_propagates_to_the_coordinator() -> None:
+    # ``_request`` has already refreshed/retried/fallen back before raising
+    # AuthenticationError — swallowing it left entities silently empty and the
+    # interactive login re-running with no reauth prompt.
+    client = api_mod.PorscheClient.__new__(api_mod.PorscheClient)
+    client._get = AsyncMock(side_effect=api_mod.AuthenticationError("dead token"))  # type: ignore[method-assign]
+    with pytest.raises(api_mod.AuthenticationError):
+        asyncio.run(client.get_status("WP0X"))
+    assert client.probe_outcomes["porsche_status"] == "AuthenticationError"
+
+
+def test_status_failure_is_recorded_and_warned_once_per_vin(caplog) -> None:
+    client = api_mod.PorscheClient.__new__(api_mod.PorscheClient)
+    err = RuntimeError("boom")
+    err.status = 403  # type: ignore[attr-defined]
+    client._get = AsyncMock(side_effect=err)  # type: ignore[method-assign]
+    with caplog.at_level("DEBUG"):
+        asyncio.run(client.get_status("WP0ZZZ123456"))
+        asyncio.run(client.get_status("WP0ZZZ123456"))
+    assert client.probe_outcomes["porsche_status"] == "RuntimeError:403"
+    warnings = [r for r in caplog.records if r.levelname == "WARNING" and "status read failed" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "123456" in warnings[0].getMessage()      # masked tail only
+    assert "WP0ZZZ123456" not in warnings[0].getMessage()
+
+
+# ── Scout corrections ─────────────────────────────────────────────────────────
+
+def _map(points: list[dict]) -> VehicleData:
+    fields = _walk_fields({"data": points})
+    return map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+
+
+def test_fuel_shaped_short_term_consumption_gets_its_own_field() -> None:
+    d = _map([{"dataFieldName": "shortTermAverageConsumption",
+               "value": "5.2 l/100km", "key": "k"}])
+    assert d.short_term_avg_fuel_consumption_l_100km == 5.2
+    assert d.short_term_avg_electric_consumption_kwh_100km is None
+
+
+def test_electric_short_term_consumption_stays_electric() -> None:
+    d = _map([{"dataFieldName": "shortTermAverageConsumption",
+               "value": "15.8 kWh/100km", "key": "k"}])
+    assert d.short_term_avg_electric_consumption_kwh_100km == 15.8
+    assert d.short_term_avg_fuel_consumption_l_100km is None
+
+
+@pytest.mark.parametrize("code", ["14", "15"])
+def test_scr_status_codes_are_not_engine_start_counts(code: str) -> None:
+    d = _map([{"dataFieldName": "scr_number_of_engine_starts", "value": code, "key": "k"}])
+    assert d.engine_starts_count is None
+
+
+def test_scr_count_range_is_still_a_count() -> None:
+    d = _map([{"dataFieldName": "scr_number_of_engine_starts", "value": "13", "key": "k"}])
+    assert d.engine_starts_count == 13
+
+
+def test_charge_report_soc_lands_on_its_own_field_not_battery_soc() -> None:
+    d = _map([{"dataFieldName": "battery_state_report.soc_at_charge_start",
+               "value": "63", "key": "k"}])
+    assert d.battery_soc_charge_report == 63
+    assert d.battery_soc is None
+
+
+def test_alarm_reason_is_mapped_verbatim() -> None:
+    # #1396 (CUPRA Raval) — anti-theft alarm reason enum, kept as-is
+    d = _map([{"dataFieldName": "dwa_alarm_reason",
+               "value": "ALARM_REASON_DRIVERSDOOROPEN", "key": "k"}])
+    assert d.alarm_reason == "ALARM_REASON_DRIVERSDOOROPEN"
+    assert d.alarm_active is None  # a reason is not an "active now" flag
+
+
+def test_blank_alarm_reason_is_not_a_value() -> None:
+    d = _map([{"dataFieldName": "dwa_alarm_reason", "value": "  ", "key": "k"}])
+    assert d.alarm_reason is None
+
+
+def test_raval_der_envelope_packet_is_consumed_not_invented() -> None:
+    # #1396 — bare ``data`` leaf = base64 DER envelope (two timestamps); it is
+    # consumed as metadata so the Scout stops re-reporting it, no sensor.
+    fields = _walk_fields({"data": [
+        {"dataFieldName": "data",
+         "value": "oRiCARGFAt6bmw8yMDI2MDkxMDIwMTMwNlqeDzIwMjYwOTEwMjAwMzA2WpwBAA==",
+         "key": "k"},
+    ]})
+    d = map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+    assert d.alarm_reason is None
+    # ``first()`` consumed it: no longer an unmapped (Scout-reported) field
+    assert "data" not in d.raw_unmapped_fields
+
+
+def test_unknown_leaf_still_surfaces_as_unmapped() -> None:
+    # guard for the test above: an unrelated leaf DOES stay visible to the Scout
+    fields = _walk_fields({"data": [
+        {"dataFieldName": "some_new_leaf", "value": "1", "key": "k"},
+    ]})
+    d = map_dataset_to_vehicle_data(fields, VehicleData(vin="X"))
+    assert "some_new_leaf" in d.raw_unmapped_fields
+
+
+# ── position: freshest fix wins ───────────────────────────────────────────────
+
+def test_freshest_position_beats_merge_order() -> None:
+    older = VehicleData(vin="X", latitude=1.0, longitude=1.0, heading=10,
+                        position_captured_at="2026-09-11T10:00:00Z")
+    newer = VehicleData(vin="X", latitude=2.0, longitude=2.0, heading=20,
+                        position_captured_at="2026-09-11T10:30:00Z")
+    merged = merge_mod.merge_channels([("eu_data_act", older), ("brand_native", newer)])
+    assert (merged.latitude, merged.longitude, merged.heading) == (2.0, 2.0, 20)
+    assert merged.position_captured_at == "2026-09-11T10:30:00Z"
+    assert merged.field_sources["latitude"] == "brand_native"
+    assert merged.field_sources["heading"] == "brand_native"
+
+
+def test_primary_keeps_position_when_it_is_the_freshest() -> None:
+    newer = VehicleData(vin="X", latitude=1.0, longitude=1.0,
+                        position_captured_at="2026-09-11T10:30:00Z")
+    older = VehicleData(vin="X", latitude=2.0, longitude=2.0,
+                        position_captured_at="2026-09-11T10:00:00Z")
+    merged = merge_mod.merge_channels([("eu_data_act", newer), ("brand_native", older)])
+    assert merged.latitude == 1.0
+    assert merged.field_sources["latitude"] == "eu_data_act"
+
+
+def test_untimestamped_pin_cannot_beat_a_timestamped_fix() -> None:
+    no_ts = VehicleData(vin="X", latitude=1.0, longitude=1.0)
+    with_ts = VehicleData(vin="X", latitude=2.0, longitude=2.0,
+                          position_captured_at="2026-09-11T10:00:00Z")
+    merged = merge_mod.merge_channels([("eu_data_act", no_ts), ("brand_native", with_ts)])
+    assert merged.latitude == 2.0
+    assert merged.field_sources["latitude"] == "brand_native"
+
+
+def test_unparseable_timestamp_is_skipped_not_fatal() -> None:
+    bad = VehicleData(vin="X", latitude=1.0, longitude=1.0, position_captured_at="yesterday")
+    good = VehicleData(vin="X", latitude=2.0, longitude=2.0,
+                       position_captured_at="2026-09-11T10:00:00Z")
+    merged = merge_mod.merge_channels([("eu_data_act", bad), ("brand_native", good)])
+    assert merged.latitude == 2.0
+
+
+def test_single_channel_position_is_untouched() -> None:
+    only = VehicleData(vin="X", latitude=1.0, longitude=1.0,
+                       position_captured_at="2026-09-11T10:00:00Z")
+    merged = merge_mod.merge_channels([("eu_data_act", only)])
+    assert merged.latitude == 1.0
+    assert merged.field_sources["latitude"] == "eu_data_act"
+
+
+# ── entities + strings ────────────────────────────────────────────────────────
+
+def test_sensor_source_gates_engine_starts_to_combustion_and_relaxes_trip_gate() -> None:
+    src = (_CC / "sensor.py").read_text(encoding="utf-8")
+    assert 'key="short_term_avg_fuel_consumption_l_100km"' in src
+    assert 'key="battery_soc_charge_report"' in src
+    # the trip-statistics capability gate only hides sensors WITHOUT a value
+    assert "and vehicle.get(desc.data_key) is None" in src
+    # engine starts on combustion cars only
+    i = src.index('key="engine_starts_count"')
+    assert 'condition="combustion"' in src[i:i + 900]
+
+
+def test_binary_sensor_source_has_connect_contract_diagnostic() -> None:
+    src = (_CC / "binary_sensor.py").read_text(encoding="utf-8")
+    i = src.index('key="connect_contract_active"')
+    assert "EntityCategory.DIAGNOSTIC" in src[i:i + 600]
+
+
+@pytest.mark.parametrize("lang", _LANGS)
+def test_new_entity_names_exist_in_every_language(lang: str) -> None:
+    d = json.loads((_CC / "translations" / f"{lang}.json").read_text(encoding="utf-8"))
+    assert d["entity"]["sensor"]["short_term_avg_fuel_consumption_l_100km"]["name"]
+    assert d["entity"]["sensor"]["battery_soc_charge_report"]["name"]
+    assert d["entity"]["sensor"]["alarm_reason"]["name"]
+    assert d["entity"]["binary_sensor"]["connect_contract_active"]["name"]
+    assert d["options"]["error"]["terms_and_conditions"]
+
+
+@pytest.mark.parametrize("lang", _LANGS)
+def test_captcha_copy_is_honest_about_where_the_answer_goes(lang: str) -> None:
+    d = json.loads((_CC / "translations" / f"{lang}.json").read_text(encoding="utf-8"))
+    desc = d["config"]["step"]["porsche_captcha"]["description"]
+    assert "{captcha_img}" in desc and "{report_url}" in desc
+    assert "never leaves" not in desc.lower()
+    assert "Porsche" in desc
+
+
+def test_strings_json_matches_en_translation() -> None:
+    s = json.loads((_CC / "strings.json").read_text(encoding="utf-8"))
+    en = json.loads((_CC / "translations" / "en.json").read_text(encoding="utf-8"))
+    for kind, key in (("sensor", "short_term_avg_fuel_consumption_l_100km"),
+                      ("sensor", "battery_soc_charge_report"),
+                      ("binary_sensor", "connect_contract_active")):
+        assert s["entity"][kind][key] == en["entity"][kind][key]
+    assert (s["config"]["step"]["porsche_captcha"]["description"]
+            == en["config"]["step"]["porsche_captcha"]["description"])
+
+
+# ── pre-push review fixes ─────────────────────────────────────────────────────
+
+def test_refresh_endpoint_hiccup_is_not_a_dead_token() -> None:
+    from custom_components.vag_connect.cariad.exceptions import APIError
+    session = _session(post_responses=[_Resp(503, text='{"error":"temporarily_unavailable"}')])
+    with pytest.raises(APIError):
+        asyncio.run(auth_mod.PorscheAuth(session).refresh("R"))
+
+
+@pytest.mark.parametrize("resp", [
+    _Resp(401), _Resp(403), _Resp(400, text='{"error":"invalid_grant"}'),
+])
+def test_refresh_rejections_mean_expired(resp: _Resp) -> None:
+    from custom_components.vag_connect.cariad.exceptions import TokenExpiredError
+    session = _session(post_responses=[resp])
+    with pytest.raises(TokenExpiredError):
+        asyncio.run(auth_mod.PorscheAuth(session).refresh("R"))
+
+
+def test_concurrent_refreshes_coalesce_into_one() -> None:
+    from custom_components.vag_connect.cariad.models import TokenSet
+    client = api_mod.PorscheClient.__new__(api_mod.PorscheClient)
+    client._tokens = TokenSet(access_token="A", refresh_token="R", id_token="")
+    client._refresh_lock = None
+    client._refresh_history = []
+    client.on_tokens_changed = None
+    client._auth = MagicMock()
+    client._auth.refresh = AsyncMock(
+        return_value=TokenSet(access_token="B", refresh_token="R2", id_token=""),
+    )
+
+    async def run() -> None:
+        await asyncio.gather(*[client._refresh(stale_access_token="A") for _ in range(3)])
+
+    asyncio.run(run())
+    assert client._auth.refresh.await_count == 1        # three cars, one refresh
+    assert client._tokens.access_token == "B"
+    assert len(client._refresh_history) == 1            # one budget slot used
+
+
+def test_refresh_without_stale_hint_still_refreshes() -> None:
+    from custom_components.vag_connect.cariad.models import TokenSet
+    client = api_mod.PorscheClient.__new__(api_mod.PorscheClient)
+    client._tokens = TokenSet(access_token="A", refresh_token="R", id_token="")
+    client._refresh_lock = None
+    client._refresh_history = []
+    client.on_tokens_changed = None
+    client._auth = MagicMock()
+    client._auth.refresh = AsyncMock(
+        return_value=TokenSet(access_token="B", refresh_token="R", id_token=""),
+    )
+    asyncio.run(client._refresh())
+    assert client._auth.refresh.await_count == 1
+
+
+def _porsche_coord(brand: str = "porsche") -> SimpleNamespace:
+    return SimpleNamespace(entry=SimpleNamespace(data={CONF_BRAND: brand}))
+
+
+def test_porsche_auth_dead_needs_two_consecutive_polls() -> None:
+    me = _porsche_coord()
+    dead = [api_mod.AuthenticationError("x"), api_mod.AuthenticationError("y")]
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1", "V2"], dead) is False
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1", "V2"], dead) is True
+
+
+def test_porsche_auth_dead_resets_on_any_success() -> None:
+    me = _porsche_coord()
+    dead = [api_mod.AuthenticationError("x")]
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1"], dead) is False
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1"], [VehicleData(vin="V1")]) is False
+    assert me._porsche_auth_fail_polls == 0
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1"], dead) is False  # counts from 1 again
+
+
+def test_porsche_auth_dead_ignores_non_auth_and_partial_failures() -> None:
+    me = _porsche_coord()
+    mixed = [api_mod.AuthenticationError("x"), RuntimeError("net")]
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1", "V2"], mixed) is False
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1", "V2"], mixed) is False
+
+
+def test_porsche_auth_dead_is_brand_gated() -> None:
+    me = _porsche_coord("skoda")
+    dead = [api_mod.AuthenticationError("x")]
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1"], dead) is False
+    assert VagConnectCoordinator._porsche_auth_dead(me, ["V1"], dead) is False
+
+
+def test_direct_body_wall_names_the_screen() -> None:
+    session = _session(
+        get_responses=[_Resp(302, location="https://identity.porsche.com/u/login/identifier?state=S1")],
+        post_responses=[
+            _Resp(200),
+            _Resp(200, text="<html><title>My Porsche consent</title><body>agree</body></html>"),
+        ],
+    )
+    auth = auth_mod.PorscheAuth(session)
+    with pytest.raises(auth_mod.PorscheLoginWallError) as ei:
+        asyncio.run(auth.authenticate("a@b.com", "pw"))
+    assert ei.value.screen.startswith("identity.porsche.com/")
+    assert ei.value.marker                      # secret-free page marker present
+    for secret in ("S1", "a@b.com", "pw"):
+        assert secret not in ei.value.screen and secret not in ei.value.marker
+
+
+def test_wall_screen_is_reset_per_attempt(monkeypatch) -> None:
+    async def fake_follow(self, location, referer, verifier=""):
+        return "CODE"
+
+    async def fake_exchange(self, code, verifier):
+        return "TOKENS"
+
+    monkeypatch.setattr(auth_mod.PorscheAuth, "_follow_to_code", fake_follow)
+    monkeypatch.setattr(auth_mod.PorscheAuth, "_exchange_code", fake_exchange)
+    session = _session(
+        get_responses=[_Resp(302, location="https://identity.porsche.com/u/login/identifier?state=S1")],
+        post_responses=[_Resp(200), _Resp(302, location="/authorize/resume?state=S1")],
+    )
+    auth = auth_mod.PorscheAuth(session)
+    auth._last_wall_screen, auth._last_wall_marker = "stale.host/old", "old marker"
+    assert asyncio.run(auth.authenticate("a@b.com", "pw")) == "TOKENS"
+    assert (auth._last_wall_screen, auth._last_wall_marker) == ("", "")
+
+
+def test_coordinator_strips_the_token_handover_unconditionally() -> None:
+    src = (_CC / "coordinator.py").read_text(encoding="utf-8")
+    i = src.index('if "porsche_initial_tokens" in self.entry.data:')
+    # the strip sits OUTSIDE the "promote only when the store is empty" block
+    assert "porsche_initial.get(\"refresh_token\")" in src[:i]
+    assert 'k != "porsche_initial_tokens"' in src[i:i + 400]

--- a/tests/test_porsche_captcha_config_flow.py
+++ b/tests/test_porsche_captcha_config_flow.py
@@ -92,9 +92,12 @@ class TestLoginWallMapping:
             return_value=client,
         ), pytest.raises(ValueError) as excinfo:
             await _validate_credentials(None, "porsche", "a@b.com", "pw")
-        assert str(excinfo.value) == "porsche_login_wall"
+        # v4.7.8 — the key now carries a ":<screen>|<marker>" suffix for the
+        # one-click report; the KEY is what matters here.
+        assert str(excinfo.value).startswith("porsche_login_wall")
+        assert _map_error(str(excinfo.value)) == "porsche_login_wall"
         # The whole point of the fix: it must NOT be the credentials error.
-        assert str(excinfo.value) != "invalid_credentials"
+        assert not str(excinfo.value).startswith("invalid_credentials")
 
     @pytest.mark.asyncio
     async def test_real_wrong_credentials_still_map_to_invalid(self) -> None:


### PR DESCRIPTION
## Porsche login done the reference way + lifecycle, Scout and merge fixes (v4.7.8)

### Porsche (#1337, #1400)
- **Settle delay after the password step.** A line-by-line comparison with the reference client (pyporscheconnectapi) showed one behavioural difference in the login flow: it waits 2.5 s after the password POST before following Porsche's resume chain. We resumed immediately, and on accounts with a vehicle attached that bounced to the `my.porsche.com` wall even after a correctly solved captcha. Now matched 1:1 (`_POST_PASSWORD_SETTLE_S`, zeroed in the test suite via an autouse fixture).
- **Plain library User-Agent** (`vag-connect-ha/4.7.8 (+repo)`) in the auth and API layers, replacing the iOS-app impersonation — the reference client identifies itself as a library too.
- **Walls are self-describing.** `PorscheLoginWallError(screen, marker)` carries the Auth0 screen (host + name) and a secret-free page marker through the config flow into the abort text and the pre-filled report link (`porsche_login_wall:<screen>|<marker>`; `_map_error` splits the suffix off).
- **Dead refresh token → reauth.** `get_status` no longer swallows `AuthenticationError`; when every car read fails authentication the coordinator starts reauth instead of silently re-running the interactive login up to 3×/hour. No second interactive login in the coordinator retry branch. The solved-captcha token hand-over (`porsche_initial_tokens`) is promoted only when it carries a refresh token and is removed from `entry.data` afterwards.
- **Token-endpoint hiccups are not dead tokens.** `PorscheAuth.refresh` now raises `APIError` for 5xx/429/other, `TokenExpiredError` only for 401/403/`invalid_grant`; concurrent per-car refreshes coalesce into one (`_refresh(stale_access_token=…)` re-checks under the lock — a 3-car account no longer burns the 3/h budget in one poll); reauth is requested only after two consecutive polls in which every car failed authentication (`_porsche_auth_dead`). Wall screen/marker are reset per attempt and also captured when Auth0 renders the wall directly on the password POST.
- **"Everything is empty" made visible:** status-read failures logged once per car at WARNING (masked VIN) + `probe_outcomes`; new diagnostic binary sensor `connect_contract_active` from the `CONNECT_CONTRACT` measurement.

### Portal / Scout / merge
- `data_act_session_expired` repair now clears once portal data flows again (raised by setup, kickoff and historical export; never deleted before).
- `shortTermAverageConsumption` in l/100 km gets its own fuel sensor (v4.7.6 consumed it and dropped it).
- `scr_number_of_engine_starts`: 14/15 are status codes, not counts; entity combustion-only.
- `battery_state_report.soc_at_charge_start` surfaced as a disabled diagnostic sensor (stops the daily Scout auto-issues #1382–#1401).
- `dwa_alarm_reason` → `alarm_reason` sensor; the bare DER-envelope `data` leaf is consumed as metadata (#1396, CUPRA Raval).
- Position: freshest capture wins across channels instead of merge order.
- VW-EU trip sensors no longer hidden by the trip-statistics gate when a value exists (#923).
- Options flow: `terms_and_conditions` error text (was a raw key) in all 12 translations.

### Docs
- CHANGELOG 4.7.6 notes and the captcha dialog copy corrected: the answer is sent to Porsche's login service (not "never leaves HA"), the report link attaches nothing automatically, `persLocation`/trip-id wording. `## [4.7.8]` notes, manifest 4.7.8.

### Verification
- Suite: 6149 passed / 15 skipped; ruff + mypy clean; new `tests/test_478_porsche_reference_parity.py` (settle order behavioural, UA, session-expired lifecycle, CONNECT_CONTRACT, auth propagation, Scout, merge, strings).
- Live: one real Porsche login with this branch — captcha at the identifier step, password POST → 302, one resume hop → code → token (refresh token present). That account has no vehicle, so the effect on vehicle-holding accounts follows from the reference-client parity and still needs confirmation from #1337 / #1400 reporters.
