### PR TITLE
Test cohort reaches the MBB command connector; per-device diagnostics keep probe outcomes (v4.7.9, #584 / #923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ Versioning: [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## [Unreleased]
 
+## [4.7.9] - 2026-09-11 — The test cohort finally reaches the MBB command connector
+
+### Fixed
+- **Test cohort: the MBB command connector never received the opt-in flag.** The connector was
+  created before the flag was applied, so the #584 fetched-role probe — the whole reason to opt
+  in on a car marked `mbb_no_legacy` — could not fire for anyone. The flag now reaches the
+  connector, applies live when you toggle it (no restart), and the probe runs for cars already
+  carrying the no-legacy verdict. The per-device diagnostics download now includes the probe
+  results and the car's MBB eligibility, so a single-car file finally carries the datapoint
+  (#584, #923 — thanks @Testius007 for the diagnostics that exposed it).
+
 ## [4.7.8] - 2026-09-11 — Porsche login done the reference way, and a round of honesty fixes
 
 ### Fixed

--- a/custom_components/vag_connect/__init__.py
+++ b/custom_components/vag_connect/__init__.py
@@ -1118,5 +1118,13 @@ async def _async_update_listener(
             refresh_spin = getattr(coordinator, "_refresh_mbb_command_spin", None)
             if callable(refresh_spin):
                 refresh_spin()
+            # v4.7.9 (#584/#923) — the test-cohort opt-in was applied at setup
+            # only, so toggling it here silently needed a restart. Re-apply live.
+            apply_cohort = getattr(coordinator, "_apply_test_cohort", None)
+            if callable(apply_cohort):
+                try:
+                    await apply_cohort()
+                except Exception:  # noqa: BLE001 — never break a settings save
+                    _LOGGER.debug("test-cohort re-apply skipped", exc_info=True)
             # Trigger one immediate refresh so users see the effect
             await coordinator.async_request_refresh()

--- a/custom_components/vag_connect/cariad/api/porsche.py
+++ b/custom_components/vag_connect/cariad/api/porsche.py
@@ -31,7 +31,7 @@ _X_CLIENT   = "41843fb4-691d-4970-85c7-2673e8ecef40"
 # #1337 (v4.7.8) — same plain library User-Agent the auth layer now sends (the
 # reference client uses ONE lib UA for both login and API reads); keep them
 # identical so Porsche sees a single consistent client.
-_USER_AGENT = "vag-connect-ha/4.7.8 (+https://github.com/its-me-prash/vwgroup-connect-ha)"
+_USER_AGENT = "vag-connect-ha/4.7.9 (+https://github.com/its-me-prash/vwgroup-connect-ha)"
 
 # v1.25.0 PR-B: storm-protection constants (mirror of base.py)
 _REFRESH_MAX_PER_HOUR = 3

--- a/custom_components/vag_connect/cariad/auth/porsche.py
+++ b/custom_components/vag_connect/cariad/auth/porsche.py
@@ -150,7 +150,7 @@ _AUDIENCE      = "https://api.porsche.com"
 # context is the more suspicious of the two to Auth0's bot scoring and is one
 # of only two request-shape differences from the flow that demonstrably gets
 # vehicle-holding accounts through. Honest, ours, not the other project's string.
-_USER_AGENT    = "vag-connect-ha/4.7.8 (+https://github.com/its-me-prash/vwgroup-connect-ha)"
+_USER_AGENT    = "vag-connect-ha/4.7.9 (+https://github.com/its-me-prash/vwgroup-connect-ha)"
 # Reference-client settle delay between the password POST and the first resume
 # hop (see the comment at the call site in ``authenticate``).
 _POST_PASSWORD_SETTLE_S = 2.5

--- a/custom_components/vag_connect/coordinator.py
+++ b/custom_components/vag_connect/coordinator.py
@@ -2809,6 +2809,28 @@ class VagConnectCoordinator(DataUpdateCoordinator):
         if has_ola:
             client._test_cohort = cohort
 
+        # v4.7.9 (#584/#923) — the MBB command connector is created by
+        # _arm_supplementary_channels BEFORE this runs and copies a still-False
+        # flag at creation; nothing ever pushed the real value down. So the
+        # fetched-role cohort probe could never fire for an MBB_ODP reporter —
+        # the exact car the cohort exists for (@Testius007's diagnostics exposed
+        # it). Push the flag into both MBB sub-connectors and, when opting in,
+        # fire the (one-shot, fail-soft) probe for cars whose operationList
+        # verdict is already cached as no-legacy — otherwise the 12 h deny cache
+        # hides the verdict branch (where the probe normally runs) until restart.
+        for attr in ("_mbb_command", "_mbb_fallback"):
+            sub = getattr(client, attr, None) if client is not None else None
+            if sub is None:
+                continue
+            sub._test_cohort = cohort
+            probe = getattr(sub, "_probe_fetched_role_cohort", None)
+            if cohort and callable(probe):
+                for _vin in sorted(getattr(sub, "mbb_no_legacy_vins", None) or ()):
+                    try:
+                        await probe(_vin)
+                    except Exception:  # noqa: BLE001 — probe is fail-soft by contract
+                        pass
+
         if cohort and (has_web or has_bff or has_ola):
             raise_issue_test_cohort_share(self.hass, self.entry.entry_id)
         else:

--- a/custom_components/vag_connect/diagnostics.py
+++ b/custom_components/vag_connect/diagnostics.py
@@ -687,6 +687,7 @@ async def async_get_device_diagnostics(
     masked = mask_vin(vin)  # the per-VIN diag sections are keyed by the masked VIN
     veh = full.get("vehicles", {})
     unexpected = full.get("unexpected_findings", {})
+    elig = full.get("mbb_eligibility", {}) or {}
     return {
         "device_vin_masked": masked,
         "config": full.get("config"),
@@ -699,6 +700,12 @@ async def async_get_device_diagnostics(
         "mbb_no_legacy": (
             [masked] if masked in full.get("mbb_no_legacy", []) else []
         ),
+        # v4.7.9 (#584/#923) — the cohort probe outcomes carry no VIN dimension
+        # (status codes keyed by host/brand/country) and are the one datapoint a
+        # no-legacy reporter's file is asked for: keep them. mbb_eligibility is
+        # VIN-keyed, so it is sliced like the other per-VIN sections.
+        "probe_outcomes": full.get("probe_outcomes", {}) or {},
+        "mbb_eligibility": {masked: elig[masked]} if masked in elig else {},
         "last_update_success": full.get("last_update_success"),
         "cloud_push_active": full.get("cloud_push_active"),
         "push_states": full.get("push_states"),

--- a/custom_components/vag_connect/manifest.json
+++ b/custom_components/vag_connect/manifest.json
@@ -23,5 +23,5 @@
     "aiomqtt>=2.0.0",
     "adb-shell==0.4.4"
   ],
-  "version": "4.7.8"
+  "version": "4.7.9"
 }

--- a/tests/test_923_test_cohort_optin.py
+++ b/tests/test_923_test_cohort_optin.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.vag_connect.cariad.auth._website_authproxy import (
     WebsiteAuthProxyConnector,
@@ -106,3 +106,72 @@ def test_cohort_on_but_no_web_channel_does_not_nag() -> None:
         asyncio.run(coord._apply_test_cohort())
     raise_m.assert_not_called()
     clear_m.assert_called_once()
+
+
+# ── v4.7.9 (#584/#923): the flag must reach the MBB command connector ────────
+
+def test_cohort_reaches_mbb_command_connector_and_probes_no_legacy_cars() -> None:
+    coord, _conn = _coord(data={CONF_TEST_COHORT: True}, options={})
+    probe = AsyncMock()
+    cmd = SimpleNamespace(
+        _test_cohort=False,
+        mbb_no_legacy_vins={"WVWZZZ0000000001", "WVWZZZ0000000000"},
+        _probe_fetched_role_cohort=probe,
+    )
+    coord._cariad_client._mbb_command = cmd
+    with patch(f"{_REPAIRS}.raise_issue_test_cohort_share"), \
+         patch(f"{_REPAIRS}.clear_issue_test_cohort_share"):
+        asyncio.run(coord._apply_test_cohort())
+    assert cmd._test_cohort is True
+    # fired once per no-legacy VIN, deterministic order
+    assert [c.args[0] for c in probe.await_args_list] == [
+        "WVWZZZ0000000000", "WVWZZZ0000000001",
+    ]
+
+
+def test_cohort_off_clears_mbb_flag_and_never_probes() -> None:
+    coord, _conn = _coord(data={CONF_TEST_COHORT: False}, options={})
+    probe = AsyncMock()
+    cmd = SimpleNamespace(
+        _test_cohort=True, mbb_no_legacy_vins={"WVWZZZ0000000001"},
+        _probe_fetched_role_cohort=probe,
+    )
+    coord._cariad_client._mbb_command = cmd
+    with patch(f"{_REPAIRS}.raise_issue_test_cohort_share"), \
+         patch(f"{_REPAIRS}.clear_issue_test_cohort_share"):
+        asyncio.run(coord._apply_test_cohort())
+    assert cmd._test_cohort is False
+    probe.assert_not_awaited()
+
+
+def test_probe_failure_never_breaks_cohort_apply() -> None:
+    coord, _conn = _coord(data={CONF_TEST_COHORT: True}, options={})
+    cmd = SimpleNamespace(
+        _test_cohort=False, mbb_no_legacy_vins={"WVWZZZ0000000001"},
+        _probe_fetched_role_cohort=AsyncMock(side_effect=RuntimeError("net")),
+    )
+    coord._cariad_client._mbb_fallback = cmd
+    with patch(f"{_REPAIRS}.raise_issue_test_cohort_share"), \
+         patch(f"{_REPAIRS}.clear_issue_test_cohort_share"):
+        asyncio.run(coord._apply_test_cohort())  # must not raise
+    assert cmd._test_cohort is True
+
+
+def test_options_save_reapplies_cohort_live() -> None:
+    from custom_components.vag_connect import _async_update_listener
+    from custom_components.vag_connect.const import (
+        CONF_BRAND, CONF_PASSWORD, CONF_USERNAME,
+    )
+    coord = SimpleNamespace(
+        _apply_test_cohort=AsyncMock(), async_request_refresh=AsyncMock(),
+    )
+    entry = SimpleNamespace(
+        entry_id="e1",
+        data={CONF_BRAND: "volkswagen", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
+        options={CONF_TEST_COHORT: True},
+        runtime_data=coord,
+    )
+    hass = MagicMock()
+    asyncio.run(_async_update_listener(hass, entry))
+    coord._apply_test_cohort.assert_awaited_once()      # applied live
+    hass.config_entries.async_reload.assert_not_called()  # no reload needed

--- a/tests/test_ha_platform_pickups.py
+++ b/tests/test_ha_platform_pickups.py
@@ -183,6 +183,9 @@ def test_device_diagnostics_slices_to_one_vin() -> None:
         "push_states": {},
         "polling_active": True,
         "raw_responses": {"selectivestatus": {"a": 1}},  # account-scoped → dropped
+        # v4.7.9 — probe outcomes have no VIN dimension → kept; eligibility sliced
+        "probe_outcomes": {"fetched_role:eudp:VW/DE": "404"},
+        "mbb_eligibility": {masked: "not_provisioned", other: "eligible"},
     }
     device = SimpleNamespace(identifiers={(DOMAIN, VIN)})
     with patch.object(
@@ -198,6 +201,8 @@ def test_device_diagnostics_slices_to_one_vin() -> None:
     assert out["unexpected_findings"] == {masked: [{"path": "x"}]}
     assert out["mbb_no_legacy"] == [masked]
     assert "raw_responses" not in out                     # account-scoped, dropped
+    assert out["probe_outcomes"] == {"fetched_role:eudp:VW/DE": "404"}
+    assert out["mbb_eligibility"] == {masked: "not_provisioned"}
 
 
 def test_device_diagnostics_settings_device_gets_no_slice() -> None:


### PR DESCRIPTION
## Test cohort reaches the MBB command connector (v4.7.9, #584 / #923)

Root cause found via @Testius007's diagnostics (#923, Touran 2024, `mbb_no_legacy`, cohort on, no probe result):

1. `_arm_supplementary_channels` creates the MBB command connector and copies `_test_cohort` from the client **before** `_apply_test_cohort` sets it, and nothing pushed the value down later. The #584 fetched-role probe could therefore never fire for any MBB_ODP reporter, restart or not.
2. The per-device diagnostics slice dropped `probe_outcomes` (only the integration-level download had it).
3. Toggling the cohort in options only took effect after a restart.

### Changes
- `_apply_test_cohort` pushes the flag into `_mbb_command` / `_mbb_fallback` and, when opting in, runs the one-shot, fail-soft `_probe_fetched_role_cohort` for VINs already in `mbb_no_legacy_vins` (bypasses the 12 h operationList deny cache).
- `_async_update_listener` soft path re-applies the cohort live.
- `async_get_device_diagnostics` keeps `probe_outcomes` (status codes keyed by host/brand/country — no VIN dimension) and the car's `mbb_eligibility` slice.
- manifest 4.7.9; the Porsche library User-Agent version string follows.

### Verification
- Suite 6166 passed / 15 skipped; ruff + mypy strict clean.
- New tests: flag + probe on the MBB connector, cohort-off clears and never probes, probe failure never breaks apply, options save re-applies live, device slice keeps probe outcomes / slices eligibility.
